### PR TITLE
Fill `ommx.v1.Solution.state` with `substituted_value` of `DecisionVariable`

### DIFF
--- a/rust/ommx/src/convert/constraint.rs
+++ b/rust/ommx/src/convert/constraint.rs
@@ -89,8 +89,8 @@ impl Arbitrary for RemovedConstraint {
     fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
         (
             Constraint::arbitrary_with(parameters),
-            String::arbitrary(),
-            proptest::collection::hash_map(String::arbitrary(), String::arbitrary(), 0..=2),
+            ".{0,3}",
+            proptest::collection::hash_map(".{0,3}", ".{0,3}", 0..=2),
         )
             .prop_map(
                 |(constraint, removed_reason, removed_reason_parameters)| RemovedConstraint {

--- a/rust/ommx/src/convert/decision_variable.rs
+++ b/rust/ommx/src/convert/decision_variable.rs
@@ -151,16 +151,16 @@ impl Arbitrary for DecisionVariable {
         ];
         let parameters = prop_oneof![
             Just(HashMap::<String, String>::new()),
-            proptest::collection::hash_map(String::arbitrary(), String::arbitrary(), 1..=3),
+            proptest::collection::hash_map(".{0,3}", ".{0,3}", 1..=3),
         ];
         (
             Just(id),
             Option::<Bound>::arbitrary(),
-            Option::<String>::arbitrary(),
+            proptest::option::of(".{0,3}"),
             Just(kind),
             subscripts,
             parameters,
-            Option::<String>::arbitrary(),
+            proptest::option::of(".{0,3}"),
         )
             .prop_map(
                 |(id, bound, name, kind, subscripts, parameters, description)| DecisionVariable {

--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -313,8 +313,8 @@ fn arbitrary_instance(
                 Option::<Description>::arbitrary(),
                 Sense::arbitrary(),
                 relaxed,
-                String::arbitrary(),
-                proptest::collection::hash_map(String::arbitrary(), String::arbitrary(), 0..=2),
+                ".{0,3}",
+                proptest::collection::hash_map(".{0,3}", ".{0,3}", 0..=2),
             )
                 .prop_map(
                     |(
@@ -389,10 +389,10 @@ impl Arbitrary for Description {
 
     fn arbitrary_with(_parameter: ()) -> Self::Strategy {
         (
-            Option::<String>::arbitrary(),
-            Option::<String>::arbitrary(),
+            proptest::option::of(".{0,3}"),
+            proptest::option::of(".{0,3}"),
             prop_oneof![Just(Vec::new()), proptest::collection::vec(".*", 1..3)],
-            Option::<String>::arbitrary(),
+            proptest::option::of(".{0,3}"),
         )
             .prop_map(|(name, description, authors, created_by)| Description {
                 name,

--- a/rust/ommx/src/convert/parameter.rs
+++ b/rust/ommx/src/convert/parameter.rs
@@ -130,14 +130,14 @@ impl Arbitrary for Parameter {
         ];
         let parameters = prop_oneof![
             Just(HashMap::<String, String>::new()),
-            proptest::collection::hash_map(String::arbitrary(), String::arbitrary(), 1..=3),
+            proptest::collection::hash_map(".{0,3}", ".{0,3}", 1..=3),
         ];
         (
             0..=max_id,
-            Option::<String>::arbitrary(),
+            proptest::option::of(".{0,3}"),
             subscripts,
             parameters,
-            Option::<String>::arbitrary(),
+            proptest::option::of(".{0,3}"),
         )
             .prop_map(
                 |(id, name, subscripts, parameters, description)| Parameter {


### PR DESCRIPTION
- `Instance::evaluate` has changed to fill `substituted_value` in `DecisionVariable`s into `Soluiton.state`. This makes the partial substitution result more consistent.
- Revise proptest settings
  - `String::arbitary` are replaced by `.{0,3}` for better test case generation
  - Combinators used in `evaluate` and `partial_evaluate` tests are revised.