### PR TITLE
Allow inequality constraints in penalty method

### DIFF
--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -490,21 +490,23 @@ class Instance(InstanceBase, UserAnnotationBase):
 
             \begin{align*}
                 \min_x & \space f(x) & \\
-                \text{ s.t. } & \space g_i(x) = 0 & (\forall i)
+                \text{ s.t. } & \space g_i(x) = 0 & (\forall i) \\
+                & \space h_j(x) \leq 0 & (\forall j)
             \end{align*}
 
         to an unconstrained problem with parameters
 
         .. math::
 
-            \min_x f(x) + \sum_i \lambda_i g_i(x)^2
+            \min_x f(x) + \sum_i \lambda_i g_i(x)^2 + \sum_j \rho_j h_j(x)^2
 
-        where :math:`\lambda_i` are the penalty weight parameters for each constraint.
+        where :math:`\lambda_i` and :math:`\rho_j` are the penalty weight parameters for each constraint.
         If you want to use single weight parameter, use :py:meth:`uniform_penalty_method` instead.
 
         The removed constrains are stored in :py:attr:`~ParametricInstance.removed_constraints`.
 
-        :raises RuntimeError: If the instance contains inequality constraints.
+        Note that this method converts inequality constraints `h(x) <= 0` to a same penalty term $|h(x)|^2$ as equality constraints `h(x) = 0`.
+        This means
 
         Examples
         =========

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -512,54 +512,51 @@ class Instance(InstanceBase, UserAnnotationBase):
         Examples
         =========
 
-        .. doctest::
+        >>> from ommx.v1 import Instance, DecisionVariable, Constraint
+        >>> x = [DecisionVariable.binary(i) for i in range(3)]
+        >>> instance = Instance.from_components(
+        ...     decision_variables=x,
+        ...     objective=sum(x),
+        ...     constraints=[x[0] + x[1] == 1, x[1] + x[2] == 1],
+        ...     sense=Instance.MAXIMIZE,
+        ... )
+        >>> instance.objective
+        Function(x0 + x1 + x2)
+        >>> pi = instance.penalty_method()
 
-            >>> from ommx.v1 import Instance, DecisionVariable, Constraint
-            >>> x = [DecisionVariable.binary(i) for i in range(3)]
-            >>> instance = Instance.from_components(
-            ...     decision_variables=x,
-            ...     objective=sum(x),
-            ...     constraints=[x[0] + x[1] == 1, x[1] + x[2] == 1],
-            ...     sense=Instance.MAXIMIZE,
-            ... )
-            >>> instance.objective
-            Function(x0 + x1 + x2)
+        The constraint is put in :attr:`removed_constraints`
 
-            >>> pi = instance.penalty_method()
+        >>> pi.get_constraints()
+        []
+        >>> len(pi.get_removed_constraints())
+        2
+        >>> pi.get_removed_constraints()[0]
+        RemovedConstraint(Function(x0 + x1 - 1) == 0, reason=penalty_method, parameter_id=3)
+        >>> pi.get_removed_constraints()[1]
+        RemovedConstraint(Function(x1 + x2 - 1) == 0, reason=penalty_method, parameter_id=4)
 
-            The constraint is put in `removed_constraints`
+        There are two parameters corresponding to the two constraints
 
-            >>> pi.get_constraints()
-            []
-            >>> len(pi.get_removed_constraints())
-            2
-            >>> pi.get_removed_constraints()[0]
-            RemovedConstraint(Function(x0 + x1 - 1) == 0, reason=penalty_method, parameter_id=3)
-            >>> pi.get_removed_constraints()[1]
-            RemovedConstraint(Function(x1 + x2 - 1) == 0, reason=penalty_method, parameter_id=4)
+        >>> len(pi.get_parameters())
+        2
+        >>> p1 = pi.get_parameters()[0]
+        >>> p1.id, p1.name
+        (3, 'penalty_weight')
+        >>> p2 = pi.get_parameters()[1]
+        >>> p2.id, p2.name
+        (4, 'penalty_weight')
 
-            There are two parameters corresponding to the two constraints
+        Substitute all parameters to zero to get the original objective
 
-            >>> len(pi.get_parameters())
-            2
-            >>> p1 = pi.get_parameters()[0]
-            >>> p1.id, p1.name
-            (3, 'penalty_weight')
-            >>> p2 = pi.get_parameters()[1]
-            >>> p2.id, p2.name
-            (4, 'penalty_weight')
+        >>> instance0 = pi.with_parameters({p1.id: 0.0, p2.id: 0.0})
+        >>> instance0.objective
+        Function(x0 + x1 + x2)
 
-            Substitute all parameters to zero to get the original objective
+        Substitute all parameters to one
 
-            >>> instance0 = pi.with_parameters({p1.id: 0.0, p2.id: 0.0})
-            >>> instance0.objective
-            Function(x0 + x1 + x2)
-
-            Substitute all parameters to one
-
-            >>> instance1 = pi.with_parameters({p1.id: 1.0, p2.id: 1.0})
-            >>> instance1.objective
-            Function(x0*x0 + 2*x0*x1 + 2*x1*x1 + 2*x1*x2 + x2*x2 - x0 - 3*x1 - x2 + 2)
+        >>> instance1 = pi.with_parameters({p1.id: 1.0, p2.id: 1.0})
+        >>> instance1.objective
+        Function(x0*x0 + 2*x0*x1 + 2*x1*x1 + 2*x1*x2 + x2*x2 - x0 - 3*x1 - x2 + 2)
 
         """
         instance = _ommx_rust.Instance.from_bytes(self.to_bytes())

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -572,69 +572,69 @@ class Instance(InstanceBase, UserAnnotationBase):
 
             \begin{align*}
                 \min_x & \space f(x) & \\
-                \text{ s.t. } & \space g_i(x) = 0 & (\forall i)
+                \text{ s.t. } & \space g_i(x) = 0 & (\forall i) \\
+                & \space h_j(x) \leq 0 & (\forall j)
             \end{align*}
 
         to an unconstrained problem with a parameter
 
         .. math::
 
-            \min_x f(x) + \lambda \sum_i g_i(x)^2
+            \min_x f(x) + \lambda \left( \sum_i g_i(x)^2 + \sum_j h_j(x)^2 \right)
 
         where :math:`\lambda` is the uniform penalty weight parameter for all constraints.
 
         The removed constrains are stored in :py:attr:`~ParametricInstance.removed_constraints`.
 
-        :raises RuntimeError: If the instance contains inequality constraints.
+        Note that this method converts inequality constraints :math:`h(x) \leq 0` to :math:`|h(x)|^2` not to :math:`\max(0, h(x))^2`.
+        This means the penalty is enforced even for :math:`h(x) < 0` cases, and :math:`h(x) = 0` is unfairly favored.
+        This feature is intended to use with :py:meth:`add_integer_slack_to_inequality`.
 
         Examples
         =========
 
-        .. doctest::
+        >>> from ommx.v1 import Instance, DecisionVariable
+        >>> x = [DecisionVariable.binary(i) for i in range(3)]
+        >>> instance = Instance.from_components(
+        ...     decision_variables=x,
+        ...     objective=sum(x),
+        ...     constraints=[sum(x) == 3],
+        ...     sense=Instance.MAXIMIZE,
+        ... )
+        >>> instance.objective
+        Function(x0 + x1 + x2)
+        >>> pi = instance.uniform_penalty_method()
 
-            >>> from ommx.v1 import Instance, DecisionVariable
-            >>> x = [DecisionVariable.binary(i) for i in range(3)]
-            >>> instance = Instance.from_components(
-            ...     decision_variables=x,
-            ...     objective=sum(x),
-            ...     constraints=[sum(x) == 3],
-            ...     sense=Instance.MAXIMIZE,
-            ... )
-            >>> instance.objective
-            Function(x0 + x1 + x2)
+        The constraint is put in :attr:`removed_constraints`
 
-            >>> pi = instance.uniform_penalty_method()
+        >>> pi.get_constraints()
+        []
+        >>> len(pi.get_removed_constraints())
+        1
+        >>> pi.get_removed_constraints()[0]
+        RemovedConstraint(Function(x0 + x1 + x2 - 3) == 0, reason=uniform_penalty_method)
 
-            The constraint is put in `removed_constraints`
+        There is only one parameter in the instance
 
-            >>> pi.get_constraints()
-            []
-            >>> len(pi.get_removed_constraints())
-            1
-            >>> pi.get_removed_constraints()[0]
-            RemovedConstraint(Function(x0 + x1 + x2 - 3) == 0, reason=uniform_penalty_method)
+        >>> len(pi.get_parameters())
+        1
+        >>> p = pi.get_parameters()[0]
+        >>> p.id
+        3
+        >>> p.name
+        'uniform_penalty_weight'
 
-            There is only one parameter in the instance
+        Substitute `p = 0` to get the original objective
 
-            >>> len(pi.get_parameters())
-            1
-            >>> p = pi.get_parameters()[0]
-            >>> p.id
-            3
-            >>> p.name
-            'uniform_penalty_weight'
+        >>> instance0 = pi.with_parameters({p.id: 0.0})
+        >>> instance0.objective
+        Function(x0 + x1 + x2)
 
-            Substitute `p = 0` to get the original objective
+        Substitute `p = 1`
 
-            >>> instance0 = pi.with_parameters({p.id: 0.0})
-            >>> instance0.objective
-            Function(x0 + x1 + x2)
-
-            Substitute `p = 1`
-
-            >>> instance1 = pi.with_parameters({p.id: 1.0})
-            >>> instance1.objective
-            Function(x0*x0 + 2*x0*x1 + 2*x0*x2 + x1*x1 + 2*x1*x2 + x2*x2 - 5*x0 - 5*x1 - 5*x2 + 9)
+        >>> instance1 = pi.with_parameters({p.id: 1.0})
+        >>> instance1.objective
+        Function(x0*x0 + 2*x0*x1 + 2*x0*x2 + x1*x1 + 2*x1*x2 + x2*x2 - 5*x0 - 5*x1 - 5*x2 + 9)
 
         """
         instance = _ommx_rust.Instance.from_bytes(self.to_bytes())

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -505,8 +505,9 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         The removed constrains are stored in :py:attr:`~ParametricInstance.removed_constraints`.
 
-        Note that this method converts inequality constraints `h(x) <= 0` to a same penalty term $|h(x)|^2$ as equality constraints `h(x) = 0`.
-        This means
+        Note that this method converts inequality constraints :math:`h(x) \leq 0` to :math:`|h(x)|^2` not to :math:`\max(0, h(x))^2`.
+        This means the penalty is enforced even for :math:`h(x) < 0` cases, and :math:`h(x) = 0` is unfairly favored.
+        This feature is intended to use with :py:meth:`add_integer_slack_to_inequality`.
 
         Examples
         =========

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -126,9 +126,6 @@ impl Instance {
         let mut parameters = Vec::new();
         let mut removed_constraints = Vec::new();
         for (i, c) in self.constraints.into_iter().enumerate() {
-            if c.equality() != Equality::EqualToZero {
-                bail!("Penalty method is only for equality constraints. Non-equality constraint is found: ID={}", c.id);
-            }
             let parameter = Parameter {
                 id: id_base + i as u64,
                 name: Some("penalty_weight".to_string()),

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -165,9 +165,6 @@ impl Instance {
         let mut removed_constraints = Vec::new();
         let mut quad_sum = Function::zero();
         for c in self.constraints.into_iter() {
-            if c.equality() != Equality::EqualToZero {
-                bail!("Uniform penalty method is only for equality constraints. Non-equality constraint is found: ID={}", c.id);
-            }
             let f = c.function().into_owned();
             quad_sum = quad_sum + f.clone() * f;
             removed_constraints.push(RemovedConstraint {


### PR DESCRIPTION
Since #369 converts inequality to inequality, the penalty method needs to support inequality.