### PR TITLE
Kind-Bound consistency in `DecisionVariable`

### DIFF
--- a/rust/ommx/src/atol.rs
+++ b/rust/ommx/src/atol.rs
@@ -40,6 +40,18 @@ impl PartialOrd<f64> for ATol {
     }
 }
 
+impl PartialEq<ATol> for f64 {
+    fn eq(&self, other: &ATol) -> bool {
+        *self == other.into_inner()
+    }
+}
+
+impl PartialOrd<ATol> for f64 {
+    fn partial_cmp(&self, other: &ATol) -> Option<std::cmp::Ordering> {
+        self.partial_cmp(&other.into_inner())
+    }
+}
+
 impl PartialEq<Coefficient> for ATol {
     fn eq(&self, other: &Coefficient) -> bool {
         self.into_inner() == other.into_inner()

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -319,15 +319,15 @@ impl Bound {
     /// ---------
     ///
     /// ```rust
-    /// use ommx::{Bound, BoundError};
+    /// use ommx::{Bound, BoundError, ATol};
     ///
     /// // Rounding with absolute tolerance
     /// let bound = Bound::new(1.000000000001, 1.99999999999).unwrap();
-    /// assert_eq!(bound.as_integer_bound(1e-6).unwrap(), Bound::new(1.0, 2.0).unwrap());
+    /// assert_eq!(bound.as_integer_bound(ATol::default()).unwrap(), Bound::new(1.0, 2.0).unwrap());
     ///
     /// // No integer value exists between 1.1 and 1.9
     /// let bound = Bound::new(1.1, 1.9).unwrap();
-    /// assert!(bound.as_integer_bound(1e-6).is_none());
+    /// assert!(bound.as_integer_bound(ATol::default()).is_none());
     /// ```
     pub fn as_integer_bound(&self, atol: crate::ATol) -> Option<Self> {
         let lower = if self.lower.is_finite() {

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -276,6 +276,10 @@ impl Bound {
         Self::new(f64::NEG_INFINITY, 0.0).unwrap()
     }
 
+    pub fn of_binary() -> Self {
+        Self::new(0.0, 1.0).unwrap()
+    }
+
     pub fn new(lower: f64, upper: f64) -> Result<Self, BoundError> {
         BoundError::check(lower, upper)?;
         Ok(Self { lower, upper })
@@ -307,9 +311,25 @@ impl Bound {
 
     /// Strengthen the bound for integer decision variables
     ///
-    /// Since the bound evaluation may be inaccurate due to floating-point arithmetic error,
-    /// this method rounds to `[ceil(lower-atol), floor(upper+atol)]`
-    pub fn as_integer_bound(&self, atol: f64) -> Self {
+    /// - Since the bound evaluation may be inaccurate due to floating-point arithmetic error,
+    ///   this method rounds to `[ceil(lower-atol), floor(upper+atol)]`
+    /// - If no integer value is in the bound, return `None`
+    ///
+    /// Examples
+    /// ---------
+    ///
+    /// ```rust
+    /// use ommx::{Bound, BoundError};
+    ///
+    /// // Rounding with absolute tolerance
+    /// let bound = Bound::new(1.000000000001, 1.99999999999).unwrap();
+    /// assert_eq!(bound.as_integer_bound(1e-6).unwrap(), Bound::new(1.0, 2.0).unwrap());
+    ///
+    /// // No integer value exists between 1.1 and 1.9
+    /// let bound = Bound::new(1.1, 1.9).unwrap();
+    /// assert!(bound.as_integer_bound(1e-6).is_none());
+    /// ```
+    pub fn as_integer_bound(&self, atol: f64) -> Option<Self> {
         let lower = if self.lower.is_finite() {
             (self.lower - atol).ceil()
         } else {
@@ -320,7 +340,11 @@ impl Bound {
         } else {
             self.upper
         };
-        Self::new(lower, upper).unwrap()
+        if upper < lower {
+            None
+        } else {
+            Some(Self { lower, upper })
+        }
     }
 
     /// `[lower, upper]` with finite `lower` and `upper`
@@ -522,16 +546,6 @@ mod tests {
         Bound::arbitrary()
             .prop_flat_map(|bound| (Just(bound), bound.arbitrary_containing(1e5)))
             .boxed()
-    }
-
-    #[test]
-    fn as_integer_bound() {
-        assert_eq!(
-            Bound::new(1.000000000001, 1.99999999999)
-                .unwrap()
-                .as_integer_bound(1e-6),
-            Bound::new(1.0, 2.0).unwrap()
-        )
     }
 
     proptest! {

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -162,7 +162,7 @@ impl DecisionVariable {
         }
         match self.kind {
             Kind::Integer | Kind::Binary | Kind::SemiInteger => {
-                if value.fract().abs() < atol {
+                if value.fract().abs() >= atol {
                     return Err(err());
                 }
             }

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -131,18 +131,23 @@ impl DecisionVariable {
         substituted_value: Option<f64>,
         atol: ATol,
     ) -> Result<Self, DecisionVariableError> {
-        Ok(Self {
+        let mut new = Self {
             id,
             kind,
             bound: kind
                 .consistent_bound(bound, atol)
                 .ok_or(DecisionVariableError::BoundInconsistentToKind { id, kind, bound })?,
-            substituted_value,
+            substituted_value: None, // will be set later
             name: None,
             subscripts: Vec::new(),
             parameters: FnvHashMap::default(),
             description: None,
-        })
+        };
+        if let Some(substituted_value) = substituted_value {
+            new.check_value_consistency(substituted_value, atol)?;
+            new.substituted_value = Some(substituted_value);
+        }
+        Ok(new)
     }
 
     /// Check if the substituted value is consistent to the bound and kind

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -145,6 +145,29 @@ impl DecisionVariable {
         })
     }
 
+    /// Check if the substituted value is consistent to the bound and kind
+    ///
+    /// Example
+    /// --------
+    ///
+    /// ```rust
+    /// use ommx::{DecisionVariable, Kind, Bound};
+    ///
+    /// let dv = DecisionVariable::new(
+    ///     0.into(),
+    ///     Kind::Integer,
+    ///     Bound::new(0.0, 2.0).unwrap(),
+    ///     None,
+    ///     1e-6,
+    /// ).unwrap();
+    ///
+    /// // 1 \in [0, 2]
+    /// assert!(dv.check_value_consistency(1.0, 1e-6).is_ok());
+    /// // 3 \in [0, 2]
+    /// assert!(dv.check_value_consistency(3.0, 1e-6).is_err());
+    /// // 0.5 \in [0, 2], but not consistent to Kind::Integer
+    /// assert!(dv.check_value_consistency(0.5, 1e-6).is_err());
+    /// ```
     pub fn check_value_consistency(
         &self,
         value: f64,

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -56,23 +56,23 @@ impl Kind {
     /// --------
     ///
     /// ```rust
-    /// use ommx::{Kind, Bound};
+    /// use ommx::{Kind, Bound, ATol};
     ///
     /// // Any bound is allowed for Kind::Continuous
     /// assert_eq!(
-    ///     Kind::Continuous.consistent_bound(Bound::new(1.0, 2.0).unwrap(), 1e-6),
+    ///     Kind::Continuous.consistent_bound(Bound::new(1.0, 2.0).unwrap(), ATol::default()),
     ///     Some(Bound::new(1.0, 2.0).unwrap())
     /// );
     ///
     /// // For Kind::Integer, the bound is restricted to integer.
     /// assert_eq!(
-    ///    Kind::Integer.consistent_bound(Bound::new(1.1, 2.9).unwrap(), 1e-6),
+    ///    Kind::Integer.consistent_bound(Bound::new(1.1, 2.9).unwrap(), ATol::default()),
     ///    Some(Bound::new(2.0, 2.0).unwrap())
     /// );
     ///
     /// // And if there is no integer in the bound, None is returned.
     /// assert_eq!(
-    ///     Kind::Integer.consistent_bound(Bound::new(1.1, 1.9).unwrap(), 1e-6),
+    ///     Kind::Integer.consistent_bound(Bound::new(1.1, 1.9).unwrap(), ATol::default()),
     ///     None
     /// );
     /// ```
@@ -151,22 +151,22 @@ impl DecisionVariable {
     /// --------
     ///
     /// ```rust
-    /// use ommx::{DecisionVariable, Kind, Bound};
+    /// use ommx::{DecisionVariable, Kind, Bound, ATol};
     ///
     /// let dv = DecisionVariable::new(
     ///     0.into(),
     ///     Kind::Integer,
     ///     Bound::new(0.0, 2.0).unwrap(),
     ///     None,
-    ///     1e-6,
+    ///     ATol::default(),
     /// ).unwrap();
     ///
     /// // 1 \in [0, 2]
-    /// assert!(dv.check_value_consistency(1.0, 1e-6).is_ok());
+    /// assert!(dv.check_value_consistency(1.0, ATol::default()).is_ok());
     /// // 3 \in [0, 2]
-    /// assert!(dv.check_value_consistency(3.0, 1e-6).is_err());
+    /// assert!(dv.check_value_consistency(3.0, ATol::default()).is_err());
     /// // 0.5 \in [0, 2], but not consistent to Kind::Integer
-    /// assert!(dv.check_value_consistency(0.5, 1e-6).is_err());
+    /// assert!(dv.check_value_consistency(0.5, ATol::default()).is_err());
     /// ```
     pub fn check_value_consistency(
         &self,

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -1,8 +1,13 @@
-use crate::{parse::*, random::unique_integers, v1, Bound};
+mod arbitrary;
+mod parse;
+
+pub use arbitrary::*;
+use getset::CopyGetters;
+
+use crate::Bound;
 use derive_more::{Deref, From};
-use fnv::{FnvHashMap, FnvHashSet};
-use proptest::prelude::*;
-use std::collections::{BTreeMap, BTreeSet};
+use fnv::FnvHashMap;
+use std::collections::BTreeSet;
 
 /// ID for decision variable and parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Deref)]
@@ -27,26 +32,6 @@ impl std::fmt::Display for VariableID {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct KindParameters(FnvHashSet<Kind>);
-
-impl KindParameters {
-    pub fn new(kinds: &[Kind]) -> anyhow::Result<Self> {
-        let inner: FnvHashSet<_> = kinds.iter().cloned().collect();
-        if inner.is_empty() {
-            Err(anyhow::anyhow!("KindParameters must not be empty"))
-        } else {
-            Ok(KindParameters(inner))
-        }
-    }
-}
-
-impl Default for KindParameters {
-    fn default() -> Self {
-        Self::new(&[Kind::Binary, Kind::Integer, Kind::Continuous]).unwrap()
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Kind {
     Continuous,
@@ -56,43 +41,79 @@ pub enum Kind {
     SemiInteger,
 }
 
-impl Arbitrary for Kind {
-    type Parameters = KindParameters;
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
-        let kinds_vec: Vec<Kind> = parameters.0.into_iter().collect();
-        debug_assert!(!kinds_vec.is_empty(), "KindParameters must not be empty");
-        proptest::sample::select(kinds_vec).boxed()
-    }
-}
-
-impl Parse for v1::decision_variable::Kind {
-    type Output = Kind;
-    type Context = ();
-    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
-        use v1::decision_variable::Kind::*;
+impl Kind {
+    /// Check and convert the bound to a consistent bound
+    ///
+    /// - For [`Kind::Continuous`] or [`Kind::SemiContinuous`], arbitrary bound is allowed.
+    /// - For [`Kind::Integer`] or [`Kind::Binary`], the bound is restricted to integer or binary.
+    ///   If there is no integer or binary in the bound, [`None`] is returned.
+    /// - For [`Kind::SemiInteger`], the bound is also restricted to integer.
+    ///   If there is no integer in the bound, on the other hand, returns `[0.0, 0.0]`.
+    ///
+    /// As a result, the returned bound, except for `None` case, is guaranteed that there is at least one possible value.
+    ///
+    /// Example
+    /// --------
+    ///
+    /// ```rust
+    /// use ommx::{Kind, Bound};
+    ///
+    /// // Any bound is allowed for Kind::Continuous
+    /// assert_eq!(
+    ///     Kind::Continuous.consistent_bound(Bound::new(1.0, 2.0).unwrap(), 1e-6),
+    ///     Some(Bound::new(1.0, 2.0).unwrap())
+    /// );
+    ///
+    /// // For Kind::Integer, the bound is restricted to integer.
+    /// assert_eq!(
+    ///    Kind::Integer.consistent_bound(Bound::new(1.1, 2.9).unwrap(), 1e-6),
+    ///    Some(Bound::new(2.0, 2.0).unwrap())
+    /// );
+    ///
+    /// // And if there is no integer in the bound, None is returned.
+    /// assert_eq!(
+    ///     Kind::Integer.consistent_bound(Bound::new(1.1, 1.9).unwrap(), 1e-6),
+    ///     None
+    /// );
+    /// ```
+    pub fn consistent_bound(&self, bound: Bound, atol: f64) -> Option<Bound> {
         match self {
-            Unspecified => Err(RawParseError::UnspecifiedEnum {
-                enum_name: "ommx.v1.decision_variable.Kind",
+            Kind::Continuous | Kind::SemiContinuous => Some(bound),
+            Kind::Integer => bound.as_integer_bound(atol),
+            Kind::SemiInteger => Some(
+                bound
+                    .as_integer_bound(atol)
+                    .unwrap_or_else(|| Bound::new(0.0, 0.0).unwrap()),
+            ),
+            Kind::Binary => {
+                let bound = bound.as_integer_bound(atol)?;
+                if bound.contains(0.0, atol) || bound.contains(1.0, atol) {
+                    Some(bound)
+                } else {
+                    None
+                }
             }
-            .into()),
-            Continuous => Ok(Kind::Continuous),
-            Integer => Ok(Kind::Integer),
-            Binary => Ok(Kind::Binary),
-            SemiContinuous => Ok(Kind::SemiContinuous),
-            SemiInteger => Ok(Kind::SemiInteger),
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// The decision variable with metadata.
+///
+/// Invariants
+/// ----------
+/// - `kind` and `bound` are consistent
+///   - i.e. `bound` is invariant under `|bound| kind.consistent_bound(bound, atol).unwrap()` for appropriate `atol`.
+///
+#[derive(Debug, Clone, PartialEq, CopyGetters)]
 pub struct DecisionVariable {
-    pub id: VariableID,
-    pub kind: Kind,
-    pub bound: Bound,
-
-    pub substituted_value: Option<f64>,
+    #[getset(get_copy = "pub")]
+    id: VariableID,
+    #[getset(get_copy = "pub")]
+    kind: Kind,
+    #[getset(get_copy = "pub")]
+    bound: Bound,
+    #[getset(get_copy = "pub")]
+    substituted_value: Option<f64>,
 
     pub name: Option<String>,
     pub subscripts: Vec<i64>,
@@ -100,97 +121,95 @@ pub struct DecisionVariable {
     pub description: Option<String>,
 }
 
-impl Arbitrary for DecisionVariable {
-    type Parameters = KindParameters;
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
-        Kind::arbitrary_with(parameters)
-            .prop_flat_map(|kind| {
-                let bound_strategy = if kind == Kind::Binary {
-                    Just(Bound::new(0.0, 1.0).unwrap()).boxed()
-                } else {
-                    Bound::arbitrary()
-                };
-                (Just(kind), bound_strategy)
-            })
-            .prop_map(|(kind, bound)| DecisionVariable {
-                id: VariableID::from(0), // Should be replaced with a unique ID, but cannot be generated here
-                kind,
-                bound,
-                substituted_value: None,
-                name: None,
-                subscripts: Vec::new(),
-                parameters: FnvHashMap::default(),
-                description: None,
-            })
-            .boxed()
-    }
-}
-
-impl Parse for v1::DecisionVariable {
-    type Output = DecisionVariable;
-    type Context = ();
-    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
-        let message = "ommx.v1.DecisionVariable";
-        Ok(DecisionVariable {
-            id: VariableID(self.id),
-            kind: self.kind().parse_as(&(), message, "kind")?,
-            bound: self
-                .bound
-                .unwrap_or_default()
-                .parse_as(&(), message, "bound")?,
-            substituted_value: self.substituted_value,
-            name: self.name,
-            subscripts: self.subscripts,
-            parameters: self.parameters.into_iter().collect(),
-            description: self.description,
+impl DecisionVariable {
+    /// Create a new decision variable.
+    pub fn new(
+        id: VariableID,
+        kind: Kind,
+        bound: Bound,
+        substituted_value: Option<f64>,
+        atol: f64,
+    ) -> Result<Self, DecisionVariableError> {
+        Ok(Self {
+            id,
+            kind,
+            bound: kind
+                .consistent_bound(bound, atol)
+                .ok_or(DecisionVariableError::BoundInconsistentToKind { id, kind, bound })?,
+            substituted_value,
+            name: None,
+            subscripts: Vec::new(),
+            parameters: FnvHashMap::default(),
+            description: None,
         })
     }
-}
 
-impl Parse for Vec<v1::DecisionVariable> {
-    type Output = BTreeMap<VariableID, DecisionVariable>;
-    type Context = ();
-    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
-        let mut decision_variables = BTreeMap::default();
-        for v in self {
-            let v: DecisionVariable = v.parse(&())?;
-            let id = v.id;
-            if decision_variables.insert(id, v).is_some() {
-                return Err(RawParseError::DuplicatedVariableID { id }.into());
-            }
+    pub fn consistent_value(&self, value: f64, atol: f64) -> bool {
+        if !self.bound.contains(value, atol) {
+            return false;
         }
-        Ok(decision_variables)
+        match self.kind {
+            Kind::Continuous | Kind::SemiContinuous => true,
+            Kind::Integer | Kind::Binary | Kind::SemiInteger => value.fract().abs() < atol,
+        }
+    }
+
+    pub fn set_bound(&mut self, bound: Bound, atol: f64) -> Result<(), DecisionVariableError> {
+        let bound = self.kind.consistent_bound(bound, atol).ok_or(
+            DecisionVariableError::BoundInconsistentToKind {
+                id: self.id,
+                kind: self.kind,
+                bound,
+            },
+        )?;
+        self.bound = bound;
+        Ok(())
+    }
+
+    pub fn substitute(&mut self, new_value: f64, atol: f64) -> Result<(), DecisionVariableError> {
+        if let Some(previous_value) = self.substituted_value {
+            if (new_value - previous_value).abs() > atol {
+                return Err(DecisionVariableError::SubstitutedValueOverwrite {
+                    id: self.id,
+                    previous_value,
+                    new_value,
+                });
+            }
+        } else if self.consistent_value(new_value, atol) {
+            self.substituted_value = Some(new_value);
+        } else {
+            return Err(DecisionVariableError::SubstitutedValueInconsistentToKind {
+                id: self.id,
+                kind: self.kind,
+                substituted_value: new_value,
+                atol,
+            });
+        }
+        Ok(())
     }
 }
 
-pub fn arbitrary_unique_variable_ids(
-    size: usize,
-    max_id: VariableID,
-) -> impl Strategy<Value = FnvHashSet<VariableID>> {
-    unique_integers(0, max_id.into_inner(), size)
-        .prop_map(|ids| ids.into_iter().map(VariableID::from).collect())
-        .boxed()
-}
+#[derive(Debug, thiserror::Error)]
+pub enum DecisionVariableError {
+    #[error("Bound for ID={id} is inconsistent to kind: kind={kind:?}, bound={bound}")]
+    BoundInconsistentToKind {
+        id: VariableID,
+        kind: Kind,
+        bound: Bound,
+    },
 
-pub fn arbitrary_decision_variables(
-    unique_ids: FnvHashSet<VariableID>,
-    parameters: KindParameters,
-) -> impl Strategy<Value = BTreeMap<VariableID, DecisionVariable>> {
-    let variables = proptest::collection::vec(
-        DecisionVariable::arbitrary_with(parameters),
-        unique_ids.len(),
-    );
-    (Just(unique_ids), variables)
-        .prop_map(|(ids, variables)| {
-            ids.into_iter()
-                .zip(variables)
-                .map(|(id, mut variable)| {
-                    variable.id = id;
-                    (id, variable)
-                })
-                .collect()
-        })
-        .boxed()
+    #[error("Substituted value for ID={id} cannot be overwrite: previous={previous_value}, new={new_value}")]
+    SubstitutedValueOverwrite {
+        id: VariableID,
+        previous_value: f64,
+        new_value: f64,
+    },
+
+    #[error("Substituted value for ID={id} is inconsistent to kind: kind={kind:?}, substituted_value={substituted_value}, atol={atol}")]
+    SubstitutedValueInconsistentToKind {
+        id: VariableID,
+        kind: Kind,
+        substituted_value: f64,
+        atol: f64,
+    },
 }

--- a/rust/ommx/src/decision_variable/arbitrary.rs
+++ b/rust/ommx/src/decision_variable/arbitrary.rs
@@ -44,7 +44,7 @@ impl Arbitrary for DecisionVariable {
         (Kind::arbitrary_with(parameters), Bound::arbitrary())
             .prop_filter_map("Bound must be consistent with Kind", |(kind, bound)| {
                 // FIXME: Constructive approach to generate bounds for faster testing
-                let bound = kind.consistent_bound(bound, 1e-6)?;
+                let bound = kind.consistent_bound(bound, ATol::default())?;
                 Some((kind, bound))
             })
             .prop_map(|(kind, bound)| DecisionVariable {

--- a/rust/ommx/src/decision_variable/arbitrary.rs
+++ b/rust/ommx/src/decision_variable/arbitrary.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+use crate::{random::unique_integers, Bound};
+use fnv::{FnvHashMap, FnvHashSet};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub struct KindParameters(FnvHashSet<Kind>);
+
+impl KindParameters {
+    pub fn new(kinds: &[Kind]) -> anyhow::Result<Self> {
+        let inner: FnvHashSet<_> = kinds.iter().cloned().collect();
+        if inner.is_empty() {
+            Err(anyhow::anyhow!("KindParameters must not be empty"))
+        } else {
+            Ok(KindParameters(inner))
+        }
+    }
+}
+
+impl Default for KindParameters {
+    fn default() -> Self {
+        Self::new(&[Kind::Binary, Kind::Integer, Kind::Continuous]).unwrap()
+    }
+}
+
+impl Arbitrary for Kind {
+    type Parameters = KindParameters;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+        let kinds_vec: Vec<Kind> = parameters.0.into_iter().collect();
+        debug_assert!(!kinds_vec.is_empty(), "KindParameters must not be empty");
+        proptest::sample::select(kinds_vec).boxed()
+    }
+}
+
+impl Arbitrary for DecisionVariable {
+    type Parameters = KindParameters;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+        (Kind::arbitrary_with(parameters), Bound::arbitrary())
+            .prop_filter_map("Bound must be consistent with Kind", |(kind, bound)| {
+                // FIXME: Constructive approach to generate bounds for faster testing
+                let bound = kind.consistent_bound(bound, 1e-6)?;
+                Some((kind, bound))
+            })
+            .prop_map(|(kind, bound)| DecisionVariable {
+                id: VariableID::from(0), // Should be replaced with a unique ID, but cannot be generated here
+                kind,
+                bound,
+                substituted_value: None,
+                name: None,
+                subscripts: Vec::new(),
+                parameters: FnvHashMap::default(),
+                description: None,
+            })
+            .boxed()
+    }
+}
+
+pub fn arbitrary_unique_variable_ids(
+    size: usize,
+    max_id: VariableID,
+) -> impl Strategy<Value = FnvHashSet<VariableID>> {
+    unique_integers(0, max_id.into_inner(), size)
+        .prop_map(|ids| ids.into_iter().map(VariableID::from).collect())
+        .boxed()
+}
+
+pub fn arbitrary_decision_variables(
+    unique_ids: FnvHashSet<VariableID>,
+    parameters: KindParameters,
+) -> impl Strategy<Value = BTreeMap<VariableID, DecisionVariable>> {
+    let variables = proptest::collection::vec(
+        DecisionVariable::arbitrary_with(parameters),
+        unique_ids.len(),
+    );
+    (Just(unique_ids), variables)
+        .prop_map(|(ids, variables)| {
+            ids.into_iter()
+                .zip(variables)
+                .map(|(id, mut variable)| {
+                    variable.id = id;
+                    (id, variable)
+                })
+                .collect()
+        })
+        .boxed()
+}

--- a/rust/ommx/src/decision_variable/arbitrary.rs
+++ b/rust/ommx/src/decision_variable/arbitrary.rs
@@ -51,7 +51,7 @@ impl Arbitrary for DecisionVariable {
                 id: VariableID::from(0), // Should be replaced with a unique ID, but cannot be generated here
                 kind,
                 bound,
-                substituted_value: None,
+                substituted_value: None, // To keep consistency in Instance level, keep this None here.
                 name: None,
                 subscripts: Vec::new(),
                 parameters: FnvHashMap::default(),

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -63,7 +63,7 @@ impl Parse for v1::DecisionVariable {
             kind,
             bound,
             self.substituted_value,
-            1e-6, // FIXME: user should provide this
+            ATol::default(), // FIXME: user should provide this
         )
         .map_err(|e| RawParseError::InvalidDecisionVariable(e).context(message, "bound"))?;
         dv.name = self.name;

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+use crate::{parse::*, v1};
+use std::collections::BTreeMap;
+
+impl Parse for v1::decision_variable::Kind {
+    type Output = Kind;
+    type Context = ();
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        use v1::decision_variable::Kind::*;
+        match self {
+            Unspecified => Err(RawParseError::UnspecifiedEnum {
+                enum_name: "ommx.v1.decision_variable.Kind",
+            }
+            .into()),
+            Continuous => Ok(Kind::Continuous),
+            Integer => Ok(Kind::Integer),
+            Binary => Ok(Kind::Binary),
+            SemiContinuous => Ok(Kind::SemiContinuous),
+            SemiInteger => Ok(Kind::SemiInteger),
+        }
+    }
+}
+
+impl TryFrom<v1::decision_variable::Kind> for Kind {
+    type Error = ParseError;
+    fn try_from(value: v1::decision_variable::Kind) -> Result<Self, Self::Error> {
+        value.parse(&())
+    }
+}
+
+impl From<Kind> for v1::decision_variable::Kind {
+    fn from(kind: Kind) -> Self {
+        use v1::decision_variable::Kind::*;
+        match kind {
+            Kind::Continuous => Continuous,
+            Kind::Integer => Integer,
+            Kind::Binary => Binary,
+            Kind::SemiContinuous => SemiContinuous,
+            Kind::SemiInteger => SemiInteger,
+        }
+    }
+}
+
+impl From<Kind> for i32 {
+    fn from(kind: Kind) -> Self {
+        v1::decision_variable::Kind::from(kind) as i32
+    }
+}
+
+impl Parse for v1::DecisionVariable {
+    type Output = DecisionVariable;
+    type Context = ();
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v1.DecisionVariable";
+        let kind = self.kind().parse_as(&(), message, "kind")?;
+        let bound = self
+            .bound
+            .unwrap_or_default()
+            .parse_as(&(), message, "bound")?;
+        let mut dv = DecisionVariable::new(
+            VariableID(self.id),
+            kind,
+            bound,
+            self.substituted_value,
+            1e-6, // FIXME: user should provide this
+        )
+        .map_err(|e| RawParseError::InvalidDecisionVariable(e).context(message, "bound"))?;
+        dv.name = self.name;
+        dv.subscripts = self.subscripts;
+        dv.parameters = self.parameters.into_iter().collect();
+        dv.description = self.description;
+        Ok(dv)
+    }
+}
+
+impl TryFrom<v1::DecisionVariable> for DecisionVariable {
+    type Error = ParseError;
+    fn try_from(value: v1::DecisionVariable) -> Result<Self, Self::Error> {
+        value.parse(&())
+    }
+}
+
+impl Parse for Vec<v1::DecisionVariable> {
+    type Output = BTreeMap<VariableID, DecisionVariable>;
+    type Context = ();
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let mut decision_variables = BTreeMap::default();
+        for v in self {
+            let v: DecisionVariable = v.parse(&())?;
+            let id = v.id;
+            if decision_variables.insert(id, v).is_some() {
+                return Err(RawParseError::DuplicatedVariableID { id }.into());
+            }
+        }
+        Ok(decision_variables)
+    }
+}
+
+impl From<DecisionVariable> for v1::DecisionVariable {
+    fn from(
+        DecisionVariable {
+            id,
+            kind,
+            bound,
+            substituted_value,
+            name,
+            subscripts,
+            parameters,
+            description,
+        }: DecisionVariable,
+    ) -> Self {
+        Self {
+            id: id.into_inner(),
+            kind: kind.into(),
+            bound: Some(bound.into()),
+            substituted_value,
+            name,
+            subscripts,
+            parameters: parameters.into_iter().collect(),
+            description,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_decision_variable() {
+        let dv = v1::DecisionVariable {
+            id: 1,
+            kind: v1::decision_variable::Kind::Integer as i32,
+            bound: Some(v1::Bound {
+                lower: 1.1,
+                upper: 1.9,
+            }),
+            ..Default::default()
+        };
+        insta::assert_snapshot!(dv.parse(&()).unwrap_err(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.DecisionVariable[bound]
+        Bound for ID=1 is inconsistent to kind: kind=Integer, bound=[1.1, 1.9]
+        "###);
+    }
+}

--- a/rust/ommx/src/instance/analysis.rs
+++ b/rust/ommx/src/instance/analysis.rs
@@ -304,15 +304,15 @@ impl Instance {
         let mut semi_integer = Bounds::default();
         let mut semi_continuous = Bounds::default();
         for (id, dv) in &self.decision_variables {
-            match dv.kind {
+            match dv.kind() {
                 Kind::Binary => binary.insert(*id),
-                Kind::Integer => integer.insert(*id, dv.bound).is_some(),
-                Kind::Continuous => continuous.insert(*id, dv.bound).is_some(),
-                Kind::SemiInteger => semi_integer.insert(*id, dv.bound).is_some(),
-                Kind::SemiContinuous => semi_continuous.insert(*id, dv.bound).is_some(),
+                Kind::Integer => integer.insert(*id, dv.bound()).is_some(),
+                Kind::Continuous => continuous.insert(*id, dv.bound()).is_some(),
+                Kind::SemiInteger => semi_integer.insert(*id, dv.bound()).is_some(),
+                Kind::SemiContinuous => semi_continuous.insert(*id, dv.bound()).is_some(),
             };
             all.insert(*id);
-            if let Some(value) = dv.substituted_value {
+            if let Some(value) = dv.substituted_value() {
                 fixed.insert(*id, value);
             }
         }

--- a/rust/ommx/src/parse.rs
+++ b/rust/ommx/src/parse.rs
@@ -1,6 +1,6 @@
 use crate::{
-    polynomial_base::QuadraticParseError, BoundError, CoefficientError, ConstraintID, OffsetError,
-    VariableID,
+    polynomial_base::QuadraticParseError, BoundError, CoefficientError, ConstraintID,
+    DecisionVariableError, OffsetError, VariableID,
 };
 use prost::DecodeError;
 use std::fmt;
@@ -115,6 +115,9 @@ pub enum RawParseError {
 
     #[error(transparent)]
     InvalidBound(#[from] BoundError),
+
+    #[error(transparent)]
+    InvalidDecisionVariable(#[from] DecisionVariableError),
 
     /// The wire format is invalid.
     #[error("Cannot decode as a Protobuf Message: {0}")]

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -499,7 +499,13 @@ impl Instance {
         // Check the bound of `a*f`
         // - If `lower > 0`, the constraint is infeasible
         // - If `upper <= 0`, the constraint is always satisfied, thus moved to `removed_constraints`
-        let bound = af.evaluate_bound(&bounds).as_integer_bound(atol);
+        let bound = af.evaluate_bound(&bounds);
+        let bound = bound.as_integer_bound(atol).ok_or_else(|| {
+            InfeasibleDetected::InequalityConstraintBound {
+                id: ConstraintID::from(constraint_id),
+                bound,
+            }
+        })?;
         if bound.lower() > 0.0 {
             bail!(InfeasibleDetected::InequalityConstraintBound {
                 id: ConstraintID::from(constraint_id),


### PR DESCRIPTION
Split from #459 

- `DecisionVariable` changed to impose the consistency condition for `kind` and `bound`.
- `kind` and `bound` are consistent if
  - At least one possible value exists. For example, `kind=Integer` and `bound=[1.1, 1.9]` are inconsistent since there is no possible integer in the bound.
  - The edge of bound must be integer for binary, integer, and semi-integer case.

Tasks
------
- [x] Split `decision_variable.rs` into submodules
- [x] `Bound::as_integer_bound` changed to return `Option<Bound>` to support a case where no integer exists in the bound.
- [x] `Kind::consistent_bound`
- [x] Make `id`, `kind`, `bound`, and `substituted_value` fields in `DecisionVariable` private to keep the invariant condition for them.