### PR TITLE
Prepare Python SDK 1.8.4 release

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [python-mip, pyscipopt, openjij]
+        name: [python-mip, pyscipopt, openjij, highs]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/__init__.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/__init__.py
@@ -2,8 +2,10 @@ from .python_mip_to_ommx import (
     model_to_instance,
 )
 from .adapter import OMMXPythonMIPAdapter
+from .exception import OMMXPythonMIPAdapterError
 
 __all__ = [
     "model_to_instance",
     "OMMXPythonMIPAdapter",
+    "OMMXPythonMIPAdapterError",
 ]


### PR DESCRIPTION
- Adds ommx-highs-adapter to the release workflow
- Fixes as a small papercut in ommx-python-mip-adapter where the exception type was not being exported in `__all__`