### PR TITLE
Ready for releasing Rust SDK 0.3.0

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Build image
-        run: cargo run --release --example artifact_archive
+        run: cargo run --release --example create_artifact
 
       # Login to GitHub Container Registry and push the image
       - name: Login to GitHub Container Registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +572,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -827,6 +856,7 @@ dependencies = [
  "colored",
  "derive_more",
  "directories",
+ "env_logger",
  "itertools 0.13.0",
  "log",
  "maplit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "_ommx_rust"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ocipkg",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "ommx"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "protogen"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,14 @@ members = [
     "python",
 ]
 
+[workspace.package]
+version = "0.3.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
 [workspace.dependencies]
 anyhow = "1.0.81"
+base64 = "0.22.1"
 built = { version = "0.7.3", features = ["git2"] }
 chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive"] }
@@ -28,3 +34,4 @@ rand_xoshiro = "0.6.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.117"
 thiserror = "1.0.58"
+url = "2.5.0"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,7 +1,15 @@
+# This is a crate built as a sub Python package `ommx._ommx_rust`
+
 [package]
 name = "_ommx_rust"
-version = "0.2.1"
-edition = "2021"
+
+# The version of Python package `ommx` is determined in `pyproject.toml`. This version is only for build-time information.
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# This crate itself is not released to crates.io.
+publish = false
 
 [lib]
 crate-type = ["cdylib"]
@@ -13,4 +21,3 @@ path = "../rust/ommx"
 anyhow.workspace = true
 ocipkg.workspace = true
 pyo3.workspace = true
-

--- a/rust/ommx/Cargo.toml
+++ b/rust/ommx/Cargo.toml
@@ -21,6 +21,7 @@ clap.workspace = true
 colored.workspace = true
 derive_more.workspace = true
 directories.workspace = true
+env_logger = "0.11.3"
 itertools.workspace = true
 log.workspace = true
 maplit.workspace = true

--- a/rust/ommx/Cargo.toml
+++ b/rust/ommx/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "ommx"
-version = "0.2.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
 
+# Inherit from workspace setting
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# crate-specific settings for publishing
 description   = "Open Mathematical prograMming eXchange (OMMX)"
 documentation = "https://docs.rs/ommx/"
 repository    = "https://github.com/Jij-Inc/ommx"
@@ -12,7 +15,7 @@ categories    = ["data-structures", "mathematics", "science"]
 
 [dependencies]
 anyhow.workspace = true
-base64 = "0.22.1"
+base64.workspace = true
 chrono.workspace = true
 clap.workspace = true
 colored.workspace = true
@@ -29,7 +32,7 @@ rand_xoshiro.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-url = "2.5.0"
+url.workspace = true
 
 [dev-dependencies]
 colored.workspace = true

--- a/rust/ommx/examples/artifact_archive.rs
+++ b/rust/ommx/examples/artifact_archive.rs
@@ -14,6 +14,11 @@ pub mod built_info {
 }
 
 fn main() -> Result<()> {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
     let mut rng = rand_xoshiro::Xoshiro256StarStar::seed_from_u64(0);
     let lp = random_lp(&mut rng, 5, 7);
 

--- a/rust/ommx/examples/create_artifact.rs
+++ b/rust/ommx/examples/create_artifact.rs
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
     let mut builder = Builder::new_archive(out.clone(), image_name)?;
     builder.add_instance(lp, annotations)?;
     builder.add_source(&Url::parse("https://github.com/Jij-Inc/ommx")?);
-    builder.add_description("Test artifact created by examples/artifact_archive.rs".to_string());
+    builder.add_description("Test artifact created by examples/create_artifact.rs".to_string());
     let _artifact = builder.build()?;
     println!("{:>12} {}", "Saved".green().bold(), out.display());
     Ok(())

--- a/rust/ommx/examples/pull_artifact.rs
+++ b/rust/ommx/examples/pull_artifact.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use ocipkg::ImageName;
+use ommx::artifact::{media_types, Artifact};
+
+fn main() -> Result<()> {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
+    let image_name = ImageName::parse("ghcr.io/jij-inc/ommx/random_lp_instance:4303c7f")?;
+
+    // Pull the artifact from remote registry
+    let mut remote = Artifact::from_remote(image_name)?;
+    let mut local = remote.pull()?;
+
+    // Load the instance message from the artifact
+    for desc in local.get_layer_descriptors(&media_types::v1_instance())? {
+        println!("{}", desc.digest());
+    }
+    Ok(())
+}

--- a/rust/ommx/src/artifact.rs
+++ b/rust/ommx/src/artifact.rs
@@ -91,11 +91,11 @@ impl Artifact<OciArchive> {
         Self::new(artifact)
     }
 
-    pub fn push(&mut self) -> Result<()> {
+    pub fn push(&mut self) -> Result<Artifact<Remote>> {
         let name = self.get_name()?;
         log::info!("Pushing: {}", name);
-        ocipkg::image::copy(self.0.deref_mut(), RemoteBuilder::new(name)?)?;
-        Ok(())
+        let out = ocipkg::image::copy(self.0.deref_mut(), RemoteBuilder::new(name)?)?;
+        Ok(Artifact(OciArtifact::new(out)))
     }
 
     pub fn load(&mut self) -> Result<()> {
@@ -117,11 +117,11 @@ impl Artifact<OciDir> {
         Self::new(artifact)
     }
 
-    pub fn push(&mut self) -> Result<()> {
+    pub fn push(&mut self) -> Result<Artifact<Remote>> {
         let name = self.get_name()?;
         log::info!("Pushing: {}", name);
-        ocipkg::image::copy(self.0.deref_mut(), RemoteBuilder::new(name)?)?;
-        Ok(())
+        let out = ocipkg::image::copy(self.0.deref_mut(), RemoteBuilder::new(name)?)?;
+        Ok(Artifact(OciArtifact::new(out)))
     }
 
     pub fn save(&mut self, output: &Path) -> Result<()> {
@@ -144,16 +144,16 @@ impl Artifact<Remote> {
         Self::new(artifact)
     }
 
-    pub fn pull(&mut self) -> Result<()> {
+    pub fn pull(&mut self) -> Result<Artifact<OciDir>> {
         let image_name = self.get_name()?;
         let path = image_dir(&image_name)?;
         if path.exists() {
             log::trace!("Already exists in locally: {}", path.display());
-            return Ok(());
+            return Ok(Artifact(OciArtifact::from_oci_dir(&path)?));
         }
         log::info!("Pulling: {}", image_name);
-        ocipkg::image::copy(self.0.deref_mut(), OciDirBuilder::new(path, image_name)?)?;
-        Ok(())
+        let out = ocipkg::image::copy(self.0.deref_mut(), OciDirBuilder::new(path, image_name)?)?;
+        Ok(Artifact(OciArtifact::new(out)))
     }
 }
 

--- a/rust/ommx/src/bin/ommx.rs
+++ b/rust/ommx/src/bin/ommx.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use clap::Parser;
 use colored::Colorize;
-use ocipkg::{image::Image, oci_spec::image::ImageManifest, ImageName};
+use ocipkg::{oci_spec::image::ImageManifest, ImageName};
 use ommx::artifact::{image_dir, Artifact};
 use std::path::{Path, PathBuf};
 

--- a/rust/ommx/src/bin/ommx.rs
+++ b/rust/ommx/src/bin/ommx.rs
@@ -113,6 +113,11 @@ impl ImageNameOrPath {
 }
 
 fn main() -> Result<()> {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
     let command = Command::parse();
     match &command {
         Command::Version => {

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -6,32 +6,6 @@ use anyhow::{bail, Context, Result};
 use std::collections::BTreeSet;
 
 /// Evaluate with a [State]
-///
-/// Examples
-/// ---------
-/// ```rust
-/// # fn main() -> anyhow::Result<()> {
-/// use ommx::{Evaluate, v1::{Linear, linear::Term, State}};
-/// use maplit::{hashmap, btreeset};
-///
-/// let raw: State = hashmap! { 1 => 1.0, 2 => 2.0, 3 => 3.0 }.into();
-///
-/// // x1 + 2*x2 + 3
-/// let linear = Linear {
-///     terms: vec![
-///         Term { id: 1, coefficient: 1.0 },
-///         Term { id: 2, coefficient: 2.0 }
-///     ],
-///     constant: 3.0,
-/// };
-///
-/// let (value, used_ids) = linear.evaluate(&raw)?;
-/// assert_eq!(value, 1.0 * 1.0 + 2.0 * 2.0 + 3.0);
-///
-/// // x1 and x2 are used, x3 is not used
-/// assert_eq!(used_ids, btreeset!{ 1, 2 });
-/// # Ok(()) }
-/// ```
 pub trait Evaluate {
     type Output;
     /// Evaluate to return the output with used variable ids

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -1,7 +1,61 @@
-//! Open Mathematics prograMming eXchange (OMMX)
+//! Rust SDK for OMMX (Open Mathematics prograMming eXchange)
 //!
-//! Message as OCI Artifact
-//! ------------------------
+//! Messages defined by protobuf schema
+//! ------------------------------------
+//! OMMX defines several messages, and their Rust bindings are in the [`v1`] module.
+//!
+//! ### Examples
+//!
+//! - Create [`v1::Linear`] message in Rust, and serialize/deserialize it
+//!
+//!   ```rust
+//!   use ommx::v1::{Linear, linear::Term};
+//!   use prost::Message; // For `encode` and `decode` methods
+//!
+//!   // Create a linear function `x1 + 2 x2 + 3`
+//!   let linear = Linear {
+//!       terms: vec![ Term { id: 1, coefficient: 1.0 }, Term { id: 2, coefficient: 2.0 } ],
+//!       constant: 3.0,
+//!   };
+//!
+//!   // Serialize the message to a byte stream
+//!   let mut buf = Vec::new();
+//!   linear.encode(&mut buf).unwrap();
+//!
+//!   // Deserialize the byte stream back into a linear function message
+//!   let decoded_linear = Linear::decode(buf.as_slice()).unwrap();
+//!
+//!   // Print the deserialized message
+//!   println!("{:?}", decoded_linear);
+//!   ```
+//!
+//! - [`Evaluate`] a [`v1::Linear`] with [`v1::State`] into `f64`
+//!
+//!   ```rust
+//!   use ommx::{Evaluate, v1::{Linear, State, linear::Term}};
+//!   use maplit::{hashmap, btreeset};
+//!
+//!   // Create a linear function `x1 + 2 x2 + 3`
+//!   let linear = Linear {
+//!       terms: vec![
+//!           Term { id: 1, coefficient: 1.0 },
+//!           Term { id: 2, coefficient: 2.0 }
+//!       ],
+//!       constant: 3.0,
+//!   };
+//!
+//!   // Create a state `x1 = 4`, `x2 = 5`, and `x3 = 6`
+//!   let state: State = hashmap! { 1 => 4.0, 2 => 5.0, 3 => 6.0 }.into();
+//!
+//!   // Evaluate the linear function with the state, and get the value and used variable ids
+//!   let (value, used_ids) = linear.evaluate(&state).unwrap();
+//!
+//!   assert_eq!(value, 1.0 * 4.0 + 2.0 * 5.0 + 3.0);
+//!   assert_eq!(used_ids, btreeset!{ 1, 2 }) // x3 is not used
+//!   ```
+//!
+//! OMMX Artifact
+//! --------------
 //! OMMX defines a protobuf schema. Then the [`v1::Instance`] and [`v1::Solution`] are serialized as protobuf messages,
 //! i.e. a byte stream satisfying the schema.
 //! This is enough for in process communication, but not enough for out of process communication.

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -133,9 +133,9 @@
 //!   let mut remote = Artifact::from_remote(image_name)?;
 //!   let mut local = remote.pull()?;
 //!
-//!   // Load the instance message from the artifact
-//!   for instance in local.get_instances()? {
-//!       dbg!(instance);
+//!   // List the digest of instances
+//!   for desc in local.get_layer_descriptors(&media_types::v1_instance())? {
+//!       println!("{}", desc.digest());
 //!   }
 //!   # Ok(()) }
 //!   ```

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -124,7 +124,7 @@
 //!
 //!   ```no_run
 //!   use ocipkg::ImageName;
-//!   use ommx::artifact::Artifact;
+//!   use ommx::artifact::{Artifact, media_types};
 //!
 //!   # fn main() -> anyhow::Result<()> {
 //!   let image_name = ImageName::parse("ghcr.io/jij-inc/ommx/random_lp_instance:testing")?;

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -119,8 +119,28 @@
 //!   artifact.push()?;
 //!   # Ok(()) }
 //!   ```
+//!
+//! - Pull an artifact from remote registry, and load the instance message
+//!
+//!   ```no_run
+//!   use ocipkg::ImageName;
+//!   use ommx::artifact::Artifact;
+//!
+//!   # fn main() -> anyhow::Result<()> {
+//!   let image_name = ImageName::parse("ghcr.io/jij-inc/ommx/random_lp_instance:testing")?;
+//!
+//!   // Pull the artifact from remote registry
+//!   let mut remote = Artifact::from_remote(image_name)?;
+//!   let mut local = remote.pull()?;
+//!
+//!   // Load the instance message from the artifact
+//!   for instance in local.get_instances()? {
+//!       dbg!(instance);
+//!   }
+//!   # Ok(()) }
+//!   ```
+//!
 
-/// Re-export of `ocipkg` crate for better compatibility
 pub use ocipkg;
 
 pub mod artifact;

--- a/rust/protogen/Cargo.toml
+++ b/rust/protogen/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "protogen"
-version = "0.1.0"
-edition = "2021"
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # This crate is only for developing in this repository
 publish = false


### PR DESCRIPTION
- Bump up crate version 0.3.0
  - `[workspace.package]` is introduced, and use it in all crates, i.e. `ommx`, `protogen`, and `_ommx_rust` crates.
- More documents
- `env_logger` is added to `ommx` executable and examples
- Add `examples/pull_artifact.rs` 