### PR TITLE
Store annotations in `ommx.v1.{Instance, Solution}` Python objects

### DIFF
--- a/ARTIFACT.md
+++ b/ARTIFACT.md
@@ -7,16 +7,16 @@ OMMX Artifact is a collection of `config`, `layers`, and annotations.
 
 - `config` is a JSON blob with the following media types:
     - `application/org.ommx.v1.config+json`
-      - TBA
 - `layers` consists of the following blobs:
     - `application/org.ommx.v1.solution` blob with the following annotations:
-        - `org.ommx.v1.solution.instance`: The digest of the corresponding instance of the solution
-        - `org.ommx.v1.solution.solver`: The digest of the solver information which generated the solution
-        - `org.ommx.v1.solution.parameters`: Solver parameters used to generate the solution as a JSON
-        - `org.ommx.v1.solution.start`: The start time of the solution as a RFC3339 string
-        - `org.ommx.v1.solution.end`: The end time of the solution as a RFC3339 string
+        - `org.ommx.v1.solution.instance`: (digest) The corresponding instance of the solution
+        - `org.ommx.v1.solution.solver`: (JSON) The solver information which generated the solution as a JSON
+        - `org.ommx.v1.solution.parameters`: (JSON) Solver parameters used to generate the solution as a JSON
+        - `org.ommx.v1.solution.start`: (RFC3339) The start time of the solution as a RFC3339 string
+        - `org.ommx.v1.solution.end`: (RFC3339) The end time of the solution as a RFC3339 string
     - `application/org.ommx.v1.instance` blob with the following annotations:
-        - TBA
+        - `org.ommx.v1.instance.title`: (Free string) The title of this instance
+        - `org.ommx.v1.instance.created`: (RFC3339) When this instance was created
 - Annotations in manifest:
   - TBA
 

--- a/notebooks/artifact.ipynb
+++ b/notebooks/artifact.ipynb
@@ -15,6 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime  # When the artifact is created\n",
+    "from dateutil.tz import tzlocal\n",
     "import uuid    # To generate random tag for testing\n",
     "import logging # To see the log of pushing artifact\n",
     "logging.basicConfig(level=logging.INFO)"
@@ -36,7 +38,7 @@
    "id": "a2779a4a-4f76-4c77-a2e2-c64d5a4c2aff",
    "metadata": {},
    "source": [
-    "## Ready `ommx.v1.Instance` to be packed into artifact"
+    "## Ready `ommx.v1.Instance` and `ommx.v1.Solution` to be packed into artifact"
    ]
   },
   {
@@ -47,7 +49,32 @@
    "outputs": [],
    "source": [
     "generator = SingleFeasibleLPGenerator(3, DataType.INT)\n",
-    "instance = generator.get_v1_instance()"
+    "instance = generator.get_v1_instance()\n",
+    "state = generator.get_v1_state()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "828b70a2-46c3-49cb-8e78-ffea742b6659",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate the instance for the state\n",
+    "solution = instance.evaluate(state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "389d7fd0-a77b-45c6-adbe-43e5d7cb65ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add annotations\n",
+    "instance.title = \"Single feasible LP instance\"\n",
+    "instance.created = datetime.now(tzlocal())  # Date is stored as RFC3339 format\n",
+    "solution.parameters = (3, \"int\")            # Solution can store a set of parameters as a JSON"
    ]
   },
   {
@@ -60,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "00061527-a0ee-4b78-8727-8472c27cac7e",
    "metadata": {},
    "outputs": [],
@@ -70,24 +97,56 @@
     "    \"ommx\",                # Repository name\n",
     "    \"single_feasible_lp\",  # Name of artifact\n",
     "    str(uuid.uuid4())      # Tag of artifact\n",
-    ")\n",
-    "builder.add_instance(instance)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6d29bf9f-9081-4fdd-829d-bb5172cc2b70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add instance to the artifact\n",
+    "instance_desc = builder.add_instance(instance)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1303fad6-79d6-465d-b309-8488442678a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add solution with the digest of instance\n",
+    "solution.instance = instance_desc.digest\n",
+    "_desc = builder.add_solution(solution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5374f4f4-1d6f-44b4-83f2-8056f349a36c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Finish building\n",
     "artifact = builder.build()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "5374f4f4-1d6f-44b4-83f2-8056f349a36c",
+   "execution_count": 10,
+   "id": "192d850d-e7c5-4e66-8f92-35f7823cd6ad",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'ghcr.io/jij-inc/ommx/single_feasible_lp:4c09b065-a55c-4358-8083-9ce3db3b6e6c'"
+       "'ghcr.io/jij-inc/ommx/single_feasible_lp:9b9083bb-9750-48bc-9847-0fd491b8bcf3'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -104,12 +163,21 @@
     "## Push artifact to container registry\n",
     "\n",
     "- This artifact will be pushed to <https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fsingle_feasible_lp>\n",
-    "- `push` requires authentication using personal access token (PAT) or `GITHUB_TOKEN` on GitHub Actions."
+    "- `push` requires authentication using personal access token (PAT) or `GITHUB_TOKEN` on GitHub Actions. There are two ways for authentication:\n",
+    "  - Run CLI `ommx login` which stores authentication info on your machine.\n",
+    "  - Use environment variables `OMMX_BASIC_AUTH_{DOMAIN,USERNAME,PASSWORD}`. For example, you can push your artifact to GitHub contaier registry from GitHub Actions with following setting:\n",
+    "\n",
+    "```yaml\n",
+    "        env:\n",
+    "          OMMX_BASIC_AUTH_DOMAIN: ghcr.io\n",
+    "          OMMX_BASIC_AUTH_USERNAME: ${{ github.actor }}\n",
+    "          OMMX_BASIC_AUTH_PASSWORD: ${{ github.token }}\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "a06ef2f5-595f-485a-9ca9-11923278123b",
    "metadata": {},
    "outputs": [
@@ -117,12 +185,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:ommx.artifact:Pushing: ghcr.io/jij-inc/ommx/single_feasible_lp:4c09b065-a55c-4358-8083-9ce3db3b6e6c\n",
+      "INFO:ommx.artifact:Pushing: ghcr.io/jij-inc/ommx/single_feasible_lp:9b9083bb-9750-48bc-9847-0fd491b8bcf3\n",
       "INFO:ocipkg.distribution.client:POST https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/uploads/\n",
-      "INFO:ocipkg.distribution.client:PUT https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/upload/ebb244fb-38e4-4472-b460-932b43569344\n",
+      "INFO:ocipkg.distribution.client:PUT https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/upload/e67c96bb-0752-4590-918a-e252806bfee2\n",
       "INFO:ocipkg.distribution.client:POST https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/uploads/\n",
-      "INFO:ocipkg.distribution.client:PUT https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/upload/09b62410-7376-4cbe-bfc2-aaac66736b43\n",
-      "INFO:ocipkg.distribution.client:PUT https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/manifests/4c09b065-a55c-4358-8083-9ce3db3b6e6c\n"
+      "INFO:ocipkg.distribution.client:PUT https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/upload/eeebecfb-7884-4dab-98c3-3e8fe74921fe\n",
+      "INFO:ocipkg.distribution.client:POST https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/uploads/\n",
+      "INFO:ocipkg.distribution.client:PUT https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/blobs/upload/2603c7ba-2768-406c-98de-dda48790273a\n",
+      "INFO:ocipkg.distribution.client:PUT https://ghcr.io/v2/jij-inc/ommx/single_feasible_lp/manifests/9b9083bb-9750-48bc-9847-0fd491b8bcf3\n"
      ]
     }
    ],

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -284,7 +284,7 @@ class ArtifactBuilder:
         """
         return ArtifactBuilder(ArtifactDirBuilder.for_github(org, repo, name, tag))
 
-    def add_instance( self, instance: Instance) -> Descriptor:
+    def add_instance(self, instance: Instance) -> Descriptor:
         """
         Add an instance to the artifact with annotations
         """

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -148,7 +148,9 @@ class Artifact:
         instance = Instance.from_bytes(blob)
         annotations = descriptor.annotations
         if "org.ommx.v1.instance.created" in annotations:
-            instance.created = datetime.fromisoformat(annotations["org.ommx.v1.instance.created"])
+            instance.created = datetime.fromisoformat(
+                annotations["org.ommx.v1.instance.created"]
+            )
         if "org.ommx.v1.instance.title" in annotations:
             instance.title = annotations["org.ommx.v1.instance.title"]
         return instance

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -158,7 +158,22 @@ class Artifact:
 
     def get_solution(self, descriptor: Descriptor) -> Solution:
         blob = self.get_blob(descriptor)
-        return Solution.from_bytes(blob)
+        solution = Solution.from_bytes(blob)
+        if "org.ommx.v1.solution.instance" in descriptor.annotations:
+            solution.instance = descriptor.annotations["org.ommx.v1.solution.instance"]
+        if "org.ommx.v1.solution.solver" in descriptor.annotations:
+            solution.solver = json.loads(descriptor.annotations["org.ommx.v1.solution.solver"])
+        if "org.ommx.v1.solution.parameters" in descriptor.annotations:
+            solution.parameters = json.loads(
+                descriptor.annotations["org.ommx.v1.solution.parameters"]
+            )
+        if "org.ommx.v1.solution.start" in descriptor.annotations:
+            solution.start = datetime.fromisoformat(
+                descriptor.annotations["org.ommx.v1.solution.start"]
+            )
+        if "org.ommx.v1.solution.end" in descriptor.annotations:
+            solution.end = datetime.fromisoformat(descriptor.annotations["org.ommx.v1.solution.end"])
+        return solution
 
 
 @dataclass(frozen=True)

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -284,13 +284,16 @@ class ArtifactBuilder:
         """
         return ArtifactBuilder(ArtifactDirBuilder.for_github(org, repo, name, tag))
 
-    def add_instance(
-        self, instance: Instance, annotations: dict[str, str] = {}
-    ) -> Descriptor:
+    def add_instance( self, instance: Instance) -> Descriptor:
         """
         Add an instance to the artifact with annotations
         """
         blob = instance.to_bytes()
+        annotations = instance.annotations.copy()
+        if instance.created:
+            annotations["org.ommx.v1.instance.created"] = instance.created.isoformat()
+        if instance.title:
+            annotations["org.ommx.v1.instance.title"] = instance.title
         return self.add_layer("application/org.ommx.v1.instance", blob, annotations)
 
     def add_layer(

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from datetime import datetime
@@ -311,6 +312,24 @@ class ArtifactBuilder:
         if instance.title:
             annotations["org.ommx.v1.instance.title"] = instance.title
         return self.add_layer("application/org.ommx.v1.instance", blob, annotations)
+
+    def add_solution(self, solution: Solution) -> Descriptor:
+        """
+        Add a solution to the artifact with annotations
+        """
+        blob = solution.to_bytes()
+        annotations = solution.annotations.copy()
+        if solution.instance:
+            annotations["org.ommx.v1.solution.instance"] = solution.instance
+        if solution.solver:
+            annotations["org.ommx.v1.solution.solver"] = json.dumps(solution.solver)
+        if solution.parameters:
+            annotations["org.ommx.v1.solution.parameters"] = json.dumps(solution.parameters)
+        if solution.start:
+            annotations["org.ommx.v1.solution.start"] = solution.start.isoformat()
+        if solution.end:
+            annotations["org.ommx.v1.solution.end"] = solution.end.isoformat()
+        return self.add_layer("application/org.ommx.v1.solution", blob, annotations)
 
     def add_layer(
         self, media_type: str, blob: bytes, annotations: dict[str, str] = {}

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -162,7 +162,9 @@ class Artifact:
         if "org.ommx.v1.solution.instance" in descriptor.annotations:
             solution.instance = descriptor.annotations["org.ommx.v1.solution.instance"]
         if "org.ommx.v1.solution.solver" in descriptor.annotations:
-            solution.solver = json.loads(descriptor.annotations["org.ommx.v1.solution.solver"])
+            solution.solver = json.loads(
+                descriptor.annotations["org.ommx.v1.solution.solver"]
+            )
         if "org.ommx.v1.solution.parameters" in descriptor.annotations:
             solution.parameters = json.loads(
                 descriptor.annotations["org.ommx.v1.solution.parameters"]
@@ -172,7 +174,9 @@ class Artifact:
                 descriptor.annotations["org.ommx.v1.solution.start"]
             )
         if "org.ommx.v1.solution.end" in descriptor.annotations:
-            solution.end = datetime.fromisoformat(descriptor.annotations["org.ommx.v1.solution.end"])
+            solution.end = datetime.fromisoformat(
+                descriptor.annotations["org.ommx.v1.solution.end"]
+            )
         return solution
 
 
@@ -339,7 +343,9 @@ class ArtifactBuilder:
         if solution.solver:
             annotations["org.ommx.v1.solution.solver"] = json.dumps(solution.solver)
         if solution.parameters:
-            annotations["org.ommx.v1.solution.parameters"] = json.dumps(solution.parameters)
+            annotations["org.ommx.v1.solution.parameters"] = json.dumps(
+                solution.parameters
+            )
         if solution.start:
             annotations["org.ommx.v1.solution.start"] = solution.start.isoformat()
         if solution.end:

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from datetime import datetime
+from dateutil import parser
 
 from ._ommx_rust import (
     ArtifactArchive,
@@ -149,7 +150,7 @@ class Artifact:
         instance = Instance.from_bytes(blob)
         annotations = descriptor.annotations
         if "org.ommx.v1.instance.created" in annotations:
-            instance.created = datetime.fromisoformat(
+            instance.created = parser.isoparse(
                 annotations["org.ommx.v1.instance.created"]
             )
         if "org.ommx.v1.instance.title" in annotations:
@@ -170,11 +171,11 @@ class Artifact:
                 descriptor.annotations["org.ommx.v1.solution.parameters"]
             )
         if "org.ommx.v1.solution.start" in descriptor.annotations:
-            solution.start = datetime.fromisoformat(
+            solution.start = parser.isoparse(
                 descriptor.annotations["org.ommx.v1.solution.start"]
             )
         if "org.ommx.v1.solution.end" in descriptor.annotations:
-            solution.end = datetime.fromisoformat(
+            solution.end = parser.isoparse(
                 descriptor.annotations["org.ommx.v1.solution.end"]
             )
         return solution

--- a/python/ommx/v1/__init__.py
+++ b/python/ommx/v1/__init__.py
@@ -87,6 +87,38 @@ class Solution:
     raw: _Solution
     """The raw protobuf message."""
 
+    instance: Optional[str] = None
+    """
+    The digest of the instance layer, stored as ``org.ommx.v1.solution.instance`` annotation in OMMX artifact.
+
+    This ``Solution`` is the solution of the mathematical programming problem described by the instance.
+    """
+
+    solver: Optional[object] = None
+    """
+    The solver which generated this solution, stored as ``org.ommx.v1.solution.solver`` annotation as a JSON in OMMX artifact.
+    """
+
+    parameters: Optional[object] = None
+    """
+    The parameters used in the optimization, stored as ``org.ommx.v1.solution.parameters`` annotation as a JSON in OMMX artifact.
+    """
+
+    start: Optional[datetime] = None
+    """
+    When the optimization started, stored as ``org.ommx.v1.solution.start`` annotation in RFC3339 format in OMMX artifact.
+    """
+
+    end: Optional[datetime] = None
+    """
+    When the optimization ended, stored as ``org.ommx.v1.solution.end`` annotation in RFC3339 format in OMMX artifact.
+    """
+
+    annotations: dict[str, str] = field(default_factory=dict)
+    """
+    Arbitrary annotations stored in OMMX artifact. Use :py:attr:`parameters` or other specific attributes if possible.
+    """
+
     @staticmethod
     def from_bytes(data: bytes) -> Solution:
         raw = _Solution()

--- a/python/ommx/v1/__init__.py
+++ b/python/ommx/v1/__init__.py
@@ -15,13 +15,28 @@ from .._ommx_rust import evaluate_instance, used_decision_variable_ids
 
 @dataclass
 class Instance:
+    """
+    Idiomatic wrapper of ``ommx.v1.Instance`` protobuf message.
+
+    Note that this class also contains annotations like :py:attr:`title` which are not contained in protobuf message but stored in OMMX artifact.
+    These annotations are loaded from annotations while reading from OMMX artifact.
+    """
+
     raw: _Instance
+    """The raw protobuf message."""
+
     title: Optional[str] = None
-    """The title of the instance, stored as ``org.ommx.v1.instance.title`` annotation in OMMX artifact."""
+    """
+    The title of the instance, stored as ``org.ommx.v1.instance.title`` annotation in OMMX artifact.
+    """
     created: Optional[datetime] = None
-    """The creation date of the instance, stored as ``org.ommx.v1.instance.created`` annotation in RFC3339 format in OMMX artifact."""
+    """
+    The creation date of the instance, stored as ``org.ommx.v1.instance.created`` annotation in RFC3339 format in OMMX artifact.
+    """
     annotations: dict[str, str] = field(default_factory=dict)
-    """Arbitrary annotations also stored in OMMX artifact."""
+    """
+    Arbitrary annotations stored in OMMX artifact. Use :py:attr:`title` or other specific attributes if possible.
+    """
 
     @staticmethod
     def from_bytes(data: bytes) -> Instance:
@@ -63,7 +78,14 @@ class Instance:
 
 @dataclass
 class Solution:
+    """
+    Idiomatic wrapper of ``ommx.v1.Solution`` protobuf message.
+
+    This also contains annotations not contained in protobuf message, and will be stored in OMMX artifact.
+    """
+
     raw: _Solution
+    """The raw protobuf message."""
 
     @staticmethod
     def from_bytes(data: bytes) -> Solution:

--- a/python/ommx/v1/__init__.py
+++ b/python/ommx/v1/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Optional
 from datetime import datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pandas import DataFrame, concat, MultiIndex
 
 from .solution_pb2 import State, Solution as _Solution
@@ -20,9 +20,8 @@ class Instance:
     """The title of the instance, stored as ``org.ommx.v1.instance.title`` annotation in OMMX artifact."""
     created: Optional[datetime] = None
     """The creation date of the instance, stored as ``org.ommx.v1.instance.created`` annotation in RFC3339 format in OMMX artifact."""
-    annotations: dict[str, str] = {}
+    annotations: dict[str, str] = field(default_factory=dict)
     """Arbitrary annotations also stored in OMMX artifact."""
-
 
     @staticmethod
     def from_bytes(data: bytes) -> Instance:

--- a/python/ommx/v1/__init__.py
+++ b/python/ommx/v1/__init__.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from typing import Optional
+from datetime import datetime
 from dataclasses import dataclass
 from pandas import DataFrame, concat, MultiIndex
 
@@ -14,6 +16,13 @@ from .._ommx_rust import evaluate_instance, used_decision_variable_ids
 @dataclass
 class Instance:
     raw: _Instance
+    title: Optional[str] = None
+    """The title of the instance, stored as ``org.ommx.v1.instance.title`` annotation in OMMX artifact."""
+    created: Optional[datetime] = None
+    """The creation date of the instance, stored as ``org.ommx.v1.instance.created`` annotation in RFC3339 format in OMMX artifact."""
+    annotations: dict[str, str] = {}
+    """Arbitrary annotations also stored in OMMX artifact."""
+
 
     @staticmethod
     def from_bytes(data: bytes) -> Instance:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "numpy>=1.23.0, <2.0.0",
     "pandas>=2.0.0, <3.0.0",
     "protobuf>=5.26.1, <6.0.0",
+    "python-dateutil>=2.9.0, <3.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Annotations like `org.ommx.v1.instance.title` are now stored in `ommx.v1.Instance` Python object as attributes.
- `ArtifactBuilder.add_instance` now does not take `annotations` argument. Annotations are set through the above `Instance` class