### PR TITLE
Use `to_qubo` in OpenJij Adapter

### DIFF
--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -5,6 +5,7 @@ from ommx.adapter import SamplerAdapter
 import openjij as oj
 from typing_extensions import deprecated
 from typing import Optional
+import copy
 
 
 class OMMXOpenJijSAAdapter(SamplerAdapter):
@@ -110,7 +111,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
         penalty_weights: dict[int, float] = {},
         inequality_integer_slack_max_range: int = 32,
     ):
-        self.ommx_instance = ommx_instance
+        self.ommx_instance = copy.deepcopy(ommx_instance)
         self.beta_min = beta_min
         self.beta_max = beta_max
         self.num_sweeps = num_sweeps

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -124,7 +124,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
 
     def _sample(self) -> oj.Response:
         sampler = oj.SASampler()
-        qubo, _offset = self.ommx_instance.as_qubo_format()
+        qubo = self.sampler_input
         return sampler.sample_qubo(
             qubo,  # type: ignore
             beta_min=self.beta_min,
@@ -189,10 +189,8 @@ def sample_qubo_sa(
     """
     Deprecated: Use :meth:`OMMXOpenJijSAAdapter.sample` instead
     """
-    q, _offset = instance.as_qubo_format()
-    sampler = oj.SASampler()
-    response = sampler.sample_qubo(
-        q,  # type: ignore
+    sampler = OMMXOpenJijSAAdapter(
+        instance,
         beta_min=beta_min,
         beta_max=beta_max,
         num_sweeps=num_sweeps,
@@ -204,4 +202,5 @@ def sample_qubo_sa(
         reinitialize_state=reinitialize_state,
         seed=seed,
     )
+    response = sampler._sample()
     return decode_to_samples(response)

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -129,3 +129,19 @@ def test_solve(instance, ans):
         instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
     )
     assert solution.extract_decision_variables("x") == ans
+
+
+@pytest.mark.parametrize(
+    "instance, ans",
+    [
+        binary_no_constraint_minimize(),
+        binary_no_constraint_maximize(),
+        binary_equality(),
+        binary_inequality(),
+        integer_equality(),
+        integer_inequality(),
+    ],
+)
+def test_sample_twice(instance, ans):
+    test_sample(instance, ans)
+    test_sample(instance, ans)

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -1,45 +1,34 @@
 from ommx.v1 import Instance, DecisionVariable
 from ommx_openjij_adapter import OMMXOpenJijSAAdapter
+import pytest
 
 
-def test_minimize():
+def binary_no_constraint_minimize():
     x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
     x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
-
     instance = Instance.from_components(
         decision_variables=[x0, x1],
         objective=x0 + x1,
         constraints=[],
         sense=Instance.MINIMIZE,
     )
-
-    # x0 = x1 = 0 is minimum
-    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
-    assert sample_set.extract_decision_variables("x", 0) == {(0,): 0.0, (1,): 0.0}
-    solution = OMMXOpenJijSAAdapter.solve(instance, num_reads=1)
-    assert solution.extract_decision_variables("x") == {(0,): 0.0, (1,): 0.0}
+    ans = {(0,): 0.0, (1,): 0.0}
+    return pytest.param(instance, ans, id="binary_no_constraint_minimize")
 
 
-def test_maximize():
+def binary_no_constraint_maximize():
     x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
     x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
-
     instance = Instance.from_components(
         decision_variables=[x0, x1],
         objective=x0 + x1,
         constraints=[],
         sense=Instance.MAXIMIZE,
     )
-    instance.as_minimization_problem()
+    ans = {(0,): 1.0, (1,): 1.0}
+    return pytest.param(instance, ans, id="binary_no_constraint_maximize")
 
-    # x0 = x1 = 1 is maximum
-    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
-    assert sample_set.extract_decision_variables("x", 0) == {(0,): 1.0, (1,): 1.0}
-    solution = OMMXOpenJijSAAdapter.solve(instance, num_reads=1)
-    assert solution.extract_decision_variables("x") == {(0,): 1.0, (1,): 1.0}
-
-
-def test_binary_equality():
+def binary_equality():
     x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
     x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
     x2 = DecisionVariable.binary(2, name="x", subscripts=[2])
@@ -52,25 +41,10 @@ def test_binary_equality():
     )
 
     # x0 = x2 = 1, x1 = 0 is maximum
-    sample_set = OMMXOpenJijSAAdapter.sample(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert sample_set.extract_decision_variables("x", 0) == {
-        (0,): 1.0,
-        (1,): 0.0,
-        (2,): 1.0,
-    }
-    solution = OMMXOpenJijSAAdapter.solve(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert solution.extract_decision_variables("x") == {
-        (0,): 1.0,
-        (1,): 0.0,
-        (2,): 1.0,
-    }
+    ans = {(0,): 1.0, (1,): 0.0, (2,): 1.0}
+    return pytest.param(instance, ans, id="binary_equality")
 
-
-def test_binary_inequality():
+def binary_inequality():
     x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
     x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
     x2 = DecisionVariable.binary(2, name="x", subscripts=[2])
@@ -83,25 +57,10 @@ def test_binary_inequality():
     )
 
     # x1 = x2 = 1, x0 = 0 is maximum
-    sample_set = OMMXOpenJijSAAdapter.sample(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert sample_set.extract_decision_variables("x", 0) == {
-        (0,): 0.0,
-        (1,): 1.0,
-        (2,): 1.0,
-    }
-    solution = OMMXOpenJijSAAdapter.solve(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert solution.extract_decision_variables("x") == {
-        (0,): 0.0,
-        (1,): 1.0,
-        (2,): 1.0,
-    }
+    ans = {(0,): 0.0, (1,): 1.0, (2,): 1.0}
+    return pytest.param(instance, ans, id="binary_inequality")
 
-
-def test_integer_equality():
+def integer_equality():
     x0 = DecisionVariable.integer(0, name="x", lower=-1, upper=1, subscripts=[0])
     x1 = DecisionVariable.integer(1, name="x", lower=-1, upper=1, subscripts=[1])
 
@@ -113,23 +72,11 @@ def test_integer_equality():
     )
 
     # x1 = -x0 = 1 is maximum
-    sample_set = OMMXOpenJijSAAdapter.sample(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert sample_set.extract_decision_variables("x", 0) == {
-        (0,): -1.0,
-        (1,): 1.0,
-    }
-    solution = OMMXOpenJijSAAdapter.solve(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert solution.extract_decision_variables("x") == {
-        (0,): -1.0,
-        (1,): 1.0,
-    }
+    ans = {(0,): -1.0, (1,): 1.0}
+    return pytest.param(instance, ans, id="integer_equality")
 
 
-def test_integer_inequality():
+def integer_inequality():
     x0 = DecisionVariable.integer(0, name="x", lower=-1, upper=1, subscripts=[0])
     x1 = DecisionVariable.integer(1, name="x", lower=-1, upper=1, subscripts=[1])
 
@@ -141,17 +88,37 @@ def test_integer_inequality():
     )
 
     # x1 = -x0 = 1 is maximum
-    sample_set = OMMXOpenJijSAAdapter.sample(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert sample_set.extract_decision_variables("x", 0) == {
-        (0,): -1.0,
-        (1,): 1.0,
-    }
-    solution = OMMXOpenJijSAAdapter.solve(
-        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
-    )
-    assert solution.extract_decision_variables("x") == {
-        (0,): -1.0,
-        (1,): 1.0,
-    }
+    ans = {(0,): -1.0, (1,): 1.0}
+    return pytest.param(instance, ans, id="integer_inequality")
+
+
+@pytest.mark.parametrize(
+    "instance, ans",
+    [
+        binary_no_constraint_minimize(),
+        binary_no_constraint_maximize(),
+        binary_equality(),
+        binary_inequality(),
+        integer_equality(),
+        integer_inequality(),
+    ],
+)
+def test_sample(instance, ans):
+    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345)
+    assert sample_set.extract_decision_variables("x", 0) == ans
+
+
+@pytest.mark.parametrize(
+    "instance, ans",
+    [
+        binary_no_constraint_minimize(),
+        binary_no_constraint_maximize(),
+        binary_equality(),
+        binary_inequality(),
+        integer_equality(),
+        integer_inequality(),
+    ],
+)
+def test_solve(instance, ans):
+    solution = OMMXOpenJijSAAdapter.solve(instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345)
+    assert solution.extract_decision_variables("x") == ans

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -12,10 +12,12 @@ def test_minimize():
         constraints=[],
         sense=Instance.MINIMIZE,
     )
-    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
 
     # x0 = x1 = 0 is minimum
+    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
     assert sample_set.extract_decision_variables("x", 0) == {(0,): 0.0, (1,): 0.0}
+    solution = OMMXOpenJijSAAdapter.solve(instance, num_reads=1)
+    assert solution.extract_decision_variables("x") == {(0,): 0.0, (1,): 0.0}
 
 
 def test_maximize():
@@ -29,10 +31,12 @@ def test_maximize():
         sense=Instance.MAXIMIZE,
     )
     instance.as_minimization_problem()
-    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
 
     # x0 = x1 = 1 is maximum
+    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1)
     assert sample_set.extract_decision_variables("x", 0) == {(0,): 1.0, (1,): 1.0}
+    solution = OMMXOpenJijSAAdapter.solve(instance, num_reads=1)
+    assert solution.extract_decision_variables("x") == {(0,): 1.0, (1,): 1.0}
 
 
 def test_binary_equality():
@@ -46,16 +50,25 @@ def test_binary_equality():
         constraints=[x1 * x2 == 0],
         sense=Instance.MAXIMIZE,
     )
+
+    # x0 = x2 = 1, x1 = 0 is maximum
     sample_set = OMMXOpenJijSAAdapter.sample(
         instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
     )
-
-    # x0 = x2 = 1, x1 = 0 is maximum
     assert sample_set.extract_decision_variables("x", 0) == {
         (0,): 1.0,
         (1,): 0.0,
         (2,): 1.0,
     }
+    solution = OMMXOpenJijSAAdapter.solve(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+    assert solution.extract_decision_variables("x") == {
+        (0,): 1.0,
+        (1,): 0.0,
+        (2,): 1.0,
+    }
+
 
 def test_binary_inequality():
     x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
@@ -68,12 +81,20 @@ def test_binary_inequality():
         constraints=[x0 + x1 + x2 <= 2],
         sense=Instance.MAXIMIZE,
     )
+
+    # x1 = x2 = 1, x0 = 0 is maximum
     sample_set = OMMXOpenJijSAAdapter.sample(
         instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
     )
-
-    # x1 = x2 = 1, x0 = 0 is maximum
     assert sample_set.extract_decision_variables("x", 0) == {
+        (0,): 0.0,
+        (1,): 1.0,
+        (2,): 1.0,
+    }
+    solution = OMMXOpenJijSAAdapter.solve(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+    assert solution.extract_decision_variables("x") == {
         (0,): 0.0,
         (1,): 1.0,
         (2,): 1.0,
@@ -91,12 +112,19 @@ def test_integer_equality():
         constraints=[x0 + x1 == 0],
         sense=Instance.MAXIMIZE,
     )
+
+    # x1 = -x0 = 1 is maximum
     sample_set = OMMXOpenJijSAAdapter.sample(
         instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
     )
-
-    # x1 = -x0 = 1 is maximum
     assert sample_set.extract_decision_variables("x", 0) == {
+        (0,): -1.0,
+        (1,): 1.0,
+    }
+    solution = OMMXOpenJijSAAdapter.solve(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+    assert solution.extract_decision_variables("x") == {
         (0,): -1.0,
         (1,): 1.0,
     }
@@ -111,12 +139,19 @@ def test_integer_inequality():
         constraints=[x0 + x1 <= 0],
         sense=Instance.MAXIMIZE,
     )
+
+    # x1 = -x0 = 1 is maximum
     sample_set = OMMXOpenJijSAAdapter.sample(
         instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
     )
-
-    # x1 = -x0 = 1 is maximum
     assert sample_set.extract_decision_variables("x", 0) == {
+        (0,): -1.0,
+        (1,): 1.0,
+    }
+    solution = OMMXOpenJijSAAdapter.solve(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+    assert solution.extract_decision_variables("x") == {
         (0,): -1.0,
         (1,): 1.0,
     }

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -101,14 +101,13 @@ def test_binary_inequality():
     }
 
 
-
 def test_integer_equality():
     x0 = DecisionVariable.integer(0, name="x", lower=-1, upper=1, subscripts=[0])
     x1 = DecisionVariable.integer(1, name="x", lower=-1, upper=1, subscripts=[1])
 
     instance = Instance.from_components(
         decision_variables=[x0, x1],
-        objective=x0 + 2*x1,
+        objective=x0 + 2 * x1,
         constraints=[x0 + x1 == 0],
         sense=Instance.MAXIMIZE,
     )
@@ -129,13 +128,14 @@ def test_integer_equality():
         (1,): 1.0,
     }
 
+
 def test_integer_inequality():
     x0 = DecisionVariable.integer(0, name="x", lower=-1, upper=1, subscripts=[0])
     x1 = DecisionVariable.integer(1, name="x", lower=-1, upper=1, subscripts=[1])
 
     instance = Instance.from_components(
         decision_variables=[x0, x1],
-        objective=x0 + 2*x1,
+        objective=x0 + 2 * x1,
         constraints=[x0 + x1 <= 0],
         sense=Instance.MAXIMIZE,
     )

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -28,6 +28,7 @@ def binary_no_constraint_maximize():
     ans = {(0,): 1.0, (1,): 1.0}
     return pytest.param(instance, ans, id="binary_no_constraint_maximize")
 
+
 def binary_equality():
     x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
     x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
@@ -44,6 +45,7 @@ def binary_equality():
     ans = {(0,): 1.0, (1,): 0.0, (2,): 1.0}
     return pytest.param(instance, ans, id="binary_equality")
 
+
 def binary_inequality():
     x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
     x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
@@ -59,6 +61,7 @@ def binary_inequality():
     # x1 = x2 = 1, x0 = 0 is maximum
     ans = {(0,): 0.0, (1,): 1.0, (2,): 1.0}
     return pytest.param(instance, ans, id="binary_inequality")
+
 
 def integer_equality():
     x0 = DecisionVariable.integer(0, name="x", lower=-1, upper=1, subscripts=[0])
@@ -104,7 +107,9 @@ def integer_inequality():
     ],
 )
 def test_sample(instance, ans):
-    sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345)
+    sample_set = OMMXOpenJijSAAdapter.sample(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
     assert sample_set.extract_decision_variables("x", 0) == ans
 
 
@@ -120,5 +125,7 @@ def test_sample(instance, ans):
     ],
 )
 def test_solve(instance, ans):
-    solution = OMMXOpenJijSAAdapter.solve(instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345)
+    solution = OMMXOpenJijSAAdapter.solve(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
     assert solution.extract_decision_variables("x") == ans

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -33,3 +33,90 @@ def test_maximize():
 
     # x0 = x1 = 1 is maximum
     assert sample_set.extract_decision_variables("x", 0) == {(0,): 1.0, (1,): 1.0}
+
+
+def test_binary_equality():
+    x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
+    x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
+    x2 = DecisionVariable.binary(2, name="x", subscripts=[2])
+
+    instance = Instance.from_components(
+        decision_variables=[x0, x1, x2],
+        objective=x0 + 2 * x1 + 3 * x2,
+        constraints=[x1 * x2 == 0],
+        sense=Instance.MAXIMIZE,
+    )
+    sample_set = OMMXOpenJijSAAdapter.sample(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+
+    # x0 = x2 = 1, x1 = 0 is maximum
+    assert sample_set.extract_decision_variables("x", 0) == {
+        (0,): 1.0,
+        (1,): 0.0,
+        (2,): 1.0,
+    }
+
+def test_binary_inequality():
+    x0 = DecisionVariable.binary(0, name="x", subscripts=[0])
+    x1 = DecisionVariable.binary(1, name="x", subscripts=[1])
+    x2 = DecisionVariable.binary(2, name="x", subscripts=[2])
+
+    instance = Instance.from_components(
+        decision_variables=[x0, x1, x2],
+        objective=x0 + 2 * x1 + 3 * x2,
+        constraints=[x0 + x1 + x2 <= 2],
+        sense=Instance.MAXIMIZE,
+    )
+    sample_set = OMMXOpenJijSAAdapter.sample(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+
+    # x1 = x2 = 1, x0 = 0 is maximum
+    assert sample_set.extract_decision_variables("x", 0) == {
+        (0,): 0.0,
+        (1,): 1.0,
+        (2,): 1.0,
+    }
+
+
+
+def test_integer_equality():
+    x0 = DecisionVariable.integer(0, name="x", lower=-1, upper=1, subscripts=[0])
+    x1 = DecisionVariable.integer(1, name="x", lower=-1, upper=1, subscripts=[1])
+
+    instance = Instance.from_components(
+        decision_variables=[x0, x1],
+        objective=x0 + 2*x1,
+        constraints=[x0 + x1 == 0],
+        sense=Instance.MAXIMIZE,
+    )
+    sample_set = OMMXOpenJijSAAdapter.sample(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+
+    # x1 = -x0 = 1 is maximum
+    assert sample_set.extract_decision_variables("x", 0) == {
+        (0,): -1.0,
+        (1,): 1.0,
+    }
+
+def test_integer_inequality():
+    x0 = DecisionVariable.integer(0, name="x", lower=-1, upper=1, subscripts=[0])
+    x1 = DecisionVariable.integer(1, name="x", lower=-1, upper=1, subscripts=[1])
+
+    instance = Instance.from_components(
+        decision_variables=[x0, x1],
+        objective=x0 + 2*x1,
+        constraints=[x0 + x1 <= 0],
+        sense=Instance.MAXIMIZE,
+    )
+    sample_set = OMMXOpenJijSAAdapter.sample(
+        instance, num_reads=1, uniform_penalty_weight=3.0, seed=12345
+    )
+
+    # x1 = -x0 = 1 is maximum
+    assert sample_set.extract_decision_variables("x", 0) == {
+        (0,): -1.0,
+        (1,): 1.0,
+    }

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -57,8 +57,8 @@ class SamplerAdapter(SolverAdapter):
         pass
 
     @classmethod
-    def solve(cls, ommx_instance: Instance) -> Solution:
-        return cls.sample(ommx_instance).best_feasible()
+    def solve(cls, ommx_instance: Instance, **kwargs) -> Solution:
+        return cls.sample(ommx_instance, **kwargs).best_feasible()
 
     @property
     def solver_input(self) -> SamplerInput:

--- a/rust/ommx/src/sorted_ids.rs
+++ b/rust/ommx/src/sorted_ids.rs
@@ -166,7 +166,9 @@ pub struct BinaryIdPair(pub u64, pub u64);
 
 impl TryFrom<Vec<u64>> for BinaryIdPair {
     type Error = anyhow::Error;
-    fn try_from(ids: Vec<u64>) -> Result<Self, Self::Error> {
+    fn try_from(mut ids: Vec<u64>) -> Result<Self, Self::Error> {
+        ids.sort_unstable();
+        ids.dedup();
         match &ids[..] {
             [a, b] if a <= b => Ok(Self(*a, *b)),
             [a, b] => Ok(Self(*b, *a)),


### PR DESCRIPTION
This pull request includes significant updates to the `python/ommx-openjij-adapter` and associated tests to enhance functionality and improve code quality. The key changes include the addition of new parameters for penalty weights, improvements in the sampling method, and extensive updates to the test cases.

Enhancements in `OMMXOpenJijSAAdapter`:

* Added new parameters `uniform_penalty_weight`, `penalty_weights`, and `inequality_integer_slack_max_range` to the `OMMXOpenJijSAAdapter` class and its methods to allow more flexible configuration of penalty weights. [[1]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aR51-R57) [[2]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aR73-R75) [[3]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aR89-R91) [[4]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aR110-R114) [[5]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aR125-R127) [[6]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aL122-R152)

Improvements in sampling method:

* Modified the `sample` and `__init__` methods to incorporate the new penalty parameters and ensure deep copying of the `ommx_instance` to prevent unintended modifications. [[1]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aR73-R75) [[2]](diffhunk://#diff-5de2903ad8082b1b024e933271672f2303a4ea07dcd8e8608cf50641bec65d8aR110-R114)
* Updated the `sampler_input` property to use the new `to_qubo` method with the added penalty parameters.

Test case updates:

* Refactored and expanded the test cases in `tests/test_sample.py` to include new scenarios for binary and integer variables with various constraints, and used `pytest` for parameterized testing.

Other changes:

* Updated the `solve` method in `adapter.py` to accept additional keyword arguments.
* Improved the `to_qubo` method in `ommx/v1/__init__.py` to handle constraints more robustly and ensure proper encoding. [[1]](diffhunk://#diff-1bdad31bc2a9551bd1fb2f700436e715f09a483c70cdce58e8723541a855d52aR550) [[2]](diffhunk://#diff-1bdad31bc2a9551bd1fb2f700436e715f09a483c70cdce58e8723541a855d52aL563-R567) [[3]](diffhunk://#diff-1bdad31bc2a9551bd1fb2f700436e715f09a483c70cdce58e8723541a855d52aR998-R1000)
* Enhanced the `try_from` method in `rust/ommx/src/sorted_ids.rs` to sort and deduplicate the input vector.