### PR TITLE
Revise benchmarks and `ommx::random` API Design

### DIFF
--- a/rust/ommx/benches/sum.rs
+++ b/rust/ommx/benches/sum.rs
@@ -211,31 +211,6 @@ fn sum_polynomial_large_little(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark for summation of linear + quadratic functions with varying terms
-fn add_linear_quadratic_large(c: &mut Criterion) {
-    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
-    let mut group = c.benchmark_group("add-linear-quadratic");
-    group.plot_config(plot_config.clone());
-    for num_terms in [10, 100, 1000] {
-        let lin: Linear = random_deterministic(FunctionParameters {
-            num_terms,
-            max_degree: 1,
-            max_id: (3 * num_terms) as u64,
-        });
-        let quad: Quadratic = random_deterministic(FunctionParameters {
-            num_terms,
-            max_degree: 2,
-            max_id: (3 * num_terms) as u64,
-        });
-        group.bench_with_input(
-            BenchmarkId::new("add-linear-quadratic", num_terms.to_string()),
-            &(lin, quad),
-            |b, (lin, quad)| b.iter(|| lin.clone() + quad.clone()),
-        );
-    }
-    group.finish();
-}
-
 fn add_small_many_linear_to_quadratic(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("add-small-many-linear-to-quadratic");
@@ -312,7 +287,6 @@ criterion_group!(
     sum_quadratic_large_little,
     sum_polynomial_small_many,
     sum_polynomial_large_little,
-    add_linear_quadratic_large,
     add_small_many_linear_to_quadratic,
     add_small_many_linear_to_polynomial,
 );

--- a/rust/ommx/benches/sum.rs
+++ b/rust/ommx/benches/sum.rs
@@ -4,7 +4,7 @@ use criterion::{
 
 use num::Zero;
 use ommx::{
-    random::{random_deterministic, FunctionParameters},
+    random::{random, random_deterministic, FunctionParameters, Rng},
     v1::{Linear, Polynomial, Quadratic},
 };
 
@@ -13,14 +13,18 @@ fn sum_linear_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-linear-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in [10, 100, 1000] {
+        let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Linear {
-                random_deterministic(FunctionParameters {
-                    num_terms: 3,
-                    max_degree: 1,
-                    max_id: num_functions,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms: 3,
+                        max_degree: 1,
+                        max_id: num_functions,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         group.bench_with_input(
@@ -43,13 +47,17 @@ fn sum_linear_large_little(c: &mut Criterion) {
     let mut group = c.benchmark_group("sum-linear-large-little");
     group.plot_config(plot_config.clone());
     for num_terms in [100, 1000, 10_000] {
+        let mut rng = Rng::deterministic();
         let functions = (0..3)
             .map(|_| -> Linear {
-                random_deterministic(FunctionParameters {
-                    num_terms,
-                    max_degree: 1,
-                    max_id: 3 * num_terms as u64,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms,
+                        max_degree: 1,
+                        max_id: 3 * num_terms as u64,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         group.bench_with_input(
@@ -72,14 +80,18 @@ fn sum_quadratic_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-quadratic-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in [10, 100, 1000] {
+        let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Quadratic {
-                random_deterministic(FunctionParameters {
-                    num_terms: 3,
-                    max_degree: 2,
-                    max_id: num_functions as u64,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms: 3,
+                        max_degree: 2,
+                        max_id: num_functions as u64,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         group.bench_with_input(
@@ -103,13 +115,17 @@ fn sum_quadratic_large_little(c: &mut Criterion) {
     let mut group = c.benchmark_group("sum-quadratic-large-little");
     group.plot_config(plot_config.clone());
     for num_terms in [100, 1000, 10_000] {
+        let mut rng = Rng::deterministic();
         let functions = (0..3)
             .map(|_| -> Quadratic {
-                random_deterministic(FunctionParameters {
-                    num_terms,
-                    max_degree: 2,
-                    max_id: (3 * num_terms) as u64,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms,
+                        max_degree: 2,
+                        max_id: (3 * num_terms) as u64,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         group.bench_with_input(
@@ -132,14 +148,18 @@ fn sum_polynomial_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-polynomial-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in [10, 100, 1000] {
+        let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Polynomial {
-                random_deterministic(FunctionParameters {
-                    num_terms: 3,
-                    max_degree: 3,
-                    max_id: num_functions as u64,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms: 3,
+                        max_degree: 3,
+                        max_id: num_functions as u64,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         group.bench_with_input(
@@ -163,13 +183,17 @@ fn sum_polynomial_large_little(c: &mut Criterion) {
     let mut group = c.benchmark_group("sum-polynomial-large-little");
     group.plot_config(plot_config.clone());
     for num_terms in [100, 1000, 10_000] {
+        let mut rng = Rng::deterministic();
         let functions = (0..3)
             .map(|_| -> Polynomial {
-                random_deterministic(FunctionParameters {
-                    num_terms,
-                    max_degree: 3,
-                    max_id: (3 * num_terms) as u64,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms,
+                        max_degree: 3,
+                        max_id: (3 * num_terms) as u64,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         group.bench_with_input(
@@ -192,7 +216,7 @@ fn add_linear_quadratic_large(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("add-linear-quadratic");
     group.plot_config(plot_config.clone());
-    for num_terms in [100, 1000, 10_000] {
+    for num_terms in [10, 100, 1000] {
         let lin: Linear = random_deterministic(FunctionParameters {
             num_terms,
             max_degree: 1,
@@ -216,14 +240,18 @@ fn add_small_many_linear_to_quadratic(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("add-small-many-linear-to-quadratic");
     group.plot_config(plot_config.clone());
-    for num_lin in [100, 1000, 10_000] {
+    for num_lin in [10, 100, 1000] {
+        let mut rng = Rng::deterministic();
         let lins = (0..num_lin)
             .map(|_| -> Linear {
-                random_deterministic(FunctionParameters {
-                    num_terms: 3,
-                    max_degree: 1,
-                    max_id: 3 * num_lin as u64,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms: 3,
+                        max_degree: 1,
+                        max_id: 3 * num_lin as u64,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         let quad: Quadratic = random_deterministic(FunctionParameters {
@@ -246,14 +274,18 @@ fn add_small_many_linear_to_polynomial(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("add-small-many-linear-to-polynomial");
     group.plot_config(plot_config.clone());
-    for num_lin in [100, 1000, 10_000] {
+    for num_lin in [10, 100, 1000] {
+        let mut rng = Rng::deterministic();
         let lins = (0..num_lin)
             .map(|_| -> Linear {
-                random_deterministic(FunctionParameters {
-                    num_terms: 3,
-                    max_degree: 1,
-                    max_id: 3 * num_lin as u64,
-                })
+                random(
+                    &mut rng,
+                    FunctionParameters {
+                        num_terms: 3,
+                        max_degree: 1,
+                        max_id: 3 * num_lin as u64,
+                    },
+                )
             })
             .collect::<Vec<_>>();
         let poly: Polynomial = random_deterministic(FunctionParameters {


### PR DESCRIPTION
Fix bug in the benchmark code in #419. The fixed benchmark reproduces the performance issue that a summation of small linear functions costs $O(n^2)$.

This pull request refactors the random sampling mechanism in the benchmarking and random utilities of the `ommx` project. It introduces a new `Rng` type alias for `proptest::test_runner::TestRunner`, replaces the use of `random_deterministic` with `random` in benchmarks, and adjusts the parameters for some benchmark loops. Additionally, it removes an unused benchmark function and simplifies the `random` utility functions.

### Benchmarking updates:

* Replaced the `random_deterministic` function with the new `random` function, which now accepts a mutable reference to `Rng`, in all benchmark functions (`sum_linear_*`, `sum_quadratic_*`, `sum_polynomial_*`, and `add_*`). This ensures consistent and reusable random number generation. [[1]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L16-R27) [[2]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07R50-R60) [[3]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L75-R94) [[4]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07R118-R128) [[5]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L135-R162) [[6]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07R186-R196) [[7]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L190-R229) [[8]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L249-R263)
* Reduced the range of benchmark loop parameters for `num_functions` and `num_terms` from `[100, 1000, 10_000]` to `[10, 100, 1000]` to make the benchmarks more manageable. [[1]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L16-R27) [[2]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L75-R94) [[3]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L135-R162) [[4]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L190-R229) [[5]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L249-R263)
* Removed the unused `add_linear_quadratic_large` benchmark function and its reference in the `criterion_group!` macro. [[1]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L190-R229) [[2]](diffhunk://#diff-1e86341802d2475c0ab8c63b6c3d0f4ae3c85a592c125a748192b4da270eaa07L283)

### Random utility refactor:

* Introduced a new `Rng` type alias for `proptest::test_runner::TestRunner` to simplify the API and improve readability.
* Updated the `random` and `sample` functions to use a mutable reference to `Rng` instead of directly passing the `TestRng`. This improves flexibility when reusing the same RNG instance. [[1]](diffhunk://#diff-4c8d12615bc2fb714faa03de157127852772285b6b4ba46e32931acdbf0ab12eR52-R62) [[2]](diffhunk://#diff-4c8d12615bc2fb714faa03de157127852772285b6b4ba46e32931acdbf0ab12eL71-R77)
* Simplified `sample_deterministic` by replacing `TestRunner::deterministic()` with the new `Rng::deterministic()` alias.

### Cleanup:

* Removed unused imports from `proptest` in `rust/ommx/src/random.rs` to streamline the code.