### PR TITLE
Revise `Parameters` in `Arbitrary` trait

### DIFF
--- a/rust/ommx/examples/create_artifact.rs
+++ b/rust/ommx/examples/create_artifact.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use ocipkg::ImageName;
 use ommx::{
     artifact::{Builder, InstanceAnnotations},
-    random::{random_deterministic, InstanceParameters},
+    random::{random_deterministic, FunctionParameters, InstanceParameters},
 };
 use std::path::Path;
 use url::Url;
@@ -18,11 +18,16 @@ fn main() -> Result<()> {
         .parse_default_env()
         .init();
 
-    let lp = random_deterministic(InstanceParameters {
-        num_constraints: 7,
+    let linear_parameter = FunctionParameters {
         num_terms: 5,
         max_degree: 1,
         max_id: 10,
+    };
+    let lp = random_deterministic(InstanceParameters {
+        num_constraints: 7,
+        objective: linear_parameter,
+        constraint: linear_parameter,
+        kinds: vec![ommx::v1::decision_variable::Kind::Continuous],
     });
 
     // "data" directory is at the root of the repository

--- a/rust/ommx/src/convert/function.rs
+++ b/rust/ommx/src/convert/function.rs
@@ -389,13 +389,13 @@ mod tests {
         }
 
         #[test]
-        fn test_as_constant_roundtrip(f in Function::arbitrary_with(FunctionParameters{ num_terms: 5, max_degree: 0,  max_id: 10})) {
+        fn test_as_constant_roundtrip(f in Function::arbitrary_with(FunctionParameters{ num_terms: 1, max_degree: 0,  max_id: 10})) {
             let c = f.clone().as_constant().unwrap();
             prop_assert!(f.abs_diff_eq(&Function::from(c), 1e-10));
         }
 
         #[test]
-        fn test_max_degree_0(f in Function::arbitrary_with(FunctionParameters{ num_terms: 5, max_degree: 0, max_id: 10})) {
+        fn test_max_degree_0(f in Function::arbitrary_with(FunctionParameters{ num_terms: 1, max_degree: 0, max_id: 10})) {
             prop_assert!(f.degree() == 0);
         }
 

--- a/rust/ommx/src/convert/instance.rs
+++ b/rust/ommx/src/convert/instance.rs
@@ -358,7 +358,7 @@ impl AbsDiffEq for Instance {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::v1::Parameters;
+    use crate::{random::InstanceParameters, v1::Parameters};
     use proptest::prelude::*;
 
     proptest! {
@@ -433,7 +433,7 @@ mod tests {
         }
 
         #[test]
-        fn test_pubo(instance in Instance::arbitrary_binary_unconstrained()) {
+        fn test_pubo(instance in Instance::arbitrary_with(InstanceParameters::default_pubo())) {
             if instance.sense() == Sense::Maximize {
                 return Ok(());
             }
@@ -444,7 +444,7 @@ mod tests {
         }
 
         #[test]
-        fn test_qubo(instance in Instance::arbitrary_quadratic_binary_unconstrained()) {
+        fn test_qubo(instance in Instance::arbitrary_with(InstanceParameters::default_qubo())) {
             if instance.sense() == Sense::Maximize {
                 return Ok(());
             }

--- a/rust/ommx/src/convert/linear.rs
+++ b/rust/ommx/src/convert/linear.rs
@@ -123,7 +123,8 @@ impl<'a> IntoIterator for &'a Linear {
             self.terms
                 .iter()
                 .map(|term| (Some(term.id), term.coefficient))
-                .chain(std::iter::once((None, self.constant))),
+                .chain(std::iter::once((None, self.constant)))
+                .filter(|(_, c)| !c.is_zero()),
         )
     }
 }

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -237,7 +237,7 @@ impl fmt::Display for Polynomial {
 
 #[cfg(test)]
 mod tests {
-    use crate::random::PolynomialParameters;
+    use crate::random::FunctionParameters;
 
     test_algebraic!(super::Polynomial);
 
@@ -253,13 +253,13 @@ mod tests {
 
     proptest! {
         #[test]
-        fn test_as_linear(p in super::Polynomial::arbitrary_with(PolynomialParameters{ num_terms: 5, max_degree: 1, max_id: 10})) {
+        fn test_as_linear(p in super::Polynomial::arbitrary_with(FunctionParameters{ num_terms: 5, max_degree: 1, max_id: 10})) {
             let linear = p.clone().as_linear().unwrap();
             prop_assert_eq!(p, super::Polynomial::from(linear));
         }
 
         #[test]
-        fn test_as_constant(p in super::Polynomial::arbitrary_with(PolynomialParameters{ num_terms: 1, max_degree: 0, max_id: 10})) {
+        fn test_as_constant(p in super::Polynomial::arbitrary_with(FunctionParameters{ num_terms: 1, max_degree: 0, max_id: 10})) {
             let c = p.clone().as_constant().unwrap();
             prop_assert_eq!(p, super::Polynomial::from(c));
         }

--- a/rust/ommx/src/convert/polynomial.rs
+++ b/rust/ommx/src/convert/polynomial.rs
@@ -259,7 +259,7 @@ mod tests {
         }
 
         #[test]
-        fn test_as_constant(p in super::Polynomial::arbitrary_with(PolynomialParameters{ num_terms: 5, max_degree: 0, max_id: 10})) {
+        fn test_as_constant(p in super::Polynomial::arbitrary_with(PolynomialParameters{ num_terms: 1, max_degree: 0, max_id: 10})) {
             let c = p.clone().as_constant().unwrap();
             prop_assert_eq!(p, super::Polynomial::from(c));
         }

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //!   # fn main() -> anyhow::Result<()> {
 //!   // Create random LP instance to be saved into an artifact
-//!   let lp = random_deterministic(InstanceParameters{ num_constraints: 7, num_terms: 5, max_degree: 1, max_id: 10 });
+//!   let lp = random_deterministic(InstanceParameters::default());
 //!
 //!   // Builder for creating an artifact as a file (e.g. `random_lp_instance.ommx`)
 //!   let mut builder = Builder::new_archive_unnamed("random_lp_instance.ommx".into())?;
@@ -84,7 +84,7 @@
 //!
 //!   # fn main() -> anyhow::Result<()> {
 //!   // Create random LP instance to be saved into an artifact
-//!   let lp = random_deterministic(InstanceParameters{ num_constraints: 7, num_terms: 5, max_degree: 1, max_id: 10 });
+//!   let lp = random_deterministic(InstanceParameters::default_lp());
 //!
 //!   // Builder for creating an artifact in local registry
 //!   let mut builder = Builder::new(

--- a/rust/ommx/src/mps/tests.rs
+++ b/rust/ommx/src/mps/tests.rs
@@ -1,16 +1,16 @@
-use crate::{mps::*, v1::Instance};
+use crate::{mps::*, random::InstanceParameters, v1::Instance};
 use approx::AbsDiffEq;
 use proptest::prelude::*;
 
 proptest! {
     #[test]
-    fn test_write_mps(instance in Instance::arbitrary_lp()) {
+    fn test_write_mps(instance in Instance::arbitrary_with(InstanceParameters::default_lp())) {
         let mut buffer = Vec::new();
         prop_assert!(to_mps::write_mps(&instance, &mut buffer).is_ok())
     }
 
     #[test]
-    fn test_roundtrip(instance in Instance::arbitrary_lp()) {
+    fn test_roundtrip(instance in Instance::arbitrary_with(InstanceParameters::default_lp())) {
         let mut buffer = Vec::new();
         prop_assert!(to_mps::write_mps(&instance, &mut buffer).is_ok());
         let loaded_instance = load_raw_reader(&buffer[..]).unwrap();

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -58,6 +58,8 @@ pub use parametric_instance::*;
 pub use polynomial::*;
 pub use quadratic::*;
 
+use crate::sorted_ids::SortedIds;
+
 /// Get random object based on [`Arbitrary`] trait with its [`Arbitrary::Parameters`].
 pub fn random<T: Arbitrary>(rng: proptest::test_runner::TestRng, parameters: T::Parameters) -> T {
     let strategy = T::arbitrary_with(parameters);
@@ -138,6 +140,23 @@ fn unique_integer_pairs(max_id: u64, num_terms: usize) -> BoxedStrategy<Vec<(u64
                 .map(|k| {
                     let tuple = map_k_to_tuple(k, 2, max_id);
                     (tuple[0], tuple[1])
+                })
+                .collect()
+        })
+        .boxed()
+}
+
+fn unique_sorted_ids(
+    max_id: u64,
+    degree: usize,
+    num_terms: usize,
+) -> BoxedStrategy<Vec<SortedIds>> {
+    unique_integers(0, multi_choose(max_id + 1, degree) - 1, num_terms)
+        .prop_map(move |ids| {
+            ids.into_iter()
+                .map(|k| {
+                    let tuple = map_k_to_tuple(k, degree, max_id);
+                    SortedIds::new(tuple)
                 })
                 .collect()
         })
@@ -232,6 +251,7 @@ mod tests {
 
     #[test]
     fn test_map_k_to_tuple_2d() {
+        assert_eq!(multi_choose(3 + 1, 2), 10);
         assert_eq!(map_k_to_tuple(0, 2, 3), vec![0, 0]);
         assert_eq!(map_k_to_tuple(1, 2, 3), vec![0, 1]);
         assert_eq!(map_k_to_tuple(2, 2, 3), vec![0, 2]);
@@ -246,6 +266,7 @@ mod tests {
 
     #[test]
     fn test_map_k_to_tuple_3d() {
+        assert_eq!(multi_choose(3 + 1, 3), 20);
         assert_eq!(map_k_to_tuple(0, 3, 3), vec![0, 0, 0]);
         assert_eq!(map_k_to_tuple(1, 3, 3), vec![0, 0, 1]);
         assert_eq!(map_k_to_tuple(2, 3, 3), vec![0, 0, 2]);

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -20,7 +20,7 @@
 //! });
 //! ```
 //!
-//! [`InstanceParameters`] and [`LinearParameters`] are used to specify the size of the generated components.
+//! [`InstanceParameters`] and [`FunctionParameters`] are used to specify the size of the generated components.
 //!
 //! Proptest Support
 //! ----------------

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -83,3 +83,9 @@ pub fn random_deterministic<T: Arbitrary>(parameters: T::Parameters) -> T {
 pub fn arbitrary_coefficient() -> BoxedStrategy<f64> {
     prop_oneof![Just(0.0), Just(1.0), Just(-1.0), -1.0..1.0].boxed()
 }
+
+pub fn arbitrary_coefficient_nonzero() -> BoxedStrategy<f64> {
+    prop_oneof![Just(1.0), Just(-1.0), -1.0..1.0]
+        .prop_filter("nonzero", |x: &f64| x.abs() > f64::EPSILON)
+        .boxed()
+}

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -53,7 +53,6 @@ pub use decision_variable::*;
 pub use function::*;
 pub use instance::*;
 pub use parameter::*;
-pub use parametric_instance::*;
 
 use crate::sorted_ids::SortedIds;
 

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -52,10 +52,8 @@ pub use constraint::*;
 pub use decision_variable::*;
 pub use function::*;
 pub use instance::*;
-pub use linear::*;
 pub use parameter::*;
 pub use parametric_instance::*;
-pub use polynomial::*;
 pub use quadratic::*;
 
 use crate::sorted_ids::SortedIds;

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -89,3 +89,11 @@ pub fn arbitrary_coefficient_nonzero() -> BoxedStrategy<f64> {
         .prop_filter("nonzero", |x: &f64| x.abs() > f64::EPSILON)
         .boxed()
 }
+
+// Only samples where `num_terms <= max_id + 1`
+fn num_terms_and_max_id(num_terms: usize, max_id: u64) -> impl Strategy<Value = (usize, u64)> {
+    (0..=max_id).prop_flat_map(move |max_id| {
+        let max_num_terms = std::cmp::min(max_id as usize + 1, num_terms);
+        (0..=max_num_terms).prop_map(move |num_terms| (num_terms, max_id))
+    })
+}

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -130,6 +130,23 @@ fn unique_integers(min_id: u64, max_id: u64, size: usize) -> BoxedStrategy<Vec<u
         .boxed()
 }
 
+/// Generate unique pairs of integers `(i, j)` where `i <= j <= max_id`
+fn unique_integer_pairs(max_id: u64, num_terms: usize) -> BoxedStrategy<Vec<(u64, u64)>> {
+    // Map `(i, j)` to a unique integer `k = i * (2 * n - i + 3) / 2 + j`
+    unique_integers(0, (max_id + 1) * (max_id + 2) / 2 - 1, num_terms)
+        .prop_map(move |ids| ids.into_iter().map(|k| map_k_to_ij(k, max_id)).collect())
+        .boxed()
+}
+
+fn map_k_to_ij(k: u64, n: u64) -> (u64, u64) {
+    let i = ((-2.0 * n as f64 - 3.0 + (((2.0 * n as f64 + 3.0).powi(2) - 8.0 * k as f64).sqrt()))
+        / -2.0)
+        .floor() as u64;
+    let start_k = i * (2 * n - i + 3) / 2;
+    let j = k - start_k + i;
+    (i, j)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -136,7 +136,7 @@ fn unique_integer_pairs(max_id: u64, num_terms: usize) -> BoxedStrategy<Vec<(u64
         .prop_map(move |ids| {
             ids.into_iter()
                 .map(|k| {
-                    let tuple = map_k_to_tuple_lexicographic(k, 2, max_id);
+                    let tuple = map_k_to_tuple(k, 2, max_id);
                     (tuple[0], tuple[1])
                 })
                 .collect()
@@ -145,24 +145,19 @@ fn unique_integer_pairs(max_id: u64, num_terms: usize) -> BoxedStrategy<Vec<(u64
 }
 
 /// Introduce lex order for `(i1, i2, ..., iD)` to a unique integer `k` to use `unique_integers` strategy
-fn map_k_to_tuple_lexicographic(k: u64, dim: usize, n: u64) -> Vec<u64> {
+fn map_k_to_tuple(k: u64, dim: usize, n: u64) -> Vec<u64> {
     let mut result = Vec::with_capacity(dim);
     let mut remaining_k = k;
-    for _ in 0..dim {
-        let mut current_digit = 0;
+    for i in 0..dim {
+        let rdim = dim - i - 1;
+        let mut current_digit = result.last().copied().unwrap_or(0);
         loop {
-            let c = combinations(
-                n + dim as u64 - result.len() as u64 - 1 - current_digit,
-                dim - result.len() - 1,
-            );
-            if remaining_k < c {
+            let h = multi_choose(n - current_digit + 1, rdim);
+            if remaining_k < h {
                 break;
             }
-            remaining_k -= c;
+            remaining_k -= h;
             current_digit += 1;
-        }
-        if let Some(&last_digit) = result.last() {
-            current_digit += last_digit;
         }
         result.push(current_digit);
     }
@@ -233,5 +228,43 @@ mod tests {
     fn test_multichoose() {
         let n = 5;
         assert_eq!(multi_choose(n, 2), 5 * 6 / 2);
+    }
+
+    #[test]
+    fn test_map_k_to_tuple_2d() {
+        assert_eq!(map_k_to_tuple(0, 2, 3), vec![0, 0]);
+        assert_eq!(map_k_to_tuple(1, 2, 3), vec![0, 1]);
+        assert_eq!(map_k_to_tuple(2, 2, 3), vec![0, 2]);
+        assert_eq!(map_k_to_tuple(3, 2, 3), vec![0, 3]);
+        assert_eq!(map_k_to_tuple(4, 2, 3), vec![1, 1]);
+        assert_eq!(map_k_to_tuple(5, 2, 3), vec![1, 2]);
+        assert_eq!(map_k_to_tuple(6, 2, 3), vec![1, 3]);
+        assert_eq!(map_k_to_tuple(7, 2, 3), vec![2, 2]);
+        assert_eq!(map_k_to_tuple(8, 2, 3), vec![2, 3]);
+        assert_eq!(map_k_to_tuple(9, 2, 3), vec![3, 3]);
+    }
+
+    #[test]
+    fn test_map_k_to_tuple_3d() {
+        assert_eq!(map_k_to_tuple(0, 3, 3), vec![0, 0, 0]);
+        assert_eq!(map_k_to_tuple(1, 3, 3), vec![0, 0, 1]);
+        assert_eq!(map_k_to_tuple(2, 3, 3), vec![0, 0, 2]);
+        assert_eq!(map_k_to_tuple(3, 3, 3), vec![0, 0, 3]);
+        assert_eq!(map_k_to_tuple(4, 3, 3), vec![0, 1, 1]);
+        assert_eq!(map_k_to_tuple(5, 3, 3), vec![0, 1, 2]);
+        assert_eq!(map_k_to_tuple(6, 3, 3), vec![0, 1, 3]);
+        assert_eq!(map_k_to_tuple(7, 3, 3), vec![0, 2, 2]);
+        assert_eq!(map_k_to_tuple(8, 3, 3), vec![0, 2, 3]);
+        assert_eq!(map_k_to_tuple(9, 3, 3), vec![0, 3, 3]);
+        assert_eq!(map_k_to_tuple(10, 3, 3), vec![1, 1, 1]);
+        assert_eq!(map_k_to_tuple(11, 3, 3), vec![1, 1, 2]);
+        assert_eq!(map_k_to_tuple(12, 3, 3), vec![1, 1, 3]);
+        assert_eq!(map_k_to_tuple(13, 3, 3), vec![1, 2, 2]);
+        assert_eq!(map_k_to_tuple(14, 3, 3), vec![1, 2, 3]);
+        assert_eq!(map_k_to_tuple(15, 3, 3), vec![1, 3, 3]);
+        assert_eq!(map_k_to_tuple(16, 3, 3), vec![2, 2, 2]);
+        assert_eq!(map_k_to_tuple(17, 3, 3), vec![2, 2, 3]);
+        assert_eq!(map_k_to_tuple(18, 3, 3), vec![2, 3, 3]);
+        assert_eq!(map_k_to_tuple(19, 3, 3), vec![3, 3, 3]);
     }
 }

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -6,17 +6,17 @@
 //! using [`random`] and [`random_deterministic`] functions.
 //!
 //! ```rust
-//! use ommx::{v1, random::*};
+//! use ommx::{v1::{Linear, Instance, decision_variable::Kind}, random::*};
 //!
 //! // Linear function with random coefficients
-//! let linear: v1::Linear = random_deterministic(LinearParameters { num_terms: 5, max_id: 10 });
+//! let linear: Linear = random_deterministic(FunctionParameters { num_terms: 5, max_degree: 1, max_id: 10 });
 //!
 //! // LP instance
-//! let instance: v1::Instance = random_deterministic(InstanceParameters {
+//! let instance: Instance = random_deterministic(InstanceParameters {
 //!   num_constraints: 7,
-//!   num_terms: 5,
-//!   max_degree: 1,
-//!   max_id: 10
+//!   objective: FunctionParameters { max_degree: 1, ..Default::default() },
+//!   constraint: FunctionParameters { max_degree: 1, ..Default::default() },
+//!   kinds: vec![Kind::Continuous],
 //! });
 //! ```
 //!

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -89,14 +89,6 @@ pub fn arbitrary_coefficient_nonzero() -> BoxedStrategy<f64> {
         .boxed()
 }
 
-// Only samples where `num_terms <= max_id + 1`
-fn num_terms_and_max_id(num_terms: usize, max_id: u64) -> impl Strategy<Value = (usize, u64)> {
-    (0..=max_id).prop_flat_map(move |max_id| {
-        let max_num_terms = std::cmp::min(max_id as usize + 1, num_terms);
-        (0..=max_num_terms).prop_map(move |num_terms| (num_terms, max_id))
-    })
-}
-
 /// Generate a strategy for producing a vector of unique integers within a given range `min_id..=max_id`
 fn unique_integers(min_id: u64, max_id: u64, size: usize) -> BoxedStrategy<Vec<u64>> {
     assert!(

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -54,7 +54,6 @@ pub use function::*;
 pub use instance::*;
 pub use parameter::*;
 pub use parametric_instance::*;
-pub use quadratic::*;
 
 use crate::sorted_ids::SortedIds;
 

--- a/rust/ommx/src/random.rs
+++ b/rust/ommx/src/random.rs
@@ -132,8 +132,7 @@ fn unique_integers(min_id: u64, max_id: u64, size: usize) -> BoxedStrategy<Vec<u
 
 /// Generate unique pairs of integers `(i, j)` where `i <= j <= max_id`
 fn unique_integer_pairs(max_id: u64, num_terms: usize) -> BoxedStrategy<Vec<(u64, u64)>> {
-    // Map `(i, j)` to a unique integer `k = i * (2 * n - i + 3) / 2 + j`
-    unique_integers(0, (max_id + 1) * (max_id + 2) / 2 - 1, num_terms)
+    unique_integers(0, multi_choose(max_id + 1, 2) - 1, num_terms)
         .prop_map(move |ids| {
             ids.into_iter()
                 .map(|k| {
@@ -145,6 +144,7 @@ fn unique_integer_pairs(max_id: u64, num_terms: usize) -> BoxedStrategy<Vec<(u64
         .boxed()
 }
 
+/// Introduce lex order for `(i1, i2, ..., iD)` to a unique integer `k` to use `unique_integers` strategy
 fn map_k_to_tuple_lexicographic(k: u64, dim: usize, n: u64) -> Vec<u64> {
     let mut result = Vec::with_capacity(dim);
     let mut remaining_k = k;
@@ -169,7 +169,7 @@ fn map_k_to_tuple_lexicographic(k: u64, dim: usize, n: u64) -> Vec<u64> {
     result
 }
 
-/// nCr (組み合わせ) を計算
+/// nCr
 fn combinations(n: u64, r: usize) -> u64 {
     if r as u64 > n {
         return 0;
@@ -185,6 +185,11 @@ fn combinations(n: u64, r: usize) -> u64 {
         res = res * (n - i as u64) / (i as u64 + 1);
     }
     res
+}
+
+/// nHr
+fn multi_choose(n: u64, r: usize) -> u64 {
+    combinations(n + r as u64 - 1, r)
 }
 
 #[cfg(test)]
@@ -222,5 +227,11 @@ mod tests {
             .expect("Failed to create a new tree");
         let ids = tree.current();
         println!("{:?}", ids);
+    }
+
+    #[test]
+    fn test_multichoose() {
+        let n = 5;
+        assert_eq!(multi_choose(n, 2), 5 * 6 / 2);
     }
 }

--- a/rust/ommx/src/random/constraint.rs
+++ b/rust/ommx/src/random/constraint.rs
@@ -85,19 +85,9 @@ impl Arbitrary for RemovedConstraint {
     }
 
     fn arbitrary() -> Self::Strategy {
-        let FunctionParameters {
-            num_terms,
-            max_degree,
-            max_id,
-        } = FunctionParameters::default();
-        (0..=num_terms, 0..=max_degree, 0..=max_id)
-            .prop_flat_map(|(num_terms, max_degree, max_id)| {
-                Self::arbitrary_with(FunctionParameters {
-                    num_terms,
-                    max_degree,
-                    max_id,
-                })
-            })
+        Self::Parameters::default()
+            .smaller()
+            .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }
 }

--- a/rust/ommx/src/random/decision_variable.rs
+++ b/rust/ommx/src/random/decision_variable.rs
@@ -1,5 +1,5 @@
 use crate::v1::{decision_variable::Kind, Bound, DecisionVariable};
-use proptest::prelude::*;
+use proptest::{prelude::*, strategy::Union};
 use std::collections::{BTreeSet, HashMap};
 
 impl Arbitrary for Bound {
@@ -103,8 +103,9 @@ impl Arbitrary for DecisionVariable {
 
 pub fn arbitrary_decision_variables(
     ids: BTreeSet<u64>,
-    kind_strategy: impl Strategy<Value = Kind> + 'static,
+    kinds: Vec<Kind>,
 ) -> BoxedStrategy<Vec<DecisionVariable>> {
+    let kind_strategy = Union::new(kinds.into_iter().map(Just));
     (
         proptest::collection::vec(
             (Just(0), kind_strategy).prop_flat_map(|(id, kind)| {

--- a/rust/ommx/src/random/function.rs
+++ b/rust/ommx/src/random/function.rs
@@ -1,77 +1,87 @@
 use crate::{
-    random::{arbitrary_coefficient, LinearParameters, PolynomialParameters, QuadraticParameters},
+    random::{
+        arbitrary_coefficient_nonzero, multi_choose, LinearParameters, PolynomialParameters,
+        QuadraticParameters,
+    },
     v1::{Function, Linear, Polynomial, Quadratic},
 };
-use proptest::prelude::*;
+use num::Zero;
+use proptest::{prelude::*, strategy::Union};
 
-use super::num_terms_and_max_id;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct FunctionParameters {
-    pub num_terms: usize,
-    pub max_degree: u32,
-    pub max_id: u64,
-}
-
-impl Default for FunctionParameters {
-    fn default() -> Self {
-        Self {
-            num_terms: 5,
-            max_degree: 2,
-            max_id: 10,
-        }
-    }
-}
+pub type FunctionParameters = PolynomialParameters;
 
 impl Arbitrary for Function {
     type Parameters = FunctionParameters;
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(
-        FunctionParameters {
-            num_terms,
-            max_degree,
-            max_id,
-        }: Self::Parameters,
-    ) -> Self::Strategy {
-        let linear = if max_degree >= 1 {
-            Linear::arbitrary_with(LinearParameters { num_terms, max_id })
-        } else {
-            arbitrary_coefficient().prop_map(Linear::from).boxed()
-        };
-        let quad = if max_degree >= 2 {
-            Quadratic::arbitrary_with(QuadraticParameters { num_terms, max_id })
-        } else {
-            linear.clone().prop_map(Quadratic::from).boxed()
-        };
-        prop_oneof![
-            arbitrary_coefficient().prop_map(Function::from),
-            linear.prop_map(Function::from),
-            quad.prop_map(Function::from),
-            Polynomial::arbitrary_with(PolynomialParameters {
-                num_terms,
-                max_degree,
-                max_id
-            })
-            .prop_map(Function::from),
-        ]
-        .boxed()
+    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
+        p.validate().unwrap();
+        let mut strategies = Vec::new();
+        if p.num_terms == 0 {
+            strategies.push(Just(Function::zero()).boxed());
+        }
+        let mut threshold = 1;
+        if p.num_terms == threshold {
+            strategies.push(
+                arbitrary_coefficient_nonzero()
+                    .prop_map(|c| Function::from(c))
+                    .boxed(),
+            );
+        }
+        threshold += multi_choose(p.max_id + 1, 1) as usize;
+        if p.num_terms <= threshold {
+            strategies.push(
+                Linear::arbitrary_with(LinearParameters {
+                    num_terms: p.num_terms,
+                    max_id: p.max_id,
+                })
+                .prop_map(Function::from)
+                .boxed(),
+            )
+        }
+        threshold += multi_choose(p.max_id + 1, 2) as usize;
+        if p.num_terms <= threshold {
+            strategies.push(
+                Quadratic::arbitrary_with(QuadraticParameters {
+                    num_terms: p.num_terms,
+                    max_id: p.max_id,
+                })
+                .prop_map(Function::from)
+                .boxed(),
+            )
+        }
+        strategies.push(
+            Polynomial::arbitrary_with(p)
+                .prop_map(Function::from)
+                .boxed(),
+        );
+        Union::new(strategies).boxed()
     }
 
     fn arbitrary() -> Self::Strategy {
-        let FunctionParameters {
-            num_terms,
-            max_degree,
-            max_id,
-        } = Self::Parameters::default();
-        (0..=max_degree, num_terms_and_max_id(num_terms, max_id))
-            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
-                Self::arbitrary_with(FunctionParameters {
-                    num_terms,
-                    max_degree,
-                    max_id,
-                })
-            })
+        Self::Parameters::default()
+            .smaller()
+            .prop_flat_map(Self::arbitrary_with)
             .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn test_arbitrary_function(f in Function::arbitrary_with(FunctionParameters { num_terms: 5, max_degree: 3, max_id: 10 })) {
+            let mut count = 0;
+            for (ids, _) in f.into_iter() {
+                prop_assert!(ids.len() <= 3);
+                for &id in ids.iter() {
+                    prop_assert!(id <= 10);
+                }
+                count += 1;
+            }
+            prop_assert_eq!(count, 5);
+        }
     }
 }

--- a/rust/ommx/src/random/function.rs
+++ b/rust/ommx/src/random/function.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use proptest::prelude::*;
 
+use super::num_terms_and_max_id;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FunctionParameters {
     pub num_terms: usize,
@@ -62,8 +64,8 @@ impl Arbitrary for Function {
             max_degree,
             max_id,
         } = Self::Parameters::default();
-        (0..=num_terms, 0..=max_degree, 0..=max_id)
-            .prop_flat_map(|(num_terms, max_degree, max_id)| {
+        (0..=max_degree, num_terms_and_max_id(num_terms, max_id))
+            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
                 Self::arbitrary_with(FunctionParameters {
                     num_terms,
                     max_degree,

--- a/rust/ommx/src/random/function.rs
+++ b/rust/ommx/src/random/function.rs
@@ -124,7 +124,7 @@ impl Arbitrary for Function {
         if p.num_terms == 1 {
             strategies.push(
                 arbitrary_coefficient_nonzero()
-                    .prop_map(|c| Function::from(c))
+                    .prop_map(Function::from)
                     .boxed(),
             );
         }

--- a/rust/ommx/src/random/function.rs
+++ b/rust/ommx/src/random/function.rs
@@ -20,15 +20,14 @@ impl Arbitrary for Function {
         if p.num_terms == 0 {
             strategies.push(Just(Function::zero()).boxed());
         }
-        let mut threshold = 1;
-        if p.num_terms == threshold {
+        if p.num_terms == 1 {
             strategies.push(
                 arbitrary_coefficient_nonzero()
                     .prop_map(|c| Function::from(c))
                     .boxed(),
             );
         }
-        threshold += multi_choose(p.max_id + 1, 1) as usize;
+        let mut threshold = multi_choose(p.max_id + 1, 1) as usize;
         if p.num_terms <= threshold {
             strategies.push(
                 Linear::arbitrary_with(LinearParameters {

--- a/rust/ommx/src/random/function.rs
+++ b/rust/ommx/src/random/function.rs
@@ -28,7 +28,7 @@ impl Arbitrary for Function {
             );
         }
         let mut threshold = multi_choose(p.max_id + 1, 1) as usize;
-        if p.num_terms <= threshold {
+        if p.num_terms <= threshold && p.max_degree >= 1 {
             strategies.push(
                 Linear::arbitrary_with(LinearParameters {
                     num_terms: p.num_terms,
@@ -39,7 +39,7 @@ impl Arbitrary for Function {
             )
         }
         threshold += multi_choose(p.max_id + 1, 2) as usize;
-        if p.num_terms <= threshold {
+        if p.num_terms <= threshold && p.max_degree >= 2 {
             strategies.push(
                 Quadratic::arbitrary_with(QuadraticParameters {
                     num_terms: p.num_terms,

--- a/rust/ommx/src/random/instance.rs
+++ b/rust/ommx/src/random/instance.rs
@@ -8,76 +8,105 @@ use crate::{
 };
 use proptest::prelude::*;
 
-use super::num_terms_and_max_id;
-
 impl Instance {
     /// Arbitrary LP problem, i.e. linear objective and constraints with continuous decision variables.
     pub fn arbitrary_lp() -> BoxedStrategy<Self> {
-        let InstanceParameters {
-            num_constraints,
-            num_terms,
-            max_id,
-            ..
-        } = Default::default();
-        (0..=num_constraints, num_terms_and_max_id(num_terms, max_id))
-            .prop_flat_map(|(num_constraints, (num_terms, max_id))| {
-                arbitrary_instance(
-                    num_constraints,
-                    num_terms,
-                    1,
-                    max_id,
-                    Just(Kind::Continuous),
-                )
-            })
-            .boxed()
+        let p = InstanceParameters {
+            num_constraints: 5,
+            objective: FunctionParameters {
+                num_terms: 5,
+                max_degree: 1,
+                max_id: 10,
+            },
+            constraint: FunctionParameters {
+                num_terms: 5,
+                max_degree: 1,
+                max_id: 10,
+            },
+            kinds: vec![Kind::Continuous],
+        };
+        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
     }
 
     pub fn arbitrary_binary() -> BoxedStrategy<Self> {
-        (0..10_usize, 0..=4_u32, num_terms_and_max_id(5, 10))
-            .prop_flat_map(|(num_constraints, max_degree, (num_terms, max_id))| {
-                arbitrary_instance(
-                    num_constraints,
-                    num_terms,
-                    max_degree,
-                    max_id,
-                    Just(Kind::Binary),
-                )
-            })
-            .boxed()
+        let p = InstanceParameters {
+            kinds: vec![Kind::Binary],
+            ..Default::default()
+        };
+        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
     }
 
     pub fn arbitrary_binary_unconstrained() -> BoxedStrategy<Self> {
-        (0..=4_u32, num_terms_and_max_id(5, 10))
-            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
-                arbitrary_instance(0, num_terms, max_degree, max_id, Just(Kind::Binary))
-            })
-            .boxed()
+        let p = InstanceParameters {
+            num_constraints: 0,
+            kinds: vec![Kind::Binary],
+            ..Default::default()
+        };
+        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
     }
 
     pub fn arbitrary_quadratic_binary_unconstrained() -> BoxedStrategy<Self> {
-        (0..=2_u32, num_terms_and_max_id(5, 10))
-            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
-                arbitrary_instance(0, num_terms, max_degree, max_id, Just(Kind::Binary))
-            })
-            .boxed()
+        let p = InstanceParameters {
+            num_constraints: 0,
+            objective: FunctionParameters {
+                num_terms: 5,
+                max_degree: 2,
+                max_id: 10,
+            },
+            kinds: vec![Kind::Binary],
+            ..Default::default()
+        };
+        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InstanceParameters {
     pub num_constraints: usize,
-    pub num_terms: usize,
-    pub max_degree: u32,
-    pub max_id: u64,
+    pub objective: FunctionParameters,
+    pub constraint: FunctionParameters,
+    pub kinds: Vec<Kind>,
+}
+
+impl Kind {
+    pub fn possibles() -> Vec<Self> {
+        vec![
+            Kind::Continuous,
+            Kind::Integer,
+            Kind::Binary,
+            Kind::SemiContinuous,
+            Kind::SemiInteger,
+        ]
+    }
+}
+
+impl InstanceParameters {
+    pub fn smaller(&self) -> BoxedStrategy<Self> {
+        (
+            0..=self.num_constraints,
+            self.objective.smaller(),
+            self.constraint.smaller(),
+            proptest::sample::subsequence(self.kinds.clone(), 1..=self.kinds.len()),
+        )
+            .prop_map(
+                |(num_constraints, objective, constraint, kinds)| InstanceParameters {
+                    objective,
+                    constraint,
+                    kinds,
+                    num_constraints,
+                },
+            )
+            .boxed()
+    }
 }
 
 impl Default for InstanceParameters {
     fn default() -> Self {
         Self {
             num_constraints: 5,
-            num_terms: 5,
-            max_degree: 3,
-            max_id: 10,
+            objective: FunctionParameters::default(),
+            constraint: FunctionParameters::default(),
+            kinds: vec![Kind::Continuous, Kind::Integer, Kind::Binary],
         }
     }
 }
@@ -89,41 +118,81 @@ impl Arbitrary for Instance {
     fn arbitrary_with(
         InstanceParameters {
             num_constraints,
-            num_terms,
-            max_degree,
-            max_id,
+            objective,
+            constraint,
+            kinds,
         }: Self::Parameters,
     ) -> Self::Strategy {
-        arbitrary_instance(
-            num_constraints,
-            num_terms,
-            max_degree,
-            max_id,
-            Kind::arbitrary(),
+        assert!(
+            !kinds.is_empty(),
+            "At least one kind of decision variable must be allowed"
+        );
+        objective.validate().unwrap();
+        constraint.validate().unwrap();
+        (
+            Function::arbitrary_with(objective),
+            arbitrary_constraints(num_constraints, constraint),
         )
+            .prop_flat_map(move |(objective, constraints)| {
+                let mut used_ids = objective.used_decision_variable_ids();
+                for c in &constraints {
+                    used_ids.extend(c.function().used_decision_variable_ids());
+                }
+                let relaxed = if constraints.is_empty() {
+                    Just(Vec::new()).boxed()
+                } else {
+                    let constraint_ids = constraints.iter().map(|c| c.id).collect::<Vec<_>>();
+                    proptest::sample::subsequence(constraint_ids, 0..=constraints.len()).boxed()
+                };
+                (
+                    Just(objective),
+                    Just(constraints),
+                    arbitrary_decision_variables(used_ids, kinds.clone()),
+                    Option::<Description>::arbitrary(),
+                    Sense::arbitrary(),
+                    relaxed,
+                    ".{0,3}",
+                    proptest::collection::hash_map(".{0,3}", ".{0,3}", 0..=2),
+                )
+                    .prop_map(
+                        |(
+                            objective,
+                            constraints,
+                            decision_variables,
+                            description,
+                            sense,
+                            relaxed,
+                            removed_reason,
+                            removed_parameters,
+                        )| {
+                            let mut instance = Instance {
+                                objective: Some(objective),
+                                constraints,
+                                decision_variables,
+                                description,
+                                sense: sense as i32,
+                                ..Default::default()
+                            };
+                            for i in relaxed {
+                                instance
+                                    .relax_constraint(
+                                        i,
+                                        removed_reason.clone(),
+                                        removed_parameters.clone(),
+                                    )
+                                    .unwrap();
+                            }
+                            instance
+                        },
+                    )
+            })
+            .boxed()
     }
 
     fn arbitrary() -> Self::Strategy {
-        let InstanceParameters {
-            num_constraints,
-            num_terms,
-            max_degree,
-            max_id,
-        } = Default::default();
-        (
-            0..=num_constraints,
-            0..=max_degree,
-            num_terms_and_max_id(num_terms, max_id),
-        )
-            .prop_flat_map(|(num_constraints, max_degree, (num_terms, max_id))| {
-                arbitrary_instance(
-                    num_constraints,
-                    num_terms,
-                    max_degree,
-                    max_id,
-                    Kind::arbitrary(),
-                )
-            })
+        Self::Parameters::default()
+            .smaller()
+            .prop_flat_map(Self::arbitrary_with)
             .boxed()
     }
 }
@@ -156,85 +225,4 @@ impl Arbitrary for Description {
             })
             .boxed()
     }
-}
-
-fn arbitrary_instance(
-    num_constraints: usize,
-    num_terms: usize,
-    max_degree: u32,
-    max_id: u64,
-    kind_strategy: impl Strategy<Value = Kind> + 'static + Clone,
-) -> BoxedStrategy<Instance> {
-    (
-        proptest::option::of(Function::arbitrary_with(FunctionParameters {
-            num_terms,
-            max_degree,
-            max_id,
-        })),
-        arbitrary_constraints(
-            num_constraints,
-            FunctionParameters {
-                num_terms,
-                max_degree,
-                max_id,
-            },
-        ),
-    )
-        .prop_flat_map(move |(objective, constraints)| {
-            let mut used_ids = objective
-                .as_ref()
-                .map(|f| f.used_decision_variable_ids())
-                .unwrap_or_default();
-            for c in &constraints {
-                used_ids.extend(c.function().used_decision_variable_ids());
-            }
-            let relaxed = if constraints.is_empty() {
-                Just(Vec::new()).boxed()
-            } else {
-                let constraint_ids = constraints.iter().map(|c| c.id).collect::<Vec<_>>();
-                proptest::sample::subsequence(constraint_ids, 0..=constraints.len()).boxed()
-            };
-            (
-                Just(objective),
-                Just(constraints),
-                arbitrary_decision_variables(used_ids, kind_strategy.clone()),
-                Option::<Description>::arbitrary(),
-                Sense::arbitrary(),
-                relaxed,
-                ".{0,3}",
-                proptest::collection::hash_map(".{0,3}", ".{0,3}", 0..=2),
-            )
-                .prop_map(
-                    |(
-                        objective,
-                        constraints,
-                        decision_variables,
-                        description,
-                        sense,
-                        relaxed,
-                        removed_reason,
-                        removed_parameters,
-                    )| {
-                        let mut instance = Instance {
-                            objective,
-                            constraints,
-                            decision_variables,
-                            description,
-                            sense: sense as i32,
-                            ..Default::default()
-                        };
-                        for i in relaxed {
-                            instance
-                                .relax_constraint(
-                                    i,
-                                    removed_reason.clone(),
-                                    removed_parameters.clone(),
-                                )
-                                .unwrap();
-                        }
-                        instance
-                    },
-                )
-        })
-        .boxed()
 }

--- a/rust/ommx/src/random/instance.rs
+++ b/rust/ommx/src/random/instance.rs
@@ -9,58 +9,6 @@ use crate::{
 use anyhow::{bail, Result};
 use proptest::prelude::*;
 
-impl Instance {
-    /// Arbitrary LP problem, i.e. linear objective and constraints with continuous decision variables.
-    pub fn arbitrary_lp() -> BoxedStrategy<Self> {
-        let p = InstanceParameters {
-            num_constraints: 5,
-            objective: FunctionParameters {
-                num_terms: 5,
-                max_degree: 1,
-                max_id: 10,
-            },
-            constraint: FunctionParameters {
-                num_terms: 5,
-                max_degree: 1,
-                max_id: 10,
-            },
-            kinds: vec![Kind::Continuous],
-        };
-        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
-    }
-
-    pub fn arbitrary_binary() -> BoxedStrategy<Self> {
-        let p = InstanceParameters {
-            kinds: vec![Kind::Binary],
-            ..Default::default()
-        };
-        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
-    }
-
-    pub fn arbitrary_binary_unconstrained() -> BoxedStrategy<Self> {
-        let p = InstanceParameters {
-            num_constraints: 0,
-            kinds: vec![Kind::Binary],
-            ..Default::default()
-        };
-        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
-    }
-
-    pub fn arbitrary_quadratic_binary_unconstrained() -> BoxedStrategy<Self> {
-        let p = InstanceParameters {
-            num_constraints: 0,
-            objective: FunctionParameters {
-                num_terms: 5,
-                max_degree: 2,
-                max_id: 10,
-            },
-            kinds: vec![Kind::Binary],
-            ..Default::default()
-        };
-        p.smaller().prop_flat_map(Instance::arbitrary_with).boxed()
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InstanceParameters {
     pub num_constraints: usize,
@@ -82,6 +30,55 @@ impl Kind {
 }
 
 impl InstanceParameters {
+    /// Example parameter for LP problem, i.e. linear objective and constraints with continuous decision variables.
+    pub fn default_lp() -> Self {
+        Self {
+            num_constraints: 5,
+            objective: FunctionParameters {
+                num_terms: 5,
+                max_degree: 1,
+                max_id: 10,
+            },
+            constraint: FunctionParameters {
+                num_terms: 5,
+                max_degree: 1,
+                max_id: 10,
+            },
+            kinds: vec![Kind::Continuous],
+        }
+    }
+
+    /// Example parameter for binary problem
+    pub fn default_binary() -> Self {
+        Self {
+            kinds: vec![Kind::Binary],
+            ..Default::default()
+        }
+    }
+
+    /// Example parameter for binary problem without constraints
+    pub fn default_pubo() -> Self {
+        Self {
+            num_constraints: 0,
+            kinds: vec![Kind::Binary],
+            ..Default::default()
+        }
+    }
+
+    /// Example parameter for binary quadratic problem without constraints (QUBO)
+    pub fn default_qubo() -> Self {
+        Self {
+            num_constraints: 0,
+            objective: FunctionParameters {
+                num_terms: 5,
+                max_degree: 2,
+                max_id: 10,
+            },
+            kinds: vec![Kind::Binary],
+            ..Default::default()
+        }
+    }
+
     pub fn validate(&self) -> Result<()> {
         self.objective.validate()?;
         self.constraint.validate()?;

--- a/rust/ommx/src/random/instance.rs
+++ b/rust/ommx/src/random/instance.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 use proptest::prelude::*;
 
+use super::num_terms_and_max_id;
+
 impl Instance {
     /// Arbitrary LP problem, i.e. linear objective and constraints with continuous decision variables.
     pub fn arbitrary_lp() -> BoxedStrategy<Self> {
@@ -17,8 +19,8 @@ impl Instance {
             max_id,
             ..
         } = Default::default();
-        (0..=num_constraints, 0..num_terms, 0..=max_id)
-            .prop_flat_map(|(num_constraints, num_terms, max_id)| {
+        (0..=num_constraints, num_terms_and_max_id(num_terms, max_id))
+            .prop_flat_map(|(num_constraints, (num_terms, max_id))| {
                 arbitrary_instance(
                     num_constraints,
                     num_terms,
@@ -31,8 +33,8 @@ impl Instance {
     }
 
     pub fn arbitrary_binary() -> BoxedStrategy<Self> {
-        (0..10_usize, 0..10_usize, 0..=4_u32, 0..10_u64)
-            .prop_flat_map(|(num_constraints, num_terms, max_degree, max_id)| {
+        (0..10_usize, 0..=4_u32, num_terms_and_max_id(5, 10))
+            .prop_flat_map(|(num_constraints, max_degree, (num_terms, max_id))| {
                 arbitrary_instance(
                     num_constraints,
                     num_terms,
@@ -45,16 +47,16 @@ impl Instance {
     }
 
     pub fn arbitrary_binary_unconstrained() -> BoxedStrategy<Self> {
-        (0..10_usize, 0..=4_u32, 0..10_u64)
-            .prop_flat_map(|(num_terms, max_degree, max_id)| {
+        (0..=4_u32, num_terms_and_max_id(5, 10))
+            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
                 arbitrary_instance(0, num_terms, max_degree, max_id, Just(Kind::Binary))
             })
             .boxed()
     }
 
     pub fn arbitrary_quadratic_binary_unconstrained() -> BoxedStrategy<Self> {
-        (0..10_usize, 0..=2_u32, 0..10_u64)
-            .prop_flat_map(|(num_terms, max_degree, max_id)| {
+        (0..=2_u32, num_terms_and_max_id(5, 10))
+            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
                 arbitrary_instance(0, num_terms, max_degree, max_id, Just(Kind::Binary))
             })
             .boxed()
@@ -110,11 +112,10 @@ impl Arbitrary for Instance {
         } = Default::default();
         (
             0..=num_constraints,
-            0..=num_terms,
             0..=max_degree,
-            0..=max_id,
+            num_terms_and_max_id(num_terms, max_id),
         )
-            .prop_flat_map(|(num_constraints, num_terms, max_degree, max_id)| {
+            .prop_flat_map(|(num_constraints, max_degree, (num_terms, max_id))| {
                 arbitrary_instance(
                     num_constraints,
                     num_terms,

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -19,6 +19,11 @@ impl Arbitrary for Linear {
         if p.num_terms == 0 {
             return Just(Linear::zero()).boxed();
         }
+        if p.max_degree == 0 {
+            return arbitrary_coefficient_nonzero()
+                .prop_map(|constant| constant.into())
+                .boxed();
+        }
 
         let constant = if p.num_terms == 1 + p.possible_max_linear_terms() {
             arbitrary_coefficient_nonzero()

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -47,14 +47,11 @@ impl Arbitrary for Linear {
                 } else {
                     num_terms
                 };
-                let ids = unique_integers(0, max_id, num_terms);
+                let ids = unique_integers(0, max_id, num_linear);
                 let coefficients =
                     proptest::collection::vec(arbitrary_coefficient_nonzero(), num_linear);
                 (ids, coefficients).prop_map(move |(ids, coefficients)| {
-                    Linear::new(
-                        coefficients.iter().zip(ids.iter()).map(|(&c, &id)| (id, c)),
-                        constant,
-                    )
+                    Linear::new(ids.into_iter().zip(coefficients.into_iter()), constant)
                 })
             })
             .boxed()

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -6,6 +6,15 @@ use super::{arbitrary_coefficient, arbitrary_coefficient_nonzero, num_terms_and_
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LinearParameters {
+    /// Number of non-zero terms in the linear function including the constant term.
+    ///
+    /// e.g. `x1 + x2 + 1` is 3 terms.
+    ///
+    /// ```rust
+    /// use ommx::{random::{LinearParameters, random_deterministic}, v1::Linear};
+    /// let lin: Linear = random_deterministic(LinearParameters { num_terms: 5, max_id: 10 });
+    /// assert_eq!(lin.into_iter().count(), 5);
+    /// ```
     pub num_terms: usize,
     pub max_id: u64,
 }

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -2,50 +2,19 @@ use crate::v1::Linear;
 use num::Zero;
 use proptest::prelude::*;
 
-use super::{arbitrary_coefficient, arbitrary_coefficient_nonzero, unique_integers};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct LinearParameters {
-    /// Number of non-zero terms in the linear function including the constant term.
-    ///
-    /// e.g. `x1 + x2 + 1` is 3 terms.
-    ///
-    /// ```rust
-    /// use ommx::{random::{LinearParameters, random_deterministic}, v1::Linear};
-    /// let lin: Linear = random_deterministic(LinearParameters { num_terms: 5, max_id: 10 });
-    /// assert_eq!(lin.into_iter().count(), 5);
-    /// ```
-    pub num_terms: usize,
-    pub max_id: u64,
-}
-
-impl Default for LinearParameters {
-    fn default() -> Self {
-        Self {
-            num_terms: 5,
-            max_id: 10,
-        }
-    }
-}
-
-impl LinearParameters {
-    pub fn smaller(&self) -> impl Strategy<Value = Self> {
-        (0..=self.max_id, Just(self.num_terms)).prop_flat_map(move |(max_id, num_terms)| {
-            let small = Self {
-                max_id,
-                num_terms: 0,
-            };
-            (0..=std::cmp::min(num_terms, small.max_id as usize + 1))
-                .prop_map(move |num_terms| Self { max_id, num_terms })
-        })
-    }
-}
+use super::{
+    arbitrary_coefficient, arbitrary_coefficient_nonzero, unique_integers, FunctionParameters,
+};
 
 impl Arbitrary for Linear {
-    type Parameters = LinearParameters;
+    type Parameters = FunctionParameters;
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(LinearParameters { num_terms, max_id }: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with(
+        FunctionParameters {
+            num_terms, max_id, ..
+        }: Self::Parameters,
+    ) -> Self::Strategy {
         assert!(
             num_terms <= max_id as usize + 1,
             "num_terms({num_terms}) must be less than or equal to max_id({max_id}) + 1 to ensure unique ids"
@@ -84,7 +53,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn test_arbitrary_linear(l in Linear::arbitrary_with(LinearParameters { num_terms: 5, max_id: 10 })) {
+        fn test_arbitrary_linear(l in Linear::arbitrary_with(FunctionParameters { num_terms: 5, max_degree: 1, max_id: 10 })) {
             let mut count = 0;
             for (ids, _) in l.into_iter() {
                 for &id in ids.iter() {
@@ -96,7 +65,7 @@ mod tests {
         }
 
         #[test]
-        fn test_max_num_terms(l in Linear::arbitrary_with(LinearParameters { num_terms: 11, max_id: 10 })) {
+        fn test_max_num_terms(l in Linear::arbitrary_with(FunctionParameters { num_terms: 11, max_degree: 1, max_id: 10 })) {
             prop_assert_eq!(l.into_iter().count(), 11);
         }
     }

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -1,4 +1,4 @@
-use crate::v1::Linear;
+use crate::{random::unique_integers, v1::Linear};
 use num::Zero;
 use proptest::prelude::*;
 
@@ -47,7 +47,7 @@ impl Arbitrary for Linear {
                 } else {
                     num_terms
                 };
-                let ids = Just((0..=max_id).collect::<Vec<_>>()).prop_shuffle();
+                let ids = unique_integers(0, max_id, num_terms);
                 let coefficients =
                     proptest::collection::vec(arbitrary_coefficient_nonzero(), num_linear);
                 (ids, coefficients).prop_map(move |(ids, coefficients)| {
@@ -85,6 +85,11 @@ mod tests {
                 count += 1;
             }
             prop_assert_eq!(count, 5);
+        }
+
+        #[test]
+        fn test_max_num_terms(l in Linear::arbitrary_with(LinearParameters { num_terms: 11, max_id: 10 })) {
+            prop_assert_eq!(l.into_iter().count(), 11);
         }
     }
 }

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -51,7 +51,7 @@ impl Arbitrary for Linear {
                 let coefficients =
                     proptest::collection::vec(arbitrary_coefficient_nonzero(), num_linear);
                 (ids, coefficients).prop_map(move |(ids, coefficients)| {
-                    Linear::new(ids.into_iter().zip(coefficients.into_iter()), constant)
+                    Linear::new(ids.into_iter().zip(coefficients), constant)
                 })
             })
             .boxed()

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -43,10 +43,13 @@ impl Arbitrary for Linear {
     }
 
     fn arbitrary() -> Self::Strategy {
-        Self::Parameters::default()
-            .smaller()
-            .prop_flat_map(Self::arbitrary_with)
-            .boxed()
+        Self::Parameters {
+            max_degree: 1,
+            ..Default::default()
+        }
+        .smaller()
+        .prop_flat_map(Self::arbitrary_with)
+        .boxed()
     }
 }
 

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -39,3 +39,15 @@ impl Arbitrary for Linear {
             .boxed()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn test_arbitrary_linear(l in Linear::arbitrary_with(LinearParameters { num_terms: 5, max_id: 10 })) {
+            prop_assert!(l.terms.len() == 5);
+        }
+    }
+}

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -10,26 +10,29 @@ impl Arbitrary for Linear {
     type Parameters = FunctionParameters;
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(
-        FunctionParameters {
-            num_terms, max_id, ..
-        }: Self::Parameters,
-    ) -> Self::Strategy {
+    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
+        p.validate().unwrap();
         assert!(
-            num_terms <= max_id as usize + 1,
-            "num_terms({num_terms}) must be less than or equal to max_id({max_id}) + 1 to ensure unique ids"
+            p.can_be_linear(),
+            "FunctionParameters ({p:?}) cannot be realized as a Linear",
         );
-        if num_terms == 0 {
+        if p.num_terms == 0 {
             return Just(Linear::zero()).boxed();
         }
-        arbitrary_coefficient()
+
+        let constant = if p.num_terms == 1 + p.possible_max_linear_terms() {
+            arbitrary_coefficient_nonzero()
+        } else {
+            arbitrary_coefficient()
+        };
+        constant
             .prop_flat_map(move |constant| {
                 let num_linear = if constant.abs() > f64::EPSILON {
-                    num_terms - 1
+                    p.num_terms - 1
                 } else {
-                    num_terms
+                    p.num_terms
                 };
-                let ids = unique_integers(0, max_id, num_linear);
+                let ids = unique_integers(0, p.max_id, num_linear);
                 let coefficients =
                     proptest::collection::vec(arbitrary_coefficient_nonzero(), num_linear);
                 (ids, coefficients).prop_map(move |(ids, coefficients)| {
@@ -65,8 +68,8 @@ mod tests {
         }
 
         #[test]
-        fn test_max_num_terms(l in Linear::arbitrary_with(FunctionParameters { num_terms: 11, max_degree: 1, max_id: 10 })) {
-            prop_assert_eq!(l.into_iter().count(), 11);
+        fn test_max_num_terms(l in Linear::arbitrary_with(FunctionParameters { num_terms: 12, max_degree: 1, max_id: 10 })) {
+            prop_assert_eq!(l.into_iter().count(), 12);
         }
     }
 }

--- a/rust/ommx/src/random/linear.rs
+++ b/rust/ommx/src/random/linear.rs
@@ -42,9 +42,13 @@ impl Arbitrary for Linear {
 
     fn arbitrary() -> Self::Strategy {
         let LinearParameters { num_terms, max_id } = Self::Parameters::default();
-        (0..=num_terms, 0..=max_id)
-            .prop_flat_map(|(num_terms, max_id)| {
-                Self::arbitrary_with(LinearParameters { num_terms, max_id })
+        // Only samples where `num_terms <= max_id + 1`
+        (0..=max_id)
+            .prop_flat_map(move |max_id| {
+                let max_num_terms = std::cmp::min(max_id as usize + 1, num_terms);
+                (0..=max_num_terms).prop_flat_map(move |num_terms| {
+                    Self::arbitrary_with(LinearParameters { num_terms, max_id })
+                })
             })
             .boxed()
     }

--- a/rust/ommx/src/random/parametric_instance.rs
+++ b/rust/ommx/src/random/parametric_instance.rs
@@ -12,8 +12,6 @@ use crate::{
 use proptest::prelude::*;
 use std::collections::BTreeSet;
 
-use super::num_terms_and_max_id;
-
 pub struct ParametricInstanceParameters {
     pub num_constraints: usize,
     pub num_terms: usize,
@@ -80,7 +78,7 @@ impl Arbitrary for ParametricInstance {
                                 Just(constraints),
                                 arbitrary_decision_variables(
                                     decision_variable_ids,
-                                    Kind::arbitrary(),
+                                    Kind::possibles(),
                                 ),
                                 arbitrary_parameters(parameter_ids),
                                 Option::<Description>::arbitrary(),
@@ -113,26 +111,7 @@ impl Arbitrary for ParametricInstance {
     }
 
     fn arbitrary() -> Self::Strategy {
-        let ParametricInstanceParameters {
-            num_constraints,
-            num_terms,
-            max_degree,
-            max_id,
-        } = ParametricInstanceParameters::default();
-        (
-            0..=num_constraints,
-            0..=max_degree,
-            num_terms_and_max_id(num_terms, max_id),
-        )
-            .prop_flat_map(move |(num_constraints, max_degree, (num_terms, max_id))| {
-                Self::arbitrary_with(ParametricInstanceParameters {
-                    num_constraints,
-                    num_terms,
-                    max_degree,
-                    max_id,
-                })
-            })
-            .boxed()
+        todo!()
     }
 }
 

--- a/rust/ommx/src/random/parametric_instance.rs
+++ b/rust/ommx/src/random/parametric_instance.rs
@@ -12,6 +12,8 @@ use crate::{
 use proptest::prelude::*;
 use std::collections::BTreeSet;
 
+use super::num_terms_and_max_id;
+
 pub struct ParametricInstanceParameters {
     pub num_constraints: usize,
     pub num_terms: usize,
@@ -119,11 +121,10 @@ impl Arbitrary for ParametricInstance {
         } = ParametricInstanceParameters::default();
         (
             0..=num_constraints,
-            0..=num_terms,
             0..=max_degree,
-            0..=max_id,
+            num_terms_and_max_id(num_terms, max_id),
         )
-            .prop_flat_map(move |(num_constraints, num_terms, max_degree, max_id)| {
+            .prop_flat_map(move |(num_constraints, max_degree, (num_terms, max_id))| {
                 Self::arbitrary_with(ParametricInstanceParameters {
                     num_constraints,
                     num_terms,

--- a/rust/ommx/src/random/parametric_instance.rs
+++ b/rust/ommx/src/random/parametric_instance.rs
@@ -1,10 +1,9 @@
 use crate::{
     random::{
         arbitrary_constraints, arbitrary_decision_variables, arbitrary_parameters,
-        FunctionParameters,
+        InstanceParameters,
     },
     v1::{
-        decision_variable::Kind,
         instance::{Description, Sense},
         Function, ParametricInstance,
     },
@@ -12,56 +11,26 @@ use crate::{
 use proptest::prelude::*;
 use std::collections::BTreeSet;
 
-pub struct ParametricInstanceParameters {
-    pub num_constraints: usize,
-    pub num_terms: usize,
-    pub max_degree: u32,
-    pub max_id: u64,
-}
-
-impl Default for ParametricInstanceParameters {
-    fn default() -> Self {
-        Self {
-            num_constraints: 5,
-            num_terms: 5,
-            max_degree: 2,
-            max_id: 10,
-        }
-    }
-}
-
 impl Arbitrary for ParametricInstance {
-    type Parameters = ParametricInstanceParameters;
+    type Parameters = InstanceParameters;
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(
-        ParametricInstanceParameters {
+    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
+        p.validate().unwrap();
+        let InstanceParameters {
             num_constraints,
-            num_terms,
-            max_degree,
-            max_id,
-        }: Self::Parameters,
-    ) -> Self::Strategy {
+            objective,
+            constraint,
+            kinds,
+        } = p;
+
         (
-            proptest::option::of(Function::arbitrary_with(FunctionParameters {
-                num_terms,
-                max_degree,
-                max_id,
-            })),
-            arbitrary_constraints(
-                num_constraints,
-                FunctionParameters {
-                    num_terms,
-                    max_degree,
-                    max_id,
-                },
-            ),
+            Function::arbitrary_with(objective),
+            arbitrary_constraints(num_constraints, constraint),
+            Just(kinds),
         )
-            .prop_flat_map(|(objective, constraints)| {
-                let mut used_ids = objective
-                    .as_ref()
-                    .map(|f| f.used_decision_variable_ids())
-                    .unwrap_or_default();
+            .prop_flat_map(|(objective, constraints, kinds)| {
+                let mut used_ids = objective.used_decision_variable_ids();
                 for c in &constraints {
                     used_ids.extend(c.function().used_decision_variable_ids());
                 }
@@ -72,14 +41,11 @@ impl Arbitrary for ParametricInstance {
                     arbitrary_split(used_ids),
                 )
                     .prop_flat_map(
-                        |(objective, constraints, (decision_variable_ids, parameter_ids))| {
+                        move |(objective, constraints, (decision_variable_ids, parameter_ids))| {
                             (
                                 Just(objective),
                                 Just(constraints),
-                                arbitrary_decision_variables(
-                                    decision_variable_ids,
-                                    Kind::possibles(),
-                                ),
+                                arbitrary_decision_variables(decision_variable_ids, kinds.clone()),
                                 arbitrary_parameters(parameter_ids),
                                 Option::<Description>::arbitrary(),
                                 Sense::arbitrary(),
@@ -94,7 +60,7 @@ impl Arbitrary for ParametricInstance {
                                         sense,
                                     )| {
                                         ParametricInstance {
-                                            objective,
+                                            objective: Some(objective),
                                             constraints,
                                             decision_variables,
                                             description,
@@ -111,7 +77,10 @@ impl Arbitrary for ParametricInstance {
     }
 
     fn arbitrary() -> Self::Strategy {
-        todo!()
+        Self::Parameters::default()
+            .smaller()
+            .prop_flat_map(Self::arbitrary_with)
+            .boxed()
     }
 }
 

--- a/rust/ommx/src/random/polynomial.rs
+++ b/rust/ommx/src/random/polynomial.rs
@@ -1,13 +1,40 @@
-use crate::{random::arbitrary_coefficient, sorted_ids::SortedIds, v1::Polynomial};
+use crate::v1::Polynomial;
 use proptest::prelude::*;
 
-use super::num_terms_and_max_id;
+use super::{arbitrary_coefficient_nonzero, multi_choose, unique_sorted_ids};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PolynomialParameters {
     pub num_terms: usize,
     pub max_degree: u32,
     pub max_id: u64,
+}
+
+impl PolynomialParameters {
+    fn possible_max_terms(&self) -> usize {
+        (0..=self.max_degree)
+            .map(|d| multi_choose(self.max_id + 1, d as usize) as usize)
+            .sum()
+    }
+
+    pub fn smaller(&self) -> impl Strategy<Value = Self> {
+        (0..=self.max_id, 0..=self.max_degree, Just(self.num_terms)).prop_flat_map(
+            move |(max_id, max_degree, num_terms)| {
+                let small = Self {
+                    max_id,
+                    max_degree,
+                    num_terms: 0,
+                };
+                (0..=std::cmp::min(num_terms, small.possible_max_terms())).prop_map(
+                    move |num_terms| Self {
+                        max_id,
+                        num_terms,
+                        max_degree,
+                    },
+                )
+            },
+        )
+    }
 }
 
 impl Default for PolynomialParameters {
@@ -31,30 +58,44 @@ impl Arbitrary for Polynomial {
             max_id,
         }: Self::Parameters,
     ) -> Self::Strategy {
-        let terms = proptest::collection::vec(
-            (
-                SortedIds::arbitrary_with((max_degree, max_id)),
-                arbitrary_coefficient(),
-            ),
-            num_terms,
+        let max_num_terms = (0..=max_degree)
+            .map(|d| multi_choose(max_id + 1, d as usize) as usize)
+            .sum();
+        assert!(
+            num_terms <= max_num_terms,
+            "num_terms({num_terms}) must be less than or equal to the possible maximum number of terms({max_num_terms})"
         );
-        terms.prop_map(|terms| terms.into_iter().collect()).boxed()
+        let ids = unique_sorted_ids(max_id, max_degree as usize, num_terms);
+        let coefficients = proptest::collection::vec(arbitrary_coefficient_nonzero(), num_terms);
+        (ids, coefficients)
+            .prop_map(|(ids, coefficients)| ids.into_iter().zip(coefficients).collect())
+            .boxed()
     }
 
     fn arbitrary() -> Self::Strategy {
-        let PolynomialParameters {
-            num_terms,
-            max_degree,
-            max_id,
-        } = Self::Parameters::default();
-        (0..=max_degree, num_terms_and_max_id(num_terms, max_id))
-            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
-                Self::arbitrary_with(PolynomialParameters {
-                    num_terms,
-                    max_degree,
-                    max_id,
-                })
-            })
+        Self::Parameters::default()
+            .smaller()
+            .prop_flat_map(Self::arbitrary_with)
             .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn test_arbitrary_polynomial(p in Polynomial::arbitrary_with(PolynomialParameters { num_terms: 5, max_degree: 3, max_id: 10 })) {
+            let mut count = 0;
+            for (ids, _) in p.into_iter() {
+                prop_assert!(ids.len() <= 3);
+                for &id in ids.iter() {
+                    prop_assert!(id <= 10);
+                }
+                count += 1;
+            }
+            prop_assert_eq!(count, 5);
+        }
     }
 }

--- a/rust/ommx/src/random/polynomial.rs
+++ b/rust/ommx/src/random/polynomial.rs
@@ -1,6 +1,8 @@
 use crate::{random::arbitrary_coefficient, sorted_ids::SortedIds, v1::Polynomial};
 use proptest::prelude::*;
 
+use super::num_terms_and_max_id;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PolynomialParameters {
     pub num_terms: usize,
@@ -45,8 +47,8 @@ impl Arbitrary for Polynomial {
             max_degree,
             max_id,
         } = Self::Parameters::default();
-        (0..=num_terms, 0..=max_degree, 0..=max_id)
-            .prop_flat_map(|(num_terms, max_degree, max_id)| {
+        (0..=max_degree, num_terms_and_max_id(num_terms, max_id))
+            .prop_flat_map(|(max_degree, (num_terms, max_id))| {
                 Self::arbitrary_with(PolynomialParameters {
                     num_terms,
                     max_degree,

--- a/rust/ommx/src/random/polynomial.rs
+++ b/rust/ommx/src/random/polynomial.rs
@@ -1,4 +1,5 @@
 use crate::v1::Polynomial;
+use num::Zero;
 use proptest::prelude::*;
 
 use super::{arbitrary_coefficient_nonzero, multi_choose, unique_sorted_ids};
@@ -15,6 +16,20 @@ impl PolynomialParameters {
         (0..=self.max_degree)
             .map(|d| multi_choose(self.max_id + 1, d as usize) as usize)
             .sum()
+    }
+
+    fn largest_degree_term_range(&self) -> std::ops::RangeInclusive<usize> {
+        let sub_max_terms = (0..self.max_degree)
+            .map(|d| multi_choose(self.max_id + 1, d as usize) as usize)
+            .sum::<usize>();
+        let largest_max_terms = multi_choose(self.max_id + 1, self.max_degree as usize) as usize;
+        let max = std::cmp::min(self.num_terms, largest_max_terms);
+        let min = if self.num_terms >= sub_max_terms {
+            self.num_terms - sub_max_terms
+        } else {
+            0
+        };
+        min..=max
     }
 
     pub fn smaller(&self) -> impl Strategy<Value = Self> {
@@ -51,24 +66,45 @@ impl Arbitrary for Polynomial {
     type Parameters = PolynomialParameters;
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(
-        PolynomialParameters {
-            num_terms,
-            max_degree,
-            max_id,
-        }: Self::Parameters,
-    ) -> Self::Strategy {
-        let max_num_terms = (0..=max_degree)
-            .map(|d| multi_choose(max_id + 1, d as usize) as usize)
-            .sum();
+    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
         assert!(
-            num_terms <= max_num_terms,
-            "num_terms({num_terms}) must be less than or equal to the possible maximum number of terms({max_num_terms})"
+            p.num_terms <= p.possible_max_terms(),
+            "num_terms({num_terms}) must be less than or equal to the possible maximum number of terms({max_num_terms})",
+            num_terms = p.num_terms,
+            max_num_terms = p.possible_max_terms()
         );
-        let ids = unique_sorted_ids(max_id, max_degree as usize, num_terms);
-        let coefficients = proptest::collection::vec(arbitrary_coefficient_nonzero(), num_terms);
-        (ids, coefficients)
-            .prop_map(|(ids, coefficients)| ids.into_iter().zip(coefficients).collect())
+        if p.max_degree == 0 {
+            if p.num_terms == 0 {
+                return Just(Polynomial::zero()).boxed();
+            }
+            return arbitrary_coefficient_nonzero()
+                .prop_map(|c| Polynomial::from(c))
+                .boxed();
+        }
+        p.largest_degree_term_range()
+            .prop_flat_map(move |num_largest| {
+                // The largest degree terms
+                let ids = unique_sorted_ids(p.max_id, p.max_degree as usize, num_largest);
+                let coefficients =
+                    proptest::collection::vec(arbitrary_coefficient_nonzero(), num_largest);
+
+                // The remaining terms
+                let num_sub = p.num_terms - num_largest;
+                let sub = Self::arbitrary_with(PolynomialParameters {
+                    num_terms: num_sub,
+                    max_degree: p.max_degree - 1,
+                    max_id: p.max_id,
+                });
+
+                (ids, coefficients, sub)
+                    .prop_map(|(ids, coefficients, sub)| {
+                        ids.into_iter()
+                            .zip(coefficients)
+                            .chain(sub.into_iter())
+                            .collect()
+                    })
+                    .boxed()
+            })
             .boxed()
     }
 

--- a/rust/ommx/src/random/polynomial.rs
+++ b/rust/ommx/src/random/polynomial.rs
@@ -15,7 +15,7 @@ impl Arbitrary for Polynomial {
                 return Just(Polynomial::zero()).boxed();
             }
             return arbitrary_coefficient_nonzero()
-                .prop_map(|c| Polynomial::from(c))
+                .prop_map(Polynomial::from)
                 .boxed();
         }
         p.largest_degree_term_range()
@@ -35,10 +35,7 @@ impl Arbitrary for Polynomial {
 
                 (ids, coefficients, sub)
                     .prop_map(|(ids, coefficients, sub)| {
-                        ids.into_iter()
-                            .zip(coefficients)
-                            .chain(sub.into_iter())
-                            .collect()
+                        ids.into_iter().zip(coefficients).chain(&sub).collect()
                     })
                     .boxed()
             })

--- a/rust/ommx/src/random/polynomial.rs
+++ b/rust/ommx/src/random/polynomial.rs
@@ -1,81 +1,11 @@
 use crate::v1::Polynomial;
-use anyhow::{bail, Result};
 use num::Zero;
 use proptest::prelude::*;
 
-use super::{arbitrary_coefficient_nonzero, multi_choose, unique_sorted_ids};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct PolynomialParameters {
-    pub num_terms: usize,
-    pub max_degree: u32,
-    pub max_id: u64,
-}
-
-impl PolynomialParameters {
-    fn possible_max_terms(&self) -> usize {
-        (0..=self.max_degree)
-            .map(|d| multi_choose(self.max_id + 1, d as usize) as usize)
-            .sum()
-    }
-
-    fn largest_degree_term_range(&self) -> std::ops::RangeInclusive<usize> {
-        let sub_max_terms = (0..self.max_degree)
-            .map(|d| multi_choose(self.max_id + 1, d as usize) as usize)
-            .sum::<usize>();
-        let largest_max_terms = multi_choose(self.max_id + 1, self.max_degree as usize) as usize;
-        let max = std::cmp::min(self.num_terms, largest_max_terms);
-        let min = if self.num_terms >= sub_max_terms {
-            self.num_terms - sub_max_terms
-        } else {
-            0
-        };
-        min..=max
-    }
-
-    pub fn validate(&self) -> Result<()> {
-        if self.num_terms > self.possible_max_terms() {
-            bail!(
-                "num_terms({num_terms}) must be less than or equal to the possible maximum number of terms({max_num_terms})",
-                num_terms = self.num_terms,
-                max_num_terms = self.possible_max_terms()
-            )
-        }
-        Ok(())
-    }
-
-    pub fn smaller(&self) -> impl Strategy<Value = Self> {
-        (0..=self.max_id, 0..=self.max_degree, Just(self.num_terms)).prop_flat_map(
-            move |(max_id, max_degree, num_terms)| {
-                let small = Self {
-                    max_id,
-                    max_degree,
-                    num_terms: 0,
-                };
-                (0..=std::cmp::min(num_terms, small.possible_max_terms())).prop_map(
-                    move |num_terms| Self {
-                        max_id,
-                        num_terms,
-                        max_degree,
-                    },
-                )
-            },
-        )
-    }
-}
-
-impl Default for PolynomialParameters {
-    fn default() -> Self {
-        Self {
-            num_terms: 5,
-            max_degree: 3,
-            max_id: 10,
-        }
-    }
-}
+use super::{arbitrary_coefficient_nonzero, unique_sorted_ids, FunctionParameters};
 
 impl Arbitrary for Polynomial {
-    type Parameters = PolynomialParameters;
+    type Parameters = FunctionParameters;
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
@@ -97,7 +27,7 @@ impl Arbitrary for Polynomial {
 
                 // The remaining terms
                 let num_sub = p.num_terms - num_largest;
-                let sub = Self::arbitrary_with(PolynomialParameters {
+                let sub = Self::arbitrary_with(FunctionParameters {
                     num_terms: num_sub,
                     max_degree: p.max_degree - 1,
                     max_id: p.max_id,
@@ -129,7 +59,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn test_arbitrary_polynomial(p in Polynomial::arbitrary_with(PolynomialParameters { num_terms: 5, max_degree: 3, max_id: 10 })) {
+        fn test_arbitrary_polynomial(p in Polynomial::arbitrary_with(FunctionParameters { num_terms: 5, max_degree: 3, max_id: 10 })) {
             let mut count = 0;
             for (ids, _) in p.into_iter() {
                 prop_assert!(ids.len() <= 3);

--- a/rust/ommx/src/random/quadratic.rs
+++ b/rust/ommx/src/random/quadratic.rs
@@ -17,24 +17,72 @@ impl Default for QuadraticParameters {
     }
 }
 
+impl QuadraticParameters {
+    fn possible_max_quad_terms(&self) -> usize {
+        ((self.max_id + 2) * (self.max_id + 1) / 2) as usize
+    }
+
+    fn possible_max_linear_terms(&self) -> usize {
+        (self.max_id + 1) as usize
+    }
+
+    // Possible maximum of the number of terms
+    //
+    // Note that `Quadratic` is not a binary function, x1 * x1 and x1 are different terms.
+    fn possible_max_terms(&self) -> usize {
+        self.possible_max_quad_terms() + self.possible_max_linear_terms()
+    }
+
+    fn linear_terms_range(&self) -> std::ops::RangeInclusive<usize> {
+        let max = std::cmp::min(self.num_terms, self.possible_max_linear_terms());
+        let min = if self.num_terms >= self.possible_max_quad_terms() {
+            self.num_terms - self.possible_max_quad_terms()
+        } else {
+            0
+        };
+        min..=max
+    }
+
+    pub fn smaller(&self) -> impl Strategy<Value = Self> {
+        (0..=self.max_id).prop_flat_map(move |max_id| {
+            let small = Self {
+                max_id,
+                num_terms: 0,
+            };
+            (0..=small.possible_max_terms()).prop_map(move |num_terms| Self { max_id, num_terms })
+        })
+    }
+}
+
 impl Arbitrary for Quadratic {
     type Parameters = QuadraticParameters;
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(
-        QuadraticParameters { num_terms, max_id }: Self::Parameters,
-    ) -> Self::Strategy {
-        (0..=num_terms)
-            .prop_flat_map(move |num_quad| {
-                let num_linear = num_terms - num_quad;
+    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
+        assert!(
+            p.num_terms <= p.possible_max_terms(),
+            "num_terms ({num_terms}) must be less than or equal to possible maximum ({possible_max_terms}) determined from max_id ({max_id})",
+            num_terms = p.num_terms,
+            max_id = p.max_id,
+            possible_max_terms = p.possible_max_terms()
+        );
+        p.linear_terms_range()
+            .prop_flat_map(move |num_linear| {
+                let num_quad = p.num_terms - num_linear;
+                assert!(
+                    num_quad <= p.possible_max_quad_terms(),
+                    "num_quad ({num_quad}) must be less than or equal to max_quad_terms({max_quad_terms})",
+                    max_quad_terms = p.possible_max_quad_terms(),
+                );
+
                 let quad = proptest::collection::hash_map(
-                    arbitrary_key(max_id),
+                    arbitrary_key(p.max_id),
                     arbitrary_coefficient_nonzero(),
                     num_quad,
                 );
                 let linear = Linear::arbitrary_with(LinearParameters {
                     num_terms: num_linear,
-                    max_id,
+                    max_id: p.max_id,
                 });
                 (quad, linear).prop_map(|(quad, linear)| {
                     let mut quad: Quadratic = quad.into_iter().collect();

--- a/rust/ommx/src/random/quadratic.rs
+++ b/rust/ommx/src/random/quadratic.rs
@@ -1,4 +1,4 @@
-use super::{arbitrary_coefficient, LinearParameters};
+use super::{arbitrary_coefficient, num_terms_and_max_id, LinearParameters};
 use crate::v1::{Linear, Quadratic};
 use proptest::prelude::*;
 
@@ -40,8 +40,8 @@ impl Arbitrary for Quadratic {
 
     fn arbitrary() -> Self::Strategy {
         let QuadraticParameters { num_terms, max_id } = Self::Parameters::default();
-        (0..=num_terms, 0..=max_id)
-            .prop_flat_map(|(num_terms, max_id)| {
+        num_terms_and_max_id(num_terms, max_id)
+            .prop_flat_map(move |(num_terms, max_id)| {
                 Self::arbitrary_with(QuadraticParameters { num_terms, max_id })
             })
             .boxed()

--- a/rust/ommx/src/random/quadratic.rs
+++ b/rust/ommx/src/random/quadratic.rs
@@ -19,6 +19,11 @@ impl Arbitrary for Quadratic {
         if p.num_terms == 0 {
             return Just(Quadratic::zero()).boxed();
         }
+        if p.max_degree < 2 {
+            return Linear::arbitrary_with(p)
+                .prop_map(|linear| linear.into())
+                .boxed();
+        }
         p.max_degree = 2;
         p.largest_degree_term_range()
             .prop_flat_map(move |num_quad| {

--- a/rust/ommx/src/random/quadratic.rs
+++ b/rust/ommx/src/random/quadratic.rs
@@ -1,6 +1,6 @@
-use super::{arbitrary_coefficient_nonzero, LinearParameters};
+use super::arbitrary_coefficient_nonzero;
 use crate::{
-    random::unique_integer_pairs,
+    random::{unique_integer_pairs, FunctionParameters},
     v1::{Linear, Quadratic},
 };
 use proptest::prelude::*;
@@ -81,8 +81,9 @@ impl Arbitrary for Quadratic {
 
                 let pairs = unique_integer_pairs(p.max_id, num_quad);
                 let values = proptest::collection::vec(arbitrary_coefficient_nonzero(), num_quad);
-                let linear = Linear::arbitrary_with(LinearParameters {
+                let linear = Linear::arbitrary_with(FunctionParameters{
                     num_terms: num_linear,
+                    max_degree: 1,
                     max_id: p.max_id,
                 });
                 (pairs, values, linear).prop_map(|(pairs, values, linear)| {

--- a/rust/ommx/src/random/quadratic.rs
+++ b/rust/ommx/src/random/quadratic.rs
@@ -27,16 +27,17 @@ impl Arbitrary for Quadratic {
         (0..=num_terms)
             .prop_flat_map(move |num_quad| {
                 let num_linear = num_terms - num_quad;
-                let terms = proptest::collection::vec(
-                    ((0..=max_id, 0..=max_id), arbitrary_coefficient_nonzero()),
+                let quad = proptest::collection::hash_map(
+                    arbitrary_key(max_id),
+                    arbitrary_coefficient_nonzero(),
                     num_quad,
                 );
                 let linear = Linear::arbitrary_with(LinearParameters {
                     num_terms: num_linear,
                     max_id,
                 });
-                (terms, linear).prop_map(|(terms, linear)| {
-                    let mut quad: Quadratic = terms.into_iter().collect();
+                (quad, linear).prop_map(|(quad, linear)| {
+                    let mut quad: Quadratic = quad.into_iter().collect();
                     quad.linear = Some(linear);
                     quad
                 })
@@ -52,6 +53,11 @@ impl Arbitrary for Quadratic {
             })
             .boxed()
     }
+}
+
+/// Generates a pair of ID `(i, j)` where `i <= j <= max_id`.
+fn arbitrary_key(max_id: u64) -> impl Strategy<Value = (u64, u64)> {
+    (0..=max_id).prop_flat_map(move |id1| (id1..=max_id).prop_map(move |id2| (id1, id2)))
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/random/quadratic.rs
+++ b/rust/ommx/src/random/quadratic.rs
@@ -1,4 +1,4 @@
-use super::{arbitrary_coefficient, num_terms_and_max_id, LinearParameters};
+use super::{arbitrary_coefficient_nonzero, num_terms_and_max_id, LinearParameters};
 use crate::v1::{Linear, Quadratic};
 use proptest::prelude::*;
 
@@ -24,16 +24,22 @@ impl Arbitrary for Quadratic {
     fn arbitrary_with(
         QuadraticParameters { num_terms, max_id }: Self::Parameters,
     ) -> Self::Strategy {
-        let terms = proptest::collection::vec(
-            ((0..=max_id, 0..=max_id), arbitrary_coefficient()),
-            num_terms,
-        );
-        let linear = Linear::arbitrary_with(LinearParameters { num_terms, max_id });
-        (terms, linear)
-            .prop_map(|(terms, linear)| {
-                let mut quad: Quadratic = terms.into_iter().collect();
-                quad.linear = Some(linear);
-                quad
+        (0..=num_terms)
+            .prop_flat_map(move |num_quad| {
+                let num_linear = num_terms - num_quad;
+                let terms = proptest::collection::vec(
+                    ((0..=max_id, 0..=max_id), arbitrary_coefficient_nonzero()),
+                    num_quad,
+                );
+                let linear = Linear::arbitrary_with(LinearParameters {
+                    num_terms: num_linear,
+                    max_id,
+                });
+                (terms, linear).prop_map(|(terms, linear)| {
+                    let mut quad: Quadratic = terms.into_iter().collect();
+                    quad.linear = Some(linear);
+                    quad
+                })
             })
             .boxed()
     }
@@ -45,5 +51,24 @@ impl Arbitrary for Quadratic {
                 Self::arbitrary_with(QuadraticParameters { num_terms, max_id })
             })
             .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn test_arbitrary_quadratic(q in Quadratic::arbitrary_with(QuadraticParameters { num_terms: 5, max_id: 10 })) {
+            let mut count = 0;
+            for (ids, _) in q.into_iter() {
+                for &id in ids.iter() {
+                    prop_assert!(id <= 10);
+                }
+                count += 1;
+            }
+            prop_assert_eq!(count, 5);
+        }
     }
 }

--- a/rust/ommx/src/random/quadratic.rs
+++ b/rust/ommx/src/random/quadratic.rs
@@ -40,10 +40,13 @@ impl Arbitrary for Quadratic {
     }
 
     fn arbitrary() -> Self::Strategy {
-        Self::Parameters::default()
-            .smaller()
-            .prop_flat_map(Self::arbitrary_with)
-            .boxed()
+        Self::Parameters {
+            max_degree: 2,
+            ..Default::default()
+        }
+        .smaller()
+        .prop_flat_map(Self::arbitrary_with)
+        .boxed()
     }
 }
 


### PR DESCRIPTION
Following up #330 

- Integrate `LinearParameters` and `QuadraticParameters` into `FunctionParameters`
- The number of terms generated with `num_terms` becomes `num_terms`, i.e. 
  ```rust
  use ommx::{random::{FunctionParameters, random_deterministic}, v1::Function};
  let f: Function = random_deterministic(FunctionParameters { num_terms: 5, max_degree: 3, max_id: 10 });
  assert_eq!(f.into_iter().count(), 5);
  ```
- Update `InstanceParameters` to store the setting for objective and constraints separately.