### PR TITLE
`penalty_weight` option of `to_qubo` is broken

### DIFF
--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -154,6 +154,20 @@ def test_add_integer_slack_to_inequality_continuous():
     )
 
 
+def test_to_qubo_penalty_weight():
+    x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(2)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=x[0],
+        constraints=[(x[1] == 1).set_id(12345)],
+        sense=Instance.MINIMIZE,
+    )
+    # QUBO = x0 + 2 * (x1 - 1)^2 = x0 + 2 * (1 - x1)
+    qubo, offset = instance.to_qubo(penalty_weights={12345: 2.0})
+    assert qubo == {(0, 0): 1.0, (1, 1): -2.0}
+    assert offset == 2.0
+
+
 def test_to_qubo_continuous():
     x = [DecisionVariable.continuous(i, lower=-1.23, upper=4.56) for i in range(3)]
     instance = Instance.from_components(

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -159,12 +159,12 @@ def test_to_qubo_penalty_weight():
     instance = Instance.from_components(
         decision_variables=x,
         objective=x[0],
-        constraints=[(x[1] == 1).set_id(12345)],
+        constraints=[(x[0] == 0).set_id(123), (x[1] == 1).set_id(456)],
         sense=Instance.MINIMIZE,
     )
-    # QUBO = x0 + 2 * (x1 - 1)^2 = x0 + 2 * (1 - x1)
-    qubo, offset = instance.to_qubo(penalty_weights={12345: 2.0})
-    assert qubo == {(0, 0): 1.0, (1, 1): -2.0}
+    # QUBO = x0 + 1 * (x0)^2 + 2 * (x1 - 1)^2 = 2*x0 - 2*x1 + 1
+    qubo, offset = instance.to_qubo(penalty_weights={123: 1.0, 456: 2.0})
+    assert qubo == {(0, 0): 2.0, (1, 1): -2.0}
     assert offset == 2.0
 
 

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -554,7 +554,9 @@ class Instance(InstanceBase, UserAnnotationBase):
                 )
             if penalty_weights:
                 pi = self.penalty_method()
-                weights = { p.id: penalty_weights[p.subscripts[0]] for p in pi.get_parameters()}
+                weights = {
+                    p.id: penalty_weights[p.subscripts[0]] for p in pi.get_parameters()
+                }
                 unconstrained = pi.with_parameters(weights)
             else:
                 if uniform_penalty_weight is None:

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -443,7 +443,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         5. Convert to QUBO with (uniform) penalty method
 
-            * If ``penalty_weights`` is given, use :py:meth:`penalty_method` with the given weights.
+            * If ``penalty_weights`` is given (in ``dict[constraint_id, weight]`` form), use :py:meth:`penalty_method` with the given weights.
             * If ``uniform_penalty_weight`` is given, use :py:meth:`uniform_penalty_method` with the given weight.
             * If both are None, defaults to ``uniform_penalty_weight = 1.0``.
 
@@ -554,13 +554,15 @@ class Instance(InstanceBase, UserAnnotationBase):
                 )
             if penalty_weights:
                 pi = self.penalty_method()
-                return pi.with_parameters(penalty_weights).as_qubo_format()
-            if uniform_penalty_weight is None:
-                # If both are None, defaults to uniform_penalty_weight = 1.0
-                uniform_penalty_weight = 1.0
-            pi = self.uniform_penalty_method()
-            weight = pi.get_parameters()[0]
-            unconstrained = pi.with_parameters({weight.id: uniform_penalty_weight})
+                weights = { p.id: penalty_weights[p.subscripts[0]] for p in pi.get_parameters()}
+                unconstrained = pi.with_parameters(weights)
+            else:
+                if uniform_penalty_weight is None:
+                    # If both are None, defaults to uniform_penalty_weight = 1.0
+                    uniform_penalty_weight = 1.0
+                pi = self.uniform_penalty_method()
+                weight = pi.get_parameters()[0]
+                unconstrained = pi.with_parameters({weight.id: uniform_penalty_weight})
             self.raw = unconstrained.raw
 
         self.log_encode()


### PR DESCRIPTION
Bug description
---------------

`penalty_weight` option of `to_qubo` is passed to `ParametricInstance.with_parameters` directory. But this is not valid since the `with_parameters` requires `dict[parameter_id, weight]`, but we cannot get the `parameter_id` before `to_qubo` call. So we have to convert given `penalty_weight: dict[constraint_id, weight]` into `dict[parameter_id, weight]` by generated parameters while `to_qubo`.

Summary
--------

This pull request introduces a new test for the `to_qubo` method and updates the method to handle penalty weights more effectively. The changes ensure that the `to_qubo` method correctly interprets penalty weights provided in a dictionary form and applies them appropriately.

### New Test Addition:

* Added `test_to_qubo_penalty_weight` to verify that `to_qubo` correctly converts an instance to QUBO format using specified penalty weights. (`python/ommx-tests/tests/test_instance.py`)

### Method Updates:

* Updated `to_qubo` method documentation to clarify that `penalty_weights` should be provided in a dictionary form (`dict[constraint_id, weight]`). (`python/ommx/ommx/v1/__init__.py`)
* Modified `to_qubo` method to map penalty weights correctly from the provided dictionary and apply them using the `penalty_method`. (`python/ommx/ommx/v1/__init__.py`)