### PR TITLE
MPS: Only write used variables to output

### DIFF
--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -28,7 +28,7 @@ impl Instance {
         }
     }
 
-    pub fn used_decision_variable_ids(&self) -> Result<BTreeSet<u64>> {
+    pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
         let mut used_ids = self.objective().used_decision_variable_ids();
         for c in &self.constraints {
             used_ids.extend(c.function().used_decision_variable_ids());
@@ -38,7 +38,7 @@ impl Instance {
                 used_ids.extend(c.function().used_decision_variable_ids());
             }
         }
-        Ok(used_ids)
+        used_ids
     }
 
     pub fn defined_ids(&self) -> BTreeSet<u64> {
@@ -68,7 +68,7 @@ impl Instance {
 
     /// Validate that all decision variable IDs used in the instance are defined.
     pub fn validate_decision_variable_ids(&self) -> Result<()> {
-        let used_ids = self.used_decision_variable_ids()?;
+        let used_ids = self.used_decision_variable_ids();
         let mut defined_ids = BTreeSet::new();
         for dv in &self.decision_variables {
             if !defined_ids.insert(dv.id) {

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -490,7 +490,7 @@ mod tests {
     fn instance_with_state() -> BoxedStrategy<(Instance, State)> {
         Instance::arbitrary()
             .prop_flat_map(|instance| {
-                let used_ids = instance.used_decision_variable_ids().unwrap();
+                let used_ids = instance.used_decision_variable_ids();
                 let state = arbitrary_state(used_ids);
                 (Just(instance), state)
             })
@@ -524,7 +524,7 @@ mod tests {
     fn instance_with_split_state() -> BoxedStrategy<(Instance, State, (State, State))> {
         Instance::arbitrary()
             .prop_flat_map(|instance| {
-                let used_ids = instance.used_decision_variable_ids().unwrap();
+                let used_ids = instance.used_decision_variable_ids();
                 (Just(instance), arbitrary_state(used_ids)).prop_flat_map(|(instance, state)| {
                     (Just(instance), Just(state.clone()), split_state(state))
                 })

--- a/rust/ommx/src/mps.rs
+++ b/rust/ommx/src/mps.rs
@@ -145,6 +145,12 @@ pub enum MpsWriteError {
     InvalidConstraintType { name: String, degree: u32 },
     #[error( "MPS format does not support nonlinear objective: Objective function has {degree}-degree term")]
     InvalidObjectiveType { degree: u32 },
+    #[error(
+        "Invalid variable ID: Functions in Instance used a variable id {0} that doesn't exist"
+    )]
+    InvalidVariableId(u64),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error("Unknown Error: {0}")]
+    UnknownError(#[from] anyhow::Error),
 }

--- a/rust/ommx/src/mps.rs
+++ b/rust/ommx/src/mps.rs
@@ -151,6 +151,4 @@ pub enum MpsWriteError {
     InvalidVariableId(u64),
     #[error(transparent)]
     Io(#[from] std::io::Error),
-    #[error("Unknown Error: {0}")]
-    UnknownError(#[from] anyhow::Error),
 }

--- a/rust/ommx/src/mps/to_mps.rs
+++ b/rust/ommx/src/mps/to_mps.rs
@@ -1,7 +1,7 @@
 use super::MpsWriteError;
 use crate::{mps::ObjSense, v1};
 use anyhow::Result;
-use std::io::Write;
+use std::{collections::HashMap, io::Write};
 
 pub(crate) const OBJ_NAME: &str = "OBJ";
 pub(crate) const CONSTR_PREFIX: &str = "OMMX_CONSTR_";
@@ -180,7 +180,7 @@ fn write_rhs<W: Write>(instance: &v1::Instance, out: &mut W) -> Result<(), MpsWr
 fn write_bounds<W: Write>(instance: &v1::Instance, out: &mut W) -> anyhow::Result<()> {
     writeln!(out, "BOUNDS")?;
     // build an id -> dvar map as the vec is not guaranteed to be in order
-    let var_by_id: std::collections::HashMap<_, _> = instance
+    let var_by_id: HashMap<_, _> = instance
         .decision_variables
         .iter()
         .map(|var| (var.id, var))

--- a/rust/ommx/src/mps/to_mps.rs
+++ b/rust/ommx/src/mps/to_mps.rs
@@ -1,6 +1,5 @@
 use super::MpsWriteError;
 use crate::{mps::ObjSense, v1};
-use anyhow::Result;
 use std::{collections::HashMap, io::Write};
 
 pub(crate) const OBJ_NAME: &str = "OBJ";
@@ -177,7 +176,7 @@ fn write_rhs<W: Write>(instance: &v1::Instance, out: &mut W) -> Result<(), MpsWr
     Ok(())
 }
 
-fn write_bounds<W: Write>(instance: &v1::Instance, out: &mut W) -> anyhow::Result<()> {
+fn write_bounds<W: Write>(instance: &v1::Instance, out: &mut W) -> Result<(), MpsWriteError> {
     writeln!(out, "BOUNDS")?;
     // build an id -> dvar map as the vec is not guaranteed to be in order
     let var_by_id: HashMap<_, _> = instance
@@ -185,7 +184,7 @@ fn write_bounds<W: Write>(instance: &v1::Instance, out: &mut W) -> anyhow::Resul
         .iter()
         .map(|var| (var.id, var))
         .collect();
-    for dvar_id in instance.used_decision_variable_ids()?.into_iter() {
+    for dvar_id in instance.used_decision_variable_ids().into_iter() {
         let dvar = var_by_id
             .get(&dvar_id)
             .ok_or(MpsWriteError::InvalidVariableId(dvar_id))?;


### PR DESCRIPTION
As a lot of solvers error out if the `BOUNDS` section includes unused variables, this PR updates the MPS output writer to only add variables that were actually used in the problem to the `BOUNDS` section. 

In this PR I also added a generic `anyhow::Error`→`MpsWriteError` conversion asn "Unknown Error", but this is mostly just to make the code compile. The method `used_variable_ids()` returns an `anyhow::Result`, but it doesn't seem to be able to produce any errors at all. Still, changing that method would be an API change so I decided to leave it as is. I added the error conversion instead of unwrapping just in case.