### PR TITLE
Fix `impl Display` and `__repr__` for `Linear` and other `Function`s

### DIFF
--- a/rust/ommx/src/convert/format.rs
+++ b/rust/ommx/src/convert/format.rs
@@ -1,16 +1,25 @@
 use std::fmt;
 
+fn write_f64_with_precision(f: &mut fmt::Formatter, coefficient: f64) -> fmt::Result {
+    if let Some(precision) = f.precision() {
+        write!(f, "{1:.0$}", precision, coefficient)?;
+    } else {
+        write!(f, "{}", coefficient)?;
+    }
+    Ok(())
+}
+
 fn write_term(f: &mut fmt::Formatter, mut ids: Vec<u64>, coefficient: f64) -> fmt::Result {
+    if ids.is_empty() {
+        write_f64_with_precision(f, coefficient)?;
+        return Ok(());
+    }
     if coefficient == -1.0 {
         write!(f, "-")?;
     } else if coefficient != 1.0 {
-        if let Some(precision) = f.precision() {
-            write!(f, "{1:.0$}", precision, coefficient)?;
-        } else {
-            write!(f, "{}", coefficient)?;
-        }
+        write_f64_with_precision(f, coefficient)?;
     }
-    if coefficient != 1.0 && !ids.is_empty() {
+    if coefficient != 1.0 {
         write!(f, "*")?;
     }
     ids.sort_unstable();

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -270,5 +270,13 @@ mod tests {
             "x1 - x2 - 2.00*x3 + 0.33*x4 + 3.00"
         );
         assert_eq!(super::Linear::zero().to_string(), "0");
+
+        let linear = super::Linear::new([(1, 1.0)].into_iter(), 1.0);
+        assert_eq!(linear.to_string(), "x1 + 1");
+        assert_eq!(format!("{:.2}", linear), "x1 + 1.00");
+
+        let linear = super::Linear::new([(1, 1.0)].into_iter(), -1.0);
+        assert_eq!(linear.to_string(), "x1 - 1");
+        assert_eq!(format!("{:.2}", linear), "x1 - 1.00");
     }
 }


### PR DESCRIPTION
Split from #134 

- Implementation of `Display` trait is incorrect when the constraint is `1.0`