### PR TITLE
Constant constraints

### DIFF
--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "ommx >= 0.5.0, < 0.6.0",
-    "mip",
+    "mip @ git+https://github.com/coin-or/python-mip.git@0ccb81115543e737ab74a4f1309891ce5650c8d5",
 ]
 
 [project.urls]

--- a/python/ommx-python-mip-adapter/tests/test_constant_constraint.py
+++ b/python/ommx-python-mip-adapter/tests/test_constant_constraint.py
@@ -1,0 +1,40 @@
+import ommx_python_mip_adapter as adapter
+from ommx.v1 import Instance, DecisionVariable, Linear
+
+
+def test_constant_constraint_feasible():
+    x = DecisionVariable.continuous(0)
+    instance = Instance.from_components(
+        decision_variables=[x],
+        objective=x,
+        constraints=[
+            # 1 >= 0 is always true
+            Linear(terms={}, constant=1) >= 0,
+            x <= 1,
+        ],
+        sense=Instance.MAXIMIZE,
+    )
+    result = adapter.solve(instance)
+    assert result.HasField("solution")
+
+    solution = result.solution
+    assert solution.state.entries == {0: 1.0}
+    assert solution.objective == 1.0
+
+    assert len(solution.evaluated_constraints) == 2
+
+
+def test_constant_constraint_infeasible():
+    x = DecisionVariable.continuous(0)
+    instance = Instance.from_components(
+        decision_variables=[x],
+        objective=x,
+        constraints=[
+            # -1 >= 0 is always false
+            Linear(terms={}, constant=-1) >= 0,
+            x <= 1,
+        ],
+        sense=Instance.MAXIMIZE,
+    )
+    result = adapter.solve(instance)
+    assert result.HasField("infeasible")


### PR DESCRIPTION
Constraint without any decision variable like following causes segmentation fault in CBC solver with Python-MIP 1.15. https://github.com/Jij-Inc/ommx/actions/runs/9698846012/job/26766373894

```python
    x = DecisionVariable.continuous(0)
    instance = Instance.from_components(
        decision_variables=[x],
        objective=x,
        constraints=[
            # 1 >= 0 is always true
            Linear(terms={}, constant=1) >= 0,
            x <= 1,
        ],
        sense=Instance.MAXIMIZE,
    )
```

This has been reported in https://github.com/coin-or/python-mip/issues/213 and some linked issues, and fixed in https://github.com/coin-or/python-mip/pull/237.

We use latest commit of Python-MIP https://github.com/coin-or/python-mip/commit/0ccb81115543e737ab74a4f1309891ce5650c8d5 until the next version is released https://github.com/coin-or/python-mip/issues/384