### PR TITLE
Pass inequality_integer_slack_max_range to add_integer_slack_to_inequality instead of hard-coded 32

### DIFF
--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -615,7 +615,9 @@ class Instance(InstanceBase, UserAnnotationBase):
                     ineq_id, inequality_integer_slack_max_range
                 )
             except RuntimeError:
-                self.add_integer_slack_to_inequality(ineq_id, 32)
+                self.add_integer_slack_to_inequality(
+                    ineq_id, inequality_integer_slack_max_range
+                )
 
         # Penalty method
         if self.get_constraints():


### PR DESCRIPTION
I attempted the following code and noticed that both instances introduced the same slack variables:

```python
import numpy as np
import jijmodeling as jm

x = jm.BinaryVar('x', shape=(2,))
problem = jm.Problem('example')
problem += jm.Constraint('c', -100*x[0] + x[1] <= 0)

instance = jm.Interpreter({}).eval_problem(problem)
qubo, const = instance.to_qubo()

instance2 = jm.Interpreter({}).eval_problem(problem)
qubo2, const2 = instance2.to_qubo(inequality_integer_slack_max_range = 31)
```

![image](https://github.com/user-attachments/assets/45bdf133-901e-4702-9777-32409988eeb7)

But I expect `instance2` to have the following variables:

![image](https://github.com/user-attachments/assets/5ae42b32-0985-425d-9b87-8bc17ffd6ef4)

I think we should pass `inequality_integer_slack_max_range` instead of hard-coded 32 to `Instance.add_integer_slack_to_inequality`.