### PR TITLE
Use Rust-idiomatic `ommx::Function` in Python SDK's `ommx._ommx_rust.Function`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,7 +123,19 @@ When implementing property-based tests (using `proptest`) for mathematical opera
 
 ## Common Pitfalls / Frequently Made Mistakes
 
-- **Incorrect `Coefficient` Creation:** When creating a `Coefficient` from an `f64` value, always use `Coefficient::try_from(value).unwrap()` instead of `Coefficient::from(value)`.
+- **Incorrect `Coefficient` Creation:** When creating a `Coefficient` from an `f64` value, always use `Coefficient::try_from(value).unwrap()` instead of `Coefficient::from(value)`. In test code and documentation, prefer using the `coeff!` macro for cleaner syntax (e.g., `coeff!(1.5)` instead of `Coefficient::try_from(1.5).unwrap()`).
+
+## Macros for Test Code and Documentation
+
+When writing test code and documentation examples, prefer using OMMX convenience macros for better readability and conciseness:
+
+- **`coeff!` macro**: Use `coeff!(value)` instead of `Coefficient::try_from(value).unwrap()` for creating coefficients.
+- **`linear!` macro**: Use `linear!(id)` for creating `ommx::Linear` monomials from variable ID literals (e.g., `linear!(1)` creates a linear monomial for variable x1).
+- **`quadratic!` macro**: Use `quadratic!(id)` for linear terms in quadratic space or `quadratic!(id1, id2)` for quadratic pair terms.
+- **`monomial!` macro**: Use `monomial!(id1, id2, ...)` for creating general monomials of any degree from variable ID literals.
+- **`assign!` macro**: Use `assign! { var_id <- expression, ... }` for creating acyclic variable assignments in test scenarios.
+
+**Important Note**: These macros accept only compile-time literals, not runtime values. For runtime values, use the corresponding constructor functions (e.g., `Coefficient::try_from()`, `LinearMonomial::Variable()`, etc.). These macros provide cleaner, more readable syntax in examples while maintaining the same functionality as their verbose counterparts.
 
 ## General Guidance
 - If relevant, consider the ommx library's conventions and APIs. Please ask if you need more specific details about ommx.

--- a/python/ommx/src/message.rs
+++ b/python/ommx/src/message.rs
@@ -285,7 +285,7 @@ impl Function {
     }
 
     pub fn content_factor(&self) -> Result<f64> {
-        todo!()
+        self.0.content_factor().map(|c| c.into_inner())
     }
 
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {

--- a/python/ommx/src/message.rs
+++ b/python/ommx/src/message.rs
@@ -37,7 +37,7 @@ impl Linear {
     }
 
     pub fn __repr__(&self) -> String {
-        todo!()
+        format!("Linear({})", self.0)
     }
 
     pub fn __add__(&self, rhs: &Linear) -> Linear {
@@ -88,7 +88,7 @@ impl Quadratic {
     }
 
     pub fn __repr__(&self) -> String {
-        todo!()
+        format!("Quadratic({})", self.0)
     }
 
     pub fn __add__(&self, rhs: &Quadratic) -> Quadratic {
@@ -147,7 +147,7 @@ impl Polynomial {
     }
 
     pub fn __repr__(&self) -> String {
-        todo!()
+        format!("Polynomial({})", self.0)
     }
 
     pub fn __add__(&self, rhs: &Polynomial) -> Polynomial {
@@ -235,7 +235,7 @@ impl Function {
     }
 
     pub fn __repr__(&self) -> String {
-        todo!()
+        format!("Function({})", self.0)
     }
 
     pub fn __add__(&self, rhs: &Function) -> Function {

--- a/python/ommx/src/message.rs
+++ b/python/ommx/src/message.rs
@@ -2,39 +2,42 @@ use std::collections::BTreeSet;
 
 use anyhow::Result;
 use approx::AbsDiffEq;
-use ommx::{v1, Evaluate, Message};
-use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyBytes};
+use ommx::{v1, Coefficient, Evaluate, Message, Parse};
+use pyo3::{prelude::*, types::PyBytes};
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pyclass)]
 #[pyclass]
-pub struct Linear(v1::Linear);
+pub struct Linear(ommx::Linear);
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pymethods)]
 #[pymethods]
 impl Linear {
     #[staticmethod]
-    pub fn single_term(id: u64, coefficient: f64) -> Self {
-        Self(v1::Linear::single_term(id, coefficient))
+    pub fn single_term(id: u64, coefficient: f64) -> Result<Self> {
+        Ok(Self(ommx::Linear::single_term(
+            id.into(),
+            coefficient.try_into()?,
+        )))
     }
 
     #[staticmethod]
-    pub fn decode(bytes: &Bound<PyBytes>) -> PyResult<Self> {
-        let inner = v1::Linear::decode(bytes.as_bytes())
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(Self(inner))
+    pub fn decode(bytes: &Bound<PyBytes>) -> Result<Self> {
+        let inner = v1::Linear::decode(bytes.as_bytes())?;
+        Ok(Self(Parse::parse(inner, &())?))
     }
 
     pub fn encode<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = self.0.encode_to_vec();
+        let inner: v1::Linear = self.0.clone().into();
+        let bytes = Message::encode_to_vec(&inner);
         Ok(PyBytes::new(py, &bytes))
     }
 
-    pub fn almost_equal(&self, other: &Linear, atol: f64) -> bool {
-        self.0.abs_diff_eq(&other.0, ommx::ATol::new(atol).unwrap())
+    pub fn almost_equal(&self, other: &Linear, atol: f64) -> Result<bool> {
+        Ok(self.0.abs_diff_eq(&other.0, ommx::ATol::new(atol)?))
     }
 
     pub fn __repr__(&self) -> String {
-        self.0.to_string()
+        todo!()
     }
 
     pub fn __add__(&self, rhs: &Linear) -> Linear {
@@ -46,34 +49,37 @@ impl Linear {
     }
 
     pub fn __mul__(&self, rhs: &Linear) -> Quadratic {
-        Quadratic(self.0.clone() * rhs.0.clone())
+        Quadratic(&self.0 * &rhs.0)
     }
 
-    pub fn add_scalar(&self, scalar: f64) -> Linear {
-        Linear(self.0.clone() + scalar)
+    pub fn add_scalar(&self, scalar: f64) -> Result<Linear> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Linear(&self.0 + coeff))
     }
 
-    pub fn mul_scalar(&self, scalar: f64) -> Linear {
-        Linear(self.0.clone() * scalar)
+    pub fn mul_scalar(&self, scalar: f64) -> Result<Linear> {
+        let scalar: Coefficient = scalar.try_into()?;
+        Ok(Linear(self.0.clone() * scalar))
     }
 }
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pyclass)]
 #[pyclass]
-pub struct Quadratic(v1::Quadratic);
+pub struct Quadratic(ommx::Quadratic);
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pymethods)]
 #[pymethods]
 impl Quadratic {
     #[staticmethod]
-    pub fn decode(bytes: &Bound<PyBytes>) -> PyResult<Self> {
-        let inner = v1::Quadratic::decode(bytes.as_bytes())
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(Self(inner))
+    pub fn decode(bytes: &Bound<PyBytes>) -> Result<Self> {
+        let inner = v1::Quadratic::decode(bytes.as_bytes())?;
+        let parsed = Parse::parse(inner, &())?;
+        Ok(Self(parsed))
     }
 
     pub fn encode<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = self.0.encode_to_vec();
+        let inner: v1::Quadratic = self.0.clone().into();
+        let bytes = Message::encode_to_vec(&inner);
         Ok(PyBytes::new(py, &bytes))
     }
 
@@ -82,7 +88,7 @@ impl Quadratic {
     }
 
     pub fn __repr__(&self) -> String {
-        self.0.to_string()
+        todo!()
     }
 
     pub fn __add__(&self, rhs: &Quadratic) -> Quadratic {
@@ -93,43 +99,46 @@ impl Quadratic {
         Quadratic(self.0.clone() - rhs.0.clone())
     }
 
-    pub fn __mul__(&self, rhs: &Quadratic) -> Polynomial {
-        Polynomial(self.0.clone() * rhs.0.clone())
+    pub fn __mul__(&self, _rhs: &Quadratic) -> Polynomial {
+        todo!()
     }
 
-    pub fn add_scalar(&self, scalar: f64) -> Quadratic {
-        Quadratic(self.0.clone() + scalar)
+    pub fn add_scalar(&self, scalar: f64) -> Result<Quadratic> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Quadratic(&self.0 + coeff))
     }
 
-    pub fn add_linear(&self, linear: &Linear) -> Quadratic {
-        Quadratic(self.0.clone() + linear.0.clone())
+    pub fn add_linear(&self, _linear: &Linear) -> Quadratic {
+        todo!()
     }
 
-    pub fn mul_scalar(&self, scalar: f64) -> Quadratic {
-        Quadratic(self.0.clone() * scalar)
+    pub fn mul_scalar(&self, scalar: f64) -> Result<Quadratic> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Quadratic(self.0.clone() * coeff))
     }
 
-    pub fn mul_linear(&self, linear: &Linear) -> Polynomial {
-        Polynomial(self.0.clone() * linear.0.clone())
+    pub fn mul_linear(&self, _linear: &Linear) -> Polynomial {
+        todo!()
     }
 }
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pyclass)]
 #[pyclass]
-pub struct Polynomial(v1::Polynomial);
+pub struct Polynomial(ommx::Polynomial);
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pymethods)]
 #[pymethods]
 impl Polynomial {
     #[staticmethod]
-    pub fn decode(bytes: &Bound<PyBytes>) -> PyResult<Self> {
-        let inner = v1::Polynomial::decode(bytes.as_bytes())
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(Self(inner))
+    pub fn decode(bytes: &Bound<PyBytes>) -> Result<Self> {
+        let inner = v1::Polynomial::decode(bytes.as_bytes())?;
+        let parsed = Parse::parse(inner, &())?;
+        Ok(Self(parsed))
     }
 
     pub fn encode<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = self.0.encode_to_vec();
+        let inner: v1::Polynomial = self.0.clone().into();
+        let bytes = Message::encode_to_vec(&inner);
         Ok(PyBytes::new(py, &bytes))
     }
 
@@ -138,82 +147,86 @@ impl Polynomial {
     }
 
     pub fn __repr__(&self) -> String {
-        self.0.to_string()
+        todo!()
     }
 
     pub fn __add__(&self, rhs: &Polynomial) -> Polynomial {
-        Polynomial(self.0.clone() + rhs.0.clone())
+        Polynomial(&self.0 + &rhs.0)
     }
 
     pub fn __sub__(&self, rhs: &Polynomial) -> Polynomial {
-        Polynomial(self.0.clone() - rhs.0.clone())
+        Polynomial(&self.0 - &rhs.0)
     }
 
-    pub fn __mul__(&self, rhs: &Polynomial) -> Polynomial {
-        Polynomial(self.0.clone() * rhs.0.clone())
+    pub fn __mul__(&self, _rhs: &Polynomial) -> Polynomial {
+        todo!()
     }
 
-    pub fn add_scalar(&self, scalar: f64) -> Polynomial {
-        Polynomial(self.0.clone() + scalar)
+    pub fn add_scalar(&self, scalar: f64) -> Result<Polynomial> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Polynomial(&self.0 + coeff))
     }
 
-    pub fn add_linear(&self, linear: &Linear) -> Polynomial {
-        Polynomial(self.0.clone() + linear.0.clone())
+    pub fn add_linear(&self, _linear: &Linear) -> Polynomial {
+        todo!()
     }
 
-    pub fn add_quadratic(&self, quadratic: &Quadratic) -> Polynomial {
-        Polynomial(self.0.clone() + quadratic.0.clone())
+    pub fn add_quadratic(&self, _quadratic: &Quadratic) -> Polynomial {
+        todo!()
     }
 
-    pub fn mul_scalar(&self, scalar: f64) -> Polynomial {
-        Polynomial(self.0.clone() * scalar)
+    pub fn mul_scalar(&self, scalar: f64) -> Result<Polynomial> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Polynomial(self.0.clone() * coeff))
     }
 
-    pub fn mul_linear(&self, linear: &Linear) -> Polynomial {
-        Polynomial(self.0.clone() * linear.0.clone())
+    pub fn mul_linear(&self, _linear: &Linear) -> Polynomial {
+        todo!()
     }
 
-    pub fn mul_quadratic(&self, quadratic: &Quadratic) -> Polynomial {
-        Polynomial(self.0.clone() * quadratic.0.clone())
+    pub fn mul_quadratic(&self, _quadratic: &Quadratic) -> Polynomial {
+        todo!()
     }
 }
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pyclass)]
 #[pyclass]
-pub struct Function(v1::Function);
+pub struct Function(ommx::Function);
 
 #[cfg_attr(feature = "stub_gen", pyo3_stub_gen::derive::gen_stub_pymethods)]
 #[pymethods]
 impl Function {
     #[staticmethod]
-    pub fn from_scalar(scalar: f64) -> Self {
-        Self(v1::Function::from(scalar))
+    pub fn from_scalar(scalar: f64) -> Result<Self> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Self(ommx::Function::from(coeff)))
     }
 
     #[staticmethod]
     pub fn from_linear(linear: &Linear) -> Self {
-        Self(v1::Function::from(linear.0.clone()))
+        Self(ommx::Function::from(linear.0.clone()))
     }
 
     #[staticmethod]
     pub fn from_quadratic(quadratic: &Quadratic) -> Self {
-        Self(v1::Function::from(quadratic.0.clone()))
+        Self(ommx::Function::from(quadratic.0.clone()))
     }
 
     #[staticmethod]
     pub fn from_polynomial(polynomial: &Polynomial) -> Self {
-        Self(v1::Function::from(polynomial.0.clone()))
+        Self(ommx::Function::from(polynomial.0.clone()))
     }
 
     #[staticmethod]
-    pub fn decode(bytes: &Bound<PyBytes>) -> PyResult<Self> {
-        let inner = v1::Function::decode(bytes.as_bytes())
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(Self(inner))
+    pub fn decode(bytes: &Bound<PyBytes>) -> Result<Self> {
+        let inner = v1::Function::decode(bytes.as_bytes())?;
+        let parsed = Parse::parse(inner, &())?;
+        Ok(Self(parsed))
     }
 
     pub fn encode<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = self.0.encode_to_vec();
+        let inner: v1::Function = self.0.clone().into();
+        let bytes = Message::encode_to_vec(&inner);
         Ok(PyBytes::new(py, &bytes))
     }
 
@@ -222,7 +235,7 @@ impl Function {
     }
 
     pub fn __repr__(&self) -> String {
-        self.0.to_string()
+        todo!()
     }
 
     pub fn __add__(&self, rhs: &Function) -> Function {
@@ -237,8 +250,9 @@ impl Function {
         Function(self.0.clone() * rhs.0.clone())
     }
 
-    pub fn add_scalar(&self, scalar: f64) -> Function {
-        Function(self.0.clone() + scalar)
+    pub fn add_scalar(&self, scalar: f64) -> Result<Function> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Function(self.0.clone() + coeff))
     }
 
     pub fn add_linear(&self, linear: &Linear) -> Function {
@@ -253,8 +267,9 @@ impl Function {
         Function(self.0.clone() + polynomial.0.clone())
     }
 
-    pub fn mul_scalar(&self, scalar: f64) -> Function {
-        Function(self.0.clone() * scalar)
+    pub fn mul_scalar(&self, scalar: f64) -> Result<Function> {
+        let coeff: Coefficient = scalar.try_into()?;
+        Ok(Function(self.0.clone() * coeff))
     }
 
     pub fn mul_linear(&self, linear: &Linear) -> Function {
@@ -270,7 +285,7 @@ impl Function {
     }
 
     pub fn content_factor(&self) -> Result<f64> {
-        self.0.content_factor()
+        todo!()
     }
 
     pub fn used_decision_variable_ids(&self) -> BTreeSet<u64> {

--- a/python/ommx/src/message.rs
+++ b/python/ommx/src/message.rs
@@ -41,11 +41,11 @@ impl Linear {
     }
 
     pub fn __add__(&self, rhs: &Linear) -> Linear {
-        Linear(self.0.clone() + rhs.0.clone())
+        Linear(&self.0 + &rhs.0)
     }
 
     pub fn __sub__(&self, rhs: &Linear) -> Linear {
-        Linear(self.0.clone() - rhs.0.clone())
+        Linear(&self.0 - &rhs.0)
     }
 
     pub fn __mul__(&self, rhs: &Linear) -> Quadratic {
@@ -92,15 +92,15 @@ impl Quadratic {
     }
 
     pub fn __add__(&self, rhs: &Quadratic) -> Quadratic {
-        Quadratic(self.0.clone() + rhs.0.clone())
+        Quadratic(&self.0 + &rhs.0)
     }
 
     pub fn __sub__(&self, rhs: &Quadratic) -> Quadratic {
-        Quadratic(self.0.clone() - rhs.0.clone())
+        Quadratic(&self.0 - &rhs.0)
     }
 
-    pub fn __mul__(&self, _rhs: &Quadratic) -> Polynomial {
-        todo!()
+    pub fn __mul__(&self, rhs: &Quadratic) -> Polynomial {
+        Polynomial(&self.0 * &rhs.0)
     }
 
     pub fn add_scalar(&self, scalar: f64) -> Result<Quadratic> {
@@ -108,8 +108,8 @@ impl Quadratic {
         Ok(Quadratic(&self.0 + coeff))
     }
 
-    pub fn add_linear(&self, _linear: &Linear) -> Quadratic {
-        todo!()
+    pub fn add_linear(&self, linear: &Linear) -> Quadratic {
+        Quadratic(&self.0 + &linear.0)
     }
 
     pub fn mul_scalar(&self, scalar: f64) -> Result<Quadratic> {
@@ -117,8 +117,8 @@ impl Quadratic {
         Ok(Quadratic(self.0.clone() * coeff))
     }
 
-    pub fn mul_linear(&self, _linear: &Linear) -> Polynomial {
-        todo!()
+    pub fn mul_linear(&self, linear: &Linear) -> Polynomial {
+        Polynomial(&self.0 * &linear.0)
     }
 }
 
@@ -158,8 +158,8 @@ impl Polynomial {
         Polynomial(&self.0 - &rhs.0)
     }
 
-    pub fn __mul__(&self, _rhs: &Polynomial) -> Polynomial {
-        todo!()
+    pub fn __mul__(&self, rhs: &Polynomial) -> Polynomial {
+        Polynomial(&self.0 * &rhs.0)
     }
 
     pub fn add_scalar(&self, scalar: f64) -> Result<Polynomial> {
@@ -167,12 +167,12 @@ impl Polynomial {
         Ok(Polynomial(&self.0 + coeff))
     }
 
-    pub fn add_linear(&self, _linear: &Linear) -> Polynomial {
-        todo!()
+    pub fn add_linear(&self, linear: &Linear) -> Polynomial {
+        Polynomial(&self.0 + &linear.0)
     }
 
-    pub fn add_quadratic(&self, _quadratic: &Quadratic) -> Polynomial {
-        todo!()
+    pub fn add_quadratic(&self, quadratic: &Quadratic) -> Polynomial {
+        Polynomial(&self.0 + &quadratic.0)
     }
 
     pub fn mul_scalar(&self, scalar: f64) -> Result<Polynomial> {
@@ -180,12 +180,12 @@ impl Polynomial {
         Ok(Polynomial(self.0.clone() * coeff))
     }
 
-    pub fn mul_linear(&self, _linear: &Linear) -> Polynomial {
-        todo!()
+    pub fn mul_linear(&self, linear: &Linear) -> Polynomial {
+        Polynomial(&self.0 * &linear.0)
     }
 
-    pub fn mul_quadratic(&self, _quadratic: &Quadratic) -> Polynomial {
-        todo!()
+    pub fn mul_quadratic(&self, quadratic: &Quadratic) -> Polynomial {
+        Polynomial(&self.0 * &quadratic.0)
     }
 }
 
@@ -239,49 +239,49 @@ impl Function {
     }
 
     pub fn __add__(&self, rhs: &Function) -> Function {
-        Function(self.0.clone() + rhs.0.clone())
+        Function(&self.0 + &rhs.0)
     }
 
     pub fn __sub__(&self, rhs: &Function) -> Function {
-        Function(self.0.clone() - rhs.0.clone())
+        Function(&self.0 - &rhs.0)
     }
 
     pub fn __mul__(&self, rhs: &Function) -> Function {
-        Function(self.0.clone() * rhs.0.clone())
+        Function(&self.0 * &rhs.0)
     }
 
     pub fn add_scalar(&self, scalar: f64) -> Result<Function> {
         let coeff: Coefficient = scalar.try_into()?;
-        Ok(Function(self.0.clone() + coeff))
+        Ok(Function(&self.0 + coeff))
     }
 
     pub fn add_linear(&self, linear: &Linear) -> Function {
-        Function(self.0.clone() + linear.0.clone())
+        Function(&self.0 + &linear.0)
     }
 
     pub fn add_quadratic(&self, quadratic: &Quadratic) -> Function {
-        Function(self.0.clone() + quadratic.0.clone())
+        Function(&self.0 + &quadratic.0)
     }
 
     pub fn add_polynomial(&self, polynomial: &Polynomial) -> Function {
-        Function(self.0.clone() + polynomial.0.clone())
+        Function(&self.0 + &polynomial.0)
     }
 
     pub fn mul_scalar(&self, scalar: f64) -> Result<Function> {
         let coeff: Coefficient = scalar.try_into()?;
-        Ok(Function(self.0.clone() * coeff))
+        Ok(Function(&self.0 * coeff))
     }
 
     pub fn mul_linear(&self, linear: &Linear) -> Function {
-        Function(self.0.clone() * linear.0.clone())
+        Function(&self.0 * &linear.0)
     }
 
     pub fn mul_quadratic(&self, quadratic: &Quadratic) -> Function {
-        Function(self.0.clone() * quadratic.0.clone())
+        Function(&self.0 * &quadratic.0)
     }
 
     pub fn mul_polynomial(&self, polynomial: &Polynomial) -> Function {
-        Function(self.0.clone() * polynomial.0.clone())
+        Function(&self.0 * &polynomial.0)
     }
 
     pub fn content_factor(&self) -> Result<f64> {

--- a/python/ommx/src/message.rs
+++ b/python/ommx/src/message.rs
@@ -37,7 +37,7 @@ impl Linear {
     }
 
     pub fn __repr__(&self) -> String {
-        format!("Linear({})", self.0)
+        self.0.to_string()
     }
 
     pub fn __add__(&self, rhs: &Linear) -> Linear {
@@ -88,7 +88,7 @@ impl Quadratic {
     }
 
     pub fn __repr__(&self) -> String {
-        format!("Quadratic({})", self.0)
+        self.0.to_string()
     }
 
     pub fn __add__(&self, rhs: &Quadratic) -> Quadratic {
@@ -147,7 +147,7 @@ impl Polynomial {
     }
 
     pub fn __repr__(&self) -> String {
-        format!("Polynomial({})", self.0)
+        self.0.to_string()
     }
 
     pub fn __add__(&self, rhs: &Polynomial) -> Polynomial {
@@ -235,7 +235,7 @@ impl Function {
     }
 
     pub fn __repr__(&self) -> String {
-        format!("Function({})", self.0)
+        self.0.to_string()
     }
 
     pub fn __add__(&self, rhs: &Function) -> Function {

--- a/rust/ommx/src/coefficient.rs
+++ b/rust/ommx/src/coefficient.rs
@@ -1,4 +1,4 @@
-use num::One;
+use num::{traits::Inv, One};
 use ordered_float::NotNan;
 use proptest::prelude::*;
 use std::ops::{Add, Deref, Mul, MulAssign, Neg, Sub};
@@ -108,6 +108,14 @@ impl Sub for Coefficient {
 impl One for Coefficient {
     fn one() -> Self {
         Coefficient(NotNan::new(1.0).unwrap())
+    }
+}
+
+impl Inv for Coefficient {
+    type Output = Self;
+    fn inv(self) -> Self::Output {
+        // Non-zero coefficient is invertible
+        Self(self.0.into_inner().recip().try_into().unwrap())
     }
 }
 

--- a/rust/ommx/src/format.rs
+++ b/rust/ommx/src/format.rs
@@ -67,3 +67,72 @@ pub fn format_polynomial(
     }
     Ok(())
 }
+
+impl<M> fmt::Display for crate::PolynomialBase<M>
+where
+    M: crate::Monomial + Into<MonomialDyn>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.num_terms() == 0 {
+            return write!(f, "0");
+        }
+        format_polynomial(
+            f,
+            self.iter()
+                .map(|(monomial, coefficient)| (monomial.clone().into(), coefficient.into_inner())),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{coeff, linear, quadratic, Linear};
+
+    #[test]
+    fn test_polynomial_base_display_empty() {
+        let poly: Linear = Linear::default();
+        assert_eq!(format!("{}", poly), "0");
+    }
+
+    #[test]
+    fn test_polynomial_base_display_single_term() {
+        let poly = coeff!(3.0) * linear!(1);
+        assert_eq!(format!("{}", poly), "3*x1");
+    }
+
+    #[test]
+    fn test_polynomial_base_display_constant() {
+        let poly = Linear::from(coeff!(5.0));
+        assert_eq!(format!("{}", poly), "5");
+    }
+
+    #[test]
+    fn test_polynomial_base_display_multiple_terms() {
+        let poly = coeff!(2.0) * linear!(1) - coeff!(3.0) * linear!(2) + coeff!(1.0);
+
+        let result = format!("{}", poly);
+        // Terms should be sorted by degree (highest first), then lexicographically
+        assert_eq!(result, "2*x1 - 3*x2 + 1");
+    }
+
+    #[test]
+    fn test_polynomial_base_display_quadratic() {
+        let poly = coeff!(4.0) * quadratic!(1, 2) - coeff!(2.0) * quadratic!(1) + coeff!(3.0);
+
+        let result = format!("{}", poly);
+        // Quadratic term should come first (highest degree), then linear, then constant
+        assert_eq!(result, "4*x1*x2 - 2*x1 + 3");
+    }
+
+    #[test]
+    fn test_polynomial_base_display_coefficient_one() {
+        let poly = coeff!(1.0) * linear!(1);
+        assert_eq!(format!("{}", poly), "x1");
+    }
+
+    #[test]
+    fn test_polynomial_base_display_coefficient_negative_one() {
+        let poly = coeff!(-1.0) * linear!(1);
+        assert_eq!(format!("{}", poly), "-x1");
+    }
+}

--- a/rust/ommx/src/format.rs
+++ b/rust/ommx/src/format.rs
@@ -84,6 +84,18 @@ where
     }
 }
 
+impl fmt::Display for crate::Function {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            crate::Function::Zero => write!(f, "0"),
+            crate::Function::Constant(c) => write!(f, "{}", c.into_inner()),
+            crate::Function::Linear(linear) => write!(f, "{}", linear),
+            crate::Function::Quadratic(quadratic) => write!(f, "{}", quadratic),
+            crate::Function::Polynomial(polynomial) => write!(f, "{}", polynomial),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{coeff, linear, quadratic, Linear};

--- a/rust/ommx/src/function.rs
+++ b/rust/ommx/src/function.rs
@@ -1,6 +1,6 @@
 use crate::{Coefficient, Degree, Linear, MonomialDyn, Polynomial, Quadratic};
 use derive_more::From;
-use num::Zero;
+use num::{traits::Inv, One, Zero};
 use std::{borrow::Cow, fmt::Debug};
 
 mod add;
@@ -116,6 +116,19 @@ impl Function {
             Function::Linear(l) => Box::new(l.keys().map(|k| MonomialDyn::from(*k))),
             Function::Quadratic(q) => Box::new(q.keys().map(|k| MonomialDyn::from(*k))),
             Function::Polynomial(p) => Box::new(p.keys().cloned()),
+        }
+    }
+
+    /// Get a minimal positive factor `a` which make all coefficients of `a * self` integer.
+    ///
+    /// This returns `1` for zero function. See also <https://en.wikipedia.org/wiki/Primitive_part_and_content>.
+    pub fn content_factor(&self) -> anyhow::Result<Coefficient> {
+        match self {
+            Function::Zero => Ok(Coefficient::one()),
+            Function::Constant(c) => Ok(c.inv()),
+            Function::Linear(l) => l.content_factor(),
+            Function::Quadratic(q) => q.content_factor(),
+            Function::Polynomial(p) => p.content_factor(),
         }
     }
 }

--- a/rust/ommx/src/function/add.rs
+++ b/rust/ommx/src/function/add.rs
@@ -188,6 +188,42 @@ impl Neg for Function {
     }
 }
 
+// Add support for &Function operations with references
+impl Add<&Coefficient> for &Function {
+    type Output = Function;
+    fn add(self, rhs: &Coefficient) -> Self::Output {
+        self.clone() + *rhs
+    }
+}
+
+impl Add<Coefficient> for &Function {
+    type Output = Function;
+    fn add(self, rhs: Coefficient) -> Self::Output {
+        self.clone() + rhs
+    }
+}
+
+impl Add<&Linear> for &Function {
+    type Output = Function;
+    fn add(self, rhs: &Linear) -> Self::Output {
+        self.clone() + rhs
+    }
+}
+
+impl Add<&Quadratic> for &Function {
+    type Output = Function;
+    fn add(self, rhs: &Quadratic) -> Self::Output {
+        self.clone() + rhs
+    }
+}
+
+impl Add<&Polynomial> for &Function {
+    type Output = Function;
+    fn add(self, rhs: &Polynomial) -> Self::Output {
+        self.clone() + rhs
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/ommx/src/function/mul.rs
+++ b/rust/ommx/src/function/mul.rs
@@ -161,6 +161,42 @@ impl One for Function {
     }
 }
 
+// Add support for &Function operations with references
+impl Mul<&Coefficient> for &Function {
+    type Output = Function;
+    fn mul(self, rhs: &Coefficient) -> Self::Output {
+        self.clone() * *rhs
+    }
+}
+
+impl Mul<Coefficient> for &Function {
+    type Output = Function;
+    fn mul(self, rhs: Coefficient) -> Self::Output {
+        self.clone() * rhs
+    }
+}
+
+impl Mul<&Linear> for &Function {
+    type Output = Function;
+    fn mul(self, rhs: &Linear) -> Self::Output {
+        self.clone() * rhs
+    }
+}
+
+impl Mul<&Quadratic> for &Function {
+    type Output = Function;
+    fn mul(self, rhs: &Quadratic) -> Self::Output {
+        self.clone() * rhs
+    }
+}
+
+impl Mul<&Polynomial> for &Function {
+    type Output = Function;
+    fn mul(self, rhs: &Polynomial) -> Self::Output {
+        self.clone() * rhs
+    }
+}
+
 // Add property-based tests for multiplication of Function
 #[cfg(test)]
 mod tests {

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -166,6 +166,7 @@ pub use evaluate::Evaluate;
 pub use function::*;
 pub use infeasible_detected::*;
 pub use instance::*;
+pub use parse::*;
 pub use polynomial_base::*;
 pub use substitute::*;
 

--- a/rust/ommx/src/polynomial_base/add.rs
+++ b/rust/ommx/src/polynomial_base/add.rs
@@ -232,6 +232,40 @@ impl<M: Monomial> Add<PolynomialBase<M>> for &PolynomialBase<M> {
     }
 }
 
+// Special implementations for MonomialDyn + LinearMonomial/QuadraticMonomial
+impl Add<&PolynomialBase<LinearMonomial>> for &PolynomialBase<MonomialDyn> {
+    type Output = PolynomialBase<MonomialDyn>;
+    fn add(self, rhs: &PolynomialBase<LinearMonomial>) -> Self::Output {
+        let mut result = self.clone();
+        for (monomial, coeff) in rhs {
+            result.add_term(MonomialDyn::from(monomial.clone()), *coeff);
+        }
+        result
+    }
+}
+
+impl Add<&PolynomialBase<QuadraticMonomial>> for &PolynomialBase<MonomialDyn> {
+    type Output = PolynomialBase<MonomialDyn>;
+    fn add(self, rhs: &PolynomialBase<QuadraticMonomial>) -> Self::Output {
+        let mut result = self.clone();
+        for (monomial, coeff) in rhs {
+            result.add_term(MonomialDyn::from(monomial.clone()), *coeff);
+        }
+        result
+    }
+}
+
+impl Add<&PolynomialBase<LinearMonomial>> for &PolynomialBase<QuadraticMonomial> {
+    type Output = PolynomialBase<QuadraticMonomial>;
+    fn add(self, rhs: &PolynomialBase<LinearMonomial>) -> Self::Output {
+        let mut result = self.clone();
+        for (monomial, coeff) in rhs {
+            result.add_term(QuadraticMonomial::from(monomial.clone()), *coeff);
+        }
+        result
+    }
+}
+
 impl<M: Monomial> Sum for PolynomialBase<M> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::default(), Add::add)

--- a/rust/ommx/src/polynomial_base/add.rs
+++ b/rust/ommx/src/polynomial_base/add.rs
@@ -238,7 +238,7 @@ impl Add<&PolynomialBase<LinearMonomial>> for &PolynomialBase<MonomialDyn> {
     fn add(self, rhs: &PolynomialBase<LinearMonomial>) -> Self::Output {
         let mut result = self.clone();
         for (monomial, coeff) in rhs {
-            result.add_term(MonomialDyn::from(monomial.clone()), *coeff);
+            result.add_term(MonomialDyn::from(*monomial), *coeff);
         }
         result
     }
@@ -249,7 +249,7 @@ impl Add<&PolynomialBase<QuadraticMonomial>> for &PolynomialBase<MonomialDyn> {
     fn add(self, rhs: &PolynomialBase<QuadraticMonomial>) -> Self::Output {
         let mut result = self.clone();
         for (monomial, coeff) in rhs {
-            result.add_term(MonomialDyn::from(monomial.clone()), *coeff);
+            result.add_term(MonomialDyn::from(*monomial), *coeff);
         }
         result
     }
@@ -260,7 +260,7 @@ impl Add<&PolynomialBase<LinearMonomial>> for &PolynomialBase<QuadraticMonomial>
     fn add(self, rhs: &PolynomialBase<LinearMonomial>) -> Self::Output {
         let mut result = self.clone();
         for (monomial, coeff) in rhs {
-            result.add_term(QuadraticMonomial::from(monomial.clone()), *coeff);
+            result.add_term(QuadraticMonomial::from(*monomial), *coeff);
         }
         result
     }


### PR DESCRIPTION
Tasks
------
- [x] Change to use `ommx::Function` and other Rust-idiomatic structs in `ommx._ommx_rust` Python submodules