### PR TITLE
Ready for Rust SDK 2.0.0 with release candidate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,13 @@ jobs:
           github_token: ${{ github.token }}
           clippy_flags: -- -Dwarnings
 
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "_ommx_rust"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "dataset"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "ommx"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "protogen"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "2.0.0-rc.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
As I said in #152
> Theoretically this should be major change in semver, but we update 1.2.0 instead of 2.0.0.

we should not introduce another rule for custom semantic versioning. We rather bump up major version as we break the compatibility as `cargo-semver-check` checks.

However, since current Rust SDK will require more breaking change until stable 2.0.0 release, I set the version to `2.0.0-rc.0`