### PR TITLE
Feasibility condition for inequality is too strict

### DIFF
--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -134,7 +134,7 @@ impl Evaluate for Instance {
                     feasible = false;
                 }
             } else if c.equality == Equality::LessThanOrEqualToZero as i32 {
-                if c.evaluated_value > 0.0 {
+                if c.evaluated_value > 1e-6 {
                     feasible = false;
                 }
             } else {


### PR DESCRIPTION
Inequality constraint `f(x) <= 0` is checked as the evaluated value of `f(x)` is larger than zero, but it should be larger than tolerance `>= 1e-6`