### PR TITLE
Add initial state support to ommx_pyscipopt_adapter

### DIFF
--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -37,14 +37,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
         # Add initial solution if provided
         if initial_state is not None:
-            initial_sol = self.model.createSol()
-            varname_map = {var.name: var for var in self.model.getVars()}
-            for var_id, value in to_state(initial_state).entries.items():
-                var_name = str(var_id)
-                if var_name in varname_map:
-                    self.model.setSolVal(initial_sol, varname_map[var_name], value)
-            # The free=True parameter means that solution will be freed afterwards.
-            self.model.addSol(initial_sol, free=True)
+            self._add_initial_state(initial_state)
 
     @classmethod
     def solve(
@@ -432,3 +425,13 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
         constant = quad.linear.constant
 
         return quad_terms + linear_terms + constant
+
+    def _add_initial_state(self, initial_state: ToState) -> None:
+        initial_sol = self.model.createSol()
+        varname_map = {var.name: var for var in self.model.getVars()}
+        for var_id, value in to_state(initial_state).entries.items():
+            var_name = str(var_id)
+            if var_name in varname_map:
+                self.model.setSolVal(initial_sol, varname_map[var_name], value)
+        # The free=True parameter means that solution will be freed afterwards.
+        self.model.addSol(initial_sol, free=True)

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -59,7 +59,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
         :param ommx_instance: The ommx.v1.Instance to solve.
         :param use_sos1: Strategy for handling SOS1 constraints.
-        :param initial_state: Optional initial solution state. 
+        :param initial_state: Optional initial solution state.
 
         Examples
         =========

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -26,6 +26,14 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
         use_sos1: Literal["disabled", "auto", "forced"] = "auto",
         initial_state: Optional[ToState] = None,
     ):
+        """
+        :param ommx_instance: The ommx.v1.Instance to solve.
+        :param use_sos1: Strategy for handling SOS1 constraints.Options:
+            - "disabled": Do not use SOS1 constraints.
+            - "auto": Use SOS1 constraints if hints are provided, otherwise solve without them.(default)
+            - "forced": Require SOS1 constraints and raise an error if no SOS1 constraint hints are found.
+        :param initial_state: Optional initial solution state.
+        """
         self.instance = ommx_instance
         self.use_sos1 = use_sos1
         self.model = pyscipopt.Model()

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -51,7 +51,10 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
         Solve the given ommx.v1.Instance using PySCIPopt, returning an ommx.v1.Solution.
 
         :param ommx_instance: The ommx.v1.Instance to solve.
-        :param use_sos1: Strategy for handling SOS1 constraints.
+        :param use_sos1: Strategy for handling SOS1 constraints.Options:
+            - "disabled": Do not use SOS1 constraints.
+            - "auto": Use SOS1 constraints if hints are provided, otherwise solve without them.(default)
+            - "forced": Require SOS1 constraints and raise an error if no SOS1 constraint hints are found.
         :param initial_state: Optional initial solution state.
 
         Examples

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -428,10 +428,9 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
     def _add_initial_state(self, initial_state: ToState) -> None:
         initial_sol = self.model.createSol()
-        varname_map = {var.name: var for var in self.model.getVars()}
         for var_id, value in to_state(initial_state).entries.items():
             var_name = str(var_id)
-            if var_name in varname_map:
-                self.model.setSolVal(initial_sol, varname_map[var_name], value)
+            if var_name in self.varname_map:
+                self.model.setSolVal(initial_sol, self.varname_map[var_name], value)
         # The free=True parameter means that solution will be freed afterwards.
         self.model.addSol(initial_sol, free=True)

--- a/python/ommx-pyscipopt-adapter/tests/test_initial_state.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_initial_state.py
@@ -1,0 +1,115 @@
+from ommx.v1 import Instance, DecisionVariable
+from ommx.v1.solution_pb2 import State
+
+from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
+
+
+def test_adapter_class_with_initial_state():
+    # Objective function: x - y (Maximize)
+    # x, y: integer variables with range [0, 5]
+    # Constraint: x + y <= 5
+    # Initial state: x = 3, y = 2
+    # Optimal solution: x = 5, y = 0
+    x = DecisionVariable.integer(1, lower=0, upper=5)
+    y = DecisionVariable.integer(2, lower=0, upper=5)
+    
+    ommx_instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x - y,
+        constraints=[x + y <= 5],
+        sense=Instance.MAXIMIZE,
+    )
+    initial_state = State(entries={
+        1: 3.0,
+        2: 2.0,
+    })
+    adapter = OMMXPySCIPOptAdapter(ommx_instance, initial_state=initial_state)
+    model = adapter.solver_input
+    sols = model.getSols()
+    sol = sols[0]
+    var_dict = {var.name: var for var in model.getVars()}
+    
+    # Verify the initial state was correctly set in the model
+    assert model.getSolVal(sol, var_dict["1"]) == 3.0
+    assert model.getSolVal(sol, var_dict["2"]) == 2.0
+
+
+def test_solve_with_initial_state():
+    # Objective function: x - y (Maximize)
+    # x, y: integer variables with range [0, 5]
+    # Constraint: x + y <= 5
+    # Initial state: x = 3, y = 2
+    # Optimal solution: x = 5, y = 0
+    x = DecisionVariable.integer(1, lower=0, upper=5)
+    y = DecisionVariable.integer(2, lower=0, upper=5)
+    
+    ommx_instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x - y,
+        constraints=[x + y <= 5],
+        sense=Instance.MAXIMIZE,
+    )
+    initial_state = State(entries={
+        1: 3.0,
+        2: 2.0,
+    })
+    solution = OMMXPySCIPOptAdapter.solve(ommx_instance, initial_state=initial_state)
+    # The solution should be the optimal one, not the initial one
+    assert solution.state.entries[1] == 5.0
+    assert solution.state.entries[2] == 0.0
+    assert solution.objective == 5.0
+
+
+def test_adapter_class_with_initial_state_from_mapping():
+    # Objective function: x - y (Maximize)
+    # x, y: integer variables with range [0, 5]
+    # Constraint: x + y <= 5
+    # Initial state: x = 3, y = 2
+    # Optimal solution: x = 5, y = 0
+    x = DecisionVariable.integer(1, lower=0, upper=5)
+    y = DecisionVariable.integer(2, lower=0, upper=5)
+    
+    ommx_instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x - y,
+        constraints=[x + y <= 5],
+        sense=Instance.MAXIMIZE,
+    )
+    initial_mapping = {
+        1: 3.0,
+        2: 2.0,
+    }
+    adapter = OMMXPySCIPOptAdapter(ommx_instance, initial_state=initial_mapping)
+    model = adapter.solver_input
+    sols = model.getSols()    
+    sol = sols[0]
+    var_dict = {var.name: var for var in model.getVars()}
+    # Verify the initial state was correctly set in the model
+    assert model.getSolVal(sol, var_dict["1"]) == 3.0
+    assert model.getSolVal(sol, var_dict["2"]) == 2.0
+
+
+def test_solve_with_initial_state_from_mapping():
+    # Objective function: x - y (Maximize)
+    # x, y: integer variables with range [0, 5]
+    # Constraint: x + y <= 5
+    # Initial state: x = 3, y = 2
+    # Optimal solution: x = 5, y = 0
+    x = DecisionVariable.integer(1, lower=0, upper=5)
+    y = DecisionVariable.integer(2, lower=0, upper=5)
+    
+    ommx_instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x - y,
+        constraints=[x + y <= 5],
+        sense=Instance.MAXIMIZE,
+    )
+    initial_mapping = {
+        1: 3.0,
+        2: 2.0,
+    }
+    solution = OMMXPySCIPOptAdapter.solve(ommx_instance, initial_state=initial_mapping)
+    # The solution should be the optimal one, not the initial one
+    assert solution.state.entries[1] == 5.0
+    assert solution.state.entries[2] == 0.0
+    assert solution.objective == 5.0

--- a/python/ommx-pyscipopt-adapter/tests/test_initial_state.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_initial_state.py
@@ -12,23 +12,25 @@ def test_adapter_class_with_initial_state():
     # Optimal solution: x = 5, y = 0
     x = DecisionVariable.integer(1, lower=0, upper=5)
     y = DecisionVariable.integer(2, lower=0, upper=5)
-    
+
     ommx_instance = Instance.from_components(
         decision_variables=[x, y],
         objective=x - y,
         constraints=[x + y <= 5],
         sense=Instance.MAXIMIZE,
     )
-    initial_state = State(entries={
-        1: 3.0,
-        2: 2.0,
-    })
+    initial_state = State(
+        entries={
+            1: 3.0,
+            2: 2.0,
+        }
+    )
     adapter = OMMXPySCIPOptAdapter(ommx_instance, initial_state=initial_state)
     model = adapter.solver_input
     sols = model.getSols()
     sol = sols[0]
     var_dict = {var.name: var for var in model.getVars()}
-    
+
     # Verify the initial state was correctly set in the model
     assert model.getSolVal(sol, var_dict["1"]) == 3.0
     assert model.getSolVal(sol, var_dict["2"]) == 2.0
@@ -42,17 +44,19 @@ def test_solve_with_initial_state():
     # Optimal solution: x = 5, y = 0
     x = DecisionVariable.integer(1, lower=0, upper=5)
     y = DecisionVariable.integer(2, lower=0, upper=5)
-    
+
     ommx_instance = Instance.from_components(
         decision_variables=[x, y],
         objective=x - y,
         constraints=[x + y <= 5],
         sense=Instance.MAXIMIZE,
     )
-    initial_state = State(entries={
-        1: 3.0,
-        2: 2.0,
-    })
+    initial_state = State(
+        entries={
+            1: 3.0,
+            2: 2.0,
+        }
+    )
     solution = OMMXPySCIPOptAdapter.solve(ommx_instance, initial_state=initial_state)
     # The solution should be the optimal one, not the initial one
     assert solution.state.entries[1] == 5.0
@@ -68,7 +72,7 @@ def test_adapter_class_with_initial_state_from_mapping():
     # Optimal solution: x = 5, y = 0
     x = DecisionVariable.integer(1, lower=0, upper=5)
     y = DecisionVariable.integer(2, lower=0, upper=5)
-    
+
     ommx_instance = Instance.from_components(
         decision_variables=[x, y],
         objective=x - y,
@@ -81,7 +85,7 @@ def test_adapter_class_with_initial_state_from_mapping():
     }
     adapter = OMMXPySCIPOptAdapter(ommx_instance, initial_state=initial_mapping)
     model = adapter.solver_input
-    sols = model.getSols()    
+    sols = model.getSols()
     sol = sols[0]
     var_dict = {var.name: var for var in model.getVars()}
     # Verify the initial state was correctly set in the model
@@ -97,7 +101,7 @@ def test_solve_with_initial_state_from_mapping():
     # Optimal solution: x = 5, y = 0
     x = DecisionVariable.integer(1, lower=0, upper=5)
     y = DecisionVariable.integer(2, lower=0, upper=5)
-    
+
     ommx_instance = Instance.from_components(
         decision_variables=[x, y],
         objective=x - y,


### PR DESCRIPTION
## Changes

* Add the feature of setting an initial state to `ommx_pyscipopt_adapter` by using the addSol method of PySCIPOpt.
* Add a test for the initial state in `test_initial_state.py`.
