### PR TITLE
Add `model_to_solution` and `model_to_state`.

### DIFF
--- a/python/ommx-python-mip-adapter/README.md
+++ b/python/ommx-python-mip-adapter/README.md
@@ -60,7 +60,7 @@ ommx_instance = Instance.from_components(
 model = adapter.instance_to_model(ommx_instance)
 model.optimize()
 # Create `ommx.v1.State` from Optimized `mip.Model`
-ommx_solutions = adapter.model_to_solution(model, ommx_instance)
+ommx_solutions = adapter.model_to_state(model, ommx_instance)
 
 print(ommx_solutions)
 ```

--- a/python/ommx-python-mip-adapter/README.md
+++ b/python/ommx-python-mip-adapter/README.md
@@ -17,7 +17,7 @@ sequenceDiagram
     P->>P: Solve with CBC, Gurobi, or other solvers
     P->>U: Optimized model
     U->>A: Optimized model and ommx.v1.Instance
-    A->>U: ommx:SolutionList
+    A->>U: ommx.v1.Solution
 ```
 
 Python-MIP as a user interface to create OMMX instance

--- a/python/ommx-python-mip-adapter/README.md
+++ b/python/ommx-python-mip-adapter/README.md
@@ -60,9 +60,9 @@ ommx_instance = Instance.from_components(
 model = adapter.instance_to_model(ommx_instance)
 model.optimize()
 # Create `ommx.v1.State` from Optimized `mip.Model`
-ommx_solutions = adapter.model_to_state(model, ommx_instance)
+ommx_state = adapter.model_to_state(model, ommx_instance)
 
-print(ommx_solutions)
+print(ommx_state)
 ```
 
 You can get `ommx.v1.Instance` from a Python-MIP model as the following:

--- a/python/ommx-python-mip-adapter/docs/source/conf.py
+++ b/python/ommx-python-mip-adapter/docs/source/conf.py
@@ -12,7 +12,7 @@ project = "ommx-python-mip-adapter"
 copyright = "2024, Jij Inc."
 author = "Jij Inc."
 
-version = "1.3.2"
+version = "1.4.0"
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/__init__.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/__init__.py
@@ -3,12 +3,14 @@ from .python_mip_to_ommx import (
     OMMXInstanceBuilder,
     model_to_instance,
     model_to_state,
+    model_to_solution,
 )
 
 __all__ = [
     "instance_to_model",
     "model_to_instance",
     "model_to_state",
+    "model_to_solution",
     "PythonMIPBuilder",
     "OMMXInstanceBuilder",
     "solve",

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/__init__.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/__init__.py
@@ -2,13 +2,13 @@ from .ommx_to_python_mip import PythonMIPBuilder, instance_to_model, solve
 from .python_mip_to_ommx import (
     OMMXInstanceBuilder,
     model_to_instance,
-    model_to_solution,
+    model_to_state,
 )
 
 __all__ = [
     "instance_to_model",
     "model_to_instance",
-    "model_to_solution",
+    "model_to_state",
     "PythonMIPBuilder",
     "OMMXInstanceBuilder",
     "solve",

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/ommx_to_python_mip.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/ommx_to_python_mip.py
@@ -154,8 +154,8 @@ def instance_to_model(
         >>> model.optimize()
         <OptimizationStatus.OPTIMAL: 0>
 
-        >>> ommx_solutions = adapter.model_to_state(model, ommx_instance)
-        >>> ommx_solutions.entries
+        >>> ommx_state = adapter.model_to_state(model, ommx_instance)
+        >>> ommx_state.entries
         {1: 0.0}
     """
     builder = PythonMIPBuilder(

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/ommx_to_python_mip.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/ommx_to_python_mip.py
@@ -10,7 +10,7 @@ from ommx.v1.solution_pb2 import Optimality, Result, Infeasible, Unbounded, Rela
 from ommx.v1 import Instance, DecisionVariable, Constraint
 
 from .exception import OMMXPythonMIPAdapterError
-from .python_mip_to_ommx import model_to_solution
+from .python_mip_to_ommx import model_to_state
 
 
 @dataclass
@@ -154,7 +154,7 @@ def instance_to_model(
         >>> model.optimize()
         <OptimizationStatus.OPTIMAL: 0>
 
-        >>> ommx_solutions = adapter.model_to_solution(model, ommx_instance)
+        >>> ommx_solutions = adapter.model_to_state(model, ommx_instance)
         >>> ommx_solutions.entries
         {1: 0.0}
     """
@@ -303,7 +303,7 @@ def solve(
     ]:
         return Result(error=f"Unknown status: {model.status}")
 
-    state = model_to_solution(model, instance)
+    state = model_to_state(model, instance)
     solution = instance.evaluate(state)
 
     assert solution.raw.feasible

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
@@ -180,8 +180,8 @@ def model_to_state(
         >>> model.optimize()
         <OptimizationStatus.OPTIMAL: 0>
 
-        >>> ommx_solutions = adapter.model_to_state(model, ommx_instance)
-        >>> ommx_solutions.entries
+        >>> ommx_state = adapter.model_to_state(model, ommx_instance)
+        >>> ommx_state.entries
         {1: 0.0}
     """
     if not (
@@ -213,7 +213,6 @@ def model_to_solution(
     .. doctest::
 
         >>> from ommx.v1 import Instance, DecisionVariable
-        >>> from ommx.v1.solution_pb2 import Optimality
         >>> from ommx_python_mip_adapter import instance_to_model, model_to_solution
 
         >>> p = [10, 13, 18, 31, 7, 15]

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
@@ -152,7 +152,7 @@ def model_to_instance(model: mip.Model) -> Instance:
     return builder.build()
 
 
-def model_to_solution(
+def model_to_state(
     model: mip.Model,
     instance: Instance,
 ) -> State:
@@ -180,7 +180,7 @@ def model_to_solution(
         >>> model.optimize()
         <OptimizationStatus.OPTIMAL: 0>
 
-        >>> ommx_solutions = adapter.model_to_solution(model, ommx_instance)
+        >>> ommx_solutions = adapter.model_to_state(model, ommx_instance)
         >>> ommx_solutions.entries
         {1: 0.0}
     """

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_python_mip_adapter"
-version = "1.3.2"
+version = "1.4.0"
 
 description = "An adapter for the Python-MIP from/to OMMX."
 authors = [
@@ -23,7 +23,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "ommx >= 1.3.2, < 2.0.0",
+    "ommx >= 1.4.0, < 2.0.0",
 
     # FIXME: This project requires latest version of Python-MIP (will be 1.16.0?), which does not release yet.
     #        https://github.com/coin-or/python-mip/issues/384

--- a/python/ommx-python-mip-adapter/tests/test_integration.py
+++ b/python/ommx-python-mip-adapter/tests/test_integration.py
@@ -21,7 +21,7 @@ def test_integration_lp(generater):
 
     model = adapter.instance_to_model(ommx_instance_bytes)
     model.optimize()
-    ommx_solution = adapter.model_to_solution(model, ommx_instance_bytes)
+    ommx_solution = adapter.model_to_state(model, ommx_instance_bytes)
     expected_solution = generater.get_v1_state()
     assert ommx_solution.entries.keys() == expected_solution.entries.keys()
     for key in ommx_solution.entries.keys():
@@ -54,7 +54,7 @@ def test_integration_milp():
 
     model = adapter.instance_to_model(ommx_instance)
     model.optimize()
-    ommx_solution = adapter.model_to_solution(model, ommx_instance)
+    ommx_solution = adapter.model_to_state(model, ommx_instance)
 
     assert ommx_solution.entries[1] == pytest.approx(3)
     assert ommx_solution.entries[2] == pytest.approx(3)

--- a/python/ommx-python-mip-adapter/tests/test_integration.py
+++ b/python/ommx-python-mip-adapter/tests/test_integration.py
@@ -21,13 +21,11 @@ def test_integration_lp(generater):
 
     model = adapter.instance_to_model(ommx_instance_bytes)
     model.optimize()
-    ommx_solution = adapter.model_to_state(model, ommx_instance_bytes)
+    ommx_state = adapter.model_to_state(model, ommx_instance_bytes)
     expected_solution = generater.get_v1_state()
-    assert ommx_solution.entries.keys() == expected_solution.entries.keys()
-    for key in ommx_solution.entries.keys():
-        assert ommx_solution.entries[key] == pytest.approx(
-            expected_solution.entries[key]
-        )
+    assert ommx_state.entries.keys() == expected_solution.entries.keys()
+    for key in ommx_state.entries.keys():
+        assert ommx_state.entries[key] == pytest.approx(expected_solution.entries[key])
 
 
 def test_integration_milp():
@@ -54,7 +52,7 @@ def test_integration_milp():
 
     model = adapter.instance_to_model(ommx_instance)
     model.optimize()
-    ommx_solution = adapter.model_to_state(model, ommx_instance)
+    ommx_state = adapter.model_to_state(model, ommx_instance)
 
-    assert ommx_solution.entries[1] == pytest.approx(3)
-    assert ommx_solution.entries[2] == pytest.approx(3)
+    assert ommx_state.entries[1] == pytest.approx(3)
+    assert ommx_state.entries[2] == pytest.approx(3)

--- a/python/ommx/docs/source/conf.py
+++ b/python/ommx/docs/source/conf.py
@@ -13,7 +13,7 @@ project = "ommx"
 copyright = "2024, Jij Inc."
 author = "Jij Inc."
 
-version = "1.3.2"
+version = "1.4.0"
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "ommx"
 
-version = "1.3.2"
+version = "1.4.0"
 description = "Open Mathematical prograMming eXchange (OMMX)"
 authors = [{ name="Jij Inc.", email="info@j-ij.com" }]
 readme = "README.md"


### PR DESCRIPTION
# 変更点
- 変更前の時点では、`model_to_solution` 関数が`ommx.v1.State`を返している状態だったため、関数名を`model_to_state`に変更しました
- `ommx.v1.Solution`を返す関数`model_to_solution`を新しく実装しました
- この変更に伴い、`solve`関数の内部処理を新規実装した`model_to_solution`に置き換えました

# 注意事項
`model_to_solution`関数の破壊的変更のため、最低でもマイナーバーションを上げる必要があります。