### PR TITLE
Add `subscripts` field into `Constraint` message

### DIFF
--- a/proto/ommx/v1/constraint.proto
+++ b/proto/ommx/v1/constraint.proto
@@ -25,13 +25,16 @@ message Constraint {
 
   Function function = 3;
 
-  // Parameters of the constraint.
+  // Integer parameters of the constraint.
   //
   // Consider for example a problem constains a series of constraints `x[i, j] + y[i, j] <= 10` for `i = 1, 2, 3` and `j = 4, 5`,
   // then 6 = 3x2 `Constraint` messages should be created corresponding to each pair of `i` and `j`.
   // The `name` field of this message is intended to be a human-readable name of `x[i, j] + y[i, j] <= 10`,
-  // and the `parameters` field is intended to be the value of `i` and `j` like `{ "i" : "1", "j": "5" }`.
+  // and the `subscripts` field is intended to be the value of `[i, j]` like `[1, 5]`.
   //
+  repeated int64 subscripts = 8;
+
+  // Key-value parameters of the constraint.
   map<string, string> parameters = 5;
 
   // Name of the constraint.
@@ -53,7 +56,10 @@ message EvaluatedConstraint {
   // IDs of decision variables used to evalute this constraint
   repeated uint64 used_decision_variable_ids = 4;
 
-  // Parameters of the constraint.
+  // Integer parameters of the constraint.
+  repeated int64 subscripts = 9;
+
+  // Key-value parameters of the constraint.
   map<string, string> parameters = 5;
 
   // Name of the constraint.

--- a/python/ommx/ommx/v1/constraint_pb2.py
+++ b/python/ommx/ommx/v1/constraint_pb2.py
@@ -17,7 +17,7 @@ from ommx.v1 import function_pb2 as ommx_dot_v1_dot_function__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b"\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto\"\xd7\x02\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x43\n\nparameters\x18\x05 \x03(\x0b\x32#.ommx.v1.Constraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description\"\xdc\x03\n\x13\x45valuatedConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12'\n\x0f\x65valuated_value\x18\x03 \x01(\x01R\x0e\x65valuatedValue\x12;\n\x1aused_decision_variable_ids\x18\x04 \x03(\x04R\x17usedDecisionVariableIds\x12L\n\nparameters\x18\x05 \x03(\x0b\x32,.ommx.v1.EvaluatedConstraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12(\n\rdual_variable\x18\x08 \x01(\x01H\x02R\x0c\x64ualVariable\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\x10\n\x0e_dual_variable*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3"
+    b"\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto\"\xf7\x02\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x1e\n\nsubscripts\x18\x08 \x03(\x03R\nsubscripts\x12\x43\n\nparameters\x18\x05 \x03(\x0b\x32#.ommx.v1.Constraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description\"\xfc\x03\n\x13\x45valuatedConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12'\n\x0f\x65valuated_value\x18\x03 \x01(\x01R\x0e\x65valuatedValue\x12;\n\x1aused_decision_variable_ids\x18\x04 \x03(\x04R\x17usedDecisionVariableIds\x12\x1e\n\nsubscripts\x18\t \x03(\x03R\nsubscripts\x12L\n\nparameters\x18\x05 \x03(\x0b\x32,.ommx.v1.EvaluatedConstraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12(\n\rdual_variable\x18\x08 \x01(\x01H\x02R\x0c\x64ualVariable\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\x10\n\x0e_dual_variable*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3"
 )
 
 _globals = globals()
@@ -32,14 +32,14 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_options = b"8\001"
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._loaded_options = None
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_options = b"8\001"
-    _globals["_EQUALITY"]._serialized_start = 886
-    _globals["_EQUALITY"]._serialized_end = 991
+    _globals["_EQUALITY"]._serialized_start = 950
+    _globals["_EQUALITY"]._serialized_end = 1055
     _globals["_CONSTRAINT"]._serialized_start = 62
-    _globals["_CONSTRAINT"]._serialized_end = 405
-    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_start = 319
-    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_end = 380
-    _globals["_EVALUATEDCONSTRAINT"]._serialized_start = 408
-    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 884
-    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_start = 319
-    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_end = 380
+    _globals["_CONSTRAINT"]._serialized_end = 437
+    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_start = 351
+    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_end = 412
+    _globals["_EVALUATEDCONSTRAINT"]._serialized_start = 440
+    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 948
+    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_start = 351
+    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_end = 412
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/ommx/v1/constraint_pb2.pyi
+++ b/python/ommx/ommx/v1/constraint_pb2.pyi
@@ -66,6 +66,7 @@ class Constraint(google.protobuf.message.Message):
     ID_FIELD_NUMBER: builtins.int
     EQUALITY_FIELD_NUMBER: builtins.int
     FUNCTION_FIELD_NUMBER: builtins.int
+    SUBSCRIPTS_FIELD_NUMBER: builtins.int
     PARAMETERS_FIELD_NUMBER: builtins.int
     NAME_FIELD_NUMBER: builtins.int
     DESCRIPTION_FIELD_NUMBER: builtins.int
@@ -86,16 +87,22 @@ class Constraint(google.protobuf.message.Message):
     @property
     def function(self) -> ommx.v1.function_pb2.Function: ...
     @property
-    def parameters(
+    def subscripts(
         self,
-    ) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """Parameters of the constraint.
+    ) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]:
+        """Integer parameters of the constraint.
 
         Consider for example a problem constains a series of constraints `x[i, j] + y[i, j] <= 10` for `i = 1, 2, 3` and `j = 4, 5`,
         then 6 = 3x2 `Constraint` messages should be created corresponding to each pair of `i` and `j`.
         The `name` field of this message is intended to be a human-readable name of `x[i, j] + y[i, j] <= 10`,
-        and the `parameters` field is intended to be the value of `i` and `j` like `{ "i" : "1", "j": "5" }`.
+        and the `subscripts` field is intended to be the value of `[i, j]` like `[1, 5]`.
         """
+
+    @property
+    def parameters(
+        self,
+    ) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
+        """Key-value parameters of the constraint."""
 
     def __init__(
         self,
@@ -103,6 +110,7 @@ class Constraint(google.protobuf.message.Message):
         id: builtins.int = ...,
         equality: global___Equality.ValueType = ...,
         function: ommx.v1.function_pb2.Function | None = ...,
+        subscripts: collections.abc.Iterable[builtins.int] | None = ...,
         parameters: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
         name: builtins.str | None = ...,
         description: builtins.str | None = ...,
@@ -141,6 +149,8 @@ class Constraint(google.protobuf.message.Message):
             b"name",
             "parameters",
             b"parameters",
+            "subscripts",
+            b"subscripts",
         ],
     ) -> None: ...
     @typing.overload
@@ -182,6 +192,7 @@ class EvaluatedConstraint(google.protobuf.message.Message):
     EQUALITY_FIELD_NUMBER: builtins.int
     EVALUATED_VALUE_FIELD_NUMBER: builtins.int
     USED_DECISION_VARIABLE_IDS_FIELD_NUMBER: builtins.int
+    SUBSCRIPTS_FIELD_NUMBER: builtins.int
     PARAMETERS_FIELD_NUMBER: builtins.int
     NAME_FIELD_NUMBER: builtins.int
     DESCRIPTION_FIELD_NUMBER: builtins.int
@@ -205,10 +216,16 @@ class EvaluatedConstraint(google.protobuf.message.Message):
         """IDs of decision variables used to evalute this constraint"""
 
     @property
+    def subscripts(
+        self,
+    ) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int]:
+        """Integer parameters of the constraint."""
+
+    @property
     def parameters(
         self,
     ) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """Parameters of the constraint."""
+        """Key-value parameters of the constraint."""
 
     def __init__(
         self,
@@ -217,6 +234,7 @@ class EvaluatedConstraint(google.protobuf.message.Message):
         equality: global___Equality.ValueType = ...,
         evaluated_value: builtins.float = ...,
         used_decision_variable_ids: collections.abc.Iterable[builtins.int] | None = ...,
+        subscripts: collections.abc.Iterable[builtins.int] | None = ...,
         parameters: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
         name: builtins.str | None = ...,
         description: builtins.str | None = ...,
@@ -262,6 +280,8 @@ class EvaluatedConstraint(google.protobuf.message.Message):
             b"name",
             "parameters",
             b"parameters",
+            "subscripts",
+            b"subscripts",
             "used_decision_variable_ids",
             b"used_decision_variable_ids",
         ],

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -109,6 +109,7 @@ impl Evaluate for Constraint {
                 evaluated_value,
                 used_decision_variable_ids,
                 name: self.name.clone(),
+                subscripts: self.subscripts.clone(),
                 parameters: self.parameters.clone(),
                 description: self.description.clone(),
                 dual_variable: None,

--- a/rust/ommx/src/ommx.v1.rs
+++ b/rust/ommx/src/ommx.v1.rs
@@ -107,13 +107,16 @@ pub struct Constraint {
     pub equality: i32,
     #[prost(message, optional, tag = "3")]
     pub function: ::core::option::Option<Function>,
-    /// Parameters of the constraint.
+    /// Integer parameters of the constraint.
     ///
     /// Consider for example a problem constains a series of constraints `x\[i, j\] + y\[i, j\] <= 10` for `i = 1, 2, 3` and `j = 4, 5`,
     /// then 6 = 3x2 `Constraint` messages should be created corresponding to each pair of `i` and `j`.
     /// The `name` field of this message is intended to be a human-readable name of `x\[i, j\] + y\[i, j\] <= 10`,
-    /// and the `parameters` field is intended to be the value of `i` and `j` like `{ "i" : "1", "j": "5" }`.
+    /// and the `subscripts` field is intended to be the value of `\[i, j\]` like `\[1, 5\]`.
     ///
+    #[prost(int64, repeated, tag = "8")]
+    pub subscripts: ::prost::alloc::vec::Vec<i64>,
+    /// Key-value parameters of the constraint.
     #[prost(map = "string, string", tag = "5")]
     pub parameters:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
@@ -138,7 +141,10 @@ pub struct EvaluatedConstraint {
     /// IDs of decision variables used to evalute this constraint
     #[prost(uint64, repeated, tag = "4")]
     pub used_decision_variable_ids: ::prost::alloc::vec::Vec<u64>,
-    /// Parameters of the constraint.
+    /// Integer parameters of the constraint.
+    #[prost(int64, repeated, tag = "9")]
+    pub subscripts: ::prost::alloc::vec::Vec<i64>,
+    /// Key-value parameters of the constraint.
     #[prost(map = "string, string", tag = "5")]
     pub parameters:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -21,9 +21,7 @@ pub fn random_lp(rng: &mut impl Rng, num_variables: usize, num_constraints: usiz
             id: constraint_id as u64,
             equality: Equality::EqualToZero as i32,
             function: Some(linear.into()),
-            name: None,
-            parameters: Default::default(),
-            description: None,
+            ..Default::default()
         });
     }
     let mut objective = v1::Linear::default();


### PR DESCRIPTION
Split from #88 

It is rather natural also for `Constraint` message to use `subscripts` for integer parameter and `parameters` for string parameters as `DecisionVariable` does.