### PR TITLE
Restore maximize after `Instance.to_qubo`

### DIFF
--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -489,9 +489,9 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         The ``instance`` object stores how converted:
 
-        * The sense is converted to minimization
+        * The sense is converted to minimization for generating QUBO, but converted back to maximization after the conversion.
 
-        >>> instance.sense == Instance.MINIMIZE
+        >>> instance.sense == Instance.MAXIMIZE
         True
 
         * Two types of decision variables are added
@@ -516,12 +516,47 @@ class Instance(InstanceBase, UserAnnotationBase):
         * The yielded :attr:`objective` and :attr:`removed_constraints` only has these binary variables.
 
         >>> instance.objective
-        Function(x3*x3 + 2*x3*x4 + 4*x3*x5 + 4*x3*x6 + 2*x3*x7 + 4*x3*x8 + x4*x4 + 4*x4*x5 + 4*x4*x6 + 2*x4*x7 + 4*x4*x8 + 4*x5*x5 + 8*x5*x6 + 4*x5*x7 + 8*x5*x8 + 4*x6*x6 + 4*x6*x7 + 8*x6*x8 + x7*x7 + 4*x7*x8 + 4*x8*x8 - 7*x3 - 7*x4 - 13*x5 - 13*x6 - 6*x7 - 12*x8 + 9)
+        Function(-x3*x3 - 2*x3*x4 - 4*x3*x5 - 4*x3*x6 - 2*x3*x7 - 4*x3*x8 - x4*x4 - 4*x4*x5 - 4*x4*x6 - 2*x4*x7 - 4*x4*x8 - 4*x5*x5 - 8*x5*x6 - 4*x5*x7 - 8*x5*x8 - 4*x6*x6 - 4*x6*x7 - 8*x6*x8 - x7*x7 - 4*x7*x8 - 4*x8*x8 + 7*x3 + 7*x4 + 13*x5 + 13*x6 + 6*x7 + 12*x8 - 9)
         >>> instance.get_removed_constraint(0)
         RemovedConstraint(Function(x3 + x4 + 2*x5 + 2*x6 + x7 + 2*x8 - 3) == 0, reason=uniform_penalty_method)
 
+        The solver will returns the solution, which only contains the log-encoded binary variables like:
+
+        >>> state = {
+        ...     3: 1, 4: 1,  # x0 = 0 + (2-1)*1 = 2
+        ...     5: 0, 6: 0,  # x1 = 0 + (2-1)*0 = 0
+        ...     7: 1, 8: 0   # x3 = 1 + 2*0 = 1
+        ... }
+
+        This can be evaluated by :py:meth:`evaluate` method.
+
+        >>> solution = instance.evaluate(state)
+
+        The log-encoded integer variables are automatically evaluated from the binary variables.
+
+        >>> solution.decision_variables.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
+               kind  lower  upper             name subscripts  value
+        id                                                          
+        0   integer    0.0    2.0                x        [0]    2.0
+        1   integer    0.0    2.0                x        [1]    0.0
+        2   integer    0.0    3.0       ommx.slack        [0]    1.0
+        3    binary    0.0    1.0  ommx.log_encode     [0, 0]    1.0
+        4    binary    0.0    1.0  ommx.log_encode     [0, 1]    1.0
+        5    binary    0.0    1.0  ommx.log_encode     [1, 0]    0.0
+        6    binary    0.0    1.0  ommx.log_encode     [1, 1]    0.0
+        7    binary    0.0    1.0  ommx.log_encode     [2, 0]    1.0
+        8    binary    0.0    1.0  ommx.log_encode     [2, 1]    0.0
+
+        >>> solution.objective
+        2.0
+
+        >>> solution.constraints.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
+           equality  value            used_ids subscripts          removed_reason
+        id                                                                       
+        0        =0    0.0  {3, 4, 5, 6, 7, 8}         []  uniform_penalty_method
+
         """
-        self.as_minimization_problem()
+        is_converted_to_minimize = self.as_minimization_problem()
 
         continuous_variables = [
             var.id
@@ -570,6 +605,11 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         self.log_encode()
         qubo = self.as_qubo_format()
+
+        if is_converted_to_minimize:
+            # Convert back to maximization
+            self.as_maximization_problem()
+
         return qubo
 
     def as_minimization_problem(self) -> bool:

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -611,6 +611,43 @@ class Instance(InstanceBase, UserAnnotationBase):
         obj = -self.objective
         self.raw.objective.CopyFrom(obj.raw)
 
+    def as_maximization_problem(self):
+        """
+        Convert the instance to a maximization problem.
+
+        If the instance is already a maximization problem, this does nothing.
+
+        Examples
+        =========
+
+        >>> from ommx.v1 import Instance, DecisionVariable
+        >>> x = [DecisionVariable.binary(i) for i in range(3)]
+        >>> instance = Instance.from_components(
+        ...     decision_variables=x,
+        ...     objective=sum(x),
+        ...     constraints=[sum(x) == 1],
+        ...     sense=Instance.MINIMIZE,
+        ... )
+        >>> instance.sense == Instance.MINIMIZE
+        True
+        >>> instance.objective
+        Function(x0 + x1 + x2)
+
+        Convert to a maximization problem
+
+        >>> instance.as_maximization_problem()
+        >>> instance.sense == Instance.MAXIMIZE
+        True
+        >>> instance.objective
+        Function(-x0 - x1 - x2)
+
+        """
+        if self.raw.sense == Instance.MAXIMIZE:
+            return
+        self.raw.sense = Instance.MAXIMIZE
+        obj = -self.objective
+        self.raw.objective.CopyFrom(obj.raw)
+
     def as_qubo_format(self) -> tuple[dict[tuple[int, int], float], float]:
         """
         Convert unconstrained quadratic instance to PyQUBO-style format.

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -572,50 +572,63 @@ class Instance(InstanceBase, UserAnnotationBase):
         qubo = self.as_qubo_format()
         return qubo
 
-    def as_minimization_problem(self):
+    def as_minimization_problem(self) -> bool:
         """
         Convert the instance to a minimization problem.
 
         If the instance is already a minimization problem, this does nothing.
 
+        :return: ``True`` if the instance is converted, ``False`` if already a minimization problem.
+
         Examples
         =========
 
-        .. doctest::
+        >>> from ommx.v1 import Instance, DecisionVariable
+        >>> x = [DecisionVariable.binary(i) for i in range(3)]
+        >>> instance = Instance.from_components(
+        ...     decision_variables=x,
+        ...     objective=sum(x),
+        ...     constraints=[sum(x) == 1],
+        ...     sense=Instance.MAXIMIZE,
+        ... )
+        >>> instance.sense == Instance.MAXIMIZE
+        True
+        >>> instance.objective
+        Function(x0 + x1 + x2)
 
-            >>> from ommx.v1 import Instance, DecisionVariable
-            >>> x = [DecisionVariable.binary(i) for i in range(3)]
-            >>> instance = Instance.from_components(
-            ...     decision_variables=x,
-            ...     objective=sum(x),
-            ...     constraints=[sum(x) == 1],
-            ...     sense=Instance.MAXIMIZE,
-            ... )
-            >>> instance.sense == Instance.MAXIMIZE
-            True
-            >>> instance.objective
-            Function(x0 + x1 + x2)
+        Convert to a minimization problem
 
-            Convert to a minimization problem
+        >>> instance.as_minimization_problem()
+        True
+        >>> instance.sense == Instance.MINIMIZE
+        True
+        >>> instance.objective
+        Function(-x0 - x1 - x2)
 
-            >>> instance.as_minimization_problem()
-            >>> instance.sense == Instance.MINIMIZE
-            True
-            >>> instance.objective
-            Function(-x0 - x1 - x2)
+        If the instance is already a minimization problem, this does nothing
+
+        >>> instance.as_minimization_problem()
+        False
+        >>> instance.sense == Instance.MINIMIZE
+        True
+        >>> instance.objective
+        Function(-x0 - x1 - x2)
 
         """
         if self.raw.sense == Instance.MINIMIZE:
-            return
+            return False
         self.raw.sense = Instance.MINIMIZE
         obj = -self.objective
         self.raw.objective.CopyFrom(obj.raw)
+        return True
 
-    def as_maximization_problem(self):
+    def as_maximization_problem(self) -> bool:
         """
         Convert the instance to a maximization problem.
 
         If the instance is already a maximization problem, this does nothing.
+
+        :return: ``True`` if the instance is converted, ``False`` if already a maximization problem.
 
         Examples
         =========
@@ -636,6 +649,16 @@ class Instance(InstanceBase, UserAnnotationBase):
         Convert to a maximization problem
 
         >>> instance.as_maximization_problem()
+        True
+        >>> instance.sense == Instance.MAXIMIZE
+        True
+        >>> instance.objective
+        Function(-x0 - x1 - x2)
+
+        If the instance is already a maximization problem, this does nothing
+
+        >>> instance.as_maximization_problem()
+        False
         >>> instance.sense == Instance.MAXIMIZE
         True
         >>> instance.objective
@@ -643,10 +666,11 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         """
         if self.raw.sense == Instance.MAXIMIZE:
-            return
+            return False
         self.raw.sense = Instance.MAXIMIZE
         obj = -self.objective
         self.raw.objective.CopyFrom(obj.raw)
+        return True
 
     def as_qubo_format(self) -> tuple[dict[tuple[int, int], float], float]:
         """

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -489,7 +489,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         The ``instance`` object stores how converted:
 
-        * The sense is converted to minimization for generating QUBO, but converted back to maximization after the conversion.
+        * For the maximization problem, the sense is converted to minimization for generating QUBO, and then converted back to maximization.
 
         >>> instance.sense == Instance.MAXIMIZE
         True


### PR DESCRIPTION
Resolve #397

This pull request includes several changes to the `to_qubo` method in the `python/ommx/ommx/v1/__init__.py` file to handle maximization problems and improve the conversion between minimization and maximization problems. The most important changes include updating documentation, adding new functionality to convert problems back to maximization, and modifying the `as_minimization_problem` method to return a boolean.

### Improvements to problem conversion:

* Updated documentation to clarify that the sense is converted to minimization for generating QUBO and then converted back to maximization.
* Added functionality to convert the instance back to a maximization problem after generating QUBO.

### Enhancements to method behavior:

* Modified the `as_minimization_problem` method to return a boolean indicating whether the instance was converted. [[1]](diffhunk://#diff-1bdad31bc2a9551bd1fb2f700436e715f09a483c70cdce58e8723541a855d52aR608-L585) [[2]](diffhunk://#diff-1bdad31bc2a9551bd1fb2f700436e715f09a483c70cdce58e8723541a855d52aR642-R713)
* Added a new `as_maximization_problem` method to convert instances to maximization problems, including returning a boolean to indicate if the conversion was necessary.

### Additional documentation and examples:

* Included detailed examples and documentation for the new `as_maximization_problem` method and updated examples for `as_minimization_problem`.