### PR TITLE
`Quadratic::used_decision_variable_ids` not include IDs of `Linear` part

### DIFF
--- a/rust/ommx/src/convert/quadratic.rs
+++ b/rust/ommx/src/convert/quadratic.rs
@@ -30,10 +30,11 @@ impl Zero for Quadratic {
 
 impl Quadratic {
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
-        self.columns
-            .iter()
-            .chain(self.rows.iter())
-            .cloned()
+        self.linear
+            .as_ref()
+            .map_or_else(BTreeSet::new, |l| l.used_decision_variable_ids())
+            .into_iter()
+            .chain(self.columns.iter().chain(self.rows.iter()).cloned())
             .collect()
     }
 


### PR DESCRIPTION
Found in #174 

This feature has been broken ever since it was introduced in #120.