### PR TITLE
Return `Instance` and `Solution` objects instead of `bytes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 rust/ommx/src/ommx.v1.rs linguist-generated=true
-python/ommx/**/* linguist-generated=true
+python/ommx/**/*_pb2.{py,pyi} linguist-generated=true

--- a/python/ommx/testing.py
+++ b/python/ommx/testing.py
@@ -81,7 +81,7 @@ class SingleFeasibleLPGenerator:
                 low=self.FLOAT_LOWER_BOUND, high=self.FLOAT_UPPER_BOUND, size=n
             )
 
-    def get_v1_instance(self) -> bytes:
+    def get_v1_instance(self) -> Instance:
         """
         Get an instance of a linear programming problem with a unique solution.
 
@@ -141,9 +141,9 @@ class SingleFeasibleLPGenerator:
             decision_variables=decision_variables,
             objective=Function(constant=0),
             constraints=constraints,
-        ).SerializeToString()
+        )
 
-    def get_v1_solution(self) -> bytes:
+    def get_v1_solution(self) -> Solution:
         """
         Get the solution of the generated instance.
 
@@ -154,5 +154,4 @@ class SingleFeasibleLPGenerator:
             >>> ommx_solution_byte = generator.get_v1_solution()
             >>> ommx_solution = SolutionList().ParseFromString(ommx_solution_byte)
         """
-        solution = Solution(entries={i: value for i, value in enumerate(self._x)})
-        return SolutionList(solutions=[solution]).SerializeToString()
+        return Solution(entries={i: value for i, value in enumerate(self._x)})

--- a/python/ommx/testing.py
+++ b/python/ommx/testing.py
@@ -87,10 +87,8 @@ class SingleFeasibleLPGenerator:
 
         Examples:
             >>> from ommx.testing import DataType, SingleFeasibleLPGenerator
-            >>> from ommx.v1.instance_pb2 import Instance
             >>> generator = SingleFeasibleLPGenerator(3, DataType.INT)
-            >>> ommx_instance_byte = generator.get_v1_instance()
-            >>> ommx_instance = Instance().ParseFromString(ommx_instance_byte)
+            >>> ommx_instance = generator.get_v1_instance()
         """
         # define decision variables
         if self._data_type == DataType.INT:
@@ -149,9 +147,7 @@ class SingleFeasibleLPGenerator:
 
         Examples:
             >>> from ommx.testing import DataType, SingleFeasibleLPGenerator
-            >>> from ommx.v1.solution_pb2 import SolutionList
             >>> generator = SingleFeasibleLPGenerator(3, DataType.INT)
-            >>> ommx_solution_byte = generator.get_v1_solution()
-            >>> ommx_solution = SolutionList().ParseFromString(ommx_solution_byte)
+            >>> ommx_solution = generator.get_v1_solution()
         """
         return Solution(entries={i: value for i, value in enumerate(self._x)})


### PR DESCRIPTION
Split from #32 

- `ommx.testing.SingleFeasibleLPGenerator` should returns `Instance` directly because this is for Python users.