### PR TITLE
Python SDK 1.8.0

### DIFF
--- a/python/ommx-openjij-adapter/pyproject.toml
+++ b/python/ommx-openjij-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_openjij_adapter"
-version = "1.7.1"
+version = "1.8.0"
 
 description = "OMMX Adapter for OpenJij."
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]

--- a/python/ommx-pyscipopt-adapter/pyproject.toml
+++ b/python/ommx-pyscipopt-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_pyscipopt_adapter"
-version = "1.7.1"
+version = "1.8.0"
 description = "An adapter for the SCIP from OMMX."
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
 readme = "README.md"

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_python_mip_adapter"
-version = "1.7.1"
+version = "1.8.0"
 
 description = "An adapter for the Python-MIP from/to OMMX."
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "ommx"
 
-version = "1.7.1"
+version = "1.8.0"
 description = "Open Mathematical prograMming eXchange (OMMX)"
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
 readme = "README.md"


### PR DESCRIPTION
Bump versions to 1.8.0 to match the release of the Adapter base class and updates to the PySCIPOpt & Python-MIP APIs