### PR TITLE
Better constructor APIs for creating `ommx.v1.Instance`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           pyright python/ommx
 
-      - name: Run Test
+      - name: Test ommx
         if: always()
         run: |
           pytest -vv --doctest-modules python/ommx
@@ -94,15 +94,16 @@ jobs:
         run: |
           pip install -v -e 'python/ommx-python-mip-adaptor/[dev]'
 
-      - name: Lint
+      - name: Lint ommx-python-mip-adaptor
         if: always()
         run: |
           pyright python/ommx-python-mip-adaptor/
 
-      - name: Run Test
+      - name: Test ommx-python-mip-adaptor
         if: always()
         run: |
           pytest -vv --doctest-modules python/ommx-python-mip-adaptor/
+          markdown-code-runner ./python/ommx-python-mip-adaptor/README.md
 
   format:
     runs-on: ubuntu-latest

--- a/python/ommx-python-mip-adaptor/README.md
+++ b/python/ommx-python-mip-adaptor/README.md
@@ -47,7 +47,6 @@ Python-MIP can be used through `ommx-python-mip-adapter` by using the following:
 ```python markdown-code-runner
 import ommx_python_mip_adapter as adapter
 from ommx.v1.decision_variables_pb2 import DecisionVariable, Bound
-from ommx.v1.instance_pb2 import Instance as _Instance
 from ommx.v1.function_pb2 import Function
 from ommx.v1.linear_pb2 import Linear
 from ommx.v1 import Instance

--- a/python/ommx-python-mip-adaptor/README.md
+++ b/python/ommx-python-mip-adaptor/README.md
@@ -51,21 +51,21 @@ from ommx.v1.function_pb2 import Function
 from ommx.v1.linear_pb2 import Linear
 from ommx.v1 import Instance
 
-ommx_instance = Instance(
-    _Instance(
-        decision_variables=[
-            DecisionVariable(
-                id=1,
-                kind=DecisionVariable.KIND_INTEGER,
-                bound=Bound(lower=0, upper=5),
-            ),
-        ],
-        objective=Function(
-            linear=Linear(
-                terms=[Linear.Term(id=1, coefficient=1)]
-            ),
+ommx_instance = Instance.from_components(
+    decision_variables=[
+        DecisionVariable(
+            id=1,
+            kind=DecisionVariable.KIND_INTEGER,
+            bound=Bound(lower=0, upper=5),
         ),
-    )
+    ],
+    objective=Function(
+        linear=Linear(
+            terms=[Linear.Term(id=1, coefficient=1)]
+        ),
+    ),
+    constraints=[],
+    sense=Instance.MINIMIZE,
 )
 
 # Convert from `ommx.v1.Instance` to `mip.Model`

--- a/python/ommx-python-mip-adaptor/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adaptor/ommx_python_mip_adapter/adapter.py
@@ -8,7 +8,6 @@ from ommx.v1.decision_variables_pb2 import DecisionVariable, Bound
 from ommx.v1.function_pb2 import Function
 from ommx.v1.linear_pb2 import Linear
 from ommx.v1.solution_pb2 import State
-from ommx.v1.instance_pb2 import Instance as _Instance
 from ommx.v1 import Instance
 
 from ommx_python_mip_adapter.exception import OMMXPythonMIPAdapterError
@@ -221,18 +220,16 @@ class OMMXInstanceBuilder:
 
     def _sense(self):
         if self._model.sense == mip.MAXIMIZE:
-            return _Instance.SENSE_MAXIMIZE
+            return Instance.MAXIMIZE
         else:
-            return _Instance.SENSE_MINIMIZE
+            return Instance.MINIMIZE
 
     def build(self) -> Instance:
-        return Instance(
-            _Instance(
-                decision_variables=self._decision_variables(),
-                objective=self._objective(),
-                constraints=self._constraints(),
-                sense=self._sense(),
-            )
+        return Instance.from_components(
+            decision_variables=self._decision_variables(),
+            objective=self._objective(),
+            constraints=self._constraints(),
+            sense=self._sense(),
         )
 
 
@@ -263,26 +260,25 @@ def instance_to_model(
 
         >>> import ommx_python_mip_adapter as adapter
         >>> from ommx.v1.decision_variables_pb2 import DecisionVariable, Bound
-        >>> from ommx.v1.instance_pb2 import Instance as _Instance
         >>> from ommx.v1.function_pb2 import Function
         >>> from ommx.v1.linear_pb2 import Linear
         >>> from ommx.v1 import Instance
 
-        >>> ommx_instance = Instance(
-        ...     _Instance(
-        ...         decision_variables=[
-        ...             DecisionVariable(
-        ...                 id=1,
-        ...                 kind=DecisionVariable.KIND_INTEGER,
-        ...                 bound=Bound(lower=0, upper=5),
-        ...             ),
-        ...         ],
-        ...         objective=Function(
-        ...             linear=Linear(
-        ...                 terms=[Linear.Term(id=1, coefficient=1)]
-        ...             ),
+        >>> ommx_instance = Instance.from_components(
+        ...     decision_variables=[
+        ...         DecisionVariable(
+        ...             id=1,
+        ...             kind=DecisionVariable.KIND_INTEGER,
+        ...             bound=Bound(lower=0, upper=5),
         ...         ),
-        ...     )
+        ...     ],
+        ...     objective=Function(
+        ...         linear=Linear(
+        ...             terms=[Linear.Term(id=1, coefficient=1)]
+        ...         ),
+        ...     ),
+        ...     constraints=[],
+        ...     sense=Instance.MINIMIZE,
         ... )
         >>> model = adapter.instance_to_model(ommx_instance)
         >>> model.optimize()
@@ -351,26 +347,25 @@ def model_to_solution(
 
         >>> import ommx_python_mip_adapter as adapter
         >>> from ommx.v1.decision_variables_pb2 import DecisionVariable, Bound
-        >>> from ommx.v1.instance_pb2 import Instance as _Instance
         >>> from ommx.v1.function_pb2 import Function
         >>> from ommx.v1.linear_pb2 import Linear
         >>> from ommx.v1 import Instance
 
-        >>> ommx_instance = Instance(
-        ...     _Instance(
-        ...         decision_variables=[
-        ...             DecisionVariable(
-        ...                 id=1,
-        ...                 kind=DecisionVariable.KIND_INTEGER,
-        ...                 bound=Bound(lower=0, upper=5),
-        ...             ),
-        ...         ],
-        ...         objective=Function(
-        ...             linear=Linear(
-        ...                 terms=[Linear.Term(id=1, coefficient=1)]
-        ...             ),
+        >>> ommx_instance = Instance.from_components(
+        ...     decision_variables=[
+        ...         DecisionVariable(
+        ...             id=1,
+        ...             kind=DecisionVariable.KIND_INTEGER,
+        ...             bound=Bound(lower=0, upper=5),
         ...         ),
-        ...     )
+        ...     ],
+        ...     objective=Function(
+        ...         linear=Linear(
+        ...             terms=[Linear.Term(id=1, coefficient=1)]
+        ...         ),
+        ...     ),
+        ...     constraints=[],
+        ...     sense=Instance.MINIMIZE,
         ... )
         >>> model = adapter.instance_to_model(ommx_instance)
         >>> model.optimize()

--- a/python/ommx/ommx/testing.py
+++ b/python/ommx/ommx/testing.py
@@ -6,7 +6,6 @@ from ommx.v1 import Instance
 from ommx.v1.constraint_pb2 import Constraint, Equality
 from ommx.v1.decision_variables_pb2 import DecisionVariable, Bound
 from ommx.v1.function_pb2 import Function
-from ommx.v1.instance_pb2 import Instance as _Instance
 from ommx.v1.linear_pb2 import Linear
 from ommx.v1.solution_pb2 import State
 
@@ -135,13 +134,12 @@ class SingleFeasibleLPGenerator:
             )
             constraints.append(constraint)
 
-        return Instance(
-            _Instance(
-                description=_Instance.Description(name="LPTest"),
-                decision_variables=decision_variables,
-                objective=Function(constant=0),
-                constraints=constraints,
-            )
+        return Instance.from_components(
+            description=Instance.Description(name="LPTest"),
+            decision_variables=decision_variables,
+            objective=Function(constant=0),
+            constraints=constraints,
+            sense=Instance.MINIMIZE,
         )
 
     def get_v1_state(self) -> State:

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional
+from typing import Optional, Iterable
 from datetime import datetime
 from dataclasses import dataclass, field
 from pandas import DataFrame, concat, MultiIndex
@@ -7,7 +7,7 @@ from pandas import DataFrame, concat, MultiIndex
 from .solution_pb2 import State, Solution as _Solution
 from .instance_pb2 import Instance as _Instance
 from .function_pb2 import Function
-from .constraint_pb2 import Equality
+from .constraint_pb2 import Equality, Constraint
 from .decision_variables_pb2 import DecisionVariable
 
 from .._ommx_rust import evaluate_instance, used_decision_variable_ids
@@ -37,6 +37,31 @@ class Instance:
     """
     Arbitrary annotations stored in OMMX artifact. Use :py:attr:`title` or other specific attributes if possible.
     """
+
+    # Re-export some enums
+    MAXIMIZE = _Instance.SENSE_MAXIMIZE
+    MINIMIZE = _Instance.SENSE_MINIMIZE
+
+    Description = _Instance.Description
+
+    @staticmethod
+    def from_components(
+        *,
+        objective: Function,
+        constraints: Iterable[Constraint],
+        sense: _Instance.Sense.ValueType,
+        decision_variables: Iterable[DecisionVariable],
+        description: Optional[_Instance.Description] = None,
+    ) -> Instance:
+        return Instance(
+            _Instance(
+                description=description,
+                decision_variables=decision_variables,
+                objective=objective,
+                constraints=constraints,
+                sense=sense,
+            )
+        )
 
     @staticmethod
     def from_bytes(data: bytes) -> Instance:


### PR DESCRIPTION
- `Instance.from_components` is introduced to create in 0.2.0 style before wrapper class `ommx.v1.Instance` has been introduced in #44.
- This reverts most of dbd99c55bab00754360a013386421d55236f038e changes to update `ommx-python-mip-adaptor`