### PR TITLE
Revise `jupyter-build` check

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -34,9 +34,7 @@ jobs:
 
       - name: Build Jupyter Book
         run: |
-          jupyter-book build docs/${{ matrix.lang }}
-          ERROR_LOGS=$(find docs/${{ matrix.lang}}/_build -type f -name "*.err.log")
-          if [ -n "$ERROR_LOGS" ]; then while IFS= read -r log; do echo "[ERROR LOG] $log" && cat "$log"; done <<< "$ERROR_LOGS" && exit 1; fi
+          jupyter-book build docs/${{ matrix.lang }} --warningiserror
 
       - name: Upload HTML
         uses: actions/upload-artifact@v4

--- a/LLMs.txt
+++ b/LLMs.txt
@@ -32,7 +32,7 @@ To address these data exchange challenges, OMMX was developed. It consists of fo
 
 ### OMMX Message
 
-OMMX Message is a data format defined with [Protocol Buffers](https://protobuf.dev/) to ensure language-agnostic and OS-independent data exchange. It encapsulates schemas for optimization problems ([`ommx.v1.Instance`](./ommx_message/instance.ipynb)) and solutions ([`ommx.v1.Solution`](./ommx_message/solution.ipynb)). Protocol Buffers allow automatic generation of libraries in many languages, which OMMX SDK provides, especially for Python and Rust.
+OMMX Message is a data format defined with [Protocol Buffers](https://protobuf.dev/) to ensure language-agnostic and OS-independent data exchange. It encapsulates schemas for optimization problems ([`ommx.v1.Instance`](./user_guide/instance.ipynb)) and solutions ([`ommx.v1.Solution`](./user_guide/solution.ipynb)). Protocol Buffers allow automatic generation of libraries in many languages, which OMMX SDK provides, especially for Python and Rust.
 
 Data structures such as `ommx.v1.Instance` are called Messages, and each Message has multiple fields. For example, `ommx.v1.Instance` has the following fields (some are omitted for simplicity):
 
@@ -61,12 +61,10 @@ OMMX Artifact is a metadata-rich package format based on the [OCI (Open Containe
 
 In OCI Artifact, the contents of the package are managed in units called layers. A single container contains multiple layers and metadata called a Manifest. When reading a container, the Manifest is first checked, and the necessary data is extracted by reading the layers based on that information. Each layer is saved as binary data (BLOB) with metadata called [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml). For example, when saving a PDF file, the Media Type `application/pdf` is attached, so software reading OCI Artifacts can recognize it as a PDF file by looking at the Media Type.
 
-One major benefit of OCI Artifact compatibility is that standard container registries, such as [DockerHub](https://hub.docker.com/) or [GitHub Container Registry](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry), can be used to store and distribute data. OMMX uses this mechanism to share large datasets like [MIPLIB 2017](https://miplib.zib.de/), made available at [GitHub Container Registry](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017). For additional details, see [Download MIPLIB Instances](./tutorial/download_miplib_instance.md).
+One major benefit of OCI Artifact compatibility is that standard container registries, such as [DockerHub](https://hub.docker.com/) or [GitHub Container Registry](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry), can be used to store and distribute data. OMMX uses this mechanism to share large datasets like [MIPLIB 2017](https://miplib.zib.de/), made available at [GitHub Container Registry](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017). For additional details, see [Download MIPLIB Instances](./tutorial/download_miplib_instance.ipynb).
 
 
 
-
-## Concept
 
 ## Tutorial
 
@@ -870,10 +868,6 @@ df = pd.DataFrame.from_dict(
 )
 ```
 
-    /Users/termoshtt/github.com/Jij-Inc/ommx/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py:30: UserWarning: linked SCIP 9.02 is not recommended for this version of PySCIPOpt - use version 9.2.1
-      self.model = pyscipopt.Model()
-
-
 
 ```python
 from myst_nb import glue
@@ -997,10 +991,10 @@ This `artifact` is the same as the one that will be explained in the next sectio
 
 
 ```python
-! ls -l $filename
+! ls $filename
 ```
 
-    -rw-r--r--  1 termoshtt  staff  11264 Feb 12 21:13 my_instance.ommx
+    my_instance.ommx
 
 
 Now you can share this `my_instance.ommx` with others using the usual file sharing methods.

--- a/docs/en/_toc.yml
+++ b/docs/en/_toc.yml
@@ -8,9 +8,6 @@ parts:
     chapters:
       - url: https://jij-inc.github.io/ommx/ja/
         title: "日本語"
-  - caption: "Concept"
-    chapters:
-      - file: concept/architecture
   - caption: "Tutorial"
     chapters:
       - file: tutorial/solve_with_ommx_adapter
@@ -20,7 +17,6 @@ parts:
       - file: tutorial/download_miplib_instance
   - caption: "User Guide"
     chapters:
-      - file: user_guide/architecture
       - file: user_guide/function
       - file: user_guide/instance
       - file: user_guide/parametric_instance

--- a/docs/en/introduction.md
+++ b/docs/en/introduction.md
@@ -31,7 +31,7 @@ To address these data exchange challenges, OMMX was developed. It consists of fo
 
 ### OMMX Message
 
-OMMX Message is a data format defined with [Protocol Buffers](https://protobuf.dev/) to ensure language-agnostic and OS-independent data exchange. It encapsulates schemas for optimization problems ([`ommx.v1.Instance`](./ommx_message/instance.ipynb)) and solutions ([`ommx.v1.Solution`](./ommx_message/solution.ipynb)). Protocol Buffers allow automatic generation of libraries in many languages, which OMMX SDK provides, especially for Python and Rust.
+OMMX Message is a data format defined with [Protocol Buffers](https://protobuf.dev/) to ensure language-agnostic and OS-independent data exchange. It encapsulates schemas for optimization problems ([`ommx.v1.Instance`](./user_guide/instance.ipynb)) and solutions ([`ommx.v1.Solution`](./user_guide/solution.ipynb)). Protocol Buffers allow automatic generation of libraries in many languages, which OMMX SDK provides, especially for Python and Rust.
 
 Data structures such as `ommx.v1.Instance` are called Messages, and each Message has multiple fields. For example, `ommx.v1.Instance` has the following fields (some are omitted for simplicity):
 
@@ -65,7 +65,7 @@ OMMX Artifact is a metadata-rich package format based on the [OCI (Open Containe
 
 In OCI Artifact, the contents of the package are managed in units called layers. A single container contains multiple layers and metadata called a Manifest. When reading a container, the Manifest is first checked, and the necessary data is extracted by reading the layers based on that information. Each layer is saved as binary data (BLOB) with metadata called [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml). For example, when saving a PDF file, the Media Type `application/pdf` is attached, so software reading OCI Artifacts can recognize it as a PDF file by looking at the Media Type.
 
-One major benefit of OCI Artifact compatibility is that standard container registries, such as [DockerHub](https://hub.docker.com/) or [GitHub Container Registry](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry), can be used to store and distribute data. OMMX uses this mechanism to share large datasets like [MIPLIB 2017](https://miplib.zib.de/), made available at [GitHub Container Registry](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017). For additional details, see [Download MIPLIB Instances](./tutorial/download_miplib_instance.md).
+One major benefit of OCI Artifact compatibility is that standard container registries, such as [DockerHub](https://hub.docker.com/) or [GitHub Container Registry](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry), can be used to store and distribute data. OMMX uses this mechanism to share large datasets like [MIPLIB 2017](https://miplib.zib.de/), made available at [GitHub Container Registry](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017). For additional details, see [Download MIPLIB Instances](./tutorial/download_miplib_instance.ipynb).
 
 ```{figure} ./assets/introduction_03.png
 :alt: Diagram showing the relationship between OMMX Message and OMMX Artifact

--- a/docs/en/tutorial/share_in_ommx_artifact.ipynb
+++ b/docs/en/tutorial/share_in_ommx_artifact.ipynb
@@ -28,16 +28,7 @@
      "hide-input"
     ]
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/termoshtt/github.com/Jij-Inc/ommx/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py:30: UserWarning: linked SCIP 9.02 is not recommended for this version of PySCIPOpt - use version 9.2.1\n",
-      "  self.model = pyscipopt.Model()\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ommx.v1 import Instance, DecisionVariable, Constraint\n",
     "from ommx_pyscipopt_adapter.adapter import OMMXPySCIPOptAdapter\n",
@@ -342,12 +333,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r--  1 termoshtt  staff  11264 Feb 12 21:13 my_instance.ommx\n"
+      "my_instance.ommx\n"
      ]
     }
    ],
    "source": [
-    "! ls -l $filename"
+    "! ls $filename"
    ]
   },
   {
@@ -534,7 +525,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/docs/ja/introduction.md
+++ b/docs/ja/introduction.md
@@ -39,7 +39,7 @@ OMMX（Open Mathematical prograMming eXchange; オミキス）とは、数理最
 
 ### OMMX Message
 
-OMMX Messageはソフトウェア間でデータ交換を行うために設計されたデータ形式です。これは[Protocol Buffers](https://protobuf.dev/)を用いて定義されており、これにより特定のプログラミング言語やOSに依存しないデータ形式を実現しています。OMMX Messageは、数理最適化の問題 ([`ommx.v1.Instance`](./ommx_message/instance.ipynb)) や解 ([`ommx.v1.Solution`](./ommx_message/solution.ipynb)) のデータなどを表現するためのスキーマを定義します。
+OMMX Messageはソフトウェア間でデータ交換を行うために設計されたデータ形式です。これは[Protocol Buffers](https://protobuf.dev/)を用いて定義されており、これにより特定のプログラミング言語やOSに依存しないデータ形式を実現しています。OMMX Messageは、数理最適化の問題 ([`ommx.v1.Instance`](./user_guide/instance.ipynb)) や解 ([`ommx.v1.Solution`](./user_guide/solution.ipynb)) のデータなどを表現するためのスキーマを定義します。
 さらに、Protocol Buffersの機能により、ほとんどの実用的なプログラミング言語に対してOMMX Messageを利用するためのライブラリを自動生成することができ、特にPythonとRust向けのライブラリはOMMX SDKの一部として提供されています。
 
 `ommx.v1.Instance` などのデータ構造はMessageと呼ばれ、それぞれのMessageは複数のフィールドを持ちます。例えば、 `ommx.v1.Instance` は次のようなフィールドを持ちます（簡単のために、一部省略しています）:
@@ -76,7 +76,7 @@ OCI Artifactでは、パッケージの中身をレイヤーという単位で�
 
 OMMXでは、OMMX Messageのそれぞれに対して `application/org.ommx.v1.instance` などのMedia Typeを定義し、OMMX MessageをProtocol Buffersでシリアライズしたバイナリを含むOCI ArtifactをOMMX Artifactと呼称しています。厳密に言えば、OMMXはOCI Artifactを何も拡張していないので、OMMX ArtifactをOCI Artifactの一種として扱うことができます。
 
-OCI Artifactをパッケージ形式として利用する利点は、これが全く正規のコンテナとして扱えることです。つまり、[DockerHub](https://hub.docker.com/) や [GitHub Container Registry](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry) をそのまま利用してデータの管理・配布を行うことができます。これにより、例えば、多くのコンテナと同様に、数GBに及ぶベンチマークセットを不特定多数に対して配布することが容易になります。OMMXではこの機能を利用して、代表的なデータセットである [MIPLIB 2017](https://miplib.zib.de/) のデータを[GitHub Container Registry](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017)で配布しています。詳しくは [MIPLIBインスタンスをダウンロードする](./tutorial/download_miplib_instance.md) を参照してください。
+OCI Artifactをパッケージ形式として利用する利点は、これが全く正規のコンテナとして扱えることです。つまり、[DockerHub](https://hub.docker.com/) や [GitHub Container Registry](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry) をそのまま利用してデータの管理・配布を行うことができます。これにより、例えば、多くのコンテナと同様に、数GBに及ぶベンチマークセットを不特定多数に対して配布することが容易になります。OMMXではこの機能を利用して、代表的なデータセットである [MIPLIB 2017](https://miplib.zib.de/) のデータを[GitHub Container Registry](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017)で配布しています。詳しくは [MIPLIBインスタンスをダウンロードする](./tutorial/download_miplib_instance.ipynb) を参照してください。
 
 ```{figure} ./assets/introduction_03.png
 :alt: OMMX MessageとOMMX Artifactの関係を表す図

--- a/docs/ja/tutorial/share_in_ommx_artifact.ipynb
+++ b/docs/ja/tutorial/share_in_ommx_artifact.ipynb
@@ -28,16 +28,7 @@
      "hide-input"
     ]
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/termoshtt/github.com/Jij-Inc/ommx/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py:30: UserWarning: linked SCIP 9.02 is not recommended for this version of PySCIPOpt - use version 9.2.1\n",
-      "  self.model = pyscipopt.Model()\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ommx.v1 import Instance, DecisionVariable, Constraint\n",
     "from ommx_pyscipopt_adapter.adapter import OMMXPySCIPOptAdapter\n",
@@ -342,12 +333,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-rw-r--r--  1 termoshtt  staff  11776 Feb 12 20:46 my_instance.ommx\n"
+      "my_instance.ommx\n"
      ]
     }
    ],
    "source": [
-    "! ls -l $filename"
+    "! ls $filename"
    ]
   },
   {
@@ -528,7 +519,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/python/ommx-highs-adapter/README.md
+++ b/python/ommx-highs-adapter/README.md
@@ -12,7 +12,7 @@ pip install ommx-highs-adapter
 
 An example usage of HiGHS through this adapter:
 
-``` python markdown-code-runner
+```python markdown-code-runner
 from ommx_highs_adapter import OMMXHighsAdapter
 from ommx.v1 import Instance, DecisionVariable
 

--- a/python/ommx-highs-adapter/Taskfile.yml
+++ b/python/ommx-highs-adapter/Taskfile.yml
@@ -12,3 +12,4 @@ tasks:
     cmds:
       - uv run pytest -vv --doctest-modules
       - uv run pyright
+      - uv run markdown-code-runner --verbose README.md

--- a/python/ommx-pyscipopt-adapter/Taskfile.yml
+++ b/python/ommx-pyscipopt-adapter/Taskfile.yml
@@ -12,3 +12,4 @@ tasks:
     cmds:
       - uv run pytest -vv --doctest-modules
       - uv run pyright
+      - uv run markdown-code-runner --verbose README.md

--- a/python/ommx-python-mip-adapter/Taskfile.yml
+++ b/python/ommx-python-mip-adapter/Taskfile.yml
@@ -12,3 +12,4 @@ tasks:
     cmds:
       - uv run pytest -vv --doctest-modules
       - uv run pyright
+      - uv run markdown-code-runner --verbose README.md


### PR DESCRIPTION
Split from #344

- Use `jupyter-book build --warningserror` (only) on CI
- Restore `markdown-code-runner` test, dropped accidentally on #327 