### PR TITLE
Exclude release notes from jupyter book execution

### DIFF
--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -10,6 +10,8 @@ author: Jij Inc.
 execute:
   execute_notebooks: force
   timeout: 60
+  exclude_patterns:
+    - 'release_note/*'
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/docs/ja/_config.yml
+++ b/docs/ja/_config.yml
@@ -10,6 +10,8 @@ author: Jij Inc.
 execute:
   execute_notebooks: force
   timeout: 60
+  exclude_patterns:
+    - 'release_note/*'
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
- Excludes the release notes directory from being executed by jupyter to avoid problems that may be caused by future releases.