### PR TITLE
Store dual variable in `EvaluatedConstraint`

### DIFF
--- a/proto/ommx/v1/constraint.proto
+++ b/proto/ommx/v1/constraint.proto
@@ -61,4 +61,8 @@ message EvaluatedConstraint {
 
   // Detail human-readable description of the constraint.
   optional string description = 7;
+
+  // Value for the Lagrangian dual variable of this constraint.
+  // This is optional because not all solvers support to evaluate dual variables.
+  optional double dual_variable = 8;
 }

--- a/python/ommx/ommx/v1/constraint_pb2.py
+++ b/python/ommx/ommx/v1/constraint_pb2.py
@@ -17,7 +17,7 @@ from ommx.v1 import function_pb2 as ommx_dot_v1_dot_function__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b"\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto\"\xd7\x02\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x43\n\nparameters\x18\x05 \x03(\x0b\x32#.ommx.v1.Constraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description\"\xa0\x03\n\x13\x45valuatedConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12'\n\x0f\x65valuated_value\x18\x03 \x01(\x01R\x0e\x65valuatedValue\x12;\n\x1aused_decision_variable_ids\x18\x04 \x03(\x04R\x17usedDecisionVariableIds\x12L\n\nparameters\x18\x05 \x03(\x0b\x32,.ommx.v1.EvaluatedConstraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3"
+    b"\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto\"\xd7\x02\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x43\n\nparameters\x18\x05 \x03(\x0b\x32#.ommx.v1.Constraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description\"\xdc\x03\n\x13\x45valuatedConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12'\n\x0f\x65valuated_value\x18\x03 \x01(\x01R\x0e\x65valuatedValue\x12;\n\x1aused_decision_variable_ids\x18\x04 \x03(\x04R\x17usedDecisionVariableIds\x12L\n\nparameters\x18\x05 \x03(\x0b\x32,.ommx.v1.EvaluatedConstraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12(\n\rdual_variable\x18\x08 \x01(\x01H\x02R\x0c\x64ualVariable\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\x10\n\x0e_dual_variable*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3"
 )
 
 _globals = globals()
@@ -32,14 +32,14 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_options = b"8\001"
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._loaded_options = None
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_options = b"8\001"
-    _globals["_EQUALITY"]._serialized_start = 826
-    _globals["_EQUALITY"]._serialized_end = 931
+    _globals["_EQUALITY"]._serialized_start = 886
+    _globals["_EQUALITY"]._serialized_end = 991
     _globals["_CONSTRAINT"]._serialized_start = 62
     _globals["_CONSTRAINT"]._serialized_end = 405
     _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_start = 319
     _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_end = 380
     _globals["_EVALUATEDCONSTRAINT"]._serialized_start = 408
-    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 824
+    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 884
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_start = 319
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_end = 380
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/ommx/v1/constraint_pb2.pyi
+++ b/python/ommx/ommx/v1/constraint_pb2.pyi
@@ -185,6 +185,7 @@ class EvaluatedConstraint(google.protobuf.message.Message):
     PARAMETERS_FIELD_NUMBER: builtins.int
     NAME_FIELD_NUMBER: builtins.int
     DESCRIPTION_FIELD_NUMBER: builtins.int
+    DUAL_VARIABLE_FIELD_NUMBER: builtins.int
     id: builtins.int
     equality: global___Equality.ValueType
     evaluated_value: builtins.float
@@ -193,6 +194,10 @@ class EvaluatedConstraint(google.protobuf.message.Message):
     """Name of the constraint."""
     description: builtins.str
     """Detail human-readable description of the constraint."""
+    dual_variable: builtins.float
+    """Value for the Lagrangian dual variable of this constraint.
+    This is optional because not all solvers support to evaluate dual variables.
+    """
     @property
     def used_decision_variable_ids(
         self,
@@ -215,16 +220,21 @@ class EvaluatedConstraint(google.protobuf.message.Message):
         parameters: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
         name: builtins.str | None = ...,
         description: builtins.str | None = ...,
+        dual_variable: builtins.float | None = ...,
     ) -> None: ...
     def HasField(
         self,
         field_name: typing.Literal[
             "_description",
             b"_description",
+            "_dual_variable",
+            b"_dual_variable",
             "_name",
             b"_name",
             "description",
             b"description",
+            "dual_variable",
+            b"dual_variable",
             "name",
             b"name",
         ],
@@ -234,10 +244,14 @@ class EvaluatedConstraint(google.protobuf.message.Message):
         field_name: typing.Literal[
             "_description",
             b"_description",
+            "_dual_variable",
+            b"_dual_variable",
             "_name",
             b"_name",
             "description",
             b"description",
+            "dual_variable",
+            b"dual_variable",
             "equality",
             b"equality",
             "evaluated_value",
@@ -256,6 +270,10 @@ class EvaluatedConstraint(google.protobuf.message.Message):
     def WhichOneof(
         self, oneof_group: typing.Literal["_description", b"_description"]
     ) -> typing.Literal["description"] | None: ...
+    @typing.overload
+    def WhichOneof(
+        self, oneof_group: typing.Literal["_dual_variable", b"_dual_variable"]
+    ) -> typing.Literal["dual_variable"] | None: ...
     @typing.overload
     def WhichOneof(
         self, oneof_group: typing.Literal["_name", b"_name"]

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -111,6 +111,7 @@ impl Evaluate for Constraint {
                 name: self.name.clone(),
                 parameters: self.parameters.clone(),
                 description: self.description.clone(),
+                dual_variable: None,
             },
             used_ids,
         ))

--- a/rust/ommx/src/ommx.v1.rs
+++ b/rust/ommx/src/ommx.v1.rs
@@ -148,6 +148,10 @@ pub struct EvaluatedConstraint {
     /// Detail human-readable description of the constraint.
     #[prost(string, optional, tag = "7")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
+    /// Value for the Lagrangian dual variable of this constraint.
+    /// This is optional because not all solvers support to evaluate dual variables.
+    #[prost(double, optional, tag = "8")]
+    pub dual_variable: ::core::option::Option<f64>,
 }
 /// Equality of a constraint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]


### PR DESCRIPTION
- `EvaluatedConstraint.dual_variable` to store Lagrangian dual variables
- `ommx_python_mip_adapter.solve` stores the dual variable if `mip.Constr.pi` exists.