### PR TITLE
Add `decision_variable_dependency` to represent polynomial dependency between decision variables

### DIFF
--- a/proto/ommx/v1/instance.proto
+++ b/proto/ommx/v1/instance.proto
@@ -60,4 +60,7 @@ message Instance {
 
   // Constraints removed via preprocessing. These are restored when evaluated into `ommx.v1.Solution`.
   repeated RemovedConstraint removed_constraints = 8;
+
+  // When a decision variable is dependent on another decision variable as polynomial, this map contains the ID of the dependent decision variable as key and the polynomial as value.
+  map<uint64, Function> decision_variable_dependency = 9;
 }

--- a/proto/ommx/v1/parametric_instance.proto
+++ b/proto/ommx/v1/parametric_instance.proto
@@ -56,4 +56,7 @@ message ParametricInstance {
 
   // Constraints removed via preprocessing. These are restored when evaluated into `ommx.v1.Solution`.
   repeated RemovedConstraint removed_constraints = 8;
+
+  // When a decision variable is dependent on another decision variable as polynomial, this map contains the ID of the dependent decision variable as key and the polynomial as value.
+  map<uint64, Function> decision_variable_dependency = 9;
 }

--- a/python/ommx/ommx/v1/instance_pb2.py
+++ b/python/ommx/ommx/v1/instance_pb2.py
@@ -20,7 +20,7 @@ from ommx.v1 import function_pb2 as ommx_dot_v1_dot_function__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x16ommx/v1/instance.proto\x12\x07ommx.v1\x1a\x18ommx/v1/constraint.proto\x1a\x1eommx/v1/constraint_hints.proto\x1a ommx/v1/decision_variables.proto\x1a\x16ommx/v1/function.proto"\x84\x01\n\nParameters\x12:\n\x07\x65ntries\x18\x01 \x03(\x0b\x32 .ommx.v1.Parameters.EntriesEntryR\x07\x65ntries\x1a:\n\x0c\x45ntriesEntry\x12\x10\n\x03key\x18\x01 \x01(\x04R\x03key\x12\x14\n\x05value\x18\x02 \x01(\x01R\x05value:\x02\x38\x01"\x85\x06\n\x08Instance\x12?\n\x0b\x64\x65scription\x18\x01 \x01(\x0b\x32\x1d.ommx.v1.Instance.DescriptionR\x0b\x64\x65scription\x12H\n\x12\x64\x65\x63ision_variables\x18\x02 \x03(\x0b\x32\x19.ommx.v1.DecisionVariableR\x11\x64\x65\x63isionVariables\x12/\n\tobjective\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\tobjective\x12\x35\n\x0b\x63onstraints\x18\x04 \x03(\x0b\x32\x13.ommx.v1.ConstraintR\x0b\x63onstraints\x12-\n\x05sense\x18\x05 \x01(\x0e\x32\x17.ommx.v1.Instance.SenseR\x05sense\x12\x38\n\nparameters\x18\x06 \x01(\x0b\x32\x13.ommx.v1.ParametersH\x00R\nparameters\x88\x01\x01\x12\x43\n\x10\x63onstraint_hints\x18\x07 \x01(\x0b\x32\x18.ommx.v1.ConstraintHintsR\x0f\x63onstraintHints\x12K\n\x13removed_constraints\x18\x08 \x03(\x0b\x32\x1a.ommx.v1.RemovedConstraintR\x12removedConstraints\x1a\xb3\x01\n\x0b\x44\x65scription\x12\x17\n\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x02 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12\x18\n\x07\x61uthors\x18\x03 \x03(\tR\x07\x61uthors\x12"\n\ncreated_by\x18\x04 \x01(\tH\x02R\tcreatedBy\x88\x01\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\r\n\x0b_created_by"F\n\x05Sense\x12\x15\n\x11SENSE_UNSPECIFIED\x10\x00\x12\x12\n\x0eSENSE_MINIMIZE\x10\x01\x12\x12\n\x0eSENSE_MAXIMIZE\x10\x02\x42\r\n\x0b_parametersBY\n\x0b\x63om.ommx.v1B\rInstanceProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
+    b'\n\x16ommx/v1/instance.proto\x12\x07ommx.v1\x1a\x18ommx/v1/constraint.proto\x1a\x1eommx/v1/constraint_hints.proto\x1a ommx/v1/decision_variables.proto\x1a\x16ommx/v1/function.proto"\x84\x01\n\nParameters\x12:\n\x07\x65ntries\x18\x01 \x03(\x0b\x32 .ommx.v1.Parameters.EntriesEntryR\x07\x65ntries\x1a:\n\x0c\x45ntriesEntry\x12\x10\n\x03key\x18\x01 \x01(\x04R\x03key\x12\x14\n\x05value\x18\x02 \x01(\x01R\x05value:\x02\x38\x01"\xdc\x07\n\x08Instance\x12?\n\x0b\x64\x65scription\x18\x01 \x01(\x0b\x32\x1d.ommx.v1.Instance.DescriptionR\x0b\x64\x65scription\x12H\n\x12\x64\x65\x63ision_variables\x18\x02 \x03(\x0b\x32\x19.ommx.v1.DecisionVariableR\x11\x64\x65\x63isionVariables\x12/\n\tobjective\x18\x03 \x01(\x0b\x32\x11.ommx.v1.FunctionR\tobjective\x12\x35\n\x0b\x63onstraints\x18\x04 \x03(\x0b\x32\x13.ommx.v1.ConstraintR\x0b\x63onstraints\x12-\n\x05sense\x18\x05 \x01(\x0e\x32\x17.ommx.v1.Instance.SenseR\x05sense\x12\x38\n\nparameters\x18\x06 \x01(\x0b\x32\x13.ommx.v1.ParametersH\x00R\nparameters\x88\x01\x01\x12\x43\n\x10\x63onstraint_hints\x18\x07 \x01(\x0b\x32\x18.ommx.v1.ConstraintHintsR\x0f\x63onstraintHints\x12K\n\x13removed_constraints\x18\x08 \x03(\x0b\x32\x1a.ommx.v1.RemovedConstraintR\x12removedConstraints\x12s\n\x1c\x64\x65\x63ision_variable_dependency\x18\t \x03(\x0b\x32\x31.ommx.v1.Instance.DecisionVariableDependencyEntryR\x1a\x64\x65\x63isionVariableDependency\x1a\xb3\x01\n\x0b\x44\x65scription\x12\x17\n\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n\x0b\x64\x65scription\x18\x02 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x12\x18\n\x07\x61uthors\x18\x03 \x03(\tR\x07\x61uthors\x12"\n\ncreated_by\x18\x04 \x01(\tH\x02R\tcreatedBy\x88\x01\x01\x42\x07\n\x05_nameB\x0e\n\x0c_descriptionB\r\n\x0b_created_by\x1a`\n\x1f\x44\x65\x63isionVariableDependencyEntry\x12\x10\n\x03key\x18\x01 \x01(\x04R\x03key\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x05value:\x02\x38\x01"F\n\x05Sense\x12\x15\n\x11SENSE_UNSPECIFIED\x10\x00\x12\x12\n\x0eSENSE_MINIMIZE\x10\x01\x12\x12\n\x0eSENSE_MAXIMIZE\x10\x02\x42\r\n\x0b_parametersBY\n\x0b\x63om.ommx.v1B\rInstanceProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
 )
 
 _globals = globals()
@@ -33,14 +33,18 @@ if not _descriptor._USE_C_DESCRIPTORS:
     ]._serialized_options = b"\n\013com.ommx.v1B\rInstanceProtoP\001\242\002\003OXX\252\002\007Ommx.V1\312\002\007Ommx\\V1\342\002\023Ommx\\V1\\GPBMetadata\352\002\010Ommx::V1"
     _globals["_PARAMETERS_ENTRIESENTRY"]._loaded_options = None
     _globals["_PARAMETERS_ENTRIESENTRY"]._serialized_options = b"8\001"
+    _globals["_INSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"]._loaded_options = None
+    _globals["_INSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"]._serialized_options = b"8\001"
     _globals["_PARAMETERS"]._serialized_start = 152
     _globals["_PARAMETERS"]._serialized_end = 284
     _globals["_PARAMETERS_ENTRIESENTRY"]._serialized_start = 226
     _globals["_PARAMETERS_ENTRIESENTRY"]._serialized_end = 284
     _globals["_INSTANCE"]._serialized_start = 287
-    _globals["_INSTANCE"]._serialized_end = 1060
-    _globals["_INSTANCE_DESCRIPTION"]._serialized_start = 794
-    _globals["_INSTANCE_DESCRIPTION"]._serialized_end = 973
-    _globals["_INSTANCE_SENSE"]._serialized_start = 975
-    _globals["_INSTANCE_SENSE"]._serialized_end = 1045
+    _globals["_INSTANCE"]._serialized_end = 1275
+    _globals["_INSTANCE_DESCRIPTION"]._serialized_start = 911
+    _globals["_INSTANCE_DESCRIPTION"]._serialized_end = 1090
+    _globals["_INSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"]._serialized_start = 1092
+    _globals["_INSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"]._serialized_end = 1188
+    _globals["_INSTANCE_SENSE"]._serialized_start = 1190
+    _globals["_INSTANCE_SENSE"]._serialized_end = 1260
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/ommx/v1/instance_pb2.pyi
+++ b/python/ommx/ommx/v1/instance_pb2.pyi
@@ -170,6 +170,28 @@ class Instance(google.protobuf.message.Message):
             self, oneof_group: typing.Literal["_name", b"_name"]
         ) -> typing.Literal["name"] | None: ...
 
+    @typing.final
+    class DecisionVariableDependencyEntry(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        KEY_FIELD_NUMBER: builtins.int
+        VALUE_FIELD_NUMBER: builtins.int
+        key: builtins.int
+        @property
+        def value(self) -> ommx.v1.function_pb2.Function: ...
+        def __init__(
+            self,
+            *,
+            key: builtins.int = ...,
+            value: ommx.v1.function_pb2.Function | None = ...,
+        ) -> None: ...
+        def HasField(
+            self, field_name: typing.Literal["value", b"value"]
+        ) -> builtins.bool: ...
+        def ClearField(
+            self, field_name: typing.Literal["key", b"key", "value", b"value"]
+        ) -> None: ...
+
     DESCRIPTION_FIELD_NUMBER: builtins.int
     DECISION_VARIABLES_FIELD_NUMBER: builtins.int
     OBJECTIVE_FIELD_NUMBER: builtins.int
@@ -178,6 +200,7 @@ class Instance(google.protobuf.message.Message):
     PARAMETERS_FIELD_NUMBER: builtins.int
     CONSTRAINT_HINTS_FIELD_NUMBER: builtins.int
     REMOVED_CONSTRAINTS_FIELD_NUMBER: builtins.int
+    DECISION_VARIABLE_DEPENDENCY_FIELD_NUMBER: builtins.int
     sense: global___Instance.Sense.ValueType
     """The sense of this problem, i.e. minimize the objective or maximize it.
 
@@ -224,6 +247,14 @@ class Instance(google.protobuf.message.Message):
     ]:
         """Constraints removed via preprocessing. These are restored when evaluated into `ommx.v1.Solution`."""
 
+    @property
+    def decision_variable_dependency(
+        self,
+    ) -> google.protobuf.internal.containers.MessageMap[
+        builtins.int, ommx.v1.function_pb2.Function
+    ]:
+        """When a decision variable is dependent on another decision variable as polynomial, this map contains the ID of the dependent decision variable as key and the polynomial as value."""
+
     def __init__(
         self,
         *,
@@ -240,6 +271,10 @@ class Instance(google.protobuf.message.Message):
         constraint_hints: ommx.v1.constraint_hints_pb2.ConstraintHints | None = ...,
         removed_constraints: collections.abc.Iterable[
             ommx.v1.constraint_pb2.RemovedConstraint
+        ]
+        | None = ...,
+        decision_variable_dependency: collections.abc.Mapping[
+            builtins.int, ommx.v1.function_pb2.Function
         ]
         | None = ...,
     ) -> None: ...
@@ -267,6 +302,8 @@ class Instance(google.protobuf.message.Message):
             b"constraint_hints",
             "constraints",
             b"constraints",
+            "decision_variable_dependency",
+            b"decision_variable_dependency",
             "decision_variables",
             b"decision_variables",
             "description",

--- a/python/ommx/ommx/v1/parametric_instance_pb2.py
+++ b/python/ommx/ommx/v1/parametric_instance_pb2.py
@@ -21,7 +21,7 @@ from ommx.v1 import instance_pb2 as ommx_dot_v1_dot_instance__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n!ommx/v1/parametric_instance.proto\x12\x07ommx.v1\x1a\x18ommx/v1/constraint.proto\x1a\x1eommx/v1/constraint_hints.proto\x1a ommx/v1/decision_variables.proto\x1a\x16ommx/v1/function.proto\x1a\x16ommx/v1/instance.proto"\x97\x02\n\tParameter\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12\x17\n\x04name\x18\x02 \x01(\tH\x00R\x04name\x88\x01\x01\x12\x1e\n\nsubscripts\x18\x03 \x03(\x03R\nsubscripts\x12\x42\n\nparameters\x18\x04 \x03(\x0b\x32".ommx.v1.Parameter.ParametersEntryR\nparameters\x12%\n\x0b\x64\x65scription\x18\x05 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description"\xfc\x03\n\x12ParametricInstance\x12?\n\x0b\x64\x65scription\x18\x01 \x01(\x0b\x32\x1d.ommx.v1.Instance.DescriptionR\x0b\x64\x65scription\x12H\n\x12\x64\x65\x63ision_variables\x18\x02 \x03(\x0b\x32\x19.ommx.v1.DecisionVariableR\x11\x64\x65\x63isionVariables\x12\x32\n\nparameters\x18\x03 \x03(\x0b\x32\x12.ommx.v1.ParameterR\nparameters\x12/\n\tobjective\x18\x04 \x01(\x0b\x32\x11.ommx.v1.FunctionR\tobjective\x12\x35\n\x0b\x63onstraints\x18\x05 \x03(\x0b\x32\x13.ommx.v1.ConstraintR\x0b\x63onstraints\x12-\n\x05sense\x18\x06 \x01(\x0e\x32\x17.ommx.v1.Instance.SenseR\x05sense\x12\x43\n\x10\x63onstraint_hints\x18\x07 \x01(\x0b\x32\x18.ommx.v1.ConstraintHintsR\x0f\x63onstraintHints\x12K\n\x13removed_constraints\x18\x08 \x03(\x0b\x32\x1a.ommx.v1.RemovedConstraintR\x12removedConstraintsBc\n\x0b\x63om.ommx.v1B\x17ParametricInstanceProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
+    b'\n!ommx/v1/parametric_instance.proto\x12\x07ommx.v1\x1a\x18ommx/v1/constraint.proto\x1a\x1eommx/v1/constraint_hints.proto\x1a ommx/v1/decision_variables.proto\x1a\x16ommx/v1/function.proto\x1a\x16ommx/v1/instance.proto"\x97\x02\n\tParameter\x12\x0e\n\x02id\x18\x01 \x01(\x04R\x02id\x12\x17\n\x04name\x18\x02 \x01(\tH\x00R\x04name\x88\x01\x01\x12\x1e\n\nsubscripts\x18\x03 \x03(\x03R\nsubscripts\x12\x42\n\nparameters\x18\x04 \x03(\x0b\x32".ommx.v1.Parameter.ParametersEntryR\nparameters\x12%\n\x0b\x64\x65scription\x18\x05 \x01(\tH\x01R\x0b\x64\x65scription\x88\x01\x01\x1a=\n\x0fParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\x07\n\x05_nameB\x0e\n\x0c_description"\xdd\x05\n\x12ParametricInstance\x12?\n\x0b\x64\x65scription\x18\x01 \x01(\x0b\x32\x1d.ommx.v1.Instance.DescriptionR\x0b\x64\x65scription\x12H\n\x12\x64\x65\x63ision_variables\x18\x02 \x03(\x0b\x32\x19.ommx.v1.DecisionVariableR\x11\x64\x65\x63isionVariables\x12\x32\n\nparameters\x18\x03 \x03(\x0b\x32\x12.ommx.v1.ParameterR\nparameters\x12/\n\tobjective\x18\x04 \x01(\x0b\x32\x11.ommx.v1.FunctionR\tobjective\x12\x35\n\x0b\x63onstraints\x18\x05 \x03(\x0b\x32\x13.ommx.v1.ConstraintR\x0b\x63onstraints\x12-\n\x05sense\x18\x06 \x01(\x0e\x32\x17.ommx.v1.Instance.SenseR\x05sense\x12\x43\n\x10\x63onstraint_hints\x18\x07 \x01(\x0b\x32\x18.ommx.v1.ConstraintHintsR\x0f\x63onstraintHints\x12K\n\x13removed_constraints\x18\x08 \x03(\x0b\x32\x1a.ommx.v1.RemovedConstraintR\x12removedConstraints\x12}\n\x1c\x64\x65\x63ision_variable_dependency\x18\t \x03(\x0b\x32;.ommx.v1.ParametricInstance.DecisionVariableDependencyEntryR\x1a\x64\x65\x63isionVariableDependency\x1a`\n\x1f\x44\x65\x63isionVariableDependencyEntry\x12\x10\n\x03key\x18\x01 \x01(\x04R\x03key\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x11.ommx.v1.FunctionR\x05value:\x02\x38\x01\x42\x63\n\x0b\x63om.ommx.v1B\x17ParametricInstanceProtoP\x01\xa2\x02\x03OXX\xaa\x02\x07Ommx.V1\xca\x02\x07Ommx\\V1\xe2\x02\x13Ommx\\V1\\GPBMetadata\xea\x02\x08Ommx::V1b\x06proto3'
 )
 
 _globals = globals()
@@ -36,10 +36,22 @@ if not _descriptor._USE_C_DESCRIPTORS:
     ]._serialized_options = b"\n\013com.ommx.v1B\027ParametricInstanceProtoP\001\242\002\003OXX\252\002\007Ommx.V1\312\002\007Ommx\\V1\342\002\023Ommx\\V1\\GPBMetadata\352\002\010Ommx::V1"
     _globals["_PARAMETER_PARAMETERSENTRY"]._loaded_options = None
     _globals["_PARAMETER_PARAMETERSENTRY"]._serialized_options = b"8\001"
+    _globals[
+        "_PARAMETRICINSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"
+    ]._loaded_options = None
+    _globals[
+        "_PARAMETRICINSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"
+    ]._serialized_options = b"8\001"
     _globals["_PARAMETER"]._serialized_start = 187
     _globals["_PARAMETER"]._serialized_end = 466
     _globals["_PARAMETER_PARAMETERSENTRY"]._serialized_start = 380
     _globals["_PARAMETER_PARAMETERSENTRY"]._serialized_end = 441
     _globals["_PARAMETRICINSTANCE"]._serialized_start = 469
-    _globals["_PARAMETRICINSTANCE"]._serialized_end = 977
+    _globals["_PARAMETRICINSTANCE"]._serialized_end = 1202
+    _globals[
+        "_PARAMETRICINSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"
+    ]._serialized_start = 1106
+    _globals[
+        "_PARAMETRICINSTANCE_DECISIONVARIABLEDEPENDENCYENTRY"
+    ]._serialized_end = 1202
 # @@protoc_insertion_point(module_scope)

--- a/python/ommx/ommx/v1/parametric_instance_pb2.pyi
+++ b/python/ommx/ommx/v1/parametric_instance_pb2.pyi
@@ -128,6 +128,28 @@ class ParametricInstance(google.protobuf.message.Message):
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
+    @typing.final
+    class DecisionVariableDependencyEntry(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        KEY_FIELD_NUMBER: builtins.int
+        VALUE_FIELD_NUMBER: builtins.int
+        key: builtins.int
+        @property
+        def value(self) -> ommx.v1.function_pb2.Function: ...
+        def __init__(
+            self,
+            *,
+            key: builtins.int = ...,
+            value: ommx.v1.function_pb2.Function | None = ...,
+        ) -> None: ...
+        def HasField(
+            self, field_name: typing.Literal["value", b"value"]
+        ) -> builtins.bool: ...
+        def ClearField(
+            self, field_name: typing.Literal["key", b"key", "value", b"value"]
+        ) -> None: ...
+
     DESCRIPTION_FIELD_NUMBER: builtins.int
     DECISION_VARIABLES_FIELD_NUMBER: builtins.int
     PARAMETERS_FIELD_NUMBER: builtins.int
@@ -136,6 +158,7 @@ class ParametricInstance(google.protobuf.message.Message):
     SENSE_FIELD_NUMBER: builtins.int
     CONSTRAINT_HINTS_FIELD_NUMBER: builtins.int
     REMOVED_CONSTRAINTS_FIELD_NUMBER: builtins.int
+    DECISION_VARIABLE_DEPENDENCY_FIELD_NUMBER: builtins.int
     sense: ommx.v1.instance_pb2.Instance.Sense.ValueType
     """The sense of this problem, i.e. minimize the objective or maximize it."""
     @property
@@ -183,6 +206,14 @@ class ParametricInstance(google.protobuf.message.Message):
     ]:
         """Constraints removed via preprocessing. These are restored when evaluated into `ommx.v1.Solution`."""
 
+    @property
+    def decision_variable_dependency(
+        self,
+    ) -> google.protobuf.internal.containers.MessageMap[
+        builtins.int, ommx.v1.function_pb2.Function
+    ]:
+        """When a decision variable is dependent on another decision variable as polynomial, this map contains the ID of the dependent decision variable as key and the polynomial as value."""
+
     def __init__(
         self,
         *,
@@ -199,6 +230,10 @@ class ParametricInstance(google.protobuf.message.Message):
         constraint_hints: ommx.v1.constraint_hints_pb2.ConstraintHints | None = ...,
         removed_constraints: collections.abc.Iterable[
             ommx.v1.constraint_pb2.RemovedConstraint
+        ]
+        | None = ...,
+        decision_variable_dependency: collections.abc.Mapping[
+            builtins.int, ommx.v1.function_pb2.Function
         ]
         | None = ...,
     ) -> None: ...
@@ -220,6 +255,8 @@ class ParametricInstance(google.protobuf.message.Message):
             b"constraint_hints",
             "constraints",
             b"constraints",
+            "decision_variable_dependency",
+            b"decision_variable_dependency",
             "decision_variables",
             b"decision_variables",
             "description",

--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -169,6 +169,7 @@ impl Instance {
             parameters,
             constraint_hints: self.constraint_hints,
             removed_constraints,
+            decision_variable_dependency: self.decision_variable_dependency,
         })
     }
 
@@ -204,6 +205,7 @@ impl Instance {
             parameters: vec![parameter],
             constraint_hints: self.constraint_hints,
             removed_constraints,
+            decision_variable_dependency: self.decision_variable_dependency,
         })
     }
 

--- a/rust/ommx/src/convert/parametric_instance.rs
+++ b/rust/ommx/src/convert/parametric_instance.rs
@@ -25,6 +25,7 @@ impl From<Instance> for ParametricInstance {
             constraint_hints,
             removed_constraints,
             parameters: _, // Drop previous parameters
+            decision_variable_dependency,
         }: Instance,
     ) -> Self {
         Self {
@@ -36,6 +37,7 @@ impl From<Instance> for ParametricInstance {
             parameters: Default::default(),
             constraint_hints,
             removed_constraints,
+            decision_variable_dependency,
         }
     }
 }
@@ -86,6 +88,7 @@ impl ParametricInstance {
             parameters: Some(parameters),
             constraint_hints: self.constraint_hints,
             removed_constraints: self.removed_constraints,
+            decision_variable_dependency: self.decision_variable_dependency,
         })
     }
 

--- a/rust/ommx/src/convert/sample_set.rs
+++ b/rust/ommx/src/convert/sample_set.rs
@@ -81,6 +81,14 @@ impl Samples {
         })
     }
 
+    pub fn states_mut(&mut self) -> impl Iterator<Item = &mut State> {
+        self.entries.iter_mut().map(|v| {
+            v.state
+                .as_mut()
+                .expect("ommx.v1.Samples.Entry must has state. Broken Data.")
+        })
+    }
+
     /// Transpose `sample_id -> decision_variable_id -> value` to `decision_variable_id -> sample_id -> value`
     pub fn transpose(&self) -> HashMap<u64, SampledValues> {
         let mut map: HashMap<u64, HashMap<OrderedFloat<f64>, Vec<u64>>> = HashMap::new();
@@ -112,15 +120,6 @@ impl Samples {
                 })
                 .collect::<Result<_>>()?,
         })
-    }
-
-    pub fn map_state(&mut self, mut f: impl FnMut(&mut State) -> Result<()>) -> Result<()> {
-        for v in &mut self.entries {
-            f(v.state
-                .as_mut()
-                .context("ommx.v1.Samples.Entry must has state. Broken Data.")?)?;
-        }
-        Ok(())
     }
 }
 

--- a/rust/ommx/src/convert/sample_set.rs
+++ b/rust/ommx/src/convert/sample_set.rs
@@ -81,11 +81,11 @@ impl Samples {
         })
     }
 
-    pub fn states_mut(&mut self) -> impl Iterator<Item = &mut State> {
+    pub fn states_mut(&mut self) -> impl Iterator<Item = Result<&mut State>> {
         self.entries.iter_mut().map(|v| {
             v.state
                 .as_mut()
-                .expect("ommx.v1.Samples.Entry must has state. Broken Data.")
+                .context("ommx.v1.Samples.Entry must has state. Broken Data.")
         })
     }
 

--- a/rust/ommx/src/convert/sample_set.rs
+++ b/rust/ommx/src/convert/sample_set.rs
@@ -113,6 +113,15 @@ impl Samples {
                 .collect::<Result<_>>()?,
         })
     }
+
+    pub fn map_state(&mut self, mut f: impl FnMut(&mut State) -> Result<()>) -> Result<()> {
+        for v in &mut self.entries {
+            f(v.state
+                .as_mut()
+                .context("ommx.v1.Samples.Entry must has state. Broken Data.")?)?;
+        }
+        Ok(())
+    }
 }
 
 impl SampleSet {

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -425,7 +425,7 @@ impl Evaluate for Instance {
             let mut new = constraints.partial_evaluate(state)?;
             used.append(&mut new);
         }
-        for (_id, d) in &mut self.decision_variable_dependency {
+        for d in self.decision_variable_dependency.values_mut() {
             let mut new = d.partial_evaluate(state)?;
             used.append(&mut new);
         }
@@ -467,7 +467,7 @@ impl Evaluate for Instance {
         // Reconstruct decision variable values
         let mut samples = samples.clone();
         for state in samples.states_mut() {
-            let mut new = eval_dependencies(&self.decision_variable_dependency, state)?;
+            let mut new = eval_dependencies(&self.decision_variable_dependency, state?)?;
             used_ids.append(&mut new);
         }
         let mut transposed = samples.transpose();
@@ -501,13 +501,13 @@ fn eval_dependencies(
     dependencies: &HashMap<u64, Function>,
     state: &mut State,
 ) -> Result<BTreeSet<u64>> {
-    let mut bucket: Vec<_> = dependencies.into_iter().collect();
+    let mut bucket: Vec<_> = dependencies.iter().collect();
     let mut last_size = bucket.len();
     let mut not_evaluated = Vec::new();
     let mut used_ids = BTreeSet::new();
     loop {
         while let Some((id, f)) = bucket.pop() {
-            match f.evaluate(&state) {
+            match f.evaluate(state) {
                 Ok((value, mut used)) => {
                     state.entries.insert(*id, value);
                     used_ids.append(&mut used);

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -545,6 +545,22 @@ mod tests {
         eval_dependencies(&dependencies, &mut state).unwrap();
         assert_eq!(state.entries[&4], 1.0 + 2.0 * 2.0);
         assert_eq!(state.entries[&5], 1.0 + 2.0 * 2.0 + 3.0 * 3.0);
+
+        // circular dependency
+        let mut state = State::from_iter(vec![(1, 1.0), (2, 2.0), (3, 3.0)]);
+        let dependencies = hashmap! {
+            4 => Function::from(Linear::new([(1, 1.0), (5, 2.0)].into_iter(), 0.0)),
+            5 => Function::from(Linear::new([(4, 1.0), (3, 3.0)].into_iter(), 0.0)),
+        };
+        assert!(eval_dependencies(&dependencies, &mut state).is_err());
+
+        // non-existing dependency
+        let mut state = State::from_iter(vec![(1, 1.0), (2, 2.0), (3, 3.0)]);
+        let dependencies = hashmap! {
+            4 => Function::from(Linear::new([(1, 1.0), (6, 2.0)].into_iter(), 0.0)),
+            5 => Function::from(Linear::new([(4, 1.0), (3, 3.0)].into_iter(), 0.0)),
+        };
+        assert!(eval_dependencies(&dependencies, &mut state).is_err());
     }
 
     #[test]

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -390,6 +390,7 @@ impl Evaluate for Instance {
                 state.entries.insert(v.id, value);
             }
         }
+        eval_dependencies(&self.decision_variable_dependency, &mut state)?;
         Ok((
             Solution {
                 decision_variables: self.decision_variables.clone(),
@@ -424,12 +425,18 @@ impl Evaluate for Instance {
             let mut new = constraints.partial_evaluate(state)?;
             used.append(&mut new);
         }
+        for (_id, d) in &mut self.decision_variable_dependency {
+            let mut new = d.partial_evaluate(state)?;
+            used.append(&mut new);
+        }
         Ok(used)
     }
 
     fn evaluate_samples(&self, samples: &Samples) -> Result<(Self::SampledOutput, BTreeSet<u64>)> {
         let mut feasible: HashMap<u64, bool> = samples.ids().map(|id| (*id, true)).collect();
         let mut used_ids = BTreeSet::new();
+
+        // Constraints
         let mut constraints = Vec::new();
         for c in &self.constraints {
             let (evaluated, mut ids) = c.evaluate_samples(samples)?;
@@ -453,8 +460,17 @@ impl Evaluate for Instance {
             constraints.push(v);
         }
 
+        // Objective
         let (objectives, mut ids) = self.objective().evaluate_samples(samples)?;
         used_ids.append(&mut ids);
+
+        // Reconstruct decision variable values
+        let mut samples = samples.clone();
+        samples.map_state(|s| {
+            let mut new = eval_dependencies(&self.decision_variable_dependency, s)?;
+            used_ids.append(&mut new);
+            Ok(())
+        })?;
         let mut transposed = samples.transpose();
         let decision_variables: Vec<SampledDecisionVariable> = self
             .decision_variables
@@ -478,6 +494,38 @@ impl Evaluate for Instance {
             },
             used_ids,
         ))
+    }
+}
+
+// FIXME: This would be better by using a topological sort
+fn eval_dependencies(
+    dependencies: &HashMap<u64, Function>,
+    state: &mut State,
+) -> Result<BTreeSet<u64>> {
+    let mut bucket: Vec<_> = dependencies.into_iter().collect();
+    let mut last_size = bucket.len();
+    let mut not_evaluated = Vec::new();
+    let mut used_ids = BTreeSet::new();
+    loop {
+        while let Some((id, f)) = bucket.pop() {
+            match f.evaluate(&state) {
+                Ok((value, mut used)) => {
+                    state.entries.insert(*id, value);
+                    used_ids.append(&mut used);
+                }
+                Err(_) => {
+                    not_evaluated.push((id, f));
+                }
+            }
+        }
+        if not_evaluated.is_empty() {
+            return Ok(used_ids);
+        }
+        if last_size == not_evaluated.len() {
+            bail!("Cannot evaluate any dependent variables.");
+        }
+        last_size = not_evaluated.len();
+        bucket.append(&mut not_evaluated);
     }
 }
 

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -536,6 +536,18 @@ mod tests {
     use proptest::prelude::*;
 
     #[test]
+    fn test_eval_dependencies() {
+        let mut state = State::from_iter(vec![(1, 1.0), (2, 2.0), (3, 3.0)]);
+        let dependencies = hashmap! {
+            4 => Function::from(Linear::new([(1, 1.0), (2, 2.0)].into_iter(), 0.0)),
+            5 => Function::from(Linear::new([(4, 1.0), (3, 3.0)].into_iter(), 0.0)),
+        };
+        eval_dependencies(&dependencies, &mut state).unwrap();
+        assert_eq!(state.entries[&4], 1.0 + 2.0 * 2.0);
+        assert_eq!(state.entries[&5], 1.0 + 2.0 * 2.0 + 3.0 * 3.0);
+    }
+
+    #[test]
     fn linear_partial_evaluate() {
         let mut linear = Linear::new([(1, 1.0), (2, 2.0), (3, 3.0), (4, 4.0)].into_iter(), 5.0);
         let state = State {

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -466,11 +466,10 @@ impl Evaluate for Instance {
 
         // Reconstruct decision variable values
         let mut samples = samples.clone();
-        samples.map_state(|s| {
-            let mut new = eval_dependencies(&self.decision_variable_dependency, s)?;
+        for state in samples.states_mut() {
+            let mut new = eval_dependencies(&self.decision_variable_dependency, state)?;
             used_ids.append(&mut new);
-            Ok(())
-        })?;
+        }
         let mut transposed = samples.transpose();
         let decision_variables: Vec<SampledDecisionVariable> = self
             .decision_variables

--- a/rust/ommx/src/ommx.v1.rs
+++ b/rust/ommx/src/ommx.v1.rs
@@ -381,6 +381,9 @@ pub struct Instance {
     /// Constraints removed via preprocessing. These are restored when evaluated into `ommx.v1.Solution`.
     #[prost(message, repeated, tag = "8")]
     pub removed_constraints: ::prost::alloc::vec::Vec<RemovedConstraint>,
+    /// When a decision variable is dependent on another decision variable as polynomial, this map contains the ID of the dependent decision variable as key and the polynomial as value.
+    #[prost(map = "uint64, message", tag = "9")]
+    pub decision_variable_dependency: ::std::collections::HashMap<u64, Function>,
 }
 /// Nested message and enum types in `Instance`.
 pub mod instance {
@@ -486,6 +489,9 @@ pub struct ParametricInstance {
     /// Constraints removed via preprocessing. These are restored when evaluated into `ommx.v1.Solution`.
     #[prost(message, repeated, tag = "8")]
     pub removed_constraints: ::prost::alloc::vec::Vec<RemovedConstraint>,
+    /// When a decision variable is dependent on another decision variable as polynomial, this map contains the ID of the dependent decision variable as key and the polynomial as value.
+    #[prost(map = "uint64, message", tag = "9")]
+    pub decision_variable_dependency: ::std::collections::HashMap<u64, Function>,
 }
 /// A set of values of decision variables, without any evaluation, even the
 /// feasiblity of the solution.


### PR DESCRIPTION
Ready for binary encoding of integer variables.

- When an integer variable $x \in [0, 3]$ is binary encoded as $x = b_1 + 2 b_2$ with $b_1, b_2 \in \{0, 1\}$, $x$ will disappear from objective function and constraints.
- Thus, $x$ is not passed to solver which only solve with $b_1$ and $b_2$. So we have to reconstruct $x$ from $b_1$ and $b_2$, but how?
- `decision_variable_dependency` field in `ommx.v1.Instance` stores this relation, i.e. $x = b_1 + 2 b_2$ as a set of the ID of $x$ and a polynomial $b_1 + 2 b_2$.