### PR TITLE
`dual_variable` and `penalty_weight` in `Constraint` message for QUBO

### DIFF
--- a/proto/ommx/v1/constraint.proto
+++ b/proto/ommx/v1/constraint.proto
@@ -42,6 +42,19 @@ message Constraint {
 
   // Detail human-readable description of the constraint.
   optional string description = 7;
+
+  // Temporal value for the Lagrangian dual variable of this constraint.
+  //
+  // This field is intended to use for storing the temporal dual variable value during the optimization process.
+  // This will be different from the optimal dual variable value.
+  //
+  // This field is also allowed to use for modified dual variable like appearing augmented Lagrangian method,
+  // which uses modified Lagrangian and thus the dual variable is also modified.
+  //
+  optional double dual_variable = 9;
+
+  // Weight of the penalty term for the constraint.
+  optional double penalty_weight = 10;
 }
 
 // A constraint evaluated with a state

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -1210,6 +1210,14 @@ class Constraint:
         self.raw.parameters.update(parameters)
         return self
 
+    def set_dual_variable(self, value: float) -> Constraint:
+        self.raw.dual_variable = value
+        return self
+
+    def set_penalty_weight(self, value: float) -> Constraint:
+        self.raw.penalty_weight = value
+        return self
+
     @property
     def function(self) -> Function:
         return Function(self.raw.function)
@@ -1237,6 +1245,14 @@ class Constraint:
     @property
     def parameters(self) -> dict[str, str]:
         return dict(self.raw.parameters)
+
+    @property
+    def dual_variable(self) -> float:
+        return self.raw.dual_variable
+
+    @property
+    def penalty_weight(self) -> float:
+        return self.raw.penalty_weight
 
     def __repr__(self) -> str:
         if self.raw.equality == Equality.EQUALITY_EQUAL_TO_ZERO:

--- a/python/ommx/ommx/v1/constraint_pb2.py
+++ b/python/ommx/ommx/v1/constraint_pb2.py
@@ -17,7 +17,7 @@ from ommx.v1 import function_pb2 as ommx_dot_v1_dot_function__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b"\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto\"\xf7\x02\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x1e\n\nsubscripts\x18\x08 \x03(\x03R\nsubscripts\x12\x43\n\nparameters\x18\x05 \x03(\x0b\x32#.ommx.v1.Constraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description\"\xfc\x03\n\x13\x45valuatedConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12'\n\x0f\x65valuated_value\x18\x03 \x01(\x01R\x0e\x65valuatedValue\x12;\n\x1aused_decision_variable_ids\x18\x04 \x03(\x04R\x17usedDecisionVariableIds\x12\x1e\n\nsubscripts\x18\t \x03(\x03R\nsubscripts\x12L\n\nparameters\x18\x05 \x03(\x0b\x32,.ommx.v1.EvaluatedConstraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12(\n\rdual_variable\x18\x08 \x01(\x01H\x02R\x0c\x64ualVariable\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\x10\n\x0e_dual_variable*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3"
+    b"\n\x18ommx/v1/constraint.proto\x12\x07ommx.v1\x1a\x16ommx/v1/function.proto\"\xf2\x03\n\nConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12-\n\x08\x66unction\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x08\x66unction\x12\x1e\n\nsubscripts\x18\x08 \x03(\x03R\nsubscripts\x12\x43\n\nparameters\x18\x05 \x03(\x0b\x32#.ommx.v1.Constraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12(\n\rdual_variable\x18\t \x01(\x01H\x02R\x0c\x64ualVariable\x88\x01\x01\x12*\n\x0epenalty_weight\x18\n \x01(\x01H\x03R\rpenaltyWeight\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\x10\n\x0e_dual_variableB\x11\n\x0f_penalty_weight\"\xfc\x03\n\x13\x45valuatedConstraint\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12-\n\x08\x65quality\x18\x02 \x01(\x0e\x32\x11.ommx.v1.EqualityR\x08\x65quality\x12'\n\x0f\x65valuated_value\x18\x03 \x01(\x01R\x0e\x65valuatedValue\x12;\n\x1aused_decision_variable_ids\x18\x04 \x03(\x04R\x17usedDecisionVariableIds\x12\x1e\n\nsubscripts\x18\t \x03(\x03R\nsubscripts\x12L\n\nparameters\x18\x05 \x03(\x0b\x32,.ommx.v1.EvaluatedConstraint.ParametersEntryR\nparameters\x12\x17\n\x04name\x18\x06 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x07 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12(\n\rdual_variable\x18\x08 \x01(\x01H\x02R\x0c\x64ualVariable\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\x10\n\x0e_dual_variable*i\n\x08\x45quality\x12\x18\n\x14\x45QUALITY_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x45QUALITY_EQUAL_TO_ZERO\x10\x01\x12'\n#EQUALITY_LESS_THAN_OR_EQUAL_TO_ZERO\x10\x02\x42[\n\x0b\x63om.ommx.v1B\x0f\x43onstraintProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3"
 )
 
 _globals = globals()
@@ -32,14 +32,14 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_options = b"8\001"
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._loaded_options = None
     _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_options = b"8\001"
-    _globals["_EQUALITY"]._serialized_start = 950
-    _globals["_EQUALITY"]._serialized_end = 1055
+    _globals["_EQUALITY"]._serialized_start = 1073
+    _globals["_EQUALITY"]._serialized_end = 1178
     _globals["_CONSTRAINT"]._serialized_start = 62
-    _globals["_CONSTRAINT"]._serialized_end = 437
-    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_start = 351
-    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_end = 412
-    _globals["_EVALUATEDCONSTRAINT"]._serialized_start = 440
-    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 948
-    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_start = 351
-    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_end = 412
+    _globals["_CONSTRAINT"]._serialized_end = 560
+    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_start = 437
+    _globals["_CONSTRAINT_PARAMETERSENTRY"]._serialized_end = 498
+    _globals["_EVALUATEDCONSTRAINT"]._serialized_start = 563
+    _globals["_EVALUATEDCONSTRAINT"]._serialized_end = 1071
+    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_start = 437
+    _globals["_EVALUATEDCONSTRAINT_PARAMETERSENTRY"]._serialized_end = 498
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/ommx/v1/constraint_pb2.pyi
+++ b/python/ommx/ommx/v1/constraint_pb2.pyi
@@ -70,6 +70,8 @@ class Constraint(google.protobuf.message.Message):
     PARAMETERS_FIELD_NUMBER: builtins.int
     NAME_FIELD_NUMBER: builtins.int
     DESCRIPTION_FIELD_NUMBER: builtins.int
+    DUAL_VARIABLE_FIELD_NUMBER: builtins.int
+    PENALTY_WEIGHT_FIELD_NUMBER: builtins.int
     id: builtins.int
     """Constraint ID
 
@@ -84,6 +86,17 @@ class Constraint(google.protobuf.message.Message):
     """Name of the constraint."""
     description: builtins.str
     """Detail human-readable description of the constraint."""
+    dual_variable: builtins.float
+    """Temporal value for the Lagrangian dual variable of this constraint.
+
+    This field is intended to use for storing the temporal dual variable value during the optimization process.
+    This will be different from the optimal dual variable value.
+
+    This field is also allowed to use for modified dual variable like appearing augmented Lagrangian method,
+    which uses modified Lagrangian and thus the dual variable is also modified.
+    """
+    penalty_weight: builtins.float
+    """Weight of the penalty term for the constraint."""
     @property
     def function(self) -> ommx.v1.function_pb2.Function: ...
     @property
@@ -114,20 +127,30 @@ class Constraint(google.protobuf.message.Message):
         parameters: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
         name: builtins.str | None = ...,
         description: builtins.str | None = ...,
+        dual_variable: builtins.float | None = ...,
+        penalty_weight: builtins.float | None = ...,
     ) -> None: ...
     def HasField(
         self,
         field_name: typing.Literal[
             "_description",
             b"_description",
+            "_dual_variable",
+            b"_dual_variable",
             "_name",
             b"_name",
+            "_penalty_weight",
+            b"_penalty_weight",
             "description",
             b"description",
+            "dual_variable",
+            b"dual_variable",
             "function",
             b"function",
             "name",
             b"name",
+            "penalty_weight",
+            b"penalty_weight",
         ],
     ) -> builtins.bool: ...
     def ClearField(
@@ -135,10 +158,16 @@ class Constraint(google.protobuf.message.Message):
         field_name: typing.Literal[
             "_description",
             b"_description",
+            "_dual_variable",
+            b"_dual_variable",
             "_name",
             b"_name",
+            "_penalty_weight",
+            b"_penalty_weight",
             "description",
             b"description",
+            "dual_variable",
+            b"dual_variable",
             "equality",
             b"equality",
             "function",
@@ -149,6 +178,8 @@ class Constraint(google.protobuf.message.Message):
             b"name",
             "parameters",
             b"parameters",
+            "penalty_weight",
+            b"penalty_weight",
             "subscripts",
             b"subscripts",
         ],
@@ -159,8 +190,16 @@ class Constraint(google.protobuf.message.Message):
     ) -> typing.Literal["description"] | None: ...
     @typing.overload
     def WhichOneof(
+        self, oneof_group: typing.Literal["_dual_variable", b"_dual_variable"]
+    ) -> typing.Literal["dual_variable"] | None: ...
+    @typing.overload
+    def WhichOneof(
         self, oneof_group: typing.Literal["_name", b"_name"]
     ) -> typing.Literal["name"] | None: ...
+    @typing.overload
+    def WhichOneof(
+        self, oneof_group: typing.Literal["_penalty_weight", b"_penalty_weight"]
+    ) -> typing.Literal["penalty_weight"] | None: ...
 
 global___Constraint = Constraint
 

--- a/rust/ommx/src/mps/convert.rs
+++ b/rust/ommx/src/mps/convert.rs
@@ -105,6 +105,8 @@ fn convert_constraints(mps: &Mps, name_id_map: &HashMap<ColumnName, u64>) -> Vec
             parameters: HashMap::new(),
             name: Some(row_name.0.clone()),
             description: None,
+            dual_variable: None,
+            penalty_weight: None,
         })
     }
     constrs

--- a/rust/ommx/src/ommx.v1.rs
+++ b/rust/ommx/src/ommx.v1.rs
@@ -126,6 +126,19 @@ pub struct Constraint {
     /// Detail human-readable description of the constraint.
     #[prost(string, optional, tag = "7")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
+    /// Temporal value for the Lagrangian dual variable of this constraint.
+    ///
+    /// This field is intended to use for storing the temporal dual variable value during the optimization process.
+    /// This will be different from the optimal dual variable value.
+    ///
+    /// This field is also allowed to use for modified dual variable like appearing augmented Lagrangian method,
+    /// which uses modified Lagrangian and thus the dual variable is also modified.
+    ///
+    #[prost(double, optional, tag = "9")]
+    pub dual_variable: ::core::option::Option<f64>,
+    /// Weight of the penalty term for the constraint.
+    #[prost(double, optional, tag = "10")]
+    pub penalty_weight: ::core::option::Option<f64>,
 }
 /// A constraint evaluated with a state
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
# Summary

- Add optional fields, `dual_variable` and `penalty_weight` in `Constraint` message.
- This will be used in #143 to create unconstrained problem. #143 will support two way to create QUBO and PUBO, penalty method and augmented Lagrangian method

# Detail
For a problem 

$$
\begin{align*}
  \min & f(x) \\
  \text{s.t.} & g(x) = 0
\end{align*}
$$

- Penalty method try to minimize $f(x) + \rho |g(x)|^2$, where $\rho$ is called penalty weight.
- Augmented Lagrangian method try to minimize $f(x) + \lambda g(x) + \rho |g(x)|^2$, where $\lambda$ is current dual variable and $\rho$ is also a penalty weight.

`dual_variable` field is intended to store $\lambda$, and `penalty_weight` stores $\rho$ in this sense.