### PR TITLE
Do not use git dependencies for Python-MIP to release 1.0.0

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,9 @@ changelog:
     - title: Rust SDK update
       labels:
         - rust
+    - title: Documentation update
+      labels:
+        - documentation
     - title: Others
       labels:
         - "*"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -17,7 +17,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12
+          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11
           working-directory: ./python/ommx
           manylinux: manylinux_2_28
 
@@ -38,7 +38,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12
+          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11
           working-directory: ./python/ommx
 
       - name: Upload wheels
@@ -58,7 +58,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12
+          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11
           working-directory: ./python/ommx
 
       - name: Upload wheels

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -25,7 +25,10 @@ classifiers = [
 ]
 dependencies = [
     "ommx >= 0.5.1, < 0.6.0",
-    "mip @ git+https://github.com/coin-or/python-mip.git@0ccb81115543e737ab74a4f1309891ce5650c8d5",
+
+    # FIXME: This project requires latest version of Python-MIP (will be 1.16.0?), which does not release yet.
+    #        https://github.com/coin-or/python-mip/issues/384
+    "mip >= 1.15.0, < 2.0.0",
 ]
 
 [project.urls]

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: MIT License",
 ]

--- a/python/ommx-python-mip-adapter/tests/test_constant_constraint.py
+++ b/python/ommx-python-mip-adapter/tests/test_constant_constraint.py
@@ -1,7 +1,11 @@
 import ommx_python_mip_adapter as adapter
 from ommx.v1 import Instance, DecisionVariable, Linear
+import pytest
 
 
+@pytest.mark.skip(
+    reason="This test causes a segfault due to a bug in the Python-MIP fixed in https://github.com/coin-or/python-mip/pull/237, which is not yet released."
+)
 def test_constant_constraint_feasible():
     x = DecisionVariable.continuous(0)
     instance = Instance.from_components(
@@ -24,6 +28,9 @@ def test_constant_constraint_feasible():
     assert len(solution.evaluated_constraints) == 2
 
 
+@pytest.mark.skip(
+    reason="This test causes a segfault due to a bug in the Python-MIP fixed in https://github.com/coin-or/python-mip/pull/237, which is not yet released."
+)
 def test_constant_constraint_infeasible():
     x = DecisionVariable.continuous(0)
     instance = Instance.from_components(

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Partially reverts #82 with `pytest.mark.skip`