### PR TITLE
Use `u32` for degree, fix `impl Arbitrary for Instance`

### DIFF
--- a/rust/ommx/src/convert/constraint.rs
+++ b/rust/ommx/src/convert/constraint.rs
@@ -54,7 +54,7 @@ impl Arbitrary for Constraint {
     }
 
     fn arbitrary() -> Self::Strategy {
-        (0..10_usize, 0..5_usize, 0..10_u64)
+        (0..10_usize, 0..5_u32, 0..10_u64)
             .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }

--- a/rust/ommx/src/convert/function.rs
+++ b/rust/ommx/src/convert/function.rs
@@ -94,7 +94,7 @@ impl Function {
         }
     }
 
-    pub fn degree(&self) -> usize {
+    pub fn degree(&self) -> u32 {
         match &self.function {
             Some(FunctionEnum::Constant(_)) => 0,
             Some(FunctionEnum::Linear(linear)) => linear.degree(),
@@ -245,7 +245,7 @@ impl Product for Function {
 }
 
 impl Arbitrary for Function {
-    type Parameters = (usize, usize, u64);
+    type Parameters = (usize, u32, u64);
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with((num_terms, max_degree, max_id): Self::Parameters) -> Self::Strategy {
@@ -271,7 +271,7 @@ impl Arbitrary for Function {
     }
 
     fn arbitrary() -> Self::Strategy {
-        (0..10_usize, 0..5_usize, 0..10_u64)
+        (0..10_usize, 0..5_u32, 0..10_u64)
             .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }
@@ -364,6 +364,21 @@ mod tests {
         fn test_as_constant_roundtrip(f in Function::arbitrary_with((5, 0, 10))) {
             let c = f.clone().as_constant().unwrap();
             prop_assert!(f.abs_diff_eq(&Function::from(c), 1e-10));
+        }
+
+        #[test]
+        fn test_max_degree_0(f in Function::arbitrary_with((5, 0, 10))) {
+            prop_assert!(f.degree() == 0);
+        }
+
+        #[test]
+        fn test_max_degree_1(f in Function::arbitrary_with((5, 1, 10))) {
+            prop_assert!(f.degree() <= 1);
+        }
+
+        #[test]
+        fn test_max_degree_2(f in Function::arbitrary_with((5, 2, 10))) {
+            prop_assert!(f.degree() <= 2);
         }
 
         #[test]

--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -48,18 +48,18 @@ impl Instance {
     }
 
     pub fn arbitrary_lp() -> BoxedStrategy<Self> {
-        (0..10_usize, 0..10_usize, 0..=1_u64, 0..10_usize)
+        (0..10_usize, 0..10_usize, 0..=1_u32, 0..10_u64)
             .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }
 }
 
 impl Arbitrary for Instance {
-    type Parameters = (usize, usize, u64, usize);
+    type Parameters = (usize, usize, u32, u64);
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(
-        (num_constraints, num_terms, max_id, max_degree): Self::Parameters,
+        (num_constraints, num_terms, max_degree, max_id): Self::Parameters,
     ) -> Self::Strategy {
         (
             proptest::option::of(Function::arbitrary_with((num_terms, max_degree, max_id))),
@@ -97,7 +97,7 @@ impl Arbitrary for Instance {
     }
 
     fn arbitrary() -> Self::Strategy {
-        (0..10_usize, 0..10_usize, 0..4_u64, 0..10_usize)
+        (0..10_usize, 0..10_usize, 0..4_u32, 0..10_u64)
             .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -52,7 +52,7 @@ impl Linear {
         self.terms.iter().map(|term| term.id).collect()
     }
 
-    pub fn degree(&self) -> usize {
+    pub fn degree(&self) -> u32 {
         if self.terms.is_empty() {
             0
         } else {

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -97,10 +97,10 @@ impl Polynomial {
             .collect()
     }
 
-    pub fn degree(&self) -> usize {
+    pub fn degree(&self) -> u32 {
         self.terms
             .iter()
-            .map(|term| term.ids.len())
+            .map(|term| term.ids.len() as u32)
             .max()
             .unwrap_or(0)
     }
@@ -198,13 +198,13 @@ impl_mul_inverse!(Quadratic, Polynomial);
 impl_neg_by_mul!(Polynomial);
 
 impl Arbitrary for Polynomial {
-    type Parameters = (usize, usize, u64);
+    type Parameters = (usize, u32, u64);
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with((num_terms, max_degree, max_id): Self::Parameters) -> Self::Strategy {
         let terms = proptest::collection::vec(
             (
-                proptest::collection::vec(0..=max_id, 0..=max_degree),
+                proptest::collection::vec(0..=max_id, 0..=(max_degree as usize)),
                 arbitrary_coefficient(),
             ),
             num_terms,
@@ -213,7 +213,7 @@ impl Arbitrary for Polynomial {
     }
 
     fn arbitrary() -> Self::Strategy {
-        (0..10_usize, 0..5_usize, 0..10_u64)
+        (0..10_usize, 0..5_u32, 0..10_u64)
             .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }

--- a/rust/ommx/src/convert/quadratic.rs
+++ b/rust/ommx/src/convert/quadratic.rs
@@ -61,7 +61,7 @@ impl Quadratic {
         self.as_linear()?.as_constant()
     }
 
-    pub fn degree(&self) -> usize {
+    pub fn degree(&self) -> u32 {
         if self.values.iter().any(|v| v.abs() > f64::EPSILON) {
             2
         } else {


### PR DESCRIPTION
Split from #162 

- Use `u32` for polynomial degree
- Fix `impl Arbitrary for Instance`. `max_degree` and `max_id` are reversed, bug of #163 