### PR TITLE
Validate wheel with twine 5.1.1, fix to maturin 1.7.5

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -46,7 +46,7 @@ runs:
       run: |
         pip install "ruff >= 0.7.0, < 0.8.0"
         pip install pytest-github-actions-annotate-failures
-        pip install twine
+        pip install "twine == 5.1.1"  # Please keep in sync with https://github.com/pypa/gh-action-pypi-publish/
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -46,6 +46,7 @@ runs:
       run: |
         pip install "ruff >= 0.7.0, < 0.8.0"
         pip install pytest-github-actions-annotate-failures
+        pip install twine
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -121,15 +121,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux, macos, windows, python-mip-adapter, pyscipopt-adapter]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-environment
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: dist
           pattern: "*"
           merge-multiple: true
-
-      - name: Setup Test Environment
-        uses: ./.github/actions/setup-test-environment
 
       - name: Check wheel
         run: twine check --strict dist/*

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -6,7 +6,6 @@ on:
       - python-*
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - python-*
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -115,6 +118,7 @@ jobs:
           retention-days: 30
 
   publish:
+    if: startsWith(github.ref, 'refs/tags/python-')
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -117,12 +117,37 @@ jobs:
           path: ./dist/
           retention-days: 30
 
+  check-wheel:
+    runs-on: ubuntu-latest
+    needs: [linux, macos, windows, python-mip-adapter, pyscipopt-adapter]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: "*"
+          merge-multiple: true
+
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-environment
+
+      - name: Check wheel
+        run: twine check --strict dist/*
+
   publish:
     if: startsWith(github.ref, 'refs/tags/python-')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    needs: [linux, macos, windows, python-mip-adapter, pyscipopt-adapter]
+    needs:
+      [
+        linux,
+        macos,
+        windows,
+        python-mip-adapter,
+        pyscipopt-adapter,
+        check-wheel,
+      ]
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.5,<2.0"]
+requires = ["maturin == 1.7.5"]
 build-backend = "maturin"
 
 [project]
@@ -7,7 +7,7 @@ name = "ommx"
 
 version = "1.4.4"
 description = "Open Mathematical prograMming eXchange (OMMX)"
-authors = [{ name="Jij Inc.", email="info@j-ij.com" }]
+authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
 readme = "README.md"
 
 classifiers = [
@@ -61,4 +61,4 @@ module-name = "ommx._ommx_rust"
 features = ["pyo3/extension-module"]
 
 [tool.ruff.lint]
-per-file-ignores = {"*_pb2.py" = ["ALL"]}
+per-file-ignores = { "*_pb2.py" = ["ALL"] }


### PR DESCRIPTION
- Use twine 5.1.1 for validating wheels until https://github.com/pypa/gh-action-pypi-publish/pull/309 is merged.
- twine 5.1.1 does not supports metadata 2.4, thus fix `maturin == 1.7.5` since it uses metadata 2.4 until 1.7.6 https://github.com/PyO3/maturin/issues/2335