### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -89,24 +89,25 @@ jobs:
         run: |
           pytest -vv --doctest-modules python/ommx
 
+      # FIXME: Python-MIP does not support Python 3.12
       - name: Install ommx-python-mip-adapter
-        if: always()
+        if: ${{ matrix.python-version != '3.12' }}
         run: |
           pip install -v -e 'python/ommx-python-mip-adapter/[dev]'
 
       - name: Lint ommx-python-mip-adapter
-        if: always()
+        if: ${{ matrix.python-version != '3.12' }}
         run: |
           pyright python/ommx-python-mip-adapter/
 
       - name: Test ommx-python-mip-adapter
-        if: always()
+        if: ${{ matrix.python-version != '3.12' }}
         run: |
           pytest -vv --doctest-modules python/ommx-python-mip-adapter/
           markdown-code-runner ./python/ommx-python-mip-adapter/README.md
 
       - name: Run notebooks
-        if: github.actor != 'dependabot[bot]'
+        if: ${{ github.actor != 'dependabot[bot]' && matrix.python-version != '3.12' }}
         run: |
           jupyter nbconvert --to notebook --execute notebooks/*.ipynb
         env:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -17,7 +17,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11
+          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12
           working-directory: ./python/ommx
           manylinux: manylinux_2_28
 
@@ -38,7 +38,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11
+          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12
           working-directory: ./python/ommx
 
       - name: Upload wheels
@@ -58,7 +58,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11
+          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12
           working-directory: ./python/ommx
 
       - name: Upload wheels

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: MIT License",
 ]

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: MIT License",
 ]

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Note that `ommx-python-mip-adapter` does not work with Python 3.12 because Python-MIP does not supports 3.12.