### PR TITLE
Remove `Function.from_linear` and others, use `__init__` instead

### DIFF
--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -957,32 +957,17 @@ def as_function(
 class Function:
     raw: _Function
 
-    def __init__(self, inner: int | float | Linear | Quadratic | Polynomial):
+    def __init__(
+        self,
+        inner: int
+        | float
+        | DecisionVariable
+        | Linear
+        | Quadratic
+        | Polynomial
+        | _Function,
+    ):
         self.raw = as_function(inner)
-
-    @staticmethod
-    def from_scalar(value: int | float) -> Function:
-        return Function.from_bytes(_ommx_rust.Function.from_scalar(value).encode())
-
-    @staticmethod
-    def from_linear(linear: DecisionVariable | Linear) -> Function:
-        if isinstance(linear, DecisionVariable):
-            inner = _ommx_rust.Linear.single_term(linear.raw.id, 1)
-        elif isinstance(linear, Linear):
-            inner = _ommx_rust.Linear.decode(linear.raw.SerializeToString())
-        else:
-            raise ValueError(f"Unknown type: {type(linear)}")
-        return Function.from_bytes(_ommx_rust.Function.from_linear(inner).encode())
-
-    @staticmethod
-    def from_quadratic(quadratic: Quadratic) -> Function:
-        inner = _ommx_rust.Quadratic.decode(quadratic.raw.SerializeToString())
-        return Function.from_bytes(_ommx_rust.Function.from_quadratic(inner).encode())
-
-    @staticmethod
-    def from_polynomial(polynomial: Polynomial) -> Function:
-        inner = _ommx_rust.Polynomial.decode(polynomial.raw.SerializeToString())
-        return Function.from_bytes(_ommx_rust.Function.from_polynomial(inner).encode())
 
     @staticmethod
     def from_bytes(data: bytes) -> Function:

--- a/python/ommx/tests/test_function.py
+++ b/python/ommx/tests/test_function.py
@@ -161,19 +161,7 @@ def test_function():
     x2 = DecisionVariable.binary(2)
     x3 = DecisionVariable.binary(3)
 
-    assert_eq(
-        Function.from_linear(x1) + Function.from_scalar(3.0),
-        Function.from_linear(x1 + 3.0),
-    )
-    assert_eq(
-        Function.from_linear(x1) + Function.from_linear(x2),
-        Function.from_linear(x1 + x2),
-    )
-    assert_eq(
-        Function.from_linear(x1) * Function.from_linear(x2),
-        Function.from_quadratic(x1 * x2),
-    )
-    assert_eq(
-        Function.from_quadratic(x1 * x2) * Function.from_linear(x3),
-        Function.from_polynomial(x1 * x2 * x3),
-    )
+    assert_eq(Function(x1) + Function(3.0), Function(x1 + 3.0))
+    assert_eq(Function(x1) + Function(x2), Function(x1 + x2))
+    assert_eq(Function(x1) * Function(x2), Function(x1 * x2))
+    assert_eq(Function(x1 * x2) * Function(x3), Function(x1 * x2 * x3))


### PR DESCRIPTION
Partially reverts #94

- `Function.__init__` is enough for converting `Linear`, `Quadratic`, and others into `Function`. `ommx._ommx_rust.Function.from_linear` and others are kept for future use.