### PR TITLE
Update PyO3 to 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
+checksum = "a7cfbf3f0feededcaa4d289fe3079b03659e85c5b5a177f4ba6fb01ab4fb3e39"
 dependencies = [
  "libc",
  "ndarray",
@@ -1458,6 +1458,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
+ "pyo3-build-config",
  "rustc-hash",
 ]
 
@@ -1813,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1832,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1842,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1863,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1875,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1888,12 +1889,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7c2d6e22cba51cc9766b6dee4087218cc445fdf99db62fa4f269e074351b46"
+checksum = "5b1eaa038342df74bf2cbf9cd8e772be6110fe1187853a993a31730dea9abc6a"
 dependencies = [
  "anyhow",
  "chrono",
+ "indexmap",
  "inventory",
  "itertools 0.13.0",
  "log",
@@ -1908,10 +1910,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee49d727163163a0c6fc3fee4636c8b5c82e1bb868e85cf411be7ae9e4e5b40"
+checksum = "f75511d4a203e2532f1a7ac360add5d6ce967f851b2b7d9575cb0052200a06cb"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -2337,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ petgraph = "0.8.1"
 proptest = "1.6.0"
 prost = "0.12.6"
 prost-build = "0.12.6"
-pyo3 = { version = "0.23.5", features = ["anyhow", "abi3-py39"] }
+pyo3 = { version = "0.24.0", features = ["anyhow"] }
 pyo3-log = "0.12.4"
-pyo3-stub-gen = "0.7.0"
+pyo3-stub-gen = "0.8.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde-pyobject = "0.6.2"
 serde_json = "1.0.140"

--- a/python/ommx-highs-adapter/pyproject.toml
+++ b/python/ommx-highs-adapter/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
 ]
 
-dependencies = ["ommx >= 1.9.0rc1, < 2.0.0","highspy>=1.9.0", "numpy>=1.17.3"]
+dependencies = ["ommx >= 1.9.0rc1, < 2.0.0", "highspy>=1.9.0", "numpy>=1.17.3"]
 
 [project.urls]
 Repository = "https://github.com/Jij-Inc/ommx"

--- a/python/ommx/ommx/_ommx_rust.pyi
+++ b/python/ommx/ommx/_ommx_rust.pyi
@@ -73,7 +73,7 @@ class Bound:
     Note: This struct is named `VariableBound` in Rust code to avoid conflicts with PyO3's `Bound` type,
     but is exposed as `Bound` in Python through the `#[pyclass(name = "Bound")]` attribute.
     """
-    def __new__(cls, lower: builtins.float, upper: builtins.float): ...
+    def __new__(cls, lower: builtins.float, upper: builtins.float) -> Bound: ...
     @staticmethod
     def unbounded() -> Bound: ...
     @staticmethod
@@ -114,7 +114,7 @@ class Constraint:
         subscripts: typing.Sequence[builtins.int] = [],
         description: typing.Optional[builtins.str] = None,
         parameters: typing.Mapping[builtins.str, builtins.str] = {},
-    ): ...
+    ) -> Constraint: ...
     @staticmethod
     def decode(bytes: bytes) -> Constraint: ...
     def encode(self) -> bytes: ...
@@ -122,46 +122,32 @@ class Constraint:
         r"""
         Set the name of the constraint
         """
-        ...
-
     def set_subscripts(self, subscripts: typing.Sequence[builtins.int]) -> None:
         r"""
         Set the subscripts of the constraint
         """
-        ...
-
     def add_subscripts(self, subscripts: typing.Sequence[builtins.int]) -> None:
         r"""
         Add subscripts to the constraint
         """
-        ...
-
     def set_id(self, id: builtins.int) -> None:
         r"""
         Set the ID of the constraint
         """
-        ...
-
     def set_description(self, description: builtins.str) -> None:
         r"""
         Set the description of the constraint
         """
-        ...
-
     def set_parameters(
         self, parameters: typing.Mapping[builtins.str, builtins.str]
     ) -> None:
         r"""
         Set the parameters of the constraint
         """
-        ...
-
     def add_parameter(self, key: builtins.str, value: builtins.str) -> None:
         r"""
         Add a parameter to the constraint
         """
-        ...
-
     def __repr__(self) -> builtins.str: ...
 
 class DecisionVariable:
@@ -185,7 +171,7 @@ class DecisionVariable:
         subscripts: typing.Sequence[builtins.int] = [],
         parameters: typing.Mapping[builtins.str, builtins.str] = {},
         description: typing.Optional[builtins.str] = None,
-    ): ...
+    ) -> DecisionVariable: ...
     @staticmethod
     def binary(
         id: builtins.int,
@@ -261,6 +247,9 @@ class Descriptor:
     media_type: builtins.str
     annotations: builtins.dict[builtins.str, builtins.str]
     user_annotations: builtins.dict[builtins.str, builtins.str]
+    r"""
+    Return annotations with key prefix "org.ommx.user."
+    """
     def to_dict(self) -> dict: ...
     @staticmethod
     def from_dict(dict: dict) -> Descriptor: ...
@@ -356,7 +345,7 @@ class Linear:
         cls,
         terms: typing.Mapping[builtins.int, builtins.float],
         constant: builtins.float = 0.0,
-    ): ...
+    ) -> Linear: ...
     @staticmethod
     def single_term(id: builtins.int, coefficient: builtins.float) -> Linear: ...
     @staticmethod
@@ -395,7 +384,7 @@ class ParametricInstance:
 class Polynomial:
     def __new__(
         cls, terms: typing.Mapping[typing.Sequence[builtins.int], builtins.float]
-    ): ...
+    ) -> Polynomial: ...
     @staticmethod
     def decode(bytes: bytes) -> Polynomial: ...
     def encode(self) -> bytes: ...
@@ -430,7 +419,7 @@ class Quadratic:
         rows: typing.Sequence[builtins.int],
         values: typing.Sequence[builtins.float],
         linear: typing.Optional[Linear] = None,
-    ): ...
+    ) -> Quadratic: ...
     @staticmethod
     def decode(bytes: bytes) -> Quadratic: ...
     def encode(self) -> bytes: ...
@@ -473,17 +462,17 @@ class RemovedConstraint:
         removed_reason_parameters: typing.Optional[
             typing.Mapping[builtins.str, builtins.str]
         ] = None,
-    ): ...
+    ) -> RemovedConstraint: ...
     @staticmethod
     def decode(bytes: bytes) -> RemovedConstraint: ...
     def encode(self) -> bytes: ...
     def __repr__(self) -> builtins.str: ...
 
 class Rng:
-    def __new__(
-        cls,
-    ): ...
-    ...
+    def __new__(cls) -> Rng:
+        r"""
+        Create a new random number generator with a deterministic seed.
+        """
 
 class SampleSet:
     @staticmethod

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -40,7 +40,7 @@ Issues = "https://github.com/Jij-Inc/ommx/issues"
 
 [tool.maturin]
 module-name = "ommx._ommx_rust"
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "pyo3/abi3-py39"]
 
 [tool.ruff.lint]
 per-file-ignores = { "*_pb2.py" = ["ALL"] }


### PR DESCRIPTION
- Though PyO3 0.25 has been released, `serde-pyobject` does not support it yet
- `pyo3-stub-gen` is upgraded to 0.8.2, not 0.9.1 since it have some problem.