### PR TITLE
NumPy support in OMMX Artifact

### DIFF
--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -366,7 +366,9 @@ class ArtifactBuilder:
             annotations["org.ommx.v1.solution.end"] = solution.end.isoformat()
         return self.add_layer("application/org.ommx.v1.solution", blob, annotations)
 
-    def add_ndarray(self, array: numpy.ndarray, annotations: dict[str, str] = {}) -> Descriptor:
+    def add_ndarray(
+        self, array: numpy.ndarray, annotations: dict[str, str] = {}
+    ) -> Descriptor:
         """
         Add a numpy ndarray to the artifact with npy format
         """

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -188,6 +188,9 @@ class Artifact:
         return solution
 
     def get_ndarray(self, descriptor: Descriptor) -> numpy.ndarray:
+        """
+        Get a numpy array from an artifact layer stored by :py:meth:`ArtifactBuilder.add_ndarray`
+        """
         assert descriptor.media_type == "application/vnd.numpy"
         blob = self.get_blob(descriptor)
         f = io.BytesIO(blob)
@@ -372,8 +375,13 @@ class ArtifactBuilder:
         """
         Add a numpy ndarray to the artifact with npy format
 
+        Example
+        ========
+
         >>> import numpy as np
         >>> array = np.array([1, 2, 3])
+
+        Store the array in the artifact with `application/vnd.numpy` media type
 
         >>> import uuid
         >>> builder = ArtifactBuilder.new_archive_unnamed(f"data/test_array.ommx.{uuid.uuid4()}")
@@ -383,6 +391,8 @@ class ArtifactBuilder:
         >>> layer = artifact.layers[0]
         >>> print(layer.media_type)
         application/vnd.numpy
+
+        Load the array from the artifact by :py:meth:`Artifact.get_ndarray`
 
         >>> ndarray = artifact.get_ndarray(layer)
         >>> print(ndarray)

--- a/python/ommx/artifact.py
+++ b/python/ommx/artifact.py
@@ -371,6 +371,23 @@ class ArtifactBuilder:
     ) -> Descriptor:
         """
         Add a numpy ndarray to the artifact with npy format
+
+        >>> import numpy as np
+        >>> array = np.array([1, 2, 3])
+
+        >>> import uuid
+        >>> builder = ArtifactBuilder.new_archive_unnamed(f"data/test_array.ommx.{uuid.uuid4()}")
+        >>> _desc = builder.add_ndarray(array)
+        >>> artifact = builder.build()
+
+        >>> layer = artifact.layers[0]
+        >>> print(layer.media_type)
+        application/vnd.numpy
+
+        >>> ndarray = artifact.get_ndarray(layer)
+        >>> print(ndarray)
+        [1 2 3]
+
         """
         f = io.BytesIO()
         numpy.save(f, array)


### PR DESCRIPTION
- `ArtifactBuilder.add_ndarray` is introduced. It serializes given `numpy.ndarray` into NPY file format by `numpy.save`, and stores this binary with `application/vnd.numpy` media type