### PR TITLE
Add `atol` in `Evaluate`

### DIFF
--- a/python/ommx/src/evaluate.rs
+++ b/python/ommx/src/evaluate.rs
@@ -16,7 +16,7 @@ macro_rules! define_evaluate_function {
         ) -> Result<f64> {
             let state = State::decode(state.as_bytes())?;
             let function = <$evaluated>::decode(function.as_bytes())?;
-            function.evaluate(&state)
+            function.evaluate(&state, 1e-9)
         }
     };
 }
@@ -37,7 +37,7 @@ macro_rules! define_evaluate_object {
         ) -> Result<Bound<'py, PyBytes>> {
             let state = State::decode(state.as_bytes())?;
             let function = <$evaluated>::decode(function.as_bytes())?;
-            let evaluated = function.evaluate(&state)?;
+            let evaluated = function.evaluate(&state, 1e-9)?;
             Ok(PyBytes::new(py, &evaluated.encode_to_vec()))
         }
     };
@@ -57,7 +57,7 @@ macro_rules! define_partial_evaluate_function {
         ) -> Result<Bound<'py, PyBytes>> {
             let state = State::decode(state.as_bytes())?;
             let mut function = <$evaluated>::decode(function.as_bytes())?;
-            function.partial_evaluate(&state)?;
+            function.partial_evaluate(&state, 1e-9)?;
             Ok(PyBytes::new(py, &function.encode_to_vec()))
         }
     };
@@ -79,7 +79,7 @@ macro_rules! define_partial_evaluate_object {
         ) -> Result<Bound<'py, PyBytes>> {
             let state = State::decode(state.as_bytes())?;
             let mut obj = <$evaluated>::decode(obj.as_bytes())?;
-            obj.partial_evaluate(&state)?;
+            obj.partial_evaluate(&state, 1e-9)?;
             Ok(PyBytes::new(py, &obj.encode_to_vec()))
         }
     };

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -90,8 +90,11 @@ impl Instance {
         constraint_id: u64,
         max_integer_range: u64,
     ) -> Result<()> {
-        self.0
-            .convert_inequality_to_equality_with_integer_slack(constraint_id, max_integer_range)
+        self.0.convert_inequality_to_equality_with_integer_slack(
+            constraint_id,
+            max_integer_range,
+            1e-6,
+        )
     }
 
     pub fn add_integer_slack_to_inequality(
@@ -127,7 +130,7 @@ impl ParametricInstance {
     }
 
     pub fn with_parameters(&self, parameters: &Parameters) -> Result<Instance> {
-        let instance = self.0.clone().with_parameters(parameters.0.clone())?;
+        let instance = self.0.clone().with_parameters(parameters.0.clone(), 1e-6)?;
         Ok(Instance(instance))
     }
 }

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -59,7 +59,7 @@ impl Instance {
     }
 
     pub fn evaluate_samples(&self, samples: &Samples) -> Result<SampleSet> {
-        Ok(SampleSet(self.0.evaluate_samples(&samples.0)?))
+        Ok(SampleSet(self.0.evaluate_samples(&samples.0, 1e-9)?))
     }
 
     pub fn relax_constraint(

--- a/rust/ommx/benches/evaluate.rs
+++ b/rust/ommx/benches/evaluate.rs
@@ -25,7 +25,7 @@ fn evaluate<T, Params>(
         group.bench_with_input(
             BenchmarkId::new(title, num_terms.to_string()),
             &(f, state),
-            |b, (f, state)| b.iter(|| f.evaluate(state)),
+            |b, (f, state)| b.iter(|| f.evaluate(state, 1e-9)),
         );
     }
     group.finish();

--- a/rust/ommx/benches/partial_evaluate.rs
+++ b/rust/ommx/benches/partial_evaluate.rs
@@ -31,7 +31,7 @@ fn bench_partial_evaluate<T, Parameters>(
                 b.iter_batched_ref(
                     || lin.clone(),
                     |f| {
-                        f.partial_evaluate(state).unwrap();
+                        f.partial_evaluate(state, 1e-9).unwrap();
                     },
                     criterion::BatchSize::SmallInput,
                 )

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -308,9 +308,8 @@ impl Bound {
     /// Strengthen the bound for integer decision variables
     ///
     /// Since the bound evaluation may be inaccurate due to floating-point arithmetic error,
-    /// this method rounds to `[ceil(lower-atol), floor(upper+atol)]` with `atol = 1e-6`.
-    pub fn as_integer_bound(&self) -> Self {
-        let atol = 1e-6;
+    /// this method rounds to `[ceil(lower-atol), floor(upper+atol)]`
+    pub fn as_integer_bound(&self, atol: f64) -> Self {
         let lower = if self.lower.is_finite() {
             (self.lower - atol).ceil()
         } else {
@@ -530,7 +529,7 @@ mod tests {
         assert_eq!(
             Bound::new(1.000000000001, 1.99999999999)
                 .unwrap()
-                .as_integer_bound(),
+                .as_integer_bound(1e-6),
             Bound::new(1.0, 2.0).unwrap()
         )
     }

--- a/rust/ommx/src/constraint/evaluate.rs
+++ b/rust/ommx/src/constraint/evaluate.rs
@@ -9,8 +9,8 @@ impl Evaluate for Constraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &crate::v1::State, atol: f64) -> anyhow::Result<Self::Output> {
-        let evaluated_value = self.function.evaluate(solution, atol)?;
+    fn evaluate(&self, solution: &crate::v1::State, _atol: f64) -> anyhow::Result<Self::Output> {
+        let evaluated_value = self.function.evaluate(solution, _atol)?;
         let used_decision_variable_ids = self
             .function
             .required_ids()
@@ -65,8 +65,8 @@ impl Evaluate for Constraint {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &crate::v1::State, atol: f64) -> anyhow::Result<()> {
-        self.function.partial_evaluate(state, atol)
+    fn partial_evaluate(&mut self, state: &crate::v1::State, _atol: f64) -> anyhow::Result<()> {
+        self.function.partial_evaluate(state, _atol)
     }
 
     fn required_ids(&self) -> VariableIDSet {

--- a/rust/ommx/src/constraint/evaluate.rs
+++ b/rust/ommx/src/constraint/evaluate.rs
@@ -41,8 +41,8 @@ impl Evaluate for Constraint {
         let feasible: HashMap<u64, bool> = evaluated_values
             .iter()
             .map(|(sample_id, value)| match self.equality {
-                Equality::EqualToZero => (*sample_id, value.abs() < 1e-6),
-                Equality::LessThanOrEqualToZero => (*sample_id, *value < 1e-6),
+                Equality::EqualToZero => (*sample_id, value.abs() < atol),
+                Equality::LessThanOrEqualToZero => (*sample_id, *value < atol),
             })
             .collect();
         Ok(SampledConstraint {

--- a/rust/ommx/src/constraint/evaluate.rs
+++ b/rust/ommx/src/constraint/evaluate.rs
@@ -9,8 +9,8 @@ impl Evaluate for Constraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &crate::v1::State, _atol: f64) -> anyhow::Result<Self::Output> {
-        let evaluated_value = self.function.evaluate(solution, _atol)?;
+    fn evaluate(&self, solution: &crate::v1::State, atol: f64) -> anyhow::Result<Self::Output> {
+        let evaluated_value = self.function.evaluate(solution, atol)?;
         let used_decision_variable_ids = self
             .function
             .required_ids()
@@ -35,9 +35,9 @@ impl Evaluate for Constraint {
     fn evaluate_samples(
         &self,
         samples: &crate::v1::Samples,
-        _atol: f64,
+        atol: f64,
     ) -> anyhow::Result<Self::SampledOutput> {
-        let evaluated_values = self.function.evaluate_samples(samples, _atol)?;
+        let evaluated_values = self.function.evaluate_samples(samples, atol)?;
         let feasible: HashMap<u64, bool> = evaluated_values
             .iter()
             .map(|(sample_id, value)| match self.equality {
@@ -65,8 +65,8 @@ impl Evaluate for Constraint {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &crate::v1::State, _atol: f64) -> anyhow::Result<()> {
-        self.function.partial_evaluate(state, _atol)
+    fn partial_evaluate(&mut self, state: &crate::v1::State, atol: f64) -> anyhow::Result<()> {
+        self.function.partial_evaluate(state, atol)
     }
 
     fn required_ids(&self) -> VariableIDSet {

--- a/rust/ommx/src/constraint/evaluate.rs
+++ b/rust/ommx/src/constraint/evaluate.rs
@@ -9,8 +9,8 @@ impl Evaluate for Constraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &crate::v1::State, _atol: f64) -> anyhow::Result<Self::Output> {
-        let evaluated_value = self.function.evaluate(solution, _atol)?;
+    fn evaluate(&self, solution: &crate::v1::State, atol: f64) -> anyhow::Result<Self::Output> {
+        let evaluated_value = self.function.evaluate(solution, atol)?;
         let used_decision_variable_ids = self
             .function
             .required_ids()
@@ -65,8 +65,8 @@ impl Evaluate for Constraint {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &crate::v1::State, _atol: f64) -> anyhow::Result<()> {
-        self.function.partial_evaluate(state, _atol)
+    fn partial_evaluate(&mut self, state: &crate::v1::State, atol: f64) -> anyhow::Result<()> {
+        self.function.partial_evaluate(state, atol)
     }
 
     fn required_ids(&self) -> VariableIDSet {

--- a/rust/ommx/src/constraint/evaluate.rs
+++ b/rust/ommx/src/constraint/evaluate.rs
@@ -9,8 +9,8 @@ impl Evaluate for Constraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &crate::v1::State) -> anyhow::Result<Self::Output> {
-        let evaluated_value = self.function.evaluate(solution)?;
+    fn evaluate(&self, solution: &crate::v1::State, _atol: f64) -> anyhow::Result<Self::Output> {
+        let evaluated_value = self.function.evaluate(solution, _atol)?;
         let used_decision_variable_ids = self
             .function
             .required_ids()
@@ -35,8 +35,9 @@ impl Evaluate for Constraint {
     fn evaluate_samples(
         &self,
         samples: &crate::v1::Samples,
+        _atol: f64,
     ) -> anyhow::Result<Self::SampledOutput> {
-        let evaluated_values = self.function.evaluate_samples(samples)?;
+        let evaluated_values = self.function.evaluate_samples(samples, _atol)?;
         let feasible: HashMap<u64, bool> = evaluated_values
             .iter()
             .map(|(sample_id, value)| match self.equality {
@@ -64,8 +65,8 @@ impl Evaluate for Constraint {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &crate::v1::State) -> anyhow::Result<()> {
-        self.function.partial_evaluate(state)
+    fn partial_evaluate(&mut self, state: &crate::v1::State, _atol: f64) -> anyhow::Result<()> {
+        self.function.partial_evaluate(state, _atol)
     }
 
     fn required_ids(&self) -> VariableIDSet {
@@ -93,9 +94,9 @@ mod tests {
     proptest! {
         #[test]
         fn test_evaluate_samples((c, samples) in constraint_and_samples()) {
-            let evaluated = c.evaluate_samples(&samples).unwrap();
+            let evaluated = c.evaluate_samples(&samples, 1e-6).unwrap();
             let evaluated_each: FnvHashMap<u64, EvaluatedConstraint> = samples.iter().map(|(parameter_id, state)| {
-                let value = c.evaluate(state).unwrap();
+                let value = c.evaluate(state, 1e-6).unwrap();
                 (*parameter_id, value)
             }).collect();
             for (sample_id, each) in evaluated_each {

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -10,13 +10,13 @@ pub trait Evaluate {
     type SampledOutput;
 
     /// Evaluate to return the output with used variable ids
-    fn evaluate(&self, state: &State, atol: f64) -> Result<Self::Output>;
+    fn evaluate(&self, state: &State, _atol: f64) -> Result<Self::Output>;
 
     /// Evaluate for each sample
-    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput>;
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput>;
 
     /// Partially evaluate the function to return the used variable ids
-    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()>;
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()>;
 
     /// Decision variable IDs required for evaluation
     fn required_ids(&self) -> VariableIDSet;

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -10,13 +10,13 @@ pub trait Evaluate {
     type SampledOutput;
 
     /// Evaluate to return the output with used variable ids
-    fn evaluate(&self, state: &State, _atol: f64) -> Result<Self::Output>;
+    fn evaluate(&self, state: &State, atol: f64) -> Result<Self::Output>;
 
     /// Evaluate for each sample
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput>;
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput>;
 
     /// Partially evaluate the function to return the used variable ids
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()>;
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()>;
 
     /// Decision variable IDs required for evaluation
     fn required_ids(&self) -> VariableIDSet;

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -10,13 +10,13 @@ pub trait Evaluate {
     type SampledOutput;
 
     /// Evaluate to return the output with used variable ids
-    fn evaluate(&self, solution: &State) -> Result<Self::Output>;
-
-    /// Partially evaluate the function to return the used variable ids
-    fn partial_evaluate(&mut self, state: &State) -> Result<()>;
+    fn evaluate(&self, state: &State, atol: f64) -> Result<Self::Output>;
 
     /// Evaluate for each sample
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput>;
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput>;
+
+    /// Partially evaluate the function to return the used variable ids
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()>;
 
     /// Decision variable IDs required for evaluation
     fn required_ids(&self) -> VariableIDSet;

--- a/rust/ommx/src/function/evaluate.rs
+++ b/rust/ommx/src/function/evaluate.rs
@@ -5,21 +5,21 @@ impl Evaluate for Function {
     type Output = f64;
     type SampledOutput = crate::v1::SampledValues;
 
-    fn evaluate(&self, solution: &crate::v1::State, _atol: f64) -> anyhow::Result<Self::Output> {
+    fn evaluate(&self, solution: &crate::v1::State, atol: f64) -> anyhow::Result<Self::Output> {
         match self {
             Function::Zero => Ok(0.0),
             Function::Constant(c) => Ok(c.into_inner()),
-            Function::Linear(f) => f.evaluate(solution, _atol),
-            Function::Quadratic(f) => f.evaluate(solution, _atol),
-            Function::Polynomial(f) => f.evaluate(solution, _atol),
+            Function::Linear(f) => f.evaluate(solution, atol),
+            Function::Quadratic(f) => f.evaluate(solution, atol),
+            Function::Polynomial(f) => f.evaluate(solution, atol),
         }
     }
 
-    fn partial_evaluate(&mut self, state: &crate::v1::State, _atol: f64) -> anyhow::Result<()> {
+    fn partial_evaluate(&mut self, state: &crate::v1::State, atol: f64) -> anyhow::Result<()> {
         match self {
-            Function::Linear(f) => f.partial_evaluate(state, _atol),
-            Function::Quadratic(f) => f.partial_evaluate(state, _atol),
-            Function::Polynomial(f) => f.partial_evaluate(state, _atol),
+            Function::Linear(f) => f.partial_evaluate(state, atol),
+            Function::Quadratic(f) => f.partial_evaluate(state, atol),
+            Function::Polynomial(f) => f.partial_evaluate(state, atol),
             _ => Ok(()),
         }
     }
@@ -36,7 +36,7 @@ impl Evaluate for Function {
     fn evaluate_samples(
         &self,
         samples: &crate::v1::Samples,
-        _atol: f64,
+        atol: f64,
     ) -> anyhow::Result<Self::SampledOutput> {
         match self {
             Function::Zero => Ok(SampledValues::zeros(samples.ids().cloned())),
@@ -44,9 +44,9 @@ impl Evaluate for Function {
                 samples.ids().cloned(),
                 c.into_inner(),
             )),
-            Function::Linear(f) => f.evaluate_samples(samples, _atol),
-            Function::Quadratic(f) => f.evaluate_samples(samples, _atol),
-            Function::Polynomial(f) => f.evaluate_samples(samples, _atol),
+            Function::Linear(f) => f.evaluate_samples(samples, atol),
+            Function::Quadratic(f) => f.evaluate_samples(samples, atol),
+            Function::Polynomial(f) => f.evaluate_samples(samples, atol),
         }
     }
 }

--- a/rust/ommx/src/function/evaluate.rs
+++ b/rust/ommx/src/function/evaluate.rs
@@ -5,21 +5,21 @@ impl Evaluate for Function {
     type Output = f64;
     type SampledOutput = crate::v1::SampledValues;
 
-    fn evaluate(&self, solution: &crate::v1::State, atol: f64) -> anyhow::Result<Self::Output> {
+    fn evaluate(&self, solution: &crate::v1::State, _atol: f64) -> anyhow::Result<Self::Output> {
         match self {
             Function::Zero => Ok(0.0),
             Function::Constant(c) => Ok(c.into_inner()),
-            Function::Linear(f) => f.evaluate(solution, atol),
-            Function::Quadratic(f) => f.evaluate(solution, atol),
-            Function::Polynomial(f) => f.evaluate(solution, atol),
+            Function::Linear(f) => f.evaluate(solution, _atol),
+            Function::Quadratic(f) => f.evaluate(solution, _atol),
+            Function::Polynomial(f) => f.evaluate(solution, _atol),
         }
     }
 
-    fn partial_evaluate(&mut self, state: &crate::v1::State, atol: f64) -> anyhow::Result<()> {
+    fn partial_evaluate(&mut self, state: &crate::v1::State, _atol: f64) -> anyhow::Result<()> {
         match self {
-            Function::Linear(f) => f.partial_evaluate(state, atol),
-            Function::Quadratic(f) => f.partial_evaluate(state, atol),
-            Function::Polynomial(f) => f.partial_evaluate(state, atol),
+            Function::Linear(f) => f.partial_evaluate(state, _atol),
+            Function::Quadratic(f) => f.partial_evaluate(state, _atol),
+            Function::Polynomial(f) => f.partial_evaluate(state, _atol),
             _ => Ok(()),
         }
     }

--- a/rust/ommx/src/function/evaluate.rs
+++ b/rust/ommx/src/function/evaluate.rs
@@ -5,21 +5,21 @@ impl Evaluate for Function {
     type Output = f64;
     type SampledOutput = crate::v1::SampledValues;
 
-    fn evaluate(&self, solution: &crate::v1::State, _atol: f64) -> anyhow::Result<Self::Output> {
+    fn evaluate(&self, solution: &crate::v1::State, atol: f64) -> anyhow::Result<Self::Output> {
         match self {
             Function::Zero => Ok(0.0),
             Function::Constant(c) => Ok(c.into_inner()),
-            Function::Linear(f) => f.evaluate(solution, _atol),
-            Function::Quadratic(f) => f.evaluate(solution, _atol),
-            Function::Polynomial(f) => f.evaluate(solution, _atol),
+            Function::Linear(f) => f.evaluate(solution, atol),
+            Function::Quadratic(f) => f.evaluate(solution, atol),
+            Function::Polynomial(f) => f.evaluate(solution, atol),
         }
     }
 
-    fn partial_evaluate(&mut self, state: &crate::v1::State, _atol: f64) -> anyhow::Result<()> {
+    fn partial_evaluate(&mut self, state: &crate::v1::State, atol: f64) -> anyhow::Result<()> {
         match self {
-            Function::Linear(f) => f.partial_evaluate(state, _atol),
-            Function::Quadratic(f) => f.partial_evaluate(state, _atol),
-            Function::Polynomial(f) => f.partial_evaluate(state, _atol),
+            Function::Linear(f) => f.partial_evaluate(state, atol),
+            Function::Quadratic(f) => f.partial_evaluate(state, atol),
+            Function::Polynomial(f) => f.partial_evaluate(state, atol),
             _ => Ok(()),
         }
     }

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -39,7 +39,7 @@
 //!   let state: State = hashmap! { 1 => 4.0, 2 => 5.0, 3 => 6.0 }.into();
 //!
 //!   // Evaluate the linear function with the state, and get the value and used variable ids
-//!   let value = linear.evaluate(&state).unwrap();
+//!   let value = linear.evaluate(&state, 1e-9).unwrap();
 //!
 //!   assert_eq!(value, 1.0 * 4.0 + 2.0 * 5.0 + 3.0);
 //!   ```

--- a/rust/ommx/src/polynomial_base/evaluate.rs
+++ b/rust/ommx/src/polynomial_base/evaluate.rs
@@ -9,7 +9,7 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, state: &State) -> Result<Self::Output> {
+    fn evaluate(&self, state: &State, _atol: f64) -> Result<Self::Output> {
         let mut result = 0.0;
         for (monomial, coefficient) in self.iter() {
             let mut out = 1.0;
@@ -24,7 +24,7 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
         Ok(result)
     }
 
-    fn partial_evaluate(&mut self, state: &State) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         if state.entries.is_empty() {
             return Ok(());
         }
@@ -56,8 +56,8 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
             .collect()
     }
 
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput> {
-        samples.map(|state| self.evaluate(state))
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+        samples.map(|state| self.evaluate(state, _atol))
     }
 }
 
@@ -78,17 +78,17 @@ mod tests {
     proptest! {
         #[test]
         fn test_evaluate_linear((linear, state) in polynomial_and_state::<LinearMonomial>()) {
-            linear.evaluate(&state).unwrap();
+            linear.evaluate(&state, 1e-9).unwrap();
         }
 
         #[test]
         fn test_evaluate_quadratic((quadratic, state) in polynomial_and_state::<QuadraticMonomial>()) {
-            quadratic.evaluate(&state).unwrap();
+            quadratic.evaluate(&state, 1e-9).unwrap();
         }
 
         #[test]
         fn test_evaluate_polynomial((polynomial, state) in polynomial_and_state::<MonomialDyn>()) {
-            polynomial.evaluate(&state).unwrap();
+            polynomial.evaluate(&state, 1e-9).unwrap();
         }
     }
 
@@ -112,9 +112,9 @@ mod tests {
                 fn $name(
                     (l1, l2, state) in two_polynomial_and_state::<$monomial>()
                 ) {
-                    let v1 = l1.evaluate(&state).unwrap();
-                    let v2 = l2.evaluate(&state).unwrap();
-                    let v3 = (&l1 $op &l2).evaluate(&state).unwrap();
+                    let v1 = l1.evaluate(&state, 1e-9).unwrap();
+                    let v2 = l2.evaluate(&state, 1e-9).unwrap();
+                    let v3 = (&l1 $op &l2).evaluate(&state, 1e-9).unwrap();
                     prop_assert!((v1 $op v2).abs_diff_eq(&v3, 1e-9));
                 }
             }
@@ -164,9 +164,9 @@ mod tests {
                 fn $name(
                     (mut poly, state, s1, s2) in polynomial_and_state_split::<$monomial>()
                 ) {
-                    let v = poly.evaluate(&state).unwrap();
-                    let _ = poly.partial_evaluate(&s1).unwrap();
-                    let w = poly.evaluate(&s2).unwrap();
+                    let v = poly.evaluate(&state, 1e-9).unwrap();
+                    let _ = poly.partial_evaluate(&s1, 1e-9).unwrap();
+                    let w = poly.evaluate(&s2, 1e-9).unwrap();
                     prop_assert!(w.abs_diff_eq(&v, 1e-9), "poly = {poly:?}, w = {w}, v = {v}");
                 }
             }
@@ -194,9 +194,9 @@ mod tests {
         fn test_evaluate_samples(
             (poly, samples) in polynomial_and_samples::<LinearMonomial>()
         ) {
-            let evaluated = poly.evaluate_samples(&samples).unwrap();
+            let evaluated = poly.evaluate_samples(&samples, 1e-9).unwrap();
             let evaluated_each: SampledValues = samples.iter().map(|(parameter_id, state)| {
-                let value = poly.evaluate(state).unwrap();
+                let value = poly.evaluate(state, 1e-9).unwrap();
                 (*parameter_id, value)
             }).collect();
             prop_assert!(evaluated.abs_diff_eq(&evaluated_each, 1e-9), "evaluated = {evaluated:?}, evaluated_each = {evaluated_each:?}");

--- a/rust/ommx/src/polynomial_base/evaluate.rs
+++ b/rust/ommx/src/polynomial_base/evaluate.rs
@@ -9,7 +9,7 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, state: &State, atol: f64) -> Result<Self::Output> {
+    fn evaluate(&self, state: &State, _atol: f64) -> Result<Self::Output> {
         let mut result = 0.0;
         for (monomial, coefficient) in self.iter() {
             let mut out = 1.0;
@@ -24,7 +24,7 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
         Ok(result)
     }
 
-    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         if state.entries.is_empty() {
             return Ok(());
         }
@@ -56,8 +56,8 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
             .collect()
     }
 
-    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
-        samples.map(|state| self.evaluate(state, atol))
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+        samples.map(|state| self.evaluate(state, _atol))
     }
 }
 

--- a/rust/ommx/src/polynomial_base/evaluate.rs
+++ b/rust/ommx/src/polynomial_base/evaluate.rs
@@ -56,8 +56,8 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
             .collect()
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
-        samples.map(|state| self.evaluate(state, _atol))
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
+        samples.map(|state| self.evaluate(state, atol))
     }
 }
 

--- a/rust/ommx/src/polynomial_base/evaluate.rs
+++ b/rust/ommx/src/polynomial_base/evaluate.rs
@@ -9,7 +9,7 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, state: &State, _atol: f64) -> Result<Self::Output> {
+    fn evaluate(&self, state: &State, atol: f64) -> Result<Self::Output> {
         let mut result = 0.0;
         for (monomial, coefficient) in self.iter() {
             let mut out = 1.0;
@@ -24,7 +24,7 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
         Ok(result)
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         if state.entries.is_empty() {
             return Ok(());
         }
@@ -56,8 +56,8 @@ impl<M: Monomial> Evaluate for PolynomialBase<M> {
             .collect()
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
-        samples.map(|state| self.evaluate(state, _atol))
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
+        samples.map(|state| self.evaluate(state, atol))
     }
 }
 

--- a/rust/ommx/src/v1_ext/constraint.rs
+++ b/rust/ommx/src/v1_ext/constraint.rs
@@ -98,8 +98,8 @@ impl Evaluate for Constraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &State) -> Result<Self::Output> {
-        let evaluated_value = self.function().evaluate(solution)?;
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<Self::Output> {
+        let evaluated_value = self.function().evaluate(solution, _atol)?;
         let used_decision_variable_ids = self
             .function()
             .required_ids()
@@ -121,16 +121,16 @@ impl Evaluate for Constraint {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &State) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         let Some(f) = self.function.as_mut() else {
             // Since empty function means zero constant, we can return an empty set
             return Ok(());
         };
-        f.partial_evaluate(state)
+        f.partial_evaluate(state, _atol)
     }
 
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput> {
-        let evaluated_values = self.function().evaluate_samples(samples)?;
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+        let evaluated_values = self.function().evaluate_samples(samples, _atol)?;
         let feasible: HashMap<u64, bool> = evaluated_values
             .iter()
             .map(|(sample_id, value)| {
@@ -174,30 +174,30 @@ impl Evaluate for RemovedConstraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &State) -> Result<Self::Output> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<Self::Output> {
         let mut out = self
             .constraint
             .as_ref()
             .context("RemovedConstraint does not contain constraint")?
-            .evaluate(solution)?;
+            .evaluate(solution, _atol)?;
         out.removed_reason = Some(self.removed_reason.clone());
         out.removed_reason_parameters = self.removed_reason_parameters.clone();
         Ok(out)
     }
 
-    fn partial_evaluate(&mut self, state: &State) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         self.constraint
             .as_mut()
             .context("RemovedConstraint does not contain constraint")?
-            .partial_evaluate(state)
+            .partial_evaluate(state, _atol)
     }
 
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let mut evaluated = self
             .constraint
             .as_ref()
             .expect("RemovedConstraint does not contain constraint")
-            .evaluate_samples(samples)?;
+            .evaluate_samples(samples, _atol)?;
         evaluated.removed_reason = Some(self.removed_reason.clone());
         evaluated.removed_reason_parameters = self.removed_reason_parameters.clone();
         Ok(evaluated)

--- a/rust/ommx/src/v1_ext/constraint.rs
+++ b/rust/ommx/src/v1_ext/constraint.rs
@@ -135,10 +135,10 @@ impl Evaluate for Constraint {
             .iter()
             .map(|(sample_id, value)| {
                 if self.equality() == Equality::EqualToZero {
-                    return Ok((*sample_id, value.abs() < 1e-6));
+                    return Ok((*sample_id, value.abs() < atol));
                 }
                 if self.equality() == Equality::LessThanOrEqualToZero {
-                    return Ok((*sample_id, *value < 1e-6));
+                    return Ok((*sample_id, *value < atol));
                 }
                 bail!("Unsupported equality: {:?}", self.equality());
             })

--- a/rust/ommx/src/v1_ext/constraint.rs
+++ b/rust/ommx/src/v1_ext/constraint.rs
@@ -98,8 +98,8 @@ impl Evaluate for Constraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &State, _atol: f64) -> Result<Self::Output> {
-        let evaluated_value = self.function().evaluate(solution, _atol)?;
+    fn evaluate(&self, solution: &State, atol: f64) -> Result<Self::Output> {
+        let evaluated_value = self.function().evaluate(solution, atol)?;
         let used_decision_variable_ids = self
             .function()
             .required_ids()
@@ -121,16 +121,16 @@ impl Evaluate for Constraint {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         let Some(f) = self.function.as_mut() else {
             // Since empty function means zero constant, we can return an empty set
             return Ok(());
         };
-        f.partial_evaluate(state, _atol)
+        f.partial_evaluate(state, atol)
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
-        let evaluated_values = self.function().evaluate_samples(samples, _atol)?;
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
+        let evaluated_values = self.function().evaluate_samples(samples, atol)?;
         let feasible: HashMap<u64, bool> = evaluated_values
             .iter()
             .map(|(sample_id, value)| {
@@ -174,30 +174,30 @@ impl Evaluate for RemovedConstraint {
     type Output = EvaluatedConstraint;
     type SampledOutput = SampledConstraint;
 
-    fn evaluate(&self, solution: &State, _atol: f64) -> Result<Self::Output> {
+    fn evaluate(&self, solution: &State, atol: f64) -> Result<Self::Output> {
         let mut out = self
             .constraint
             .as_ref()
             .context("RemovedConstraint does not contain constraint")?
-            .evaluate(solution, _atol)?;
+            .evaluate(solution, atol)?;
         out.removed_reason = Some(self.removed_reason.clone());
         out.removed_reason_parameters = self.removed_reason_parameters.clone();
         Ok(out)
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         self.constraint
             .as_mut()
             .context("RemovedConstraint does not contain constraint")?
-            .partial_evaluate(state, _atol)
+            .partial_evaluate(state, atol)
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let mut evaluated = self
             .constraint
             .as_ref()
             .expect("RemovedConstraint does not contain constraint")
-            .evaluate_samples(samples, _atol)?;
+            .evaluate_samples(samples, atol)?;
         evaluated.removed_reason = Some(self.removed_reason.clone());
         evaluated.removed_reason_parameters = self.removed_reason_parameters.clone();
         Ok(evaluated)

--- a/rust/ommx/src/v1_ext/function.rs
+++ b/rust/ommx/src/v1_ext/function.rs
@@ -416,30 +416,30 @@ impl Evaluate for Function {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
         let out = match &self.function {
             Some(FunctionEnum::Constant(c)) => *c,
-            Some(FunctionEnum::Linear(linear)) => linear.evaluate(solution, _atol)?,
-            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.evaluate(solution, _atol)?,
-            Some(FunctionEnum::Polynomial(poly)) => poly.evaluate(solution, _atol)?,
+            Some(FunctionEnum::Linear(linear)) => linear.evaluate(solution, atol)?,
+            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.evaluate(solution, atol)?,
+            Some(FunctionEnum::Polynomial(poly)) => poly.evaluate(solution, atol)?,
             None => 0.0,
         };
         Ok(out)
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         match &mut self.function {
-            Some(FunctionEnum::Linear(linear)) => linear.partial_evaluate(state, _atol)?,
-            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.partial_evaluate(state, _atol)?,
-            Some(FunctionEnum::Polynomial(poly)) => poly.partial_evaluate(state, _atol)?,
+            Some(FunctionEnum::Linear(linear)) => linear.partial_evaluate(state, atol)?,
+            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.partial_evaluate(state, atol)?,
+            Some(FunctionEnum::Polynomial(poly)) => poly.partial_evaluate(state, atol)?,
             _ => {}
         };
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s, _atol)?;
+            let value = self.evaluate(s, atol)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/function.rs
+++ b/rust/ommx/src/v1_ext/function.rs
@@ -416,30 +416,30 @@ impl Evaluate for Function {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State) -> Result<f64> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
         let out = match &self.function {
             Some(FunctionEnum::Constant(c)) => *c,
-            Some(FunctionEnum::Linear(linear)) => linear.evaluate(solution)?,
-            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.evaluate(solution)?,
-            Some(FunctionEnum::Polynomial(poly)) => poly.evaluate(solution)?,
+            Some(FunctionEnum::Linear(linear)) => linear.evaluate(solution, _atol)?,
+            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.evaluate(solution, _atol)?,
+            Some(FunctionEnum::Polynomial(poly)) => poly.evaluate(solution, _atol)?,
             None => 0.0,
         };
         Ok(out)
     }
 
-    fn partial_evaluate(&mut self, state: &State) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         match &mut self.function {
-            Some(FunctionEnum::Linear(linear)) => linear.partial_evaluate(state)?,
-            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.partial_evaluate(state)?,
-            Some(FunctionEnum::Polynomial(poly)) => poly.partial_evaluate(state)?,
+            Some(FunctionEnum::Linear(linear)) => linear.partial_evaluate(state, _atol)?,
+            Some(FunctionEnum::Quadratic(quadratic)) => quadratic.partial_evaluate(state, _atol)?,
+            Some(FunctionEnum::Polynomial(poly)) => poly.partial_evaluate(state, _atol)?,
             _ => {}
         };
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s)?;
+            let value = self.evaluate(s, _atol)?;
             Ok(value)
         })?;
         Ok(out)
@@ -587,7 +587,7 @@ mod tests {
                 })
         ) {
             let bound = f.evaluate_bound(&bounds);
-            let value = f.evaluate(&state).unwrap();
+            let value = f.evaluate(&state, 1e-9).unwrap();
             prop_assert!(bound.contains(value, 1e-7));
         }
 

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -681,7 +681,7 @@ impl Evaluate for Instance {
     type Output = Solution;
     type SampledOutput = SampleSet;
 
-    fn evaluate(&self, state: &State, _atol: f64) -> Result<Self::Output> {
+    fn evaluate(&self, state: &State, atol: f64) -> Result<Self::Output> {
         self.check_bound(state, 1e-7)?;
         let mut evaluated_constraints = Vec::new();
         let mut feasible_relaxed = true;
@@ -730,7 +730,7 @@ impl Evaluate for Instance {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         for v in &mut self.decision_variables {
             if let Some(value) = state.entries.get(&v.id) {
                 v.substituted_value = Some(*value);
@@ -751,7 +751,7 @@ impl Evaluate for Instance {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let mut feasible_relaxed: HashMap<u64, bool> =
             samples.ids().map(|id| (*id, true)).collect();
 

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -681,7 +681,7 @@ impl Evaluate for Instance {
     type Output = Solution;
     type SampledOutput = SampleSet;
 
-    fn evaluate(&self, state: &State, atol: f64) -> Result<Self::Output> {
+    fn evaluate(&self, state: &State, _atol: f64) -> Result<Self::Output> {
         self.check_bound(state, 1e-7)?;
         let mut evaluated_constraints = Vec::new();
         let mut feasible_relaxed = true;
@@ -730,7 +730,7 @@ impl Evaluate for Instance {
         })
     }
 
-    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         for v in &mut self.decision_variables {
             if let Some(value) = state.entries.get(&v.id) {
                 v.substituted_value = Some(*value);
@@ -751,7 +751,7 @@ impl Evaluate for Instance {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let mut feasible_relaxed: HashMap<u64, bool> =
             samples.ids().map(|id| (*id, true)).collect();
 

--- a/rust/ommx/src/v1_ext/linear.rs
+++ b/rust/ommx/src/v1_ext/linear.rs
@@ -249,7 +249,7 @@ impl Evaluate for Linear {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State) -> Result<f64> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
         let mut sum = self.constant;
         for Term { id, coefficient } in &self.terms {
             let s = solution
@@ -261,7 +261,7 @@ impl Evaluate for Linear {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         let mut i = 0;
         while i < self.terms.len() {
             let Term { id, coefficient } = self.terms[i];
@@ -275,9 +275,9 @@ impl Evaluate for Linear {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s)?;
+            let value = self.evaluate(s, 1e-9)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/linear.rs
+++ b/rust/ommx/src/v1_ext/linear.rs
@@ -275,9 +275,9 @@ impl Evaluate for Linear {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s, 1e-9)?;
+            let value = self.evaluate(s, atol)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/linear.rs
+++ b/rust/ommx/src/v1_ext/linear.rs
@@ -249,7 +249,7 @@ impl Evaluate for Linear {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
         let mut sum = self.constant;
         for Term { id, coefficient } in &self.terms {
             let s = solution
@@ -261,7 +261,7 @@ impl Evaluate for Linear {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         let mut i = 0;
         while i < self.terms.len() {
             let Term { id, coefficient } = self.terms[i];
@@ -275,7 +275,7 @@ impl Evaluate for Linear {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
             let value = self.evaluate(s, 1e-9)?;
             Ok(value)

--- a/rust/ommx/src/v1_ext/linear.rs
+++ b/rust/ommx/src/v1_ext/linear.rs
@@ -249,7 +249,7 @@ impl Evaluate for Linear {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
         let mut sum = self.constant;
         for Term { id, coefficient } in &self.terms {
             let s = solution
@@ -261,7 +261,7 @@ impl Evaluate for Linear {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         let mut i = 0;
         while i < self.terms.len() {
             let Term { id, coefficient } = self.terms[i];
@@ -275,7 +275,7 @@ impl Evaluate for Linear {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
             let value = self.evaluate(s, 1e-9)?;
             Ok(value)

--- a/rust/ommx/src/v1_ext/parametric_instance.rs
+++ b/rust/ommx/src/v1_ext/parametric_instance.rs
@@ -47,7 +47,7 @@ impl From<Parameters> for State {
 
 impl ParametricInstance {
     /// Create a new [Instance] with the given parameters.
-    pub fn with_parameters(mut self, parameters: Parameters) -> Result<Instance> {
+    pub fn with_parameters(mut self, parameters: Parameters, atol: f64) -> Result<Instance> {
         let required_ids: BTreeSet<u64> = self.parameters.iter().map(|p| p.id).collect();
         let given_ids: BTreeSet<u64> = parameters.entries.keys().cloned().collect();
         if !required_ids.is_subset(&given_ids) {
@@ -64,10 +64,10 @@ impl ParametricInstance {
 
         let state = State::from(parameters.clone());
         if let Some(f) = self.objective.as_mut() {
-            f.partial_evaluate(&state, 1e-9)?;
+            f.partial_evaluate(&state, atol)?;
         }
         for constraint in self.constraints.iter_mut() {
-            constraint.partial_evaluate(&state, 1e-9)?;
+            constraint.partial_evaluate(&state, atol)?;
         }
 
         Ok(Instance {
@@ -166,7 +166,7 @@ mod tests {
         #[test]
         fn test_parametric_instance_conversion(instance in Instance::arbitrary()) {
             let parametric_instance: ParametricInstance = instance.clone().into();
-            let converted_instance: Instance = parametric_instance.with_parameters(Parameters::default()).unwrap();
+            let converted_instance: Instance = parametric_instance.with_parameters(Parameters::default(), 1e-9).unwrap();
             prop_assert_eq!(&converted_instance.parameters, &Some(Parameters::default()));
             prop_assert!(
                 abs_diff_eq!(instance, converted_instance, epsilon = 1e-10),

--- a/rust/ommx/src/v1_ext/parametric_instance.rs
+++ b/rust/ommx/src/v1_ext/parametric_instance.rs
@@ -64,10 +64,10 @@ impl ParametricInstance {
 
         let state = State::from(parameters.clone());
         if let Some(f) = self.objective.as_mut() {
-            f.partial_evaluate(&state)?;
+            f.partial_evaluate(&state, 1e-9)?;
         }
         for constraint in self.constraints.iter_mut() {
-            constraint.partial_evaluate(&state)?;
+            constraint.partial_evaluate(&state, 1e-9)?;
         }
 
         Ok(Instance {

--- a/rust/ommx/src/v1_ext/polynomial.rs
+++ b/rust/ommx/src/v1_ext/polynomial.rs
@@ -238,7 +238,7 @@ impl Evaluate for Polynomial {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
         let mut sum = 0.0;
         for term in &self.terms {
             let mut v = term.coefficient;
@@ -253,7 +253,7 @@ impl Evaluate for Polynomial {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         let mut monomials = BTreeMap::new();
         for term in self.terms.iter() {
             let mut value = term.coefficient;
@@ -281,7 +281,7 @@ impl Evaluate for Polynomial {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
             let value = self.evaluate(s, 1e-9)?;
             Ok(value)

--- a/rust/ommx/src/v1_ext/polynomial.rs
+++ b/rust/ommx/src/v1_ext/polynomial.rs
@@ -238,7 +238,7 @@ impl Evaluate for Polynomial {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
         let mut sum = 0.0;
         for term in &self.terms {
             let mut v = term.coefficient;
@@ -253,7 +253,7 @@ impl Evaluate for Polynomial {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         let mut monomials = BTreeMap::new();
         for term in self.terms.iter() {
             let mut value = term.coefficient;
@@ -281,7 +281,7 @@ impl Evaluate for Polynomial {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
             let value = self.evaluate(s, 1e-9)?;
             Ok(value)

--- a/rust/ommx/src/v1_ext/polynomial.rs
+++ b/rust/ommx/src/v1_ext/polynomial.rs
@@ -281,9 +281,9 @@ impl Evaluate for Polynomial {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s, 1e-9)?;
+            let value = self.evaluate(s, atol)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/polynomial.rs
+++ b/rust/ommx/src/v1_ext/polynomial.rs
@@ -238,7 +238,7 @@ impl Evaluate for Polynomial {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State) -> Result<f64> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
         let mut sum = 0.0;
         for term in &self.terms {
             let mut v = term.coefficient;
@@ -253,7 +253,7 @@ impl Evaluate for Polynomial {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         let mut monomials = BTreeMap::new();
         for term in self.terms.iter() {
             let mut value = term.coefficient;
@@ -281,9 +281,9 @@ impl Evaluate for Polynomial {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s)?;
+            let value = self.evaluate(s, 1e-9)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/quadratic.rs
+++ b/rust/ommx/src/v1_ext/quadratic.rs
@@ -288,9 +288,9 @@ impl Evaluate for Quadratic {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
         let mut sum = if let Some(linear) = &self.linear {
-            linear.evaluate(solution, atol)?
+            linear.evaluate(solution, _atol)?
         } else {
             0.0
         };
@@ -310,7 +310,7 @@ impl Evaluate for Quadratic {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         let mut linear = BTreeMap::new();
         let mut constant = self.linear.as_ref().map_or(0.0, |l| l.constant);
         for term in self.linear.iter().flat_map(|l| l.terms.iter()) {
@@ -353,9 +353,9 @@ impl Evaluate for Quadratic {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s, atol)?;
+            let value = self.evaluate(s, _atol)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/quadratic.rs
+++ b/rust/ommx/src/v1_ext/quadratic.rs
@@ -288,9 +288,9 @@ impl Evaluate for Quadratic {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
         let mut sum = if let Some(linear) = &self.linear {
-            linear.evaluate(solution, _atol)?
+            linear.evaluate(solution, atol)?
         } else {
             0.0
         };
@@ -353,9 +353,9 @@ impl Evaluate for Quadratic {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s, _atol)?;
+            let value = self.evaluate(s, atol)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/quadratic.rs
+++ b/rust/ommx/src/v1_ext/quadratic.rs
@@ -288,9 +288,9 @@ impl Evaluate for Quadratic {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
+    fn evaluate(&self, solution: &State, atol: f64) -> Result<f64> {
         let mut sum = if let Some(linear) = &self.linear {
-            linear.evaluate(solution, _atol)?
+            linear.evaluate(solution, atol)?
         } else {
             0.0
         };
@@ -310,7 +310,7 @@ impl Evaluate for Quadratic {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, atol: f64) -> Result<()> {
         let mut linear = BTreeMap::new();
         let mut constant = self.linear.as_ref().map_or(0.0, |l| l.constant);
         for term in self.linear.iter().flat_map(|l| l.terms.iter()) {
@@ -353,9 +353,9 @@ impl Evaluate for Quadratic {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s, _atol)?;
+            let value = self.evaluate(s, atol)?;
             Ok(value)
         })?;
         Ok(out)

--- a/rust/ommx/src/v1_ext/quadratic.rs
+++ b/rust/ommx/src/v1_ext/quadratic.rs
@@ -288,9 +288,9 @@ impl Evaluate for Quadratic {
     type Output = f64;
     type SampledOutput = SampledValues;
 
-    fn evaluate(&self, solution: &State) -> Result<f64> {
+    fn evaluate(&self, solution: &State, _atol: f64) -> Result<f64> {
         let mut sum = if let Some(linear) = &self.linear {
-            linear.evaluate(solution)?
+            linear.evaluate(solution, _atol)?
         } else {
             0.0
         };
@@ -310,7 +310,7 @@ impl Evaluate for Quadratic {
         Ok(sum)
     }
 
-    fn partial_evaluate(&mut self, state: &State) -> Result<()> {
+    fn partial_evaluate(&mut self, state: &State, _atol: f64) -> Result<()> {
         let mut linear = BTreeMap::new();
         let mut constant = self.linear.as_ref().map_or(0.0, |l| l.constant);
         for term in self.linear.iter().flat_map(|l| l.terms.iter()) {
@@ -353,9 +353,9 @@ impl Evaluate for Quadratic {
         Ok(())
     }
 
-    fn evaluate_samples(&self, samples: &Samples) -> Result<Self::SampledOutput> {
+    fn evaluate_samples(&self, samples: &Samples, _atol: f64) -> Result<Self::SampledOutput> {
         let out = samples.map(|s| {
-            let value = self.evaluate(s)?;
+            let value = self.evaluate(s, _atol)?;
             Ok(value)
         })?;
         Ok(out)


### PR DESCRIPTION
- Add `atol` parameter in `Evaluate::{evaluate, evaluate_samples, partial_evaluate}`, and other API like `as_integer_bound`.