### PR TITLE
Partial evaluation of `ommx.v1.Function`

### DIFF
--- a/rust/ommx/src/convert.rs
+++ b/rust/ommx/src/convert.rs
@@ -147,3 +147,9 @@ mod linear;
 mod polynomial;
 mod quadratic;
 mod state;
+
+use proptest::prelude::*;
+
+fn arbitrary_coefficient() -> BoxedStrategy<f64> {
+    prop_oneof![Just(0.0), Just(1.0), Just(-1.0), -1.0..1.0].boxed()
+}

--- a/rust/ommx/src/convert.rs
+++ b/rust/ommx/src/convert.rs
@@ -146,12 +146,4 @@ mod function;
 mod linear;
 mod polynomial;
 mod quadratic;
-
-use crate::v1::State;
-use std::collections::HashMap;
-
-impl From<HashMap<u64, f64>> for State {
-    fn from(entries: HashMap<u64, f64>) -> Self {
-        Self { entries }
-    }
-}
+mod state;

--- a/rust/ommx/src/convert/function.rs
+++ b/rust/ommx/src/convert/function.rs
@@ -93,6 +93,15 @@ impl Function {
             _ => BTreeSet::new(),
         }
     }
+
+    pub fn as_constant(self) -> Option<f64> {
+        match self.function? {
+            FunctionEnum::Constant(c) => Some(c),
+            FunctionEnum::Linear(linear) => linear.as_constant(),
+            FunctionEnum::Quadratic(quadratic) => quadratic.as_constant(),
+            FunctionEnum::Polynomial(poly) => poly.as_constant(),
+        }
+    }
 }
 
 impl Add for Function {

--- a/rust/ommx/src/convert/function.rs
+++ b/rust/ommx/src/convert/function.rs
@@ -217,17 +217,23 @@ impl Product for Function {
 }
 
 impl Arbitrary for Function {
-    type Parameters = ();
+    type Parameters = (usize, usize, u64);
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with((num_terms, max_degree, max_id): Self::Parameters) -> Self::Strategy {
         prop_oneof![
             prop_oneof![Just(0.0), -1.0..1.0_f64].prop_map(Function::from),
-            any::<Linear>().prop_map(Function::from),
-            any::<Quadratic>().prop_map(Function::from),
-            any::<Polynomial>().prop_map(Function::from),
+            Linear::arbitrary_with((num_terms, max_id)).prop_map(Function::from),
+            Quadratic::arbitrary_with((num_terms, max_id)).prop_map(Function::from),
+            Polynomial::arbitrary_with((num_terms, max_degree, max_id)).prop_map(Function::from),
         ]
         .boxed()
+    }
+
+    fn arbitrary() -> Self::Strategy {
+        (0..10_usize, 0..5_usize, 0..10_u64)
+            .prop_flat_map(Self::arbitrary_with)
+            .boxed()
     }
 }
 

--- a/rust/ommx/src/convert/function.rs
+++ b/rust/ommx/src/convert/function.rs
@@ -222,7 +222,7 @@ impl Arbitrary for Function {
 
     fn arbitrary_with((num_terms, max_degree, max_id): Self::Parameters) -> Self::Strategy {
         prop_oneof![
-            prop_oneof![Just(0.0), -1.0..1.0_f64].prop_map(Function::from),
+            super::arbitrary_coefficient().prop_map(Function::from),
             Linear::arbitrary_with((num_terms, max_id)).prop_map(Function::from),
             Quadratic::arbitrary_with((num_terms, max_id)).prop_map(Function::from),
             Polynomial::arbitrary_with((num_terms, max_degree, max_id)).prop_map(Function::from),

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -198,20 +198,21 @@ impl Mul for Linear {
 }
 
 impl Arbitrary for Linear {
-    type Parameters = ();
+    type Parameters = (usize /* num_terms */, u64 /* Max ID */);
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        let num_terms = 0..10_usize;
-        let terms = num_terms.prop_flat_map(|num_terms| {
-            proptest::collection::vec(
-                (0..(2 * num_terms as u64), prop_oneof![Just(0.0), -1.0..1.0]),
-                num_terms,
-            )
-        });
+    fn arbitrary_with((num_terms, max_id): Self::Parameters) -> Self::Strategy {
+        let terms =
+            proptest::collection::vec((0..=max_id, prop_oneof![Just(0.0), -1.0..1.0]), num_terms);
         let constant = prop_oneof![Just(0.0), -1.0..1.0];
         (terms, constant)
             .prop_map(|(terms, constant)| Linear::new(terms.into_iter(), constant))
+            .boxed()
+    }
+
+    fn arbitrary() -> Self::Strategy {
+        (0..5_usize, 0..10_u64)
+            .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }
 }

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -9,6 +9,8 @@ use std::{
     ops::*,
 };
 
+use super::arbitrary_coefficient;
+
 impl Zero for Linear {
     fn zero() -> Self {
         Self::from(0.0)
@@ -202,9 +204,8 @@ impl Arbitrary for Linear {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with((num_terms, max_id): Self::Parameters) -> Self::Strategy {
-        let terms =
-            proptest::collection::vec((0..=max_id, prop_oneof![Just(0.0), -1.0..1.0]), num_terms);
-        let constant = prop_oneof![Just(0.0), -1.0..1.0];
+        let terms = proptest::collection::vec((0..=max_id, arbitrary_coefficient()), num_terms);
+        let constant = arbitrary_coefficient();
         (terms, constant)
             .prop_map(|(terms, constant)| Linear::new(terms.into_iter(), constant))
             .boxed()

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -51,6 +51,15 @@ impl Linear {
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
         self.terms.iter().map(|term| term.id).collect()
     }
+
+    /// Downcast to a constant if the linear function is constant.
+    pub fn as_constant(self) -> Option<f64> {
+        if self.terms.is_empty() {
+            Some(self.constant)
+        } else {
+            None
+        }
+    }
 }
 
 /// Create a linear function with a single term by regarding the input as the id of the term.

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -96,6 +96,23 @@ impl Polynomial {
             .cloned()
             .collect()
     }
+
+    pub fn degree(&self) -> usize {
+        self.terms
+            .iter()
+            .map(|term| term.ids.len())
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Downcast to a constant if the polynomial is a constant.
+    pub fn as_constant(self) -> Option<f64> {
+        if self.terms.len() == 1 && self.terms[0].ids.is_empty() {
+            Some(self.terms[0].coefficient)
+        } else {
+            None
+        }
+    }
 }
 
 impl Add for Polynomial {

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -104,7 +104,11 @@ impl Add for Polynomial {
     fn add(self, rhs: Self) -> Self {
         let mut terms = BTreeMap::new();
         for term in self.terms.iter().chain(rhs.terms.iter()) {
-            *terms.entry(term.ids.clone()).or_default() += term.coefficient;
+            let value: &mut f64 = terms.entry(term.ids.clone()).or_default();
+            *value += term.coefficient;
+            if value.abs() <= f64::EPSILON {
+                terms.remove(&term.ids);
+            }
         }
         Self {
             terms: terms

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -107,11 +107,17 @@ impl Polynomial {
 
     /// Downcast to a constant if the polynomial is a constant.
     pub fn as_constant(self) -> Option<f64> {
-        if self.terms.len() == 1 && self.terms[0].ids.is_empty() {
-            Some(self.terms[0].coefficient)
-        } else {
-            None
+        if self.terms.len() >= 2 {
+            return None;
         }
+        if self.terms.len() == 1 {
+            if self.terms[0].ids.is_empty() {
+                return Some(self.terms[0].coefficient);
+            } else {
+                return None;
+            }
+        }
+        Some(0.0)
     }
 }
 

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -8,7 +8,7 @@ use std::{
     ops::{Add, Mul},
 };
 
-use super::format::format_polynomial;
+use super::{arbitrary_coefficient, format::format_polynomial};
 
 impl Zero for Polynomial {
     fn zero() -> Self {
@@ -167,7 +167,7 @@ impl Arbitrary for Polynomial {
         let terms = proptest::collection::vec(
             (
                 proptest::collection::vec(0..=max_id, 0..=max_degree),
-                prop_oneof![Just(0.0), -1.0..1.0],
+                arbitrary_coefficient(),
             ),
             num_terms,
         );

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -160,21 +160,24 @@ impl_mul_inverse!(Quadratic, Polynomial);
 impl_neg_by_mul!(Polynomial);
 
 impl Arbitrary for Polynomial {
-    type Parameters = ();
+    type Parameters = (usize, usize, u64);
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        let num_terms = 0..10_usize;
-        let terms = num_terms.prop_flat_map(|num_terms| {
-            proptest::collection::vec(
-                (
-                    proptest::collection::vec(0..(2 * num_terms as u64), 0..=num_terms),
-                    prop_oneof![Just(0.0), -1.0..1.0],
-                ),
-                num_terms,
-            )
-        });
+    fn arbitrary_with((num_terms, max_degree, max_id): Self::Parameters) -> Self::Strategy {
+        let terms = proptest::collection::vec(
+            (
+                proptest::collection::vec(0..=max_id, 0..=max_degree),
+                prop_oneof![Just(0.0), -1.0..1.0],
+            ),
+            num_terms,
+        );
         terms.prop_map(|terms| terms.into_iter().collect()).boxed()
+    }
+
+    fn arbitrary() -> Self::Strategy {
+        (0..10_usize, 0..5_usize, 0..10_u64)
+            .prop_flat_map(Self::arbitrary_with)
+            .boxed()
     }
 }
 

--- a/rust/ommx/src/convert/quadratic.rs
+++ b/rust/ommx/src/convert/quadratic.rs
@@ -8,7 +8,7 @@ use std::{
     ops::{Add, Mul},
 };
 
-use super::format::format_polynomial;
+use super::{arbitrary_coefficient, format::format_polynomial};
 
 impl Zero for Quadratic {
     fn zero() -> Self {
@@ -223,7 +223,7 @@ impl Arbitrary for Quadratic {
 
     fn arbitrary_with((num_terms, max_id): Self::Parameters) -> Self::Strategy {
         let terms = proptest::collection::vec(
-            ((0..=max_id, 0..=max_id), prop_oneof![Just(0.0), -1.0..1.0]),
+            ((0..=max_id, 0..=max_id), arbitrary_coefficient()),
             num_terms,
         );
         let linear = Linear::arbitrary_with((num_terms, max_id));

--- a/rust/ommx/src/convert/quadratic.rs
+++ b/rust/ommx/src/convert/quadratic.rs
@@ -46,6 +46,20 @@ impl Quadratic {
             .zip(self.values.iter())
             .map(|((column, row), value)| ((*column, *row), *value))
     }
+
+    /// Downcast to a linear function if the quadratic function is linear.
+    pub fn as_linear(self) -> Option<Linear> {
+        if self.values.iter().all(|v| v.abs() <= f64::EPSILON) {
+            Some(self.linear.unwrap_or_default())
+        } else {
+            None
+        }
+    }
+
+    /// Downcast to a constant if the quadratic function is constant.
+    pub fn as_constant(self) -> Option<f64> {
+        self.as_linear()?.as_constant()
+    }
 }
 
 impl From<f64> for Quadratic {

--- a/rust/ommx/src/convert/state.rs
+++ b/rust/ommx/src/convert/state.rs
@@ -1,0 +1,25 @@
+use crate::v1::State;
+use std::collections::HashMap;
+
+impl From<HashMap<u64, f64>> for State {
+    fn from(value: HashMap<u64, f64>) -> Self {
+        Self { entries: value }
+    }
+}
+
+impl FromIterator<(u64, f64)> for State {
+    fn from_iter<T: IntoIterator<Item = (u64, f64)>>(iter: T) -> Self {
+        Self {
+            entries: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl IntoIterator for State {
+    type Item = (u64, f64);
+    type IntoIter = std::collections::hash_map::IntoIter<u64, f64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
+    }
+}

--- a/rust/ommx/src/convert/state.rs
+++ b/rust/ommx/src/convert/state.rs
@@ -1,4 +1,5 @@
 use crate::v1::State;
+use proptest::prelude::*;
 use std::collections::HashMap;
 
 impl From<HashMap<u64, f64>> for State {
@@ -21,5 +22,22 @@ impl IntoIterator for State {
 
     fn into_iter(self) -> Self::IntoIter {
         self.entries.into_iter()
+    }
+}
+
+impl Arbitrary for State {
+    type Parameters = (usize, u64);
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with((size, max_id): Self::Parameters) -> Self::Strategy {
+        proptest::collection::hash_map(0..=max_id, super::arbitrary_coefficient(), 0..=size)
+            .prop_map(Self::from)
+            .boxed()
+    }
+
+    fn arbitrary() -> Self::Strategy {
+        (0..20_usize, 0..20_u64)
+            .prop_flat_map(Self::arbitrary_with)
+            .boxed()
     }
 }

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -104,7 +104,7 @@ impl Evaluate for Quadratic {
         let mut used = BTreeSet::new();
         let mut linear = BTreeMap::new();
         let mut constant = self.linear.as_ref().map_or(0.0, |l| l.constant);
-        for term in self.linear.iter().map(|l| l.terms.iter()).flatten() {
+        for term in self.linear.iter().flat_map(|l| l.terms.iter()) {
             if let Some(value) = state.entries.get(&term.id) {
                 constant += term.coefficient * value;
                 used.insert(term.id);

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -330,5 +330,33 @@ mod tests {
             let (h_value, _) = (f * g).evaluate(&s).unwrap();
             prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
         }
+
+        #[test]
+        fn linear_partial_eval(mut f in any::<Linear>(), s in any::<State>()) {
+            let Ok((v, _)) = f.evaluate(&s) else { return Ok(()) };
+            let ss = partial_state(&s);
+            f.partial_evaluate(&ss).unwrap();
+            let (u, _) = f.evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(v, u, epsilon = 1e-9));
+        }
+
+        #[test]
+        fn quadratic_partial_eval(mut f in any::<Quadratic>(), s in any::<State>()) {
+            let Ok((v, _)) = f.evaluate(&s) else { return Ok(()) };
+            let ss = partial_state(&s);
+            f.partial_evaluate(&ss).unwrap();
+            let (u, _) = f.evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(v, u, epsilon = 1e-9));
+        }
+    }
+
+    fn partial_state(state: &State) -> State {
+        let mut ss = State::default();
+        for (n, (id, value)) in state.entries.iter().enumerate() {
+            if n % 2 == 0 {
+                ss.entries.insert(*id, *value);
+            }
+        }
+        ss
     }
 }

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -274,63 +274,42 @@ mod tests {
         assert_eq!(linear.terms[0].coefficient, 4.0);
     }
 
+    /// f(x) + g(x) = (f + g)(x)
+    macro_rules! evaluate_add_commutativity {
+        ($t:ty, $name:ident) => {
+            proptest! {
+                #[test]
+                fn $name(f in any::<$t>(), g in any::<$t>(), s in any::<State>()) {
+                    let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+                    let (h_value, _) = (f + g).evaluate(&s).unwrap();
+                    prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
+                }
+            }
+        };
+    }
+    /// f(x) * g(x) = (f * g)(x)
+    macro_rules! evaluate_mul_commutativity {
+        ($t:ty, $name:ident) => {
+            proptest! {
+                #[test]
+                fn $name(f in any::<$t>(), g in any::<$t>(), s in any::<State>()) {
+                    let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+                    let (h_value, _) = (f * g).evaluate(&s).unwrap();
+                    prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
+                }
+            }
+        };
+    }
+    evaluate_add_commutativity!(Linear, linear_evaluate_add_commutativity);
+    evaluate_mul_commutativity!(Linear, linear_evaluate_mul_commutativity);
+    evaluate_add_commutativity!(Quadratic, quadratic_evaluate_add_commutativity);
+    evaluate_mul_commutativity!(Quadratic, quadratic_evaluate_mul_commutativity);
+    evaluate_add_commutativity!(Polynomial, polynomial_evaluate_add_commutativity);
+    evaluate_mul_commutativity!(Polynomial, polynomial_evaluate_mul_commutativity);
+    evaluate_add_commutativity!(Function, function_evaluate_add_commutativity);
+    evaluate_mul_commutativity!(Function, function_evaluate_mul_commutativity);
+
     proptest! {
-        #[test]
-        fn linear_evaluate_add(f in any::<Linear>(), g in any::<Linear>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f + g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
-        #[test]
-        fn linear_evaluate_mul(f in any::<Linear>(), g in any::<Linear>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f * g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
-        #[test]
-        fn quadratic_evaluate_add(f in any::<Quadratic>(), g in any::<Quadratic>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f + g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
-        #[test]
-        fn quadratic_evaluate_mull(f in any::<Quadratic>(), g in any::<Quadratic>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f * g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
-        #[test]
-        fn polynomial_evaluate_add(f in any::<Polynomial>(), g in any::<Polynomial>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f + g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
-        #[test]
-        fn polynomial_evaluate_mul(f in any::<Polynomial>(), g in any::<Polynomial>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f * g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
-        #[test]
-        fn function_evaluate_add(f in any::<Function>(), g in any::<Function>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f + g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
-        #[test]
-        fn function_evaluate_mul(f in any::<Function>(), g in any::<Function>(), s in any::<State>()) {
-            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, _) = (f * g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
-        }
-
         #[test]
         fn linear_partial_eval(mut f in any::<Linear>(), s in any::<State>()) {
             let Ok((v, _)) = f.evaluate(&s) else { return Ok(()) };

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -226,8 +226,11 @@ impl Evaluate for Constraint {
         ))
     }
 
-    fn partial_evaluate(&mut self, _state: &State) -> Result<BTreeSet<u64>> {
-        todo!()
+    fn partial_evaluate(&mut self, state: &State) -> Result<BTreeSet<u64>> {
+        self.function
+            .as_mut()
+            .context("Function is not set")?
+            .partial_evaluate(state)
     }
 }
 
@@ -276,8 +279,17 @@ impl Evaluate for Instance {
         ))
     }
 
-    fn partial_evaluate(&mut self, _state: &State) -> Result<BTreeSet<u64>> {
-        todo!()
+    fn partial_evaluate(&mut self, state: &State) -> Result<BTreeSet<u64>> {
+        let mut used = self
+            .objective
+            .as_mut()
+            .context("Objective is not set")?
+            .partial_evaluate(state)?;
+        for constraints in &mut self.constraints {
+            let mut new = constraints.partial_evaluate(state)?;
+            used.append(&mut new);
+        }
+        Ok(used)
     }
 }
 

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -277,18 +277,16 @@ mod tests {
     proptest! {
         #[test]
         fn linear_evaluate_add(f in any::<Linear>(), g in any::<Linear>(), s in any::<State>()) {
-            let (Ok((f_value, f_used)), Ok((g_value, g_used))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, h_used) = (f + g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(f_value + g_value, h_value));
-            prop_assert_eq!(f_used.union(&g_used).cloned().collect::<BTreeSet<_>>(), h_used);
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f + g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
         }
 
         #[test]
         fn linear_evaluate_mul(f in any::<Linear>(), g in any::<Linear>(), s in any::<State>()) {
-            let (Ok((f_value, f_used)), Ok((g_value, g_used))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
-            let (h_value, h_used) = (f * g).evaluate(&s).unwrap();
-            prop_assert!(abs_diff_eq!(f_value * g_value, h_value));
-            prop_assert_eq!(f_used.union(&g_used).cloned().collect::<BTreeSet<_>>(), h_used);
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f * g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
         }
     }
 }

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -288,5 +288,47 @@ mod tests {
             let (h_value, _) = (f * g).evaluate(&s).unwrap();
             prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
         }
+
+        #[test]
+        fn quadratic_evaluate_add(f in any::<Quadratic>(), g in any::<Quadratic>(), s in any::<State>()) {
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f + g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
+        }
+
+        #[test]
+        fn quadratic_evaluate_mull(f in any::<Quadratic>(), g in any::<Quadratic>(), s in any::<State>()) {
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f * g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
+        }
+
+        #[test]
+        fn polynomial_evaluate_add(f in any::<Polynomial>(), g in any::<Polynomial>(), s in any::<State>()) {
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f + g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
+        }
+
+        #[test]
+        fn polynomial_evaluate_mul(f in any::<Polynomial>(), g in any::<Polynomial>(), s in any::<State>()) {
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f * g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
+        }
+
+        #[test]
+        fn function_evaluate_add(f in any::<Function>(), g in any::<Function>(), s in any::<State>()) {
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f + g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value + g_value), dbg!(h_value), epsilon = 1e-9));
+        }
+
+        #[test]
+        fn function_evaluate_mul(f in any::<Function>(), g in any::<Function>(), s in any::<State>()) {
+            let (Ok((f_value, _)), Ok((g_value, _))) = (f.evaluate(&s), g.evaluate(&s)) else { return Ok(()); };
+            let (h_value, _) = (f * g).evaluate(&s).unwrap();
+            prop_assert!(abs_diff_eq!(dbg!(f_value * g_value), dbg!(h_value), epsilon = 1e-9));
+        }
     }
 }


### PR DESCRIPTION
Split from #146 

- Substitute decision variables partially. For example, substitute $x_1 = 1$ to $x_1 x_2 + x_1 + 1$ yielding $x_2 + 2$