### PR TITLE
Custom GitHub Actions for install executables

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -36,6 +36,7 @@ runs:
         cache: "pip"
 
     - name: Setup ruff
+      shell: bash
       run: |
         pip install "ruff >= 0.7.0, < 0.8.0"
         ruff --version

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -1,6 +1,12 @@
 name: "Setup Test Environment"
 description: "Setup common environment for testing jobs"
 
+inputs:
+  python-version:
+    description: "Python version to setup"
+    required: true
+    default: "3.8"
+
 runs:
   using: "composite"
   steps:
@@ -22,3 +28,9 @@ runs:
 
     - name: Setup caching for Rust
       uses: Swatinem/rust-cache@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: "pip"

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -34,3 +34,8 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: "pip"
+
+    - name: Setup ruff
+      run: |
+        pip install "ruff >= 0.7.0, < 0.8.0"
+        ruff --version

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -1,0 +1,27 @@
+name: "Setup Test Environment"
+description: "Setup common environment for testing jobs"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup protobuf compiler
+      uses: arduino/setup-protoc@v3
+      with:
+        version: "26.1"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup buf
+      uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ github.token }}
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+
+    - name: Setup caching for Rust
+      uses: Swatinem/rust-cache@v2

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        components: rustfmt
+        components: rustfmt, clippy
 
     - name: Setup caching for Rust
       uses: Swatinem/rust-cache@v2

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: arduino/setup-protoc@v3
       with:
         version: "26.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ github.token }}
 
     - name: Setup buf
       uses: bufbuild/buf-setup-action@v1

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -4,9 +4,6 @@ description: "Setup common environment for testing jobs"
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
     - name: Setup protobuf compiler
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,30 +11,14 @@ jobs:
   protogen:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup protobuf compiler
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "26.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.8"
           cache: "pip"
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,6 +11,9 @@ jobs:
   protogen:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup Environment
         uses: ./.github/actions/setup-test-environment
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,12 +17,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-test-environment
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-          cache: "pip"
-
       - name: Install dependencies
         run: |
           pip install "python/ommx/[dev]"
@@ -47,16 +41,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-          cache: "pip"
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
 
       - name: Install dependencies
         run: |
@@ -81,16 +67,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
 
       - name: Install ommx
         run: |
@@ -143,16 +123,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-          cache: "pip"
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,10 +44,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-test-environment
 
-      - name: Install dependencies
-        run: |
-          pip install "python/ommx/[dev]"
-
       - name: Regenerate stub file
         uses: actions-rs/cargo@v1
         with:
@@ -125,10 +121,6 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-test-environment
-
-      - name: Install Dependencies
-        run: |
-          pip install -v -e 'python/ommx/[dev]'
 
       - name: Format
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,9 +14,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
@@ -25,13 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
+
       - uses: giraffate/clippy-action@v1
         with:
           reporter: "github-pr-check"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           clippy_flags: -- -Dwarnings
 
   test:
@@ -40,10 +40,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
 
       - name: Run tests
         run: cargo test
@@ -54,18 +52,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Setup protobuf compiler
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "26.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
 
       - name: Regenerate Rust codes from proto files
         run: cargo run --bin=protogen

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "numpy",
     "pyright",
     "pytest",
-    "ruff",
+    "ruff >= 0.7.0, < 0.8.0",
     "sphinx",
     "sphinx-autoapi",
     "sphinx_fontawesome",

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "networkx",
     "pyright",
     "pytest",
-    "ruff >= 0.4.4, < 0.5.0",
+    "ruff >= 0.7.0, < 0.8.0",
     "sphinx",
     "sphinx-autoapi",
     "sphinx_fontawesome",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+[format]
+exclude = ["*.ipynb"]


### PR DESCRIPTION
- Gather common setups in jobs into `.github/actions/setup-test-environment` 
- Upgrade ruff to 0.7.4
- Replace `pip install -ve python/ommx[dev]` by `pip install ruff` for some cases