### PR TITLE
Python SDK version updater

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -46,3 +46,6 @@ runs:
       run: |
         pip install "ruff >= 0.7.0, < 0.8.0"
         pip install pytest-github-actions-annotate-failures
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.8"
-      
+
       - name: Build wheel
         run: |
           python -m pip install --upgrade pip build
@@ -129,3 +129,26 @@ jobs:
 
       - name: Upload wheels to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  next_version:
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-test-environment
+        with:
+          python-version: "3.8"
+
+      - name: Bump version
+        run: |
+          echo "NEW_VERSION=$(uv run python/set-version.py)" >> $GITHUB_ENV
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "Start developing OMMX Python SDK ${{ env.NEW_VERSION }}"
+          branch: "python-version-update/${{ env.NEW_VERSION }}"
+          base: "main"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -72,6 +72,21 @@ tasks:
       - markdown-code-runner python/ommx-pyscipopt-adapter/README.md
       - pyright python/ommx-pyscipopt-adapter/
 
+  doc_python:
+    cmds:
+      - task: doc_python_sdk
+      - task: doc_python_mip_adapter
+
+  doc_python_sdk:
+    cmds:
+      - sphinx-build -b html source build
+    dir: python/ommx/docs
+
+  doc_python_mip_adapter:
+    cmds:
+      - sphinx-build -b html source build
+    dir: python/ommx-python-mip-adapter/docs
+
   stubgen:
     cmds:
       - cargo run --bin stub_gen --features=stub_gen

--- a/python/ommx-python-mip-adapter/docs/source/conf.py
+++ b/python/ommx-python-mip-adapter/docs/source/conf.py
@@ -4,6 +4,8 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import sphinx_rtd_theme
+import tomlkit
+from pathlib import Path
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -12,7 +14,9 @@ project = "ommx-python-mip-adapter"
 copyright = "2024, Jij Inc."
 author = "Jij Inc."
 
-version = "1.4.2"
+here = Path(__file__).parent
+pyproject_toml = tomlkit.loads((here.parent.parent / "pyproject.toml").read_text())
+version = str(pyproject_toml["project"]["version"])  # type: ignore
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -37,7 +37,6 @@ Issues = "https://github.com/Jij-Inc/ommx-python-mip-adapter/issues"
 [project.optional-dependencies]
 dev = [
     "markdown-code-runner",
-    "mypy",
     "numpy",
     "pyright",
     "pytest",
@@ -46,4 +45,5 @@ dev = [
     "sphinx-autoapi",
     "sphinx_fontawesome",
     "sphinx_rtd_theme",
+    "tomlkit",
 ]

--- a/python/ommx/docs/source/conf.py
+++ b/python/ommx/docs/source/conf.py
@@ -5,6 +5,8 @@
 
 # -- Path setup --------------------------------------------------------------
 import sphinx_rtd_theme
+import tomlkit
+from pathlib import Path
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -13,7 +15,9 @@ project = "ommx"
 copyright = "2024, Jij Inc."
 author = "Jij Inc."
 
-version = "1.4.2"
+here = Path(__file__).parent
+pyproject_toml = tomlkit.loads((here.parent.parent / "pyproject.toml").read_text())
+version = str(pyproject_toml["project"]["version"])  # type: ignore
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "sphinx-autoapi",
     "sphinx_fontawesome",
     "sphinx_rtd_theme",
+    "tomlkit",
     "types-protobuf>=0.1.14",
 ]
 

--- a/python/set-version.py
+++ b/python/set-version.py
@@ -1,0 +1,76 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#   "tomlkit"
+# ]
+# ///
+
+# Bump up versions of OMMX Python SDK and adapters
+#
+# Usage
+# ------
+#
+# Set the version of the OMMX Python SDK and adapters to the specified version.
+#
+# ```shell
+# uv run python/set-version.py 0.1.0
+# ```
+#
+# Bump up patch version of the OMMX Python SDK and adapters
+#
+# ```shell
+# uv run python/set-version.py
+# ```
+#
+
+from pathlib import Path
+import tomlkit
+import argparse
+
+
+def update_version(pyproject_path: Path, new_version: str):
+    with open(pyproject_path, "r") as file:
+        pyproject_data = tomlkit.parse(file.read())
+
+    pyproject_data["project"]["version"] = new_version  # type: ignore
+
+    with open(pyproject_path, "w") as file:
+        file.write(tomlkit.dumps(pyproject_data))
+
+
+def generrate_next_version(sdk: Path) -> str:
+    with open(sdk, "r") as file:
+        pyproject_data = tomlkit.parse(file.read())
+    current = str(pyproject_data["project"]["version"])  # type: ignore
+    major, minor, patch = current.split(".")
+    return f"{major}.{minor}.{int(patch) + 1}"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", help="New version to set", default=None, nargs="?")
+
+    args = parser.parse_args()
+
+    here = Path(__file__).parent
+    sdk = here / "ommx" / "pyproject.toml"
+    adapters = [
+        here / name / "pyproject.toml"
+        for name in [
+            "ommx-pyscipopt-adapter",
+            "ommx-python-mip-adapter",
+            # Add new adapter here
+        ]
+    ]
+
+    if args.version:
+        new_version = args.version
+    else:
+        new_version = generrate_next_version(sdk)
+
+    for pyproject in [sdk] + adapters:
+        update_version(pyproject, new_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/set-version.py
+++ b/python/set-version.py
@@ -67,6 +67,7 @@ def main():
         new_version = args.version
     else:
         new_version = generrate_next_version(sdk)
+    print(new_version)
 
     for pyproject in [sdk] + adapters:
         update_version(pyproject, new_version)


### PR DESCRIPTION
Add `python/set-version.py` to update versions of Python SDK and adapters. To update specific version (with `uv`):

```shell
uv run python/set-version.py 1.4.2
```

To bump up patch version:

```shell
uv run python/set-version.py
```
