### PR TITLE
Get optimality from model in adapters' model_to_solution

### DIFF
--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/ommx_to_pyscipopt.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/ommx_to_pyscipopt.py
@@ -297,7 +297,9 @@ def model_to_solution(model: pyscipopt.Model, instance: Instance) -> Solution:
     solution = instance.evaluate(state)
 
     # Set solution.optimality based on the model
-    if model.getStatus() == "optimal": # pyscipopt does not appear to have an enum or constant for this
+    if (
+        model.getStatus() == "optimal"
+    ):  # pyscipopt does not appear to have an enum or constant for this
         solution.raw.optimality = Optimality.OPTIMALITY_OPTIMAL
 
     # TODO: Add the feature to store dual variables in `solution`.

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/ommx_to_pyscipopt.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/ommx_to_pyscipopt.py
@@ -4,7 +4,7 @@ import pyscipopt
 
 from ommx.v1 import Constraint, Instance, DecisionVariable, Solution
 from ommx.v1.function_pb2 import Function
-from ommx.v1.solution_pb2 import State
+from ommx.v1.solution_pb2 import State, Optimality
 
 from .exception import OMMXPySCIPOptAdapterError
 
@@ -295,6 +295,10 @@ def model_to_solution(model: pyscipopt.Model, instance: Instance) -> Solution:
     """
     state = model_to_state(model, instance)
     solution = instance.evaluate(state)
+
+    # Set solution.optimality based on the model
+    if model.getStatus() == "optimal": # pyscipopt does not appear to have an enum or constant for this
+        solution.raw.optimality = Optimality.OPTIMALITY_OPTIMAL
 
     # TODO: Add the feature to store dual variables in `solution`.
 

--- a/python/ommx-pyscipopt-adapter/tests/test_ommx_pyscipopt.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_ommx_pyscipopt.py
@@ -1,0 +1,20 @@
+from ommx.v1 import Instance, DecisionVariable
+from ommx.v1.solution_pb2 import Optimality
+
+import ommx_pyscipopt_adapter as adapter
+
+
+def test_solution_optimality():
+    x = DecisionVariable.integer(1, lower=0, upper=5)
+    y = DecisionVariable.integer(1, lower=0, upper=5)
+    ommx_instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x + y,
+        constraints=[],
+        sense=Instance.MAXIMIZE,
+    )
+
+    model = adapter.instance_to_model(ommx_instance)
+    model.optimize()
+    solution = adapter.model_to_solution(model, ommx_instance)
+    assert solution.optimality == Optimality.OPTIMALITY_OPTIMAL

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/ommx_to_python_mip.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/ommx_to_python_mip.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import mip
 
 from ommx.v1.function_pb2 import Function
-from ommx.v1.solution_pb2 import Optimality, Result, Infeasible, Unbounded, Relaxation
+from ommx.v1.solution_pb2 import Result, Infeasible, Unbounded, Relaxation
 from ommx.v1 import Instance, DecisionVariable, Constraint
 
 from .exception import OMMXPythonMIPAdapterError
@@ -304,9 +304,6 @@ def solve(
         return Result(error=f"Unknown status: {model.status}")
 
     solution = model_to_solution(model, instance)
-
-    if model.status == mip.OptimizationStatus.OPTIMAL:
-        solution.raw.optimality = Optimality.OPTIMALITY_OPTIMAL
 
     if relax:
         solution.raw.relaxation = Relaxation.RELAXATION_LP_RELAXED

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
@@ -7,7 +7,7 @@ from mip.exceptions import ParameterNotAvailable
 from ommx.v1.constraint_pb2 import Constraint, Equality
 from ommx.v1.function_pb2 import Function
 from ommx.v1.linear_pb2 import Linear
-from ommx.v1.solution_pb2 import State
+from ommx.v1.solution_pb2 import State, Optimality
 from ommx.v1 import Instance, DecisionVariable, Solution
 
 from .exception import OMMXPythonMIPAdapterError
@@ -247,5 +247,8 @@ def model_to_solution(
         id = constraint.id
         if id in dual_variables:
             constraint.dual_variable = dual_variables[id]
+
+    if model.status == mip.OptimizationStatus.OPTIMAL:
+        solution.raw.optimality = Optimality.OPTIMALITY_OPTIMAL
 
     return solution

--- a/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
+++ b/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
@@ -1,6 +1,7 @@
 import mip
 
 from ommx.v1 import Instance, DecisionVariable, Constraint
+from ommx.v1.solution_pb2 import Optimality
 
 import ommx_python_mip_adapter as adapter
 
@@ -200,3 +201,19 @@ def test_no_objective_model():
     constraint2_term_x3 = constraint2.function.linear.terms[1]
     assert constraint2_term_x3.id == 1
     assert constraint2_term_x3.coefficient == 3
+
+
+def test_solution_optimality():
+    x = DecisionVariable.integer(1, lower=0, upper=5)
+    y = DecisionVariable.integer(1, lower=0, upper=5)
+    ommx_instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x + y,
+        constraints=[],
+        sense=Instance.MAXIMIZE,
+    )
+
+    model = adapter.instance_to_model(ommx_instance)
+    model.optimize()
+    solution = adapter.model_to_solution(model, ommx_instance)
+    assert solution.optimality == Optimality.OPTIMALITY_OPTIMAL


### PR DESCRIPTION
Fixes #199.

- ommx-pyscipopt-adapter's `model_to_solution` now checks the model status and updates the `Solution`'s optimality value accordingly if the solver deems it optimal.
  - As we discussed, statuses other than "optimal" are left as `Optimality.UNSPECIFIED`. 
- To match the above, I moved the similar check the ommx-python-mip-adapter had from the `solve` function to that adapter's `model_to_solution`. There's no reason why only `solve` should perform that check.
  - As `solve` calls `model_to_solution`, this does not change `solve`'s behavior 