### PR TITLE
Regard `None` for `ommx::v1::Function::function` as zero

### DIFF
--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -147,20 +147,18 @@ impl AbsDiffEq for Instance {
     }
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        let (Some(f), Some(g)) = (&self.objective, &other.objective) else {
-            // Return false if one of instance is invalid
-            return false;
-        };
+        let f = self.objective();
+        let g = other.objective();
         match (self.sense.try_into(), other.sense.try_into()) {
             (Ok(Sense::Minimize), Ok(Sense::Minimize))
             | (Ok(Sense::Maximize), Ok(Sense::Maximize)) => {
-                if !f.abs_diff_eq(g, epsilon) {
+                if !f.abs_diff_eq(&g, epsilon) {
                     return false;
                 }
             }
             (Ok(Sense::Minimize), Ok(Sense::Maximize))
             | (Ok(Sense::Maximize), Ok(Sense::Minimize)) => {
-                if !f.abs_diff_eq(&-g, epsilon) {
+                if !f.abs_diff_eq(&-g.as_ref(), epsilon) {
                     return false;
                 }
             }

--- a/rust/ommx/src/convert/parametric_instance.rs
+++ b/rust/ommx/src/convert/parametric_instance.rs
@@ -2,7 +2,7 @@ use crate::{
     v1::{Function, Instance, Parameters, ParametricInstance, State},
     Evaluate,
 };
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use std::{borrow::Cow, collections::BTreeSet};
 
 impl From<Instance> for ParametricInstance {
@@ -57,10 +57,9 @@ impl ParametricInstance {
         }
 
         let state = State::from(parameters.clone());
-        self.objective
-            .as_mut()
-            .context("Objective function of ParametricInstance is empty")?
-            .partial_evaluate(&state)?;
+        if let Some(f) = self.objective.as_mut() {
+            f.partial_evaluate(&state)?;
+        }
         for constraint in self.constraints.iter_mut() {
             constraint.partial_evaluate(&state)?;
         }

--- a/rust/ommx/src/convert/parametric_instance.rs
+++ b/rust/ommx/src/convert/parametric_instance.rs
@@ -3,7 +3,7 @@ use crate::{
     Evaluate,
 };
 use anyhow::{bail, Context, Result};
-use std::collections::BTreeSet;
+use std::{borrow::Cow, collections::BTreeSet};
 
 impl From<Instance> for ParametricInstance {
     fn from(
@@ -75,17 +75,18 @@ impl ParametricInstance {
         })
     }
 
-    pub fn objective(&self) -> Result<&Function> {
-        self.objective
-            .as_ref()
-            .context("Objective function of ParametricInstance is empty")
+    pub fn objective(&self) -> Cow<Function> {
+        match &self.objective {
+            Some(f) => Cow::Borrowed(f),
+            None => Cow::Owned(Function::default()),
+        }
     }
 
     /// Used decision variable and parameter IDs in the objective and constraints.
     pub fn used_ids(&self) -> Result<BTreeSet<u64>> {
-        let mut used_ids = self.objective()?.used_decision_variable_ids();
+        let mut used_ids = self.objective().used_decision_variable_ids();
         for c in &self.constraints {
-            used_ids.extend(c.function()?.used_decision_variable_ids());
+            used_ids.extend(c.function().used_decision_variable_ids());
         }
         Ok(used_ids)
     }


### PR DESCRIPTION
`ommx::v1::Function` is defined as following:

```rust
pub struct Function {
    pub function: Option<Function>,
}
```

This `Option` is due to the `prost` compiles `oneof` in protobuf in this form.

Before this PR, `Function { function: None }` is regarded as invalid state, but it will be regarded as valid state and equals to `Funciton::zero()`.

Changes
--------
- `impl Evaluate for Function` returns `0.0` for `None` case
- `Instance::objective` and `Constraint::function` returns `Cow<Function>` instead of `Result<Function>`
- `impl Arbitrary for Instance, Constraint` generates `None` case.