### PR TITLE
Add permission to Publish Python Package

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -35,6 +35,8 @@ jobs:
     name: Publish Python Package
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      id-token: write
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# 変更点
- リリースの際の権限が不足していた為、権限を付与しました