### PR TITLE
QUBO and PUBO format output

### DIFF
--- a/rust/ommx/src/convert.rs
+++ b/rust/ommx/src/convert.rs
@@ -143,6 +143,7 @@ macro_rules! test_algebraic {
 
 mod format;
 mod function;
+mod instance;
 mod linear;
 mod polynomial;
 mod quadratic;

--- a/rust/ommx/src/convert/function.rs
+++ b/rust/ommx/src/convert/function.rs
@@ -84,6 +84,24 @@ impl FromIterator<(Vec<u64>, f64)> for Function {
     }
 }
 
+impl<'a> IntoIterator for &'a Function {
+    type Item = (Vec<u64>, f64);
+    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.function.as_ref().expect("Empty Function") {
+            FunctionEnum::Constant(c) => Box::new(std::iter::once((vec![], *c))),
+            FunctionEnum::Linear(linear) => Box::new(
+                linear
+                    .into_iter()
+                    .map(|(k, v)| (k.into_iter().collect(), v)),
+            ),
+            FunctionEnum::Quadratic(quadratic) => quadratic.into_iter(),
+            FunctionEnum::Polynomial(poly) => poly.into_iter(),
+        }
+    }
+}
+
 impl Function {
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
         match &self.function {

--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -1,0 +1,42 @@
+use crate::v1::{decision_variable::Kind, Instance};
+use anyhow::{bail, Context, Result};
+use std::collections::{BTreeMap, BTreeSet};
+
+impl Instance {
+    fn binary_variables(&self) -> BTreeSet<u64> {
+        self.decision_variables
+            .iter()
+            .filter_map(|v| {
+                if v.kind == Kind::Binary as i32 {
+                    Some(v.id)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn to_pubo(&self) -> Result<BTreeMap<Vec<u64>, f64>> {
+        let binary = self.binary_variables();
+
+        let objective = self
+            .objective
+            .as_ref()
+            .context("No objective found in the instance")?;
+
+        if !objective.used_decision_variable_ids().is_subset(&binary) {
+            bail!("Objective contains non-binary variables");
+        }
+
+        let objective_pubo: BTreeMap<Vec<u64>, f64> = objective
+            .into_iter()
+            .map(|(mut id, coefficient)| {
+                // Order reduction for binary variable by x^2 = x
+                id.dedup();
+                (id, coefficient)
+            })
+            .collect();
+
+        Ok(objective_pubo)
+    }
+}

--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -40,8 +40,20 @@ impl Instance {
         Ok(objective_pubo)
     }
 
-    pub fn to_qubo(&self) -> Result<(BTreeMap<(u64, u64), f64>, f64)> {
-        let pubo = self.to_pubo()?;
+    pub fn to_qubo(&self) -> Result<Qubo> {
+        Qubo::from_pubo(self.to_pubo()?)
+    }
+}
+
+/// Quadratic unconstrained binary optimization (QUBO)
+#[derive(Debug, Clone)]
+pub struct Qubo {
+    pub qubo: BTreeMap<(u64, u64), f64>,
+    pub constant: f64,
+}
+
+impl Qubo {
+    pub fn from_pubo(pubo: BTreeMap<Vec<u64>, f64>) -> Result<Self> {
         let mut constant = 0.0;
         let mut qubo = BTreeMap::new();
         for (id, coefficient) in pubo {
@@ -55,9 +67,9 @@ impl Instance {
                 [] => {
                     constant += coefficient;
                 }
-                _ => bail!("QUBO can only contain pairs of variables"),
+                _ => bail!("Higher order terms are not supported: {id:?}"),
             }
         }
-        Ok((qubo, constant))
+        Ok(Self { qubo, constant })
     }
 }

--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -39,4 +39,25 @@ impl Instance {
 
         Ok(objective_pubo)
     }
+
+    pub fn to_qubo(&self) -> Result<(BTreeMap<(u64, u64), f64>, f64)> {
+        let pubo = self.to_pubo()?;
+        let mut constant = 0.0;
+        let mut qubo = BTreeMap::new();
+        for (id, coefficient) in pubo {
+            match id[..] {
+                [a, b] => {
+                    qubo.insert((a, b), coefficient);
+                }
+                [a] => {
+                    qubo.insert((a, a), coefficient);
+                }
+                [] => {
+                    constant += coefficient;
+                }
+                _ => bail!("QUBO can only contain pairs of variables"),
+            }
+        }
+        Ok((qubo, constant))
+    }
 }

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -50,7 +50,10 @@ impl Linear {
         self.terms.iter().map(|term| term.id).collect()
     }
 
-    pub fn to_qubo(&self) -> (BTreeMap<(u64, u64), f64>, f64) {
+    /// Convert to QUBO format, which may contain non-binary variables.
+    ///
+    /// This returns a valid QUBO only when `self` consists of binary variables.
+    pub(crate) fn to_qubo_format(&self) -> (BTreeMap<(u64, u64), f64>, f64) {
         (
             self.terms
                 .iter()
@@ -60,7 +63,10 @@ impl Linear {
         )
     }
 
-    pub fn to_pubo(&self) -> BTreeMap<Vec<u64>, f64> {
+    /// Convert to PUBO format, which may contain non-binary variables.
+    ///
+    /// This returns a valid PUBO only when `self` consists of binary variables.
+    pub(crate) fn to_pubo_format(&self) -> BTreeMap<Vec<u64>, f64> {
         self.terms
             .iter()
             .map(|term| (vec![term.id], term.coefficient))
@@ -301,7 +307,7 @@ mod tests {
     #[test]
     fn to_qubo() {
         let linear = super::Linear::new([(1, 1.0), (2, -1.0), (3, -2.0)].into_iter(), 3.0);
-        let (qubo, constant) = linear.to_qubo();
+        let (qubo, constant) = linear.to_qubo_format();
         assert_eq!(qubo.len(), 3);
         assert_eq!(qubo[&(1, 1)], 1.0);
         assert_eq!(qubo[&(2, 2)], -1.0);
@@ -312,7 +318,7 @@ mod tests {
     #[test]
     fn to_pubo() {
         let linear = super::Linear::new([(1, 1.0), (2, -1.0), (3, -2.0)].into_iter(), 3.0);
-        let pubo = linear.to_pubo();
+        let pubo = linear.to_pubo_format();
         assert_eq!(pubo.len(), 4);
         assert_eq!(pubo[&vec![1]], 1.0);
         assert_eq!(pubo[&vec![2]], -1.0);

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -49,6 +49,24 @@ impl Linear {
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
         self.terms.iter().map(|term| term.id).collect()
     }
+
+    pub fn to_qubo(&self) -> (BTreeMap<(u64, u64), f64>, f64) {
+        (
+            self.terms
+                .iter()
+                .map(|term| ((term.id, term.id), term.coefficient))
+                .collect(),
+            self.constant,
+        )
+    }
+
+    pub fn to_pubo(&self) -> BTreeMap<Vec<u64>, f64> {
+        self.terms
+            .iter()
+            .map(|term| (vec![term.id], term.coefficient))
+            .chain(std::iter::once((vec![], self.constant)))
+            .collect()
+    }
 }
 
 /// Create a linear function with a single term by regarding the input as the id of the term.
@@ -278,5 +296,27 @@ mod tests {
         let linear = super::Linear::new([(1, 1.0)].into_iter(), -1.0);
         assert_eq!(linear.to_string(), "x1 - 1");
         assert_eq!(format!("{:.2}", linear), "x1 - 1.00");
+    }
+
+    #[test]
+    fn to_qubo() {
+        let linear = super::Linear::new([(1, 1.0), (2, -1.0), (3, -2.0)].into_iter(), 3.0);
+        let (qubo, constant) = linear.to_qubo();
+        assert_eq!(qubo.len(), 3);
+        assert_eq!(qubo[&(1, 1)], 1.0);
+        assert_eq!(qubo[&(2, 2)], -1.0);
+        assert_eq!(qubo[&(3, 3)], -2.0);
+        assert_eq!(constant, 3.0);
+    }
+
+    #[test]
+    fn to_pubo() {
+        let linear = super::Linear::new([(1, 1.0), (2, -1.0), (3, -2.0)].into_iter(), 3.0);
+        let pubo = linear.to_pubo();
+        assert_eq!(pubo.len(), 4);
+        assert_eq!(pubo[&vec![1]], 1.0);
+        assert_eq!(pubo[&vec![2]], -1.0);
+        assert_eq!(pubo[&vec![3]], -2.0);
+        assert_eq!(pubo[&vec![]], 3.0);
     }
 }

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -49,30 +49,6 @@ impl Linear {
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
         self.terms.iter().map(|term| term.id).collect()
     }
-
-    /// Convert to QUBO format, which may contain non-binary variables.
-    ///
-    /// This returns a valid QUBO only when `self` consists of binary variables.
-    pub(crate) fn to_qubo_format(&self) -> (BTreeMap<(u64, u64), f64>, f64) {
-        (
-            self.terms
-                .iter()
-                .map(|term| ((term.id, term.id), term.coefficient))
-                .collect(),
-            self.constant,
-        )
-    }
-
-    /// Convert to PUBO format, which may contain non-binary variables.
-    ///
-    /// This returns a valid PUBO only when `self` consists of binary variables.
-    pub(crate) fn to_pubo_format(&self) -> BTreeMap<Vec<u64>, f64> {
-        self.terms
-            .iter()
-            .map(|term| (vec![term.id], term.coefficient))
-            .chain(std::iter::once((vec![], self.constant)))
-            .collect()
-    }
 }
 
 /// Create a linear function with a single term by regarding the input as the id of the term.
@@ -302,27 +278,5 @@ mod tests {
         let linear = super::Linear::new([(1, 1.0)].into_iter(), -1.0);
         assert_eq!(linear.to_string(), "x1 - 1");
         assert_eq!(format!("{:.2}", linear), "x1 - 1.00");
-    }
-
-    #[test]
-    fn to_qubo() {
-        let linear = super::Linear::new([(1, 1.0), (2, -1.0), (3, -2.0)].into_iter(), 3.0);
-        let (qubo, constant) = linear.to_qubo_format();
-        assert_eq!(qubo.len(), 3);
-        assert_eq!(qubo[&(1, 1)], 1.0);
-        assert_eq!(qubo[&(2, 2)], -1.0);
-        assert_eq!(qubo[&(3, 3)], -2.0);
-        assert_eq!(constant, 3.0);
-    }
-
-    #[test]
-    fn to_pubo() {
-        let linear = super::Linear::new([(1, 1.0), (2, -1.0), (3, -2.0)].into_iter(), 3.0);
-        let pubo = linear.to_pubo_format();
-        assert_eq!(pubo.len(), 4);
-        assert_eq!(pubo[&vec![1]], 1.0);
-        assert_eq!(pubo[&vec![2]], -1.0);
-        assert_eq!(pubo[&vec![3]], -2.0);
-        assert_eq!(pubo[&vec![]], 3.0);
     }
 }


### PR DESCRIPTION
- This PR adds methods `to_qubo` and `to_pubo` to create Quadratic Unconstrained Binary Optimization (QUBO) and Polynomial ... (PUBO) formats.
- PUBO contains arbitrary order of polynomial, i.e. QUBO is also a valid PUBO. Since the maximum order may be linear or quadratic, we use PUBO instead of HUBO (higher-order ...).