### PR TITLE
Introduce `SamplerAdapter` and `OMMXOpenJijSAAdapter`

### DIFF
--- a/python/Taskfile.yml
+++ b/python/Taskfile.yml
@@ -65,3 +65,8 @@ tasks:
     desc: Generate stubs files for Rust extension
     cmds:
       - cargo run --bin stub_gen --features=stub_gen
+
+  generate-llms-txt:
+    desc: Generate LLMs.txt
+    cmds:
+      - uv run generate_llms_txt.py

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -31,8 +31,8 @@ class OMMXHighsAdapter(SolverAdapter):
         self._set_objective()
         self._set_constraints()
 
-    @staticmethod
-    def solve(ommx_instance: Instance, *, verbose: bool = False) -> Solution:
+    @classmethod
+    def solve(cls, ommx_instance: Instance, *, verbose: bool = False) -> Solution:
         """
         Solve the given ommx.v1.Instance using HiGHS, returning an ommx.v1.Solution.
 
@@ -122,7 +122,7 @@ class OMMXHighsAdapter(SolverAdapter):
         #     ...
         # ommx.adapter.UnboundedDetected: Model was unbounded
         # ````
-        adapter = OMMXHighsAdapter(ommx_instance, verbose=verbose)
+        adapter = cls(ommx_instance, verbose=verbose)
         model = adapter.solver_input
         model.run()
         return adapter.decode(model)

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -6,7 +6,7 @@ import openjij as oj
 from typing_extensions import deprecated
 
 
-class OMMXOpenJijAdapter(SamplerAdapter):
+class OMMXOpenJijSAAdapter(SamplerAdapter):
     """
     Sampling QUBO with Simulated Annealing (SA) by `openjij.SASampler <https://openjij.github.io/OpenJij/reference/openjij/index.html#openjij.SASampler>`_
     """

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -126,7 +126,7 @@ class OMMXOpenJijAdapter(SamplerAdapter):
         sampler = oj.SASampler()
         qubo, _offset = self.ommx_instance.as_qubo_format()
         return sampler.sample_qubo(
-            qubo, # type: ignore
+            qubo,  # type: ignore
             beta_min=self.beta_min,
             beta_max=self.beta_max,
             num_sweeps=self.num_sweeps,

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -171,7 +171,7 @@ def decode_to_samples(response: oj.Response) -> Samples:
     return Samples(entries=entries)
 
 
-@deprecated("Use `OMMXOpenJijAdapter.sample` instead")
+@deprecated("Use `OMMXOpenJijSAAdapter.sample` instead")
 def sample_qubo_sa(
     instance: Instance,
     *,
@@ -187,7 +187,7 @@ def sample_qubo_sa(
     seed: int | None = None,
 ) -> Samples:
     """
-    Deprecated: Use :meth:`OMMXOpenJijAdapter.sample` instead
+    Deprecated: Use :meth:`OMMXOpenJijSAAdapter.sample` instead
     """
     q, _offset = instance.as_qubo_format()
     sampler = oj.SASampler()

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -1,12 +1,156 @@
 from __future__ import annotations
 
-from ommx.v1 import Instance, State, Samples
+from ommx.v1 import Instance, State, Samples, SampleSet
+from ommx.adapter import SamplerAdapter
 import openjij as oj
+from typing_extensions import deprecated
 
 
+class OMMXOpenJijAdapter(SamplerAdapter):
+    """
+    Sampling QUBO with Simulated Annealing (SA) by `openjij.SASampler <https://openjij.github.io/OpenJij/reference/openjij/index.html#openjij.SASampler>`_
+    """
+
+    ommx_instance: Instance
+    """
+    ommx.v1.Instance representing a QUBO problem
+
+    The input `instance` must be a QUBO (Quadratic Unconstrained Binary Optimization) problem, i.e.
+
+    - Every decision variables are binary
+    - No constraint
+    - Objective function is quadratic
+    - Minimization problem
+
+    You can convert an instance to QUBO via :meth:`ommx.v1.Instance.penalty_method` or other corresponding method.
+    """
+
+    beta_min: float | None = None
+    """ minimal value of inverse temperature """
+    beta_max: float | None = None
+    """ maximum value of inverse temperature """
+    num_sweeps: int | None = None
+    """ number of sweeps """
+    num_reads: int | None = None
+    """ number of reads """
+    schedule: list | None = None
+    """ list of inverse temperature """
+    initial_state: list | dict | None = None
+    """ initial state """
+    updater: str | None = None
+    """ updater algorithm """
+    sparse: bool | None = None
+    """ use sparse matrix or not """
+    reinitialize_state: bool | None = None
+    """ if true reinitialize state for each run """
+    seed: int | None = None
+    """ seed for Monte Carlo algorithm """
+
+    @classmethod
+    def sample(
+        cls,
+        ommx_instance: Instance,
+        *,
+        beta_min: float | None = None,
+        beta_max: float | None = None,
+        num_sweeps: int | None = None,
+        num_reads: int | None = None,
+        schedule: list | None = None,
+        initial_state: list | dict | None = None,
+        updater: str | None = None,
+        sparse: bool | None = None,
+        reinitialize_state: bool | None = None,
+        seed: int | None = None,
+    ) -> SampleSet:
+        sampler = cls(
+            ommx_instance,
+            beta_min=beta_min,
+            beta_max=beta_max,
+            num_sweeps=num_sweeps,
+            num_reads=num_reads,
+            schedule=schedule,
+            initial_state=initial_state,
+            updater=updater,
+            sparse=sparse,
+            reinitialize_state=reinitialize_state,
+            seed=seed,
+        )
+        response = sampler._sample()
+        return sampler.decode_to_sampleset(response)
+
+    def __init__(
+        self,
+        ommx_instance: Instance,
+        *,
+        beta_min: float | None = None,
+        beta_max: float | None = None,
+        num_sweeps: int | None = None,
+        num_reads: int | None = None,
+        schedule: list | None = None,
+        initial_state: list | dict | None = None,
+        updater: str | None = None,
+        sparse: bool | None = None,
+        reinitialize_state: bool | None = None,
+        seed: int | None = None,
+    ):
+        self.ommx_instance = ommx_instance
+        self.beta_min = beta_min
+        self.beta_max = beta_max
+        self.num_sweeps = num_sweeps
+        self.num_reads = num_reads
+        self.schedule = schedule
+        self.initial_state = initial_state
+        self.updater = updater
+        self.sparse = sparse
+        self.reinitialize_state = reinitialize_state
+        self.seed = seed
+
+    def decode_to_sampleset(self, data: oj.Response) -> SampleSet:
+        samples = decode_to_samples(data)
+        return self.ommx_instance.evaluate_samples(samples)
+
+    def decode_to_samples(self, data: oj.Response) -> Samples:
+        """
+        Convert `openjij.Response <https://openjij.github.io/OpenJij/reference/openjij/index.html#openjij.Response>`_ to :class:`Samples`
+
+        There is a static method :meth:`decode_to_samples` that does the same thing.
+        """
+        return decode_to_samples(data)
+
+    @property
+    def sampler_input(self) -> dict[tuple[int, int], float]:
+        qubo, _offset = self.ommx_instance.as_qubo_format()
+        return qubo
+
+    def _sample(self) -> oj.Response:
+        sampler = oj.SASampler()
+        qubo, _offset = self.ommx_instance.as_qubo_format()
+        return sampler.sample_qubo(
+            qubo, # type: ignore
+            beta_min=self.beta_min,
+            beta_max=self.beta_max,
+            num_sweeps=self.num_sweeps,
+            num_reads=self.num_reads,
+            schedule=self.schedule,
+            initial_state=self.initial_state,
+            updater=self.updater,
+            sparse=self.sparse,
+            reinitialize_state=self.reinitialize_state,
+            seed=self.seed,
+        )
+
+
+@deprecated("Renamed to `decode_to_samples`")
 def response_to_samples(response: oj.Response) -> Samples:
     """
-    Convert OpenJij's `Response` to `ommx.v1.Samples`
+    Deprecated: renamed to :meth:`decode_to_samples`
+    """
+    return decode_to_samples(response)
+
+
+def decode_to_samples(response: oj.Response) -> Samples:
+    """
+    Convert `openjij.Response <https://openjij.github.io/OpenJij/reference/openjij/index.html#openjij.Response>`_ to :class:`Samples`
     """
     # Filling into ommx.v1.Samples
     # Since OpenJij does not issue the sample ID, we need to generate it in the responsibility of this OMMX Adapter
@@ -27,6 +171,7 @@ def response_to_samples(response: oj.Response) -> Samples:
     return Samples(entries=entries)
 
 
+@deprecated("Use `OMMXOpenJijAdapter.sample` instead")
 def sample_qubo_sa(
     instance: Instance,
     *,
@@ -42,32 +187,7 @@ def sample_qubo_sa(
     seed: int | None = None,
 ) -> Samples:
     """
-    Sampling QUBO with Simulated Annealing (SA) by [`openjij.SASampler`](https://openjij.github.io/OpenJij/reference/openjij/index.html#openjij.SASampler)
-
-    The input `instance` must be a QUBO (Quadratic Unconstrained Binary Optimization) problem, i.e.
-
-    - Every decision variables are binary
-    - No constraint
-    - Objective function is quadratic
-    - Minimization problem
-
-    You can convert a problem to QUBO via [`ommx.v1.Instance.penalty_method`](https://jij-inc.github.io/ommx/python/ommx/autoapi/ommx/v1/index.html#ommx.v1.Instance.penalty_method) or other corresponding method.
-
-    :param instance: ommx.v1.Instance representing a QUBO problem
-    :param beta_min: minimal value of inverse temperature
-    :param beta_max: maximum value of inverse temperature
-    :param num_sweeps: number of sweeps
-    :param num_reads: number of reads
-    :param schedule: list of inverse temperature
-    :param initial_state: initial state
-    :param updater: updater algorithm
-    :param sparse: use sparse matrix or not.
-    :param reinitialize_state: if true reinitialize state for each run
-    :param seed: seed for Monte Carlo algorithm
-
-    Note that this is a simple wrapper function for `openjij.SASampler.sample_qubo` method.
-    For more advanced usage, you can use `ommx.v1.Instance.as_qubo_format` to get QUBO matrix,
-    and use OpenJij manually, and convert the `openjij.Response` via `response_to_samples` function.
+    Deprecated: Use :meth:`OMMXOpenJijAdapter.sample` instead
     """
     q, _offset = instance.as_qubo_format()
     sampler = oj.SASampler()
@@ -84,4 +204,4 @@ def sample_qubo_sa(
         reinitialize_state=reinitialize_state,
         seed=seed,
     )
-    return response_to_samples(response)
+    return decode_to_samples(response)

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -1,5 +1,5 @@
 from ommx.v1 import Instance, DecisionVariable
-from ommx_openjij_adapter import OMMXOpenJijAdapter
+from ommx_openjij_adapter import OMMXOpenJijSAAdapter
 
 
 def test_minimize():
@@ -12,7 +12,7 @@ def test_minimize():
         constraints=[],
         sense=Instance.MINIMIZE,
     )
-    sample_set = OMMXOpenJijAdapter.sample(instance, num_reads=1)
+    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
 
     # x0 = x1 = 0 is minimum
     assert sample_set.extract_decision_variables("x", 0) == {(0,): 0.0, (1,): 0.0}
@@ -29,7 +29,7 @@ def test_maximize():
         sense=Instance.MAXIMIZE,
     )
     instance.as_minimization_problem()
-    sample_set = OMMXOpenJijAdapter.sample(instance, num_reads=1)
+    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
 
     # x0 = x1 = 1 is maximum
     assert sample_set.extract_decision_variables("x", 0) == {(0,): 1.0, (1,): 1.0}

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -1,5 +1,5 @@
 from ommx.v1 import Instance, DecisionVariable
-import ommx_openjij_adapter as adapter
+from ommx_openjij_adapter import OMMXOpenJijAdapter
 
 
 def test_minimize():
@@ -12,8 +12,7 @@ def test_minimize():
         constraints=[],
         sense=Instance.MINIMIZE,
     )
-    samples = adapter.sample_qubo_sa(instance, num_reads=1)
-    sample_set = instance.evaluate_samples(samples)
+    sample_set = OMMXOpenJijAdapter.sample(instance, num_reads=1)
 
     # x0 = x1 = 0 is minimum
     assert sample_set.extract_decision_variables("x", 0) == {(0,): 0.0, (1,): 0.0}
@@ -30,8 +29,7 @@ def test_maximize():
         sense=Instance.MAXIMIZE,
     )
     instance.as_minimization_problem()
-    samples = adapter.sample_qubo_sa(instance, num_reads=1)
-    sample_set = instance.evaluate_samples(samples)
+    sample_set = OMMXOpenJijAdapter.sample(instance, num_reads=1)
 
     # x0 = x1 = 1 is maximum
     assert sample_set.extract_decision_variables("x", 0) == {(0,): 1.0, (1,): 1.0}

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -34,8 +34,9 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
         self._set_objective()
         self._set_constraints()
 
-    @staticmethod
+    @classmethod
     def solve(
+        cls,
         ommx_instance: Instance,
         *,
         use_sos1: Literal["disabled", "auto", "forced"] = "auto",
@@ -126,7 +127,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                     ...
                 ommx.adapter.UnboundedDetected: Model was unbounded
         """
-        adapter = OMMXPySCIPOptAdapter(ommx_instance, use_sos1=use_sos1)
+        adapter = cls(ommx_instance, use_sos1=use_sos1)
         model = adapter.solver_input
         model.optimize()
         return adapter.decode(model)

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
@@ -58,8 +58,9 @@ class OMMXPythonMIPAdapter(SolverAdapter):
         else:
             self._relax = False
 
-    @staticmethod
+    @classmethod
     def solve(
+        cls,
         ommx_instance: Instance,
         relax: bool = False,
         verbose: bool = False,
@@ -173,7 +174,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
                 1.0
 
         """
-        adapter = OMMXPythonMIPAdapter(ommx_instance, relax=relax, verbose=verbose)
+        adapter = cls(ommx_instance, relax=relax, verbose=verbose)
         model = adapter.solver_input
         model.optimize(relax=relax)
         return adapter.decode(model)

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -13,8 +13,7 @@ class SolverAdapter(ABC):
     """
     An abstract interface for OMMX Solver Adapters, defining how solvers should be used with OMMX.
 
-    See the `implementation guide` for more details.
-    .. _implementation guide: https://jij-inc.github.io/ommx/en/user_guide/solver_adapter.html
+    See the `implementation guide <https://jij-inc.github.io/ommx/en/user_guide/solver_adapter.html>`_ for more details.
     """
 
     @abstractmethod
@@ -40,8 +39,7 @@ class SamplerAdapter(SolverAdapter):
     """
     An abstract interface for OMMX Sampler Adapters, defining how samplers should be used with OMMX.
 
-    See the `implementation guide` for more details.
-    .. _implementation guide: https://jij-inc.github.io/ommx/en/user_guide/solver_adapter.html
+    See the `implementation guide <https://jij-inc.github.io/ommx/en/user_guide/solver_adapter.html>`_ for more details.
     """
 
     @classmethod


### PR DESCRIPTION
Split from #344

- Introduce `ommx.adapter.SamplerAdapter`
  - https://ommx--350.org.readthedocs.build/en/350/autoapi/ommx/adapter/index.html#ommx.adapter.SamplerAdapter
- Introduce `ommx_openjij_adapter.OMMXOpenJijSAAdapter` inheriting `SamplerAdapter`
  - Mark `sample_qubo_sa` as `@deprecated`
  - https://ommx--350.org.readthedocs.build/en/350/autoapi/ommx_openjij_adapter/index.html