### PR TITLE
Store descriptions of decision variables and constraints in Solution

### DIFF
--- a/proto/ommx/v1/constraint.proto
+++ b/proto/ommx/v1/constraint.proto
@@ -4,6 +4,26 @@ package ommx.v1;
 
 import "ommx/v1/function.proto";
 
+// Equality of a constraint.
+enum Equality {
+  EQUALITY_UNSPECIFIED = 0;
+  EQUALITY_EQUAL_TO_ZERO = 1;
+  EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO = 2;
+}
+
+// Additional infomations of the constraint for human-readable output
+//
+// Consider for example a problem constains a series of constraints `x[i, j] + y[i, j] <= 10` for `i = 1, 2, 3` and `j = 4, 5`,
+// then 6 = 3x2 `Constraint` messages should be created corresponding to each pair of `i` and `j`.
+// The `name` field of this message is intended to be a human-readable name of `x[i, j] + y[i, j] <= 10`,
+// and the `parameters` field is intended to be the value of `i` and `j` like `{ "i" : "1", "j": "5" }`.
+message ConstraintDescription {
+  // Name of the constraint
+  string name = 1;
+  // Parameters of the constraint.
+  map<string, string> parameters = 2;
+}
+
 message Constraint {
   // Constraint ID
   //
@@ -14,27 +34,20 @@ message Constraint {
   // - IDs must be unique with other types of constraints.
   uint64 id = 1;
 
-  // Equality of a constraint.
-  enum Equality {
-    EQUALITY_UNSPECIFIED = 0;
-    EQUALITY_EQUAL_TO_ZERO = 1;
-    EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO = 2;
-  }
   Equality equality = 2;
 
   Function function = 3;
 
-  // Additional infomations of the constraint for human-readable output
-  //
-  // Consider for example a problem constains a series of constraints `x[i, j] + y[i, j] <= 10` for `i = 1, 2, 3` and `j = 4, 5`,
-  // then 6 = 3x2 `Constraint` messages should be created corresponding to each pair of `i` and `j`.
-  // The `name` field of this message is intended to be a human-readable name of `x[i, j] + y[i, j] <= 10`,
-  // and the `parameters` field is intended to be the value of `i` and `j` like `{ "i" : "1", "j": "5" }`.
-  message Description {
-    // Name of the constraint
-    string name = 1;
-    // Parameters of the constraint.
-    map<string, string> parameters = 2;
-  }
-  optional Description description = 4;
+  optional ConstraintDescription description = 4;
+}
+
+// Evaluated constraint
+message EvaluatedConstraint {
+  uint64 id = 1;
+
+  Equality equality = 2;
+
+  double evaluated_value = 3;
+
+  optional ConstraintDescription description = 4;
 }

--- a/proto/ommx/v1/constraint.proto
+++ b/proto/ommx/v1/constraint.proto
@@ -4,13 +4,6 @@ package ommx.v1;
 
 import "ommx/v1/function.proto";
 
-// Equality of a constraint.
-enum Equality {
-  EQUALITY_UNSPECIFIED = 0;
-  EQUALITY_EQUAL_TO_ZERO = 1;
-  EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO = 2;
-}
-
 message Constraint {
   // Constraint ID
   //
@@ -21,13 +14,27 @@ message Constraint {
   // - IDs must be unique with other types of constraints.
   uint64 id = 1;
 
+  // Equality of a constraint.
+  enum Equality {
+    EQUALITY_UNSPECIFIED = 0;
+    EQUALITY_EQUAL_TO_ZERO = 1;
+    EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO = 2;
+  }
   Equality equality = 2;
 
   Function function = 3;
 
+  // Additional infomations of the constraint for human-readable output
+  //
+  // Consider for example a problem constains a series of constraints `x[i, j] + y[i, j] <= 10` for `i = 1, 2, 3` and `j = 4, 5`,
+  // then 6 = 3x2 `Constraint` messages should be created corresponding to each pair of `i` and `j`.
+  // The `name` field of this message is intended to be a human-readable name of `x[i, j] + y[i, j] <= 10`,
+  // and the `parameters` field is intended to be the value of `i` and `j` like `{ "i" : "1", "j": "5" }`.
   message Description {
+    // Name of the constraint
     string name = 1;
-    repeated int64 forall = 2;
+    // Parameters of the constraint.
+    map<string, string> parameters = 2;
   }
   optional Description description = 4;
 }

--- a/proto/ommx/v1/decision_variables.proto
+++ b/proto/ommx/v1/decision_variables.proto
@@ -42,9 +42,14 @@ message DecisionVariable {
   message Description {
     // Name of the decision variable.
     string name = 1;
-    // The subscripts of a deicision variable which is defined as multi-dimensional array.
-    // Empty list means that the decision variable is scalar
-    repeated uint64 subscripts = 2;
+
+    // The parameters for parameterized decision variables
+    //
+    // This field is intended to use for multidimensional variables like x[i, j] where `i` and `j` are integer parameter.
+    // `DecisionVariable` message represents a single decision variable like `x[1, 3]`,
+    // and the `name` is `x` and `parameters` is `{"i": "1", "j": "3"}`.
+    // The value of the parameter is string because the parameter may not be integer.
+    map<string, string> parameters = 2;
   }
 
   // This is optional since the name and subscripts does not exist in general mathematical programming situation

--- a/proto/ommx/v1/solution.proto
+++ b/proto/ommx/v1/solution.proto
@@ -15,19 +15,22 @@ message RawSolutionList {
   repeated RawSolution solutions = 1;
 }
 
-// Evaluated constraint with its equality
-message EvaluatedConstraint {
-  Equality equality = 1;
-  double value = 2;
-}
-
 // Solution with evaluated objective and constraints
 message Solution {
   RawSolution raw_solution = 1;
   double objective = 2;
+
+  // Evaluated constraint with its equality
+  message EvaluatedConstraint {
+    Constraint.Equality equality = 1;
+    double value = 2;
+    optional Constraint.Description description = 3;
+  }
   map<uint64, EvaluatedConstraint> constraints = 3;
+
   // Whether the solution is feasible, i.e. all constraints are satisfied or not.
   bool feasible = 4;
+
   // Whether the solution is optimal. This field is optional and should be used only by the solvers which can guarantee the optimality.
   optional bool optimal = 5;
 }

--- a/proto/ommx/v1/solution.proto
+++ b/proto/ommx/v1/solution.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package ommx.v1;
 
 import "ommx/v1/constraint.proto";
+import "ommx/v1/decision_variables.proto";
 
 // Pure solution state without any evaluation, even the feasiblity of the solution.
 message RawSolution {
@@ -20,19 +21,14 @@ message Solution {
   RawSolution raw_solution = 1;
   double objective = 2;
 
-  // Evaluated constraint with its equality
-  message EvaluatedConstraint {
-    Constraint.Equality equality = 1;
-    double value = 2;
-    optional Constraint.Description description = 3;
-  }
-  map<uint64, EvaluatedConstraint> constraints = 3;
+  repeated DecisionVariable decision_variables = 3;
+  repeated EvaluatedConstraint evaluated_constraints = 4;
 
   // Whether the solution is feasible, i.e. all constraints are satisfied or not.
-  bool feasible = 4;
+  bool feasible = 5;
 
   // Whether the solution is optimal. This field is optional and should be used only by the solvers which can guarantee the optimality.
-  optional bool optimal = 5;
+  optional bool optimal = 6;
 }
 
 // List of Solution

--- a/python/ommx/v1/constraint_pb2.py
+++ b/python/ommx/v1/constraint_pb2.py
@@ -17,7 +17,7 @@ from ommx.v1 import function_pb2 as ommx_dot_v1_dot_function__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b"\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto\"\x8d\x02\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x46\n\x0b\x64\x65scription\x18\x04 \x01(\x0b\x32\x1f.ommx.v1.Constraint.DescriptionH\x00R\x0b\x64\x65scription\x88\x01\x01\x1a\x39\n\x0b\x44\x65scription\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n\x06\x66orall\x18\x02 \x03(\x03R\x06\x66orallB\x0e\n\x0c_description*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3"
+    b'\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto"\xba\x01\n\x15\x43onstraintDescription\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12N\n\nparameters\x18\x02 \x03(\x0b\x32..ommx.v1.ConstraintDescription.ParametersEntryR\nparameters\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"\xd1\x01\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x45\n\x0b\x64\x65scription\x18\x04 \x01(\x0b\x32\x1e.ommx.v1.ConstraintDescriptionH\x00R\x0b\x64\x65scription\x88\x01\x01\x42\x0e\n\x0c_description"\xd4\x01\n\x13\x45valuatedConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12\'\n\x0f\x65valuated_value\x18\x03 \x01(\x01R\x0e\x65valuatedValue\x12\x45\n\x0b\x64\x65scription\x18\x04 \x01(\x0b\x32\x1e.ommx.v1.ConstraintDescriptionH\x00R\x0b\x64\x65scription\x88\x01\x01\x42\x0e\n\x0c_description*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12\'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
 )
 
 _globals = globals()
@@ -28,10 +28,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals[
         "DESCRIPTOR"
     ]._serialized_options = b"\n\013com.ommx.v1B\017ConstraintProtoP\001\242\002\003OXX\252\002\007Ommx.V1\312\002\007Ommx\\V1\342\002\023Ommx\\V1\\GPBMetadata\352\002\010Ommx::V1"
-    _globals["_EQUALITY"]._serialized_start = 333
-    _globals["_EQUALITY"]._serialized_end = 438
-    _globals["_CONSTRAINT"]._serialized_start = 62
-    _globals["_CONSTRAINT"]._serialized_end = 331
-    _globals["_CONSTRAINT_DESCRIPTION"]._serialized_start = 258
-    _globals["_CONSTRAINT_DESCRIPTION"]._serialized_end = 315
+    _globals["_CONSTRAINTDESCRIPTION_PARAMETERSENTRY"]._loaded_options = None
+    _globals["_CONSTRAINTDESCRIPTION_PARAMETERSENTRY"]._serialized_options = b"8\001"
+    _globals["_EQUALITY"]._serialized_start = 677
+    _globals["_EQUALITY"]._serialized_end = 782
+    _globals["_CONSTRAINTDESCRIPTION"]._serialized_start = 62
+    _globals["_CONSTRAINTDESCRIPTION"]._serialized_end = 248
+    _globals["_CONSTRAINTDESCRIPTION_PARAMETERSENTRY"]._serialized_start = 187
+    _globals["_CONSTRAINTDESCRIPTION_PARAMETERSENTRY"]._serialized_end = 248
+    _globals["_CONSTRAINT"]._serialized_start = 251
+    _globals["_CONSTRAINT"]._serialized_end = 460
+    _globals["_EVALUATEDCONSTRAINT"]._serialized_start = 463
+    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 675
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/v1/constraint_pb2.pyi
+++ b/python/ommx/v1/constraint_pb2.pyi
@@ -42,31 +42,60 @@ EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO: Equality.ValueType  # 2
 global___Equality = Equality
 
 @typing.final
-class Constraint(google.protobuf.message.Message):
+class ConstraintDescription(google.protobuf.message.Message):
+    """Additional infomations of the constraint for human-readable output
+
+    Consider for example a problem constains a series of constraints `x[i, j] + y[i, j] <= 10` for `i = 1, 2, 3` and `j = 4, 5`,
+    then 6 = 3x2 `Constraint` messages should be created corresponding to each pair of `i` and `j`.
+    The `name` field of this message is intended to be a human-readable name of `x[i, j] + y[i, j] <= 10`,
+    and the `parameters` field is intended to be the value of `i` and `j` like `{ "i" : "1", "j": "5" }`.
+    """
+
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     @typing.final
-    class Description(google.protobuf.message.Message):
+    class ParametersEntry(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-        NAME_FIELD_NUMBER: builtins.int
-        FORALL_FIELD_NUMBER: builtins.int
-        name: builtins.str
-        @property
-        def forall(
-            self,
-        ) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[
-            builtins.int
-        ]: ...
+        KEY_FIELD_NUMBER: builtins.int
+        VALUE_FIELD_NUMBER: builtins.int
+        key: builtins.str
+        value: builtins.str
         def __init__(
             self,
             *,
-            name: builtins.str = ...,
-            forall: collections.abc.Iterable[builtins.int] | None = ...,
+            key: builtins.str = ...,
+            value: builtins.str = ...,
         ) -> None: ...
         def ClearField(
-            self, field_name: typing.Literal["forall", b"forall", "name", b"name"]
+            self, field_name: typing.Literal["key", b"key", "value", b"value"]
         ) -> None: ...
+
+    NAME_FIELD_NUMBER: builtins.int
+    PARAMETERS_FIELD_NUMBER: builtins.int
+    name: builtins.str
+    """Name of the constraint"""
+    @property
+    def parameters(
+        self,
+    ) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
+        """Parameters of the constraint."""
+
+    def __init__(
+        self,
+        *,
+        name: builtins.str = ...,
+        parameters: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
+    ) -> None: ...
+    def ClearField(
+        self, field_name: typing.Literal["name", b"name", "parameters", b"parameters"]
+    ) -> None: ...
+
+global___ConstraintDescription = ConstraintDescription
+
+@typing.final
+class Constraint(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     ID_FIELD_NUMBER: builtins.int
     EQUALITY_FIELD_NUMBER: builtins.int
@@ -85,14 +114,14 @@ class Constraint(google.protobuf.message.Message):
     @property
     def function(self) -> ommx.v1.function_pb2.Function: ...
     @property
-    def description(self) -> global___Constraint.Description: ...
+    def description(self) -> global___ConstraintDescription: ...
     def __init__(
         self,
         *,
         id: builtins.int = ...,
         equality: global___Equality.ValueType = ...,
         function: ommx.v1.function_pb2.Function | None = ...,
-        description: global___Constraint.Description | None = ...,
+        description: global___ConstraintDescription | None = ...,
     ) -> None: ...
     def HasField(
         self,
@@ -125,3 +154,53 @@ class Constraint(google.protobuf.message.Message):
     ) -> typing.Literal["description"] | None: ...
 
 global___Constraint = Constraint
+
+@typing.final
+class EvaluatedConstraint(google.protobuf.message.Message):
+    """Evaluated constraint"""
+
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    ID_FIELD_NUMBER: builtins.int
+    EQUALITY_FIELD_NUMBER: builtins.int
+    EVALUATED_VALUE_FIELD_NUMBER: builtins.int
+    DESCRIPTION_FIELD_NUMBER: builtins.int
+    id: builtins.int
+    equality: global___Equality.ValueType
+    evaluated_value: builtins.float
+    @property
+    def description(self) -> global___ConstraintDescription: ...
+    def __init__(
+        self,
+        *,
+        id: builtins.int = ...,
+        equality: global___Equality.ValueType = ...,
+        evaluated_value: builtins.float = ...,
+        description: global___ConstraintDescription | None = ...,
+    ) -> None: ...
+    def HasField(
+        self,
+        field_name: typing.Literal[
+            "_description", b"_description", "description", b"description"
+        ],
+    ) -> builtins.bool: ...
+    def ClearField(
+        self,
+        field_name: typing.Literal[
+            "_description",
+            b"_description",
+            "description",
+            b"description",
+            "equality",
+            b"equality",
+            "evaluated_value",
+            b"evaluated_value",
+            "id",
+            b"id",
+        ],
+    ) -> None: ...
+    def WhichOneof(
+        self, oneof_group: typing.Literal["_description", b"_description"]
+    ) -> typing.Literal["description"] | None: ...
+
+global___EvaluatedConstraint = EvaluatedConstraint

--- a/python/ommx/v1/decision_variables_pb2.py
+++ b/python/ommx/v1/decision_variables_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n ommx/v1/decision_variables.proto\x12\x07ommx.v1"3\n\x05\x42ound\x12\x14\n\x05lower\x18\x01 \x01(\x01R\x05lower\x12\x14\n\x05upper\x18\x02 \x01(\x01R\x05upper"\xb4\x03\n\x10\x44\x65\x63isionVariable\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12\x32\n\x04kind\x18\x02 \x01(\x0e\x32\x1e.ommx.v1.DecisionVariable.KindR\x04kind\x12)\n\x05\x62ound\x18\x03 \x01(\x0b\x32\x0e.ommx.v1.BoundH\x00R\x05\x62ound\x88\x01\x01\x12L\n\x0b\x64\x65scription\x18\x04 \x01(\x0b\x32%.ommx.v1.DecisionVariable.DescriptionH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a\x41\n\x0b\x44\x65scription\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x1e\n\nsubscripts\x18\x02 \x03(\x04R\nsubscripts"\x85\x01\n\x04Kind\x12\x14\n\x10KIND_UNSPECIFIED\x10\x00\x12\x0f\n\x0bKIND_BINARY\x10\x01\x12\x10\n\x0cKIND_INTEGER\x10\x02\x12\x13\n\x0fKIND_CONTINUOUS\x10\x03\x12\x15\n\x11KIND_SEMI_INTEGER\x10\x04\x12\x18\n\x14KIND_SEMI_CONTINUOUS\x10\x05\x42\x08\n\x06_boundB\x0e\n\x0c_descriptionBb\n\x0b\x63om.ommx.v1B\x16\x44\x65\x63isionVariablesProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
+    b'\n ommx/v1/decision_variables.proto\x12\x07ommx.v1"3\n\x05\x42ound\x12\x14\n\x05lower\x18\x01 \x01(\x01R\x05lower\x12\x14\n\x05upper\x18\x02 \x01(\x01R\x05upper"\xab\x04\n\x10\x44\x65\x63isionVariable\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12\x32\n\x04kind\x18\x02 \x01(\x0e\x32\x1e.ommx.v1.DecisionVariable.KindR\x04kind\x12)\n\x05\x62ound\x18\x03 \x01(\x0b\x32\x0e.ommx.v1.BoundH\x00R\x05\x62ound\x88\x01\x01\x12L\n\x0b\x64\x65scription\x18\x04 \x01(\x0b\x32%.ommx.v1.DecisionVariable.DescriptionH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a\xb7\x01\n\x0b\x44\x65scription\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12U\n\nparameters\x18\x02 \x03(\x0b\x32\x35.ommx.v1.DecisionVariable.Description.ParametersEntryR\nparameters\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"\x85\x01\n\x04Kind\x12\x14\n\x10KIND_UNSPECIFIED\x10\x00\x12\x0f\n\x0bKIND_BINARY\x10\x01\x12\x10\n\x0cKIND_INTEGER\x10\x02\x12\x13\n\x0fKIND_CONTINUOUS\x10\x03\x12\x15\n\x11KIND_SEMI_INTEGER\x10\x04\x12\x18\n\x14KIND_SEMI_CONTINUOUS\x10\x05\x42\x08\n\x06_boundB\x0e\n\x0c_descriptionBb\n\x0b\x63om.ommx.v1B\x16\x44\x65\x63isionVariablesProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
 )
 
 _globals = globals()
@@ -27,12 +27,18 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals[
         "DESCRIPTOR"
     ]._serialized_options = b"\n\013com.ommx.v1B\026DecisionVariablesProtoP\001\242\002\003OXX\252\002\007Ommx.V1\312\002\007Ommx\\V1\342\002\023Ommx\\V1\\GPBMetadata\352\002\010Ommx::V1"
+    _globals["_DECISIONVARIABLE_DESCRIPTION_PARAMETERSENTRY"]._loaded_options = None
+    _globals[
+        "_DECISIONVARIABLE_DESCRIPTION_PARAMETERSENTRY"
+    ]._serialized_options = b"8\001"
     _globals["_BOUND"]._serialized_start = 45
     _globals["_BOUND"]._serialized_end = 96
     _globals["_DECISIONVARIABLE"]._serialized_start = 99
-    _globals["_DECISIONVARIABLE"]._serialized_end = 535
-    _globals["_DECISIONVARIABLE_DESCRIPTION"]._serialized_start = 308
-    _globals["_DECISIONVARIABLE_DESCRIPTION"]._serialized_end = 373
-    _globals["_DECISIONVARIABLE_KIND"]._serialized_start = 376
-    _globals["_DECISIONVARIABLE_KIND"]._serialized_end = 509
+    _globals["_DECISIONVARIABLE"]._serialized_end = 654
+    _globals["_DECISIONVARIABLE_DESCRIPTION"]._serialized_start = 309
+    _globals["_DECISIONVARIABLE_DESCRIPTION"]._serialized_end = 492
+    _globals["_DECISIONVARIABLE_DESCRIPTION_PARAMETERSENTRY"]._serialized_start = 431
+    _globals["_DECISIONVARIABLE_DESCRIPTION_PARAMETERSENTRY"]._serialized_end = 492
+    _globals["_DECISIONVARIABLE_KIND"]._serialized_start = 495
+    _globals["_DECISIONVARIABLE_KIND"]._serialized_end = 628
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/v1/decision_variables_pb2.pyi
+++ b/python/ommx/v1/decision_variables_pb2.pyi
@@ -90,29 +90,50 @@ class DecisionVariable(google.protobuf.message.Message):
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
+        @typing.final
+        class ParametersEntry(google.protobuf.message.Message):
+            DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+            KEY_FIELD_NUMBER: builtins.int
+            VALUE_FIELD_NUMBER: builtins.int
+            key: builtins.str
+            value: builtins.str
+            def __init__(
+                self,
+                *,
+                key: builtins.str = ...,
+                value: builtins.str = ...,
+            ) -> None: ...
+            def ClearField(
+                self, field_name: typing.Literal["key", b"key", "value", b"value"]
+            ) -> None: ...
+
         NAME_FIELD_NUMBER: builtins.int
-        SUBSCRIPTS_FIELD_NUMBER: builtins.int
+        PARAMETERS_FIELD_NUMBER: builtins.int
         name: builtins.str
         """Name of the decision variable."""
         @property
-        def subscripts(
+        def parameters(
             self,
-        ) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[
-            builtins.int
-        ]:
-            """The subscripts of a deicision variable which is defined as multi-dimensional array.
-            Empty list means that the decision variable is scalar
+        ) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
+            """The parameters for parameterized decision variables
+
+            This field is intended to use for multidimensional variables like x[i, j] where `i` and `j` are integer parameter.
+            `DecisionVariable` message represents a single decision variable like `x[1, 3]`,
+            and the `name` is `x` and `parameters` is `{"i": "1", "j": "3"}`.
+            The value of the parameter is string because the parameter may not be integer.
             """
 
         def __init__(
             self,
             *,
             name: builtins.str = ...,
-            subscripts: collections.abc.Iterable[builtins.int] | None = ...,
+            parameters: collections.abc.Mapping[builtins.str, builtins.str]
+            | None = ...,
         ) -> None: ...
         def ClearField(
             self,
-            field_name: typing.Literal["name", b"name", "subscripts", b"subscripts"],
+            field_name: typing.Literal["name", b"name", "parameters", b"parameters"],
         ) -> None: ...
 
     ID_FIELD_NUMBER: builtins.int

--- a/python/ommx/v1/solution_pb2.py
+++ b/python/ommx/v1/solution_pb2.py
@@ -14,10 +14,11 @@ _sym_db = _symbol_database.Default()
 
 
 from ommx.v1 import constraint_pb2 as ommx_dot_v1_dot_constraint__pb2
+from ommx.v1 import decision_variables_pb2 as ommx_dot_v1_dot_decision__variables__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x16ommx/v1/solution.proto\x12\x07ommx.v1\x1a\x18ommx/v1/constraint.proto"\x86\x01\n\x0bRawSolution\x12;\n\x07\x65ntries\x18\x01 \x03(\x0b\x32!.ommx.v1.RawSolution.EntriesEntryR\x07\x65ntries\x1a:\n\x0c\x45ntriesEntry\x12\x10\n\x03key\x18\x01 \x01(\x04R\x03key\x12\x14\n\x05value\x18\x02 \x01(\x01R\x05value:\x02\x38\x01"E\n\x0fRawSolutionList\x12\x32\n\tsolutions\x18\x01 \x03(\x0b\x32\x14.ommx.v1.RawSolutionR\tsolutions"Z\n\x13\x45valuatedConstraint\x12-\n\x08\x65quality\x18\x01 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12\x14\n\x05value\x18\x02 \x01(\x01R\x05value"\xcc\x02\n\x08Solution\x12\x37\n\x0craw_solution\x18\x01 \x01(\x0b\x32\x14.ommx.v1.RawSolutionR\x0brawSolution\x12\x1c\n\tobjective\x18\x02 \x01(\x01R\tobjective\x12\x44\n\x0b\x63onstraints\x18\x03 \x03(\x0b\x32".ommx.v1.Solution.ConstraintsEntryR\x0b\x63onstraints\x12\x1a\n\x08\x66\x65\x61sible\x18\x04 \x01(\x08R\x08\x66\x65\x61sible\x12\x1d\n\x07optimal\x18\x05 \x01(\x08H\x00R\x07optimal\x88\x01\x01\x1a\\\n\x10\x43onstraintsEntry\x12\x10\n\x03key\x18\x01 \x01(\x04R\x03key\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32\x1c.ommx.v1.EvaluatedConstraintR\x05value:\x02\x38\x01\x42\n\n\x08_optimal"?\n\x0cSolutionList\x12/\n\tsolutions\x18\x01 \x03(\x0b\x32\x11.ommx.v1.SolutionR\tsolutionsBY\n\x0b\x63om.ommx.v1B\rSolutionProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
+    b'\n\x16ommx/v1/solution.proto\x12\x07ommx.v1\x1a\x18ommx/v1/constraint.proto\x1a ommx/v1/decision_variables.proto"\x86\x01\n\x0bRawSolution\x12;\n\x07\x65ntries\x18\x01 \x03(\x0b\x32!.ommx.v1.RawSolution.EntriesEntryR\x07\x65ntries\x1a:\n\x0c\x45ntriesEntry\x12\x10\n\x03key\x18\x01 \x01(\x04R\x03key\x12\x14\n\x05value\x18\x02 \x01(\x01R\x05value:\x02\x38\x01"E\n\x0fRawSolutionList\x12\x32\n\tsolutions\x18\x01 \x03(\x0b\x32\x14.ommx.v1.RawSolutionR\tsolutions"\xc5\x02\n\x08Solution\x12\x37\n\x0craw_solution\x18\x01 \x01(\x0b\x32\x14.ommx.v1.RawSolutionR\x0brawSolution\x12\x1c\n\tobjective\x18\x02 \x01(\x01R\tobjective\x12H\n\x12\x64\x65\x63ision_variables\x18\x03 \x03(\x0b\x32\x19.ommx.v1.DecisionVariableR\x11\x64\x65\x63isionVariables\x12Q\n\x15\x65valuated_constraints\x18\x04 \x03(\x0b\x32\x1c.ommx.v1.EvaluatedConstraintR\x14\x65valuatedConstraints\x12\x1a\n\x08\x66\x65\x61sible\x18\x05 \x01(\x08R\x08\x66\x65\x61sible\x12\x1d\n\x07optimal\x18\x06 \x01(\x08H\x00R\x07optimal\x88\x01\x01\x42\n\n\x08_optimal"?\n\x0cSolutionList\x12/\n\tsolutions\x18\x01 \x03(\x0b\x32\x11.ommx.v1.SolutionR\tsolutionsBY\n\x0b\x63om.ommx.v1B\rSolutionProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
 )
 
 _globals = globals()
@@ -30,20 +31,14 @@ if not _descriptor._USE_C_DESCRIPTORS:
     ]._serialized_options = b"\n\013com.ommx.v1B\rSolutionProtoP\001\242\002\003OXX\252\002\007Ommx.V1\312\002\007Ommx\\V1\342\002\023Ommx\\V1\\GPBMetadata\352\002\010Ommx::V1"
     _globals["_RAWSOLUTION_ENTRIESENTRY"]._loaded_options = None
     _globals["_RAWSOLUTION_ENTRIESENTRY"]._serialized_options = b"8\001"
-    _globals["_SOLUTION_CONSTRAINTSENTRY"]._loaded_options = None
-    _globals["_SOLUTION_CONSTRAINTSENTRY"]._serialized_options = b"8\001"
-    _globals["_RAWSOLUTION"]._serialized_start = 62
-    _globals["_RAWSOLUTION"]._serialized_end = 196
-    _globals["_RAWSOLUTION_ENTRIESENTRY"]._serialized_start = 138
-    _globals["_RAWSOLUTION_ENTRIESENTRY"]._serialized_end = 196
-    _globals["_RAWSOLUTIONLIST"]._serialized_start = 198
-    _globals["_RAWSOLUTIONLIST"]._serialized_end = 267
-    _globals["_EVALUATEDCONSTRAINT"]._serialized_start = 269
-    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 359
-    _globals["_SOLUTION"]._serialized_start = 362
-    _globals["_SOLUTION"]._serialized_end = 694
-    _globals["_SOLUTION_CONSTRAINTSENTRY"]._serialized_start = 590
-    _globals["_SOLUTION_CONSTRAINTSENTRY"]._serialized_end = 682
-    _globals["_SOLUTIONLIST"]._serialized_start = 696
-    _globals["_SOLUTIONLIST"]._serialized_end = 759
+    _globals["_RAWSOLUTION"]._serialized_start = 96
+    _globals["_RAWSOLUTION"]._serialized_end = 230
+    _globals["_RAWSOLUTION_ENTRIESENTRY"]._serialized_start = 172
+    _globals["_RAWSOLUTION_ENTRIESENTRY"]._serialized_end = 230
+    _globals["_RAWSOLUTIONLIST"]._serialized_start = 232
+    _globals["_RAWSOLUTIONLIST"]._serialized_end = 301
+    _globals["_SOLUTION"]._serialized_start = 304
+    _globals["_SOLUTION"]._serialized_end = 629
+    _globals["_SOLUTIONLIST"]._serialized_start = 631
+    _globals["_SOLUTIONLIST"]._serialized_end = 694
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/v1/solution_pb2.pyi
+++ b/python/ommx/v1/solution_pb2.pyi
@@ -9,6 +9,7 @@ import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
 import ommx.v1.constraint_pb2
+import ommx.v1.decision_variables_pb2
 import typing
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
@@ -78,58 +79,15 @@ class RawSolutionList(google.protobuf.message.Message):
 global___RawSolutionList = RawSolutionList
 
 @typing.final
-class EvaluatedConstraint(google.protobuf.message.Message):
-    """Evaluated constraint with its equality"""
-
-    DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-    EQUALITY_FIELD_NUMBER: builtins.int
-    VALUE_FIELD_NUMBER: builtins.int
-    equality: ommx.v1.constraint_pb2.Equality.ValueType
-    value: builtins.float
-    def __init__(
-        self,
-        *,
-        equality: ommx.v1.constraint_pb2.Equality.ValueType = ...,
-        value: builtins.float = ...,
-    ) -> None: ...
-    def ClearField(
-        self, field_name: typing.Literal["equality", b"equality", "value", b"value"]
-    ) -> None: ...
-
-global___EvaluatedConstraint = EvaluatedConstraint
-
-@typing.final
 class Solution(google.protobuf.message.Message):
     """Solution with evaluated objective and constraints"""
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    @typing.final
-    class ConstraintsEntry(google.protobuf.message.Message):
-        DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-        KEY_FIELD_NUMBER: builtins.int
-        VALUE_FIELD_NUMBER: builtins.int
-        key: builtins.int
-        @property
-        def value(self) -> global___EvaluatedConstraint: ...
-        def __init__(
-            self,
-            *,
-            key: builtins.int = ...,
-            value: global___EvaluatedConstraint | None = ...,
-        ) -> None: ...
-        def HasField(
-            self, field_name: typing.Literal["value", b"value"]
-        ) -> builtins.bool: ...
-        def ClearField(
-            self, field_name: typing.Literal["key", b"key", "value", b"value"]
-        ) -> None: ...
-
     RAW_SOLUTION_FIELD_NUMBER: builtins.int
     OBJECTIVE_FIELD_NUMBER: builtins.int
-    CONSTRAINTS_FIELD_NUMBER: builtins.int
+    DECISION_VARIABLES_FIELD_NUMBER: builtins.int
+    EVALUATED_CONSTRAINTS_FIELD_NUMBER: builtins.int
     FEASIBLE_FIELD_NUMBER: builtins.int
     OPTIMAL_FIELD_NUMBER: builtins.int
     objective: builtins.float
@@ -140,17 +98,29 @@ class Solution(google.protobuf.message.Message):
     @property
     def raw_solution(self) -> global___RawSolution: ...
     @property
-    def constraints(
+    def decision_variables(
         self,
-    ) -> google.protobuf.internal.containers.MessageMap[
-        builtins.int, global___EvaluatedConstraint
+    ) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[
+        ommx.v1.decision_variables_pb2.DecisionVariable
+    ]: ...
+    @property
+    def evaluated_constraints(
+        self,
+    ) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[
+        ommx.v1.constraint_pb2.EvaluatedConstraint
     ]: ...
     def __init__(
         self,
         *,
         raw_solution: global___RawSolution | None = ...,
         objective: builtins.float = ...,
-        constraints: collections.abc.Mapping[builtins.int, global___EvaluatedConstraint]
+        decision_variables: collections.abc.Iterable[
+            ommx.v1.decision_variables_pb2.DecisionVariable
+        ]
+        | None = ...,
+        evaluated_constraints: collections.abc.Iterable[
+            ommx.v1.constraint_pb2.EvaluatedConstraint
+        ]
         | None = ...,
         feasible: builtins.bool = ...,
         optimal: builtins.bool | None = ...,
@@ -171,8 +141,10 @@ class Solution(google.protobuf.message.Message):
         field_name: typing.Literal[
             "_optimal",
             b"_optimal",
-            "constraints",
-            b"constraints",
+            "decision_variables",
+            b"decision_variables",
+            "evaluated_constraints",
+            b"evaluated_constraints",
             "feasible",
             b"feasible",
             "objective",


### PR DESCRIPTION
- Move `EvaluatedConstraint` message from `Solution.*` to `ommx.v1.*`
- Move `Constraint.Description` into `ommx.v1.ConstraintDescription`, and revise `forall` field into `parameters` which stores string-string map instead of `repeated int64`
- Add `decision_variables` in `Solution` message