### PR TITLE
`ToSamples` type hint is broken for `list[dict[int, int]]` case

### DIFF
--- a/python/ommx-tests/tests/test_sample_set.py
+++ b/python/ommx-tests/tests/test_sample_set.py
@@ -1,0 +1,21 @@
+from ommx.v1 import Instance, DecisionVariable
+
+
+def test_evaluate_samples_type_check():
+    """
+    Reported case in bug report https://github.com/Jij-Inc/ommx/issues/393
+    """
+    x = [DecisionVariable.binary(i) for i in range(3)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=x[0] + 2*x[1] + 3*x[2],
+        constraints=[x[1] + x[2] <= 1],
+        sense=Instance.MAXIMIZE,
+    )
+
+    samples = [
+        {0: 1, 1: 0, 2: 0},
+        {0: 0, 1: 0, 2: 1},
+        {0: 1, 1: 1, 2: 0},
+    ]
+    sample_set = instance.evaluate_samples(samples)

--- a/python/ommx-tests/tests/test_sample_set.py
+++ b/python/ommx-tests/tests/test_sample_set.py
@@ -5,7 +5,7 @@ def test_evaluate_samples_type_check():
     """
     Reported case in bug report https://github.com/Jij-Inc/ommx/issues/393
     """
-    x = [DecisionVariable.binary(i) for i in range(3)]
+    x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,
         objective=x[0] + 2 * x[1] + 3 * x[2],
@@ -19,3 +19,7 @@ def test_evaluate_samples_type_check():
         {0: 1, 1: 1, 2: 0},
     ]
     sample_set = instance.evaluate_samples(samples)
+
+    assert sample_set.extract_decision_variables("x", 0) == {(0,): 1, (1,): 0, (2,): 0}
+    assert sample_set.extract_decision_variables("x", 1) == {(0,): 0, (1,): 0, (2,): 1}
+    assert sample_set.extract_decision_variables("x", 2) == {(0,): 1, (1,): 1, (2,): 0}

--- a/python/ommx-tests/tests/test_sample_set.py
+++ b/python/ommx-tests/tests/test_sample_set.py
@@ -8,7 +8,7 @@ def test_evaluate_samples_type_check():
     x = [DecisionVariable.binary(i) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,
-        objective=x[0] + 2*x[1] + 3*x[2],
+        objective=x[0] + 2 * x[1] + 3 * x[2],
         constraints=[x[1] + x[2] <= 1],
         sense=Instance.MAXIMIZE,
     )

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Optional, Iterable, overload, Mapping
-from typing_extensions import deprecated, TypeAlias, Union
+from typing_extensions import deprecated, TypeAlias, Union, Sequence
 from dataclasses import dataclass, field
 from pandas import DataFrame, NA, Series
 from abc import ABC, abstractmethod
@@ -77,7 +77,7 @@ def to_state(state: ToState) -> State:
     return State(entries=state)
 
 
-ToSamples: TypeAlias = Union[Samples, Mapping[int, ToState], list[ToState]]
+ToSamples: TypeAlias = Union[Samples, Mapping[int, ToState], Sequence[ToState]]
 """
 Type alias for convertible types to :class:`Samples`.
 """

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -4,6 +4,7 @@ from typing_extensions import deprecated, TypeAlias, Union, Sequence
 from dataclasses import dataclass, field
 from pandas import DataFrame, NA, Series
 from abc import ABC, abstractmethod
+import collections.abc
 
 from .solution_pb2 import State, Optimality, Relaxation, Solution as _Solution
 from .instance_pb2 import Instance as _Instance, Parameters
@@ -84,7 +85,7 @@ Type alias for convertible types to :class:`Samples`.
 
 
 def to_samples(samples: ToSamples) -> Samples:
-    if isinstance(samples, list):
+    if isinstance(samples, collections.abc.Sequence):
         samples = {i: state for i, state in enumerate(samples)}
     if not isinstance(samples, Samples):
         # Do not compress the samples


### PR DESCRIPTION
Resolve #393

```text
        Type parameter "_T@list" is invariant, but "dict[int, int]" is not the same as "ToState"
        Consider switching from "list" to "Sequence" which is covariant (reportArgumentType)
1 error, 0 warnings, 0 informations 
```

This PR replaces `list` to `Sequence`.