### PR TITLE
Update tsp_sampling_with_openjij_adapter.ipynb

### DIFF
--- a/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.ipynb
+++ b/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.ipynb
@@ -298,7 +298,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "上で説明したように `uniform_penalty_method` は単一のペナルティ重みをパラメータとして持つので一つだけパラメータが存在します。これを $\\lambda = 1.0$ に固定するには次のように `with_parameters` でパラメータを指定します。この関数はパラメータのIDに対して値を指定する辞書 `dict[int, float]` を引数に取ります。"
+    "上で説明したように `uniform_penalty_method` は単一のペナルティ重みをパラメータとして持つので一つだけパラメータが存在します。これを $\\lambda = 20.0$ に固定するには次のように `with_parameters` でパラメータを指定します。この関数はパラメータのIDに対して値を指定する辞書 `dict[int, float]` を引数に取ります。"
    ]
   },
   {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c27784e5-2fc7-46c5-9b16-4cdb7cb49dae)
が画像の部分で文章が lambda = 1.0 となっているので 20.0 に修正