### PR TITLE
Split document Taskfile.yml

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,60 +6,14 @@ includes:
   api_reference:
     taskfile: docs/api_reference/Taskfile.yml
     dir: docs/api_reference
+  book_ja:
+    taskfile: docs/ja/Taskfile.yml
+    dir: docs/ja
+  book_en:
+    taskfile: docs/en/Taskfile.yml
+    dir: docs/en
 
 tasks:
-  # Documents
-  build_book_ja:
-    cmds:
-      - jupyter-book build docs/ja
-
-  build_book_ja_all:
-    cmds:
-      - jupyter-book build docs/ja --all
-
-  open_book_ja:
-    cmds:
-      - python -m webbrowser file:///$(pwd)/docs/ja/_build/html/index.html
-
-  book_ja:
-    cmds:
-      - task: build_book_ja
-      - task: open_book_ja
-
-  book_ja_all:
-    cmds:
-      - task: build_book_ja_all
-      - task: open_book_ja
-
-  watch_build_book_ja:
-    cmds:
-      - fswatch -o $(find docs/ja/ -name "*.ipynb" -or -name "*.md") | xargs -n1 -I{} jupyter-book build docs/ja
-
-  build_book_en:
-    cmds:
-      - jupyter-book build docs/en
-
-  build_book_en_all:
-    cmds:
-      - jupyter-book build docs/en --all
-
-  open_book_en:
-    cmds:
-      - python -m webbrowser file:///$(pwd)/docs/en/_build/html/index.html
-
-  book_en:
-    cmds:
-      - task: build_book_en
-      - task: open_book_en
-
-  book_en_all:
-    cmds:
-      - task: build_book_en_all
-      - task: open_book_en
-
-  watch_build_book_en:
-    cmds:
-      - fswatch -o $(find docs/en/ -name "*.ipynb" -or -name "*.md") | xargs -n1 -I{} jupyter-book build docs/en
 
   doc_rust:
     cmds:

--- a/docs/en/Taskfile.yml
+++ b/docs/en/Taskfile.yml
@@ -1,0 +1,25 @@
+# https://taskfile.dev
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+tasks:
+  build:
+    desc: "Build the book in docs/en"
+    cmds:
+      - jupyter-book build .
+
+  open:
+    desc: "Open the book in docs/en"
+    cmds:
+      - python -m webbrowser file:///$(pwd)/_build/html/index.html
+
+  watch:
+    desc: "Watch the book in docs/en"
+    cmds:
+      - fswatch -o $(find . -name '*.ipynb' -or -name '*.md') | xargs -n1 -I{} jupyter-book build .
+
+  default:
+    desc: "Build and open the book in docs/en"
+    cmds:
+      - task: build
+      - task: open

--- a/docs/ja/Taskfile.yml
+++ b/docs/ja/Taskfile.yml
@@ -1,0 +1,25 @@
+# https://taskfile.dev
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+tasks:
+  build:
+    desc: "Build the book in docs/ja"
+    cmds:
+      - jupyter-book build .
+
+  open:
+    desc: "Open the book in docs/ja"
+    cmds:
+      - python -m webbrowser file:///$(pwd)/_build/html/index.html
+
+  watch:
+    desc: "Watch the book in docs/ja"
+    cmds:
+      - fswatch -o $(find . -name '*.ipynb' -or -name '*.md') | xargs -n1 -I{} jupyter-book build .
+
+  default:
+    desc: "Build and open the book in docs/ja"
+    cmds:
+      - task: build
+      - task: open


### PR DESCRIPTION
Split the Taskfile.yml into separate files for `docs/ja` and `docs/en`.

* Add `Taskfile.yml` to `docs/ja` directory with tasks for building, opening, watching, and default.
* Add `Taskfile.yml` to `docs/en` directory with tasks for building, opening, watching, and default.
* Modify the root `Taskfile.yml` to include the new `Taskfile.yml` files from `docs/ja` and `docs/en`.
* Remove tasks related to `book_ja` and `book_en` from the root `Taskfile.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jij-Inc/ommx/pull/325?shareId=ef899e0d-b264-40c2-a26f-67d9350e4c33).