### PR TITLE
Introduce `VariableIDSet` type

### DIFF
--- a/python/ommx/src/evaluate.rs
+++ b/python/ommx/src/evaluate.rs
@@ -92,5 +92,5 @@ define_partial_evaluate_object!(Instance, partial_evaluate_instance);
 #[pyfunction]
 pub fn used_decision_variable_ids(function: &Bound<PyBytes>) -> BTreeSet<u64> {
     let function = Function::decode(function.as_bytes()).unwrap();
-    function.used_decision_variable_ids()
+    function.required_ids()
 }

--- a/python/ommx/src/evaluate.rs
+++ b/python/ommx/src/evaluate.rs
@@ -92,5 +92,9 @@ define_partial_evaluate_object!(Instance, partial_evaluate_instance);
 #[pyfunction]
 pub fn used_decision_variable_ids(function: &Bound<PyBytes>) -> BTreeSet<u64> {
     let function = Function::decode(function.as_bytes()).unwrap();
-    function.required_ids()
+    function
+        .required_ids()
+        .into_iter()
+        .map(|id| id.into_inner())
+        .collect()
 }

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -29,7 +29,11 @@ impl Instance {
     }
 
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
-        self.0.used_decision_variable_ids()
+        self.0
+            .required_ids()
+            .into_iter()
+            .map(|id| id.into_inner())
+            .collect()
     }
 
     pub fn as_pubo_format<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyDict>> {

--- a/python/ommx/src/message.rs
+++ b/python/ommx/src/message.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use anyhow::Result;
 use approx::AbsDiffEq;
-use ommx::{v1, Message};
+use ommx::{v1, Evaluate, Message};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyBytes};
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pyclass)]
@@ -274,6 +274,10 @@ impl Function {
     }
 
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
-        self.0.used_decision_variable_ids()
+        self.0
+            .required_ids()
+            .into_iter()
+            .map(|id| id.into_inner())
+            .collect()
     }
 }

--- a/rust/ommx/benches/partial_evaluate.rs
+++ b/rust/ommx/benches/partial_evaluate.rs
@@ -5,7 +5,7 @@ use criterion::{
 use ommx::{
     random::{arbitrary_state, random_deterministic, sample_deterministic},
     Evaluate, Linear, LinearParameters, Polynomial, PolynomialParameters, Quadratic,
-    QuadraticParameters, VariableID,
+    QuadraticParameters, VariableID, VariableIDSet,
 };
 use proptest::prelude::Arbitrary;
 use std::collections::BTreeSet;
@@ -13,7 +13,7 @@ use std::collections::BTreeSet;
 fn bench_partial_evaluate<T, Parameters>(
     c: &mut Criterion,
     group_name: &str,
-    id_selector: impl Fn(BTreeSet<u64>) -> BTreeSet<u64>,
+    id_selector: impl Fn(VariableIDSet) -> VariableIDSet,
     parameter_generator: impl Fn(usize) -> Parameters,
 ) where
     T: Evaluate + Clone + Arbitrary<Parameters = Parameters>,
@@ -42,16 +42,16 @@ fn bench_partial_evaluate<T, Parameters>(
     group.finish();
 }
 
-fn all_ids(ids: BTreeSet<u64>) -> BTreeSet<u64> {
+fn all_ids(ids: VariableIDSet) -> VariableIDSet {
     ids
 }
 
-fn half_ids(ids: BTreeSet<u64>) -> BTreeSet<u64> {
+fn half_ids(ids: VariableIDSet) -> VariableIDSet {
     let n = ids.len() / 2;
     ids.into_iter().take(n).collect()
 }
 
-fn one_id(ids: BTreeSet<u64>) -> BTreeSet<u64> {
+fn one_id(ids: VariableIDSet) -> VariableIDSet {
     ids.into_iter().take(1).collect()
 }
 

--- a/rust/ommx/benches/partial_evaluate.rs
+++ b/rust/ommx/benches/partial_evaluate.rs
@@ -8,7 +8,6 @@ use ommx::{
     QuadraticParameters, VariableID, VariableIDSet,
 };
 use proptest::prelude::Arbitrary;
-use std::collections::BTreeSet;
 
 fn bench_partial_evaluate<T, Parameters>(
     c: &mut Criterion,

--- a/rust/ommx/src/constraint/evaluate.rs
+++ b/rust/ommx/src/constraint/evaluate.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     v1::{EvaluatedConstraint, SampledConstraint},
-    Evaluate, FnvHashMapExt,
+    Evaluate, FnvHashMapExt, VariableIDSet,
 };
 use std::collections::HashMap;
 
@@ -11,7 +11,12 @@ impl Evaluate for Constraint {
 
     fn evaluate(&self, solution: &crate::v1::State) -> anyhow::Result<Self::Output> {
         let evaluated_value = self.function.evaluate(solution)?;
-        let used_decision_variable_ids = self.function.required_ids().into_iter().collect();
+        let used_decision_variable_ids = self
+            .function
+            .required_ids()
+            .into_iter()
+            .map(|id| id.into_inner())
+            .collect();
         Ok(EvaluatedConstraint {
             id: self.id.into_inner(),
             equality: self.equality.into(),
@@ -42,7 +47,12 @@ impl Evaluate for Constraint {
         Ok(SampledConstraint {
             id: self.id.into_inner(),
             evaluated_values: Some(evaluated_values),
-            used_decision_variable_ids: self.function.required_ids().into_iter().collect(),
+            used_decision_variable_ids: self
+                .function
+                .required_ids()
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
             name: self.name.clone(),
             subscripts: self.subscripts.clone(),
             parameters: self.parameters.to_std(),
@@ -58,7 +68,7 @@ impl Evaluate for Constraint {
         self.function.partial_evaluate(state)
     }
 
-    fn required_ids(&self) -> std::collections::BTreeSet<u64> {
+    fn required_ids(&self) -> VariableIDSet {
         self.function.required_ids()
     }
 }

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -6,6 +6,7 @@ use proptest::prelude::*;
 /// ID for decision variable and parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Deref)]
 pub struct VariableID(u64);
+pub type VariableIDSet = FnvHashSet<VariableID>;
 
 impl VariableID {
     pub fn into_inner(&self) -> u64 {

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -2,11 +2,12 @@ use crate::{parse::*, random::unique_integers, v1, Bound};
 use derive_more::{Deref, From};
 use fnv::{FnvHashMap, FnvHashSet};
 use proptest::prelude::*;
+use std::collections::BTreeSet;
 
 /// ID for decision variable and parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Deref)]
 pub struct VariableID(u64);
-pub type VariableIDSet = FnvHashSet<VariableID>;
+pub type VariableIDSet = BTreeSet<VariableID>;
 
 impl VariableID {
     pub fn into_inner(&self) -> u64 {

--- a/rust/ommx/src/function/evaluate.rs
+++ b/rust/ommx/src/function/evaluate.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{v1::SampledValues, Evaluate};
+use crate::{v1::SampledValues, Evaluate, VariableIDSet};
 
 impl Evaluate for Function {
     type Output = f64;
@@ -24,13 +24,12 @@ impl Evaluate for Function {
         }
     }
 
-    fn required_ids(&self) -> std::collections::BTreeSet<u64> {
+    fn required_ids(&self) -> VariableIDSet {
         match self {
-            Function::Zero => std::collections::BTreeSet::new(),
-            Function::Constant(_) => std::collections::BTreeSet::new(),
             Function::Linear(f) => f.required_ids(),
             Function::Quadratic(f) => f.required_ids(),
             Function::Polynomial(f) => f.required_ids(),
+            _ => VariableIDSet::default(),
         }
     }
 

--- a/rust/ommx/src/instance/analysis.rs
+++ b/rust/ommx/src/instance/analysis.rs
@@ -319,10 +319,8 @@ impl Instance {
             }
         }
 
-        let used_in_objective: FnvHashSet<VariableID> = self
-            .objective
-            .required_ids()
-            .into_iter().collect();
+        let used_in_objective: FnvHashSet<VariableID> =
+            self.objective.required_ids().into_iter().collect();
         debug_assert!(
             used_in_objective.is_subset(&all),
             "Objective function uses variables not in the instance"
@@ -333,10 +331,7 @@ impl Instance {
         for constraint in self.constraints.values() {
             used_in_constraints.insert(
                 constraint.id,
-                constraint
-                    .function
-                    .required_ids()
-                    .into_iter().collect(),
+                constraint.function.required_ids().into_iter().collect(),
             );
         }
         debug_assert!(

--- a/rust/ommx/src/instance/analysis.rs
+++ b/rust/ommx/src/instance/analysis.rs
@@ -322,9 +322,7 @@ impl Instance {
         let used_in_objective: FnvHashSet<VariableID> = self
             .objective
             .required_ids()
-            .into_iter()
-            .map(VariableID::from)
-            .collect();
+            .into_iter().collect();
         debug_assert!(
             used_in_objective.is_subset(&all),
             "Objective function uses variables not in the instance"
@@ -338,9 +336,7 @@ impl Instance {
                 constraint
                     .function
                     .required_ids()
-                    .into_iter()
-                    .map(VariableID::from)
-                    .collect(),
+                    .into_iter().collect(),
             );
         }
         debug_assert!(

--- a/rust/ommx/src/instance/arbitrary.rs
+++ b/rust/ommx/src/instance/arbitrary.rs
@@ -165,9 +165,8 @@ impl Arbitrary for Instance {
         (objective, constraints, irrelevant_candidates)
             .prop_flat_map(move |(objective, constraints, irrelevant_candidates)| {
                 // Collect all required IDs from the objective and constraints
-                let mut unique_ids: FnvHashSet<VariableID> = objective
-                    .required_ids()
-                    .into_iter().collect();
+                let mut unique_ids: FnvHashSet<VariableID> =
+                    objective.required_ids().into_iter().collect();
                 for c in constraints.values() {
                     unique_ids.extend(c.function.required_ids().into_iter());
                 }

--- a/rust/ommx/src/instance/arbitrary.rs
+++ b/rust/ommx/src/instance/arbitrary.rs
@@ -167,11 +167,9 @@ impl Arbitrary for Instance {
                 // Collect all required IDs from the objective and constraints
                 let mut unique_ids: FnvHashSet<VariableID> = objective
                     .required_ids()
-                    .into_iter()
-                    .map(VariableID::from)
-                    .collect();
+                    .into_iter().collect();
                 for c in constraints.values() {
-                    unique_ids.extend(c.function.required_ids().into_iter().map(VariableID::from));
+                    unique_ids.extend(c.function.required_ids().into_iter());
                 }
                 unique_ids.extend(irrelevant_candidates.into_iter().map(VariableID::from));
                 (

--- a/rust/ommx/src/mps.rs
+++ b/rust/ommx/src/mps.rs
@@ -62,6 +62,8 @@ mod tests;
 
 use parser::*;
 
+use crate::VariableID;
+
 /// Reads and parses the reader as a gzipped MPS file.
 pub fn load_zipped_reader(reader: impl Read) -> Result<crate::v1::Instance, MpsParseError> {
     let mps_data = Mps::from_zipped_reader(reader)?;
@@ -148,7 +150,7 @@ pub enum MpsWriteError {
     #[error(
         "Invalid variable ID: Functions in Instance used a variable id {0} that doesn't exist"
     )]
-    InvalidVariableId(u64),
+    InvalidVariableId(VariableID),
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }

--- a/rust/ommx/src/mps/to_mps.rs
+++ b/rust/ommx/src/mps/to_mps.rs
@@ -1,5 +1,5 @@
 use super::MpsWriteError;
-use crate::{mps::ObjSense, v1};
+use crate::{mps::ObjSense, v1, Evaluate};
 use std::{collections::HashMap, io::Write};
 
 pub(crate) const OBJ_NAME: &str = "OBJ";
@@ -184,7 +184,7 @@ fn write_bounds<W: Write>(instance: &v1::Instance, out: &mut W) -> Result<(), Mp
         .iter()
         .map(|var| (var.id, var))
         .collect();
-    for dvar_id in instance.used_decision_variable_ids().into_iter() {
+    for dvar_id in instance.required_ids().into_iter() {
         let dvar = var_by_id
             .get(&dvar_id)
             .ok_or(MpsWriteError::InvalidVariableId(dvar_id))?;

--- a/rust/ommx/src/polynomial_base/evaluate.rs
+++ b/rust/ommx/src/polynomial_base/evaluate.rs
@@ -1,10 +1,9 @@
 use super::*;
 use crate::{
     v1::{SampledValues, Samples, State},
-    Evaluate,
+    Evaluate, VariableIDSet,
 };
 use anyhow::{anyhow, Result};
-use std::collections::BTreeSet;
 
 impl<M: Monomial> Evaluate for PolynomialBase<M> {
     type Output = f64;
@@ -50,11 +49,10 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
         Ok(())
     }
 
-    fn required_ids(&self) -> BTreeSet<u64> {
+    fn required_ids(&self) -> VariableIDSet {
         self.terms
             .keys()
             .flat_map(|monomial| monomial.ids())
-            .map(|id| id.into_inner())
             .collect()
     }
 

--- a/rust/ommx/src/random/decision_variable.rs
+++ b/rust/ommx/src/random/decision_variable.rs
@@ -1,6 +1,9 @@
-use crate::v1::{decision_variable::Kind, Bound, DecisionVariable};
+use crate::{
+    v1::{decision_variable::Kind, Bound, DecisionVariable},
+    VariableIDSet,
+};
 use proptest::{prelude::*, strategy::Union};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
 impl Arbitrary for Bound {
     type Parameters = ();
@@ -102,7 +105,7 @@ impl Arbitrary for DecisionVariable {
 }
 
 pub fn arbitrary_decision_variables(
-    ids: BTreeSet<u64>,
+    ids: VariableIDSet,
     kinds: Vec<Kind>,
 ) -> BoxedStrategy<Vec<DecisionVariable>> {
     let kind_strategy = Union::new(kinds.into_iter().map(Just));
@@ -117,7 +120,7 @@ pub fn arbitrary_decision_variables(
     )
         .prop_map(|(mut dvs, used_ids)| {
             for (dv, id) in dvs.iter_mut().zip(used_ids.iter()) {
-                dv.id = *id;
+                dv.id = id.into_inner();
             }
             dvs
         })

--- a/rust/ommx/src/random/instance.rs
+++ b/rust/ommx/src/random/instance.rs
@@ -5,6 +5,7 @@ use crate::{
         instance::{Description, Sense},
         Function, Instance,
     },
+    Evaluate,
 };
 use anyhow::{bail, Result};
 use proptest::prelude::*;
@@ -136,9 +137,9 @@ impl Arbitrary for Instance {
             arbitrary_constraints(num_constraints, constraint),
         )
             .prop_flat_map(move |(objective, constraints)| {
-                let mut used_ids = objective.used_decision_variable_ids();
+                let mut used_ids = objective.required_ids();
                 for c in &constraints {
-                    used_ids.extend(c.function().used_decision_variable_ids());
+                    used_ids.extend(c.function().required_ids());
                 }
                 let relaxed = if constraints.is_empty() {
                     Just(Vec::new()).boxed()

--- a/rust/ommx/src/random/parameter.rs
+++ b/rust/ommx/src/random/parameter.rs
@@ -1,6 +1,6 @@
-use crate::v1::Parameter;
+use crate::{v1::Parameter, VariableIDSet};
 use proptest::prelude::*;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
 impl Arbitrary for Parameter {
     type Parameters = u64;
@@ -35,14 +35,14 @@ impl Arbitrary for Parameter {
     }
 }
 
-pub fn arbitrary_parameters(ids: BTreeSet<u64>) -> BoxedStrategy<Vec<Parameter>> {
+pub fn arbitrary_parameters(ids: VariableIDSet) -> BoxedStrategy<Vec<Parameter>> {
     (
         proptest::collection::vec(Parameter::arbitrary(), ids.len()),
         Just(ids),
     )
         .prop_map(|(mut dvs, used_ids)| {
             for (dv, id) in dvs.iter_mut().zip(used_ids.iter()) {
-                dv.id = *id;
+                dv.id = id.into_inner();
             }
             dvs
         })

--- a/rust/ommx/src/random/parametric_instance.rs
+++ b/rust/ommx/src/random/parametric_instance.rs
@@ -7,9 +7,9 @@ use crate::{
         instance::{Description, Sense},
         Function, ParametricInstance,
     },
+    Evaluate, VariableIDSet,
 };
 use proptest::prelude::*;
-use std::collections::BTreeSet;
 
 impl Arbitrary for ParametricInstance {
     type Parameters = InstanceParameters;
@@ -30,9 +30,9 @@ impl Arbitrary for ParametricInstance {
             Just(kinds),
         )
             .prop_flat_map(|(objective, constraints, kinds)| {
-                let mut used_ids = objective.used_decision_variable_ids();
+                let mut used_ids = objective.required_ids();
                 for c in &constraints {
-                    used_ids.extend(c.function().used_decision_variable_ids());
+                    used_ids.extend(c.function().required_ids());
                 }
 
                 (
@@ -84,12 +84,12 @@ impl Arbitrary for ParametricInstance {
     }
 }
 
-fn arbitrary_split(ids: BTreeSet<u64>) -> BoxedStrategy<(BTreeSet<u64>, BTreeSet<u64>)> {
+fn arbitrary_split(ids: VariableIDSet) -> BoxedStrategy<(VariableIDSet, VariableIDSet)> {
     let flips = proptest::collection::vec(bool::arbitrary(), ids.len());
     flips
         .prop_map(move |flips| {
-            let mut used_ids = BTreeSet::new();
-            let mut defined_ids = BTreeSet::new();
+            let mut used_ids = VariableIDSet::default();
+            let mut defined_ids = VariableIDSet::default();
             for (flip, id) in flips.into_iter().zip(ids.iter()) {
                 if flip {
                     used_ids.insert(*id);

--- a/rust/ommx/src/random/samples.rs
+++ b/rust/ommx/src/random/samples.rs
@@ -76,14 +76,14 @@ pub fn arbitrary_samples(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::random::arbitrary_state;
+    use crate::{random::arbitrary_state, VariableID};
 
     proptest! {
         #[test]
         fn test_arbitrary_samples(
             samples in arbitrary_samples(
                 SamplesParameters::new(10, 100, 1000).unwrap(),
-                arbitrary_state((0..=5).collect())
+                arbitrary_state((0..=5).map(VariableID::from).collect())
             )
         ) {
             prop_assert_eq!(samples.entries.len(), 10);

--- a/rust/ommx/src/random/state.rs
+++ b/rust/ommx/src/random/state.rs
@@ -1,6 +1,5 @@
-use crate::{random::arbitrary_coefficient, v1::State};
+use crate::{random::arbitrary_coefficient, v1::State, VariableIDSet};
 use proptest::prelude::*;
-use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StateParameters {
@@ -38,13 +37,17 @@ impl Arbitrary for State {
     }
 }
 
-pub fn arbitrary_state(ids: BTreeSet<u64>) -> BoxedStrategy<State> {
+pub fn arbitrary_state(ids: VariableIDSet) -> BoxedStrategy<State> {
     (
         proptest::collection::vec(arbitrary_coefficient(), ids.len()),
         Just(ids),
     )
         .prop_map(|(coefficients, ids)| {
-            let entries = ids.into_iter().zip(coefficients).collect();
+            let entries = ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .zip(coefficients)
+                .collect();
             State { entries }
         })
         .boxed()

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -880,7 +880,7 @@ mod tests {
 
             // Put every penalty weights to zero
             let parameters = Parameters {
-                entries: p_ids.iter().map(|&id| (id, 0.0)).collect(),
+                entries: p_ids.iter().map(|&id| (id.into_inner(), 0.0)).collect(),
             };
             let substituted = parametric_instance.clone().with_parameters(parameters).unwrap();
             prop_assert!(instance.objective().abs_diff_eq(&substituted.objective(), 1e-10));
@@ -888,7 +888,7 @@ mod tests {
 
             // Put every penalty weights to two
             let parameters = Parameters {
-                entries: p_ids.iter().map(|&id| (id, 2.0)).collect(),
+                entries: p_ids.iter().map(|&id| (id.into_inner(), 2.0)).collect(),
             };
             let substituted = parametric_instance.with_parameters(parameters).unwrap();
             let mut objective = instance.objective().into_owned();
@@ -913,7 +913,7 @@ mod tests {
 
             // Put every penalty weights to zero
             let parameters = Parameters {
-                entries: p_ids.iter().map(|&id| (id, 0.0)).collect(),
+                entries: p_ids.iter().map(|&id| (id.into_inner(), 0.0)).collect(),
             };
             let substituted = parametric_instance.clone().with_parameters(parameters).unwrap();
             prop_assert!(instance.objective().abs_diff_eq(&substituted.objective(), 1e-10));
@@ -921,7 +921,7 @@ mod tests {
 
             // Put every penalty weights to two
             let parameters = Parameters {
-                entries: p_ids.iter().map(|&id| (id, 2.0)).collect(),
+                entries: p_ids.iter().map(|&id| (id.into_inner(), 2.0)).collect(),
             };
             let substituted = parametric_instance.with_parameters(parameters).unwrap();
             let mut objective = instance.objective().into_owned();

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -481,7 +481,6 @@ impl Instance {
 
         // If the constraint contains continuous decision variables, integer slack variable cannot be introduced
         for id in function.required_ids() {
-            let id = VariableID::from(id);
             let kind = kinds
                 .get(&id)
                 .with_context(|| format!("Decision variable ID {id:?} not found"))?;
@@ -579,7 +578,6 @@ impl Instance {
             .with_context(|| format!("Constraint ID {} does not have a function", constraint_id))?;
 
         for id in f.required_ids() {
-            let id = VariableID::from(id);
             let kind = kinds
                 .get(&id)
                 .with_context(|| format!("Decision variable ID {id:?} not found"))?;

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -4,8 +4,8 @@ use crate::{
         Linear, Optimality, Parameter, ParametricInstance, Relaxation, RemovedConstraint,
         SampleSet, SampledDecisionVariable, Samples, Solution, State,
     },
-    Bound, Bounds, ConstraintID, Evaluate, InfeasibleDetected, VariableID,
-    {BinaryIdPair, BinaryIds},
+    BinaryIdPair, BinaryIds, Bound, Bounds, ConstraintID, Evaluate, InfeasibleDetected, VariableID,
+    VariableIDSet,
 };
 use anyhow::{bail, ensure, Context, Result};
 use approx::AbsDiffEq;
@@ -60,19 +60,6 @@ impl Instance {
             .collect()
     }
 
-    pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
-        let mut used_ids = self.objective().used_decision_variable_ids();
-        for c in &self.constraints {
-            used_ids.extend(c.function().used_decision_variable_ids());
-        }
-        for c in &self.removed_constraints {
-            if let Some(c) = &c.constraint {
-                used_ids.extend(c.function().used_decision_variable_ids());
-            }
-        }
-        used_ids
-    }
-
     pub fn defined_ids(&self) -> BTreeSet<u64> {
         self.decision_variables
             .iter()
@@ -100,10 +87,10 @@ impl Instance {
 
     /// Validate that all decision variable IDs used in the instance are defined.
     pub fn validate_decision_variable_ids(&self) -> Result<()> {
-        let used_ids = self.used_decision_variable_ids();
-        let mut defined_ids = BTreeSet::new();
+        let used_ids = self.required_ids();
+        let mut defined_ids = VariableIDSet::default();
         for dv in &self.decision_variables {
-            if !defined_ids.insert(dv.id) {
+            if !defined_ids.insert(dv.id.into()) {
                 bail!("Duplicated definition of decision variable ID: {}", dv.id);
             }
         }
@@ -199,11 +186,11 @@ impl Instance {
         })
     }
 
-    pub fn binary_ids(&self) -> BTreeSet<u64> {
+    pub fn binary_ids(&self) -> VariableIDSet {
         self.decision_variables
             .iter()
             .filter(|dv| dv.kind() == Kind::Binary)
-            .map(|dv| dv.id)
+            .map(|dv| dv.id.into())
             .collect()
     }
 
@@ -256,7 +243,7 @@ impl Instance {
         }
         if !self
             .objective()
-            .used_decision_variable_ids()
+            .required_ids()
             .is_subset(&self.binary_ids())
         {
             bail!("The objective function uses non-binary decision variables.");
@@ -304,7 +291,7 @@ impl Instance {
         }
         if !self
             .objective()
-            .used_decision_variable_ids()
+            .required_ids()
             .is_subset(&self.binary_ids())
         {
             bail!("The objective function uses non-binary decision variables.");
@@ -493,7 +480,7 @@ impl Instance {
             .with_context(|| format!("Constraint ID {} does not have a function", constraint_id))?;
 
         // If the constraint contains continuous decision variables, integer slack variable cannot be introduced
-        for id in function.used_decision_variable_ids() {
+        for id in function.required_ids() {
             let id = VariableID::from(id);
             let kind = kinds
                 .get(&id)
@@ -591,7 +578,7 @@ impl Instance {
             .as_ref()
             .with_context(|| format!("Constraint ID {} does not have a function", constraint_id))?;
 
-        for id in f.used_decision_variable_ids() {
+        for id in f.required_ids() {
             let id = VariableID::from(id);
             let kind = kinds
                 .get(&id)
@@ -823,8 +810,17 @@ impl Evaluate for Instance {
         })
     }
 
-    fn required_ids(&self) -> BTreeSet<u64> {
-        self.used_decision_variable_ids()
+    fn required_ids(&self) -> VariableIDSet {
+        let mut used_ids = self.objective().required_ids();
+        for c in &self.constraints {
+            used_ids.extend(c.function().required_ids());
+        }
+        for c in &self.removed_constraints {
+            if let Some(c) = &c.constraint {
+                used_ids.extend(c.function().required_ids());
+            }
+        }
+        used_ids
     }
 }
 

--- a/rust/ommx/src/v1_ext/linear.rs
+++ b/rust/ommx/src/v1_ext/linear.rs
@@ -1,17 +1,12 @@
 use crate::{
     macros::*,
     v1::{linear::Term, Linear, Quadratic, SampledValues, Samples, State},
-    Evaluate, VariableID,
+    Evaluate, VariableID, VariableIDSet,
 };
 use anyhow::{Context, Result};
 use approx::AbsDiffEq;
 use num::Zero;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-    iter::Sum,
-    ops::*,
-};
+use std::{collections::BTreeMap, fmt, iter::Sum, ops::*};
 
 impl Zero for Linear {
     fn zero() -> Self {
@@ -48,10 +43,6 @@ impl Linear {
             terms: vec![Term { id, coefficient }],
             constant: 0.0,
         }
-    }
-
-    pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
-        self.terms.iter().map(|term| term.id).collect()
     }
 
     pub fn degree(&self) -> u32 {
@@ -292,8 +283,11 @@ impl Evaluate for Linear {
         Ok(out)
     }
 
-    fn required_ids(&self) -> BTreeSet<u64> {
-        self.used_decision_variable_ids()
+    fn required_ids(&self) -> VariableIDSet {
+        self.terms
+            .iter()
+            .map(|term| VariableID::from(term.id))
+            .collect()
     }
 }
 

--- a/rust/ommx/src/v1_ext/polynomial.rs
+++ b/rust/ommx/src/v1_ext/polynomial.rs
@@ -1,13 +1,13 @@
 use crate::{
     macros::*,
     v1::{Linear, Monomial, Polynomial, Quadratic, SampledValues, Samples, State},
-    Evaluate, MonomialDyn, VariableID,
+    Evaluate, MonomialDyn, VariableID, VariableIDSet,
 };
 use anyhow::{Context, Result};
 use approx::AbsDiffEq;
 use num::Zero;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     fmt,
     ops::{Add, Mul},
 };
@@ -93,14 +93,6 @@ impl<'a> IntoIterator for &'a Polynomial {
 }
 
 impl Polynomial {
-    pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {
-        self.terms
-            .iter()
-            .flat_map(|term| term.ids.iter())
-            .cloned()
-            .collect()
-    }
-
     pub fn degree(&self) -> u32 {
         self.terms
             .iter()
@@ -297,8 +289,11 @@ impl Evaluate for Polynomial {
         Ok(out)
     }
 
-    fn required_ids(&self) -> BTreeSet<u64> {
-        self.used_decision_variable_ids()
+    fn required_ids(&self) -> VariableIDSet {
+        self.terms
+            .iter()
+            .flat_map(|term| term.ids.iter().map(|id| VariableID::from(*id)))
+            .collect()
     }
 }
 


### PR DESCRIPTION
Tasks
------
- [x] Introduce `VariableIDSet = BTreeSet<VariableID>`
  - Keep using `BTreeSet` because it makes the behavior easier for users to understand
- [x] Use `VariableIDSet` entirely
- [x] Remove `Function::used_decision_variable_ids` and other same named APIs, unified into `Evaluate::required_ids`