### PR TITLE
Revise `Instance.get_decision_variables` and related APIs

### DIFF
--- a/PYTHON_SDK_MIGRATION_GUIDE.md
+++ b/PYTHON_SDK_MIGRATION_GUIDE.md
@@ -13,9 +13,9 @@ solution.raw.evaluated_constraints[0].evaluated_value
 instance.raw.decision_variables
 sample_set.raw.samples
 
-# ✅ Recommended: Use direct methods
+# ✅ Recommended: Use direct properties and methods
 solution.get_constraint_value(0)
-instance.get_decision_variables()
+instance.decision_variables  # Now a property returning a list
 sample_set.get(sample_id)
 ```
 
@@ -171,7 +171,7 @@ def _make_quadratic_expr(self, f: Function) -> pyscipopt.Expr:
 
 - **`AttributeError: 'builtins.Function' object has no attribute 'HasField'`**: Use `.degree()` check followed by direct property access (`.linear_terms`, `.constant_term`, etc.)
 - **`TypeError: 'float' object is not callable`**: Access `function.constant_term` as a property, not `function.constant_term()`
-- **Using `.raw` attributes**: The `raw` attribute is deprecated. Use methods directly available on the classes (e.g., `solution.get_constraint_value()`, `instance.get_decision_variables()`) for better performance and type safety
+- **Using `.raw` attributes**: The `raw` attribute is deprecated. Use methods directly available on the classes (e.g., `solution.get_constraint_value()`, `instance.decision_variables`) for better performance and type safety
 
 ## Important Notes
 
@@ -462,9 +462,9 @@ return State(entries={
 **Individual Access**:
 ```python
 # Get specific items by ID (with KeyError on missing ID)
-var = instance.get_decision_variable(variable_id)
-constraint = instance.get_constraint(constraint_id)
-removed_constraint = instance.get_removed_constraint(constraint_id)
+var = instance.get_decision_variable_by_id(variable_id)  # Individual variable access
+constraint = instance.get_constraint_by_id(constraint_id)  # Individual constraint access
+removed_constraint = instance.get_removed_constraint(constraint_id)  # Individual removed constraint access
 ```
 
 ### Required Adapter Changes
@@ -473,6 +473,7 @@ removed_constraint = instance.get_removed_constraint(constraint_id)
 2. **Update iteration patterns**: Change from `dict.items()` to direct list iteration
 3. **Access individual IDs**: Use `.id` property on each object instead of dict keys
 4. **Update sense access**: Use `instance.sense` instead of `instance.raw.sense`
+5. **Use new individual access methods**: Use `get_decision_variable_by_id()` and `get_constraint_by_id()` for individual item access
 
 ### Migration Checklist for Adapters
 
@@ -482,6 +483,8 @@ removed_constraint = instance.get_removed_constraint(constraint_id)
 - [ ] Update variable access from `(var_id, var)` → `var` (use `var.id`)
 - [ ] Update constraint access from `(constraint_id, constraint)` → `constraint` (use `constraint.id`)
 - [ ] Update test assertions from `len(instance.decision_variables())` → `len(instance.decision_variables)`
+- [ ] Use `instance.get_decision_variable_by_id(id)` for individual variable access
+- [ ] Use `instance.get_constraint_by_id(id)` for individual constraint access
 
 ---
 

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -414,18 +414,18 @@ class OMMXHighsAdapter(SolverAdapter):
         return State(
             entries={
                 var.id: solution.col_value[i]
-                for i, var in enumerate(self.instance.decision_variables())
+                for i, var in enumerate(self.instance.decision_variables)
             }
         )
 
     def _set_decision_variables(self):
-        num_cols = len(self.instance.raw.decision_variables)
+        num_cols = len(self.instance.decision_variables)
         lower = np.zeros(num_cols)
         upper = np.zeros(num_cols)
         types = []
         var_ids = []
 
-        for i, var in enumerate(self.instance.decision_variables()):
+        for i, var in enumerate(self.instance.decision_variables):
             var_ids.append(var.id)
             if var.kind == DecisionVariable.BINARY:
                 lower[i] = 0
@@ -476,7 +476,7 @@ class OMMXHighsAdapter(SolverAdapter):
             raise OMMXHighsAdapterError(f"Unsupported sense: {self.instance.sense}")
 
     def _set_constraints(self):
-        for constr in self.instance.constraints():
+        for constr in self.instance.constraints:
             const_expr = self._linear_expr_conversion(constr.function)
             if isinstance(const_expr, float):
                 val = const_expr

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -414,7 +414,7 @@ class OMMXHighsAdapter(SolverAdapter):
         return State(
             entries={
                 var.id: solution.col_value[i]
-                for i, var in enumerate(self.instance.get_decision_variables())
+                for i, var in enumerate(self.instance.decision_variables())
             }
         )
 
@@ -425,7 +425,7 @@ class OMMXHighsAdapter(SolverAdapter):
         types = []
         var_ids = []
 
-        for i, var in enumerate(self.instance.get_decision_variables()):
+        for i, var in enumerate(self.instance.decision_variables()):
             var_ids.append(var.id)
             if var.kind == DecisionVariable.BINARY:
                 lower[i] = 0
@@ -476,7 +476,7 @@ class OMMXHighsAdapter(SolverAdapter):
             raise OMMXHighsAdapterError(f"Unsupported sense: {self.instance.sense}")
 
     def _set_constraints(self):
-        for constr in self.instance.get_constraints():
+        for constr in self.instance.constraints():
             const_expr = self._linear_expr_conversion(constr.function)
             if isinstance(const_expr, float):
                 val = const_expr

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -271,8 +271,8 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             varname_map = {var.name: var for var in data.getVars()}
             return State(
                 entries={
-                    var_id: sol[varname_map[str(var_id)]]
-                    for var_id, _ in self.instance.raw.decision_variables.items()
+                    var.id: sol[varname_map[str(var.id)]]
+                    for var in self.instance.decision_variables
                 }
             )
         except Exception:
@@ -281,7 +281,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             )
 
     def _set_decision_variables(self):
-        for var in self.instance.decision_variables():
+        for var in self.instance.decision_variables:
             if var.kind == DecisionVariable.BINARY:
                 self.model.addVar(name=str(var.id), vtype="B")
             elif var.kind == DecisionVariable.INTEGER:
@@ -382,7 +382,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                 vars = [self.varname_map[str(v)] for v in sos1.variables]
                 self.model.addConsSOS1(vars, name=name)
 
-        for constraint in self.instance.constraints():
+        for constraint in self.instance.constraints:
             if constraint.id in excluded:
                 continue
 

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -281,7 +281,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             )
 
     def _set_decision_variables(self):
-        for var in self.instance.get_decision_variables():
+        for var in self.instance.decision_variables():
             if var.kind == DecisionVariable.BINARY:
                 self.model.addVar(name=str(var.id), vtype="B")
             elif var.kind == DecisionVariable.INTEGER:
@@ -382,7 +382,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                 vars = [self.varname_map[str(v)] for v in sos1.variables]
                 self.model.addConsSOS1(vars, name=name)
 
-        for constraint in self.instance.get_constraints():
+        for constraint in self.instance.constraints():
             if constraint.id in excluded:
                 continue
 

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
@@ -27,13 +27,13 @@ class OMMXPythonMIPAdapter(SolverAdapter):
         :param solver: Passes a specific solver to the Python-MIP model.
         :param verbose: If True, enable Python-MIP's verbose mode
         """
-        if ommx_instance.raw.sense == Instance.MAXIMIZE:
+        if ommx_instance.sense == Instance.MAXIMIZE:
             sense = mip.MAXIMIZE
-        elif ommx_instance.raw.sense == Instance.MINIMIZE:
+        elif ommx_instance.sense == Instance.MINIMIZE:
             sense = mip.MINIMIZE
         else:
             raise OMMXPythonMIPAdapterError(
-                f"Unsupported sense: {ommx_instance.raw.sense}"
+                f"Unsupported sense: {ommx_instance.sense}"
             )
         self.instance = ommx_instance
         self.model = mip.Model(
@@ -297,13 +297,13 @@ class OMMXPythonMIPAdapter(SolverAdapter):
 
         return State(
             entries={
-                var_id: data.var_by_name(str(var_id)).x  # type: ignore
-                for var_id, var in self.instance.raw.decision_variables.items()
+                var.id: data.var_by_name(str(var.id)).x  # type: ignore
+                for var in self.instance.decision_variables
             }
         )
 
     def _set_decision_variables(self):
-        for var_id, var in self.instance.raw.decision_variables.items():
+        for var in self.instance.decision_variables:
             if var.kind == DecisionVariable.BINARY:
                 self.model.add_var(
                     name=str(var.id),
@@ -358,7 +358,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
         self.model.objective = self._as_lin_expr(self.instance.objective)
 
     def _set_constraints(self):
-        for constraint in self.instance.constraints():
+        for constraint in self.instance.constraints:
             lin_expr = self._as_lin_expr(constraint.function)
             if constraint.equality == Constraint.EQUAL_TO_ZERO:
                 constr_expr = lin_expr == 0

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
@@ -358,7 +358,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
         self.model.objective = self._as_lin_expr(self.instance.objective)
 
     def _set_constraints(self):
-        for constraint in self.instance.get_constraints():
+        for constraint in self.instance.constraints():
             lin_expr = self._as_lin_expr(constraint.function)
             if constraint.equality == Constraint.EQUAL_TO_ZERO:
                 constr_expr = lin_expr == 0

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
@@ -32,9 +32,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
         elif ommx_instance.sense == Instance.MINIMIZE:
             sense = mip.MINIMIZE
         else:
-            raise OMMXPythonMIPAdapterError(
-                f"Unsupported sense: {ommx_instance.sense}"
-            )
+            raise OMMXPythonMIPAdapterError(f"Unsupported sense: {ommx_instance.sense}")
         self.instance = ommx_instance
         self.model = mip.Model(
             sense=sense,

--- a/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
+++ b/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
@@ -48,7 +48,7 @@ def test_milp():
     assert ommx_instance.sense == Instance.MINIMIZE
 
     # Check the decision variables
-    assert len(ommx_instance.get_decision_variables()) == 3
+    assert len(ommx_instance.decision_variables()) == 3
     decision_variables_x1 = ommx_instance.get_decision_variable(0)
     assert decision_variables_x1.id == 0
     assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
@@ -78,7 +78,7 @@ def test_milp():
     assert linear_terms[2] == -3
 
     # Check the constraints
-    assert len(ommx_instance.get_constraints()) == 3
+    assert len(ommx_instance.constraints()) == 3
 
     constraint1 = ommx_instance.get_constraint(0)
     assert constraint1.equality == Constraint.EQUAL_TO_ZERO
@@ -141,7 +141,7 @@ def test_no_objective_model():
     assert ommx_instance.sense == Instance.MAXIMIZE
 
     # Check the decision variables
-    assert len(ommx_instance.get_decision_variables()) == 2
+    assert len(ommx_instance.decision_variables()) == 2
     decision_variables_x1 = ommx_instance.get_decision_variable(0)
     assert decision_variables_x1.id == 0
     assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
@@ -160,7 +160,7 @@ def test_no_objective_model():
     assert ommx_instance.objective.num_terms() == 0  # Zero function has 0 terms
 
     # Check the constraints
-    assert len(ommx_instance.get_constraints()) == 2
+    assert len(ommx_instance.constraints()) == 2
 
     constraint1 = ommx_instance.get_constraint(0)
     assert constraint1.equality == Constraint.EQUAL_TO_ZERO

--- a/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
+++ b/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
@@ -49,19 +49,19 @@ def test_milp():
 
     # Check the decision variables
     assert len(ommx_instance.decision_variables) == 3
-    decision_variables_x1 = ommx_instance.get_decision_variable(0)
+    decision_variables_x1 = ommx_instance.get_decision_variable_by_id(0)
     assert decision_variables_x1.id == 0
     assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
     assert decision_variables_x1.bound.lower == CONTINUOUS_LOWER_BOUND
     assert decision_variables_x1.bound.upper == CONTINUOUS_UPPER_BOUND
     assert decision_variables_x1.name == "1"
-    decision_variables_x2 = ommx_instance.get_decision_variable(1)
+    decision_variables_x2 = ommx_instance.get_decision_variable_by_id(1)
     assert decision_variables_x2.id == 1
     assert decision_variables_x2.kind == DecisionVariable.INTEGER
     assert decision_variables_x2.bound.lower == INTEGER_LOWER_BOUND
     assert decision_variables_x2.bound.upper == INTEGER_UPPER_BOUND
     assert decision_variables_x2.name == "2"
-    decision_variables_x3 = ommx_instance.get_decision_variable(2)
+    decision_variables_x3 = ommx_instance.get_decision_variable_by_id(2)
     assert decision_variables_x3.id == 2
     assert decision_variables_x3.kind == DecisionVariable.BINARY
     assert decision_variables_x3.bound.lower == 0
@@ -80,7 +80,7 @@ def test_milp():
     # Check the constraints
     assert len(ommx_instance.constraints) == 3
 
-    constraint1 = ommx_instance.get_constraint(0)
+    constraint1 = ommx_instance.get_constraint_by_id(0)
     assert constraint1.equality == Constraint.EQUAL_TO_ZERO
     assert constraint1.function.degree() == 1
     assert constraint1.function.constant_term == 6
@@ -89,7 +89,7 @@ def test_milp():
     assert constraint1_terms[0] == 4
     assert constraint1_terms[1] == -5
 
-    constraint2 = ommx_instance.get_constraint(1)
+    constraint2 = ommx_instance.get_constraint_by_id(1)
     assert constraint2.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
     assert constraint2.function.degree() == 1
     assert constraint2.function.constant_term == -9
@@ -98,7 +98,7 @@ def test_milp():
     assert constraint2_terms[0] == -7
     assert constraint2_terms[2] == 8
 
-    constraint3 = ommx_instance.get_constraint(2)
+    constraint3 = ommx_instance.get_constraint_by_id(2)
     assert constraint3.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
     assert constraint3.function.degree() == 1
     assert constraint3.function.constant_term == -12
@@ -142,13 +142,13 @@ def test_no_objective_model():
 
     # Check the decision variables
     assert len(ommx_instance.decision_variables) == 2
-    decision_variables_x1 = ommx_instance.get_decision_variable(0)
+    decision_variables_x1 = ommx_instance.get_decision_variable_by_id(0)
     assert decision_variables_x1.id == 0
     assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
     assert decision_variables_x1.bound.lower == LOWER_BOUND
     assert decision_variables_x1.bound.upper == UPPER_BOUND
     assert decision_variables_x1.name == "1"
-    decision_variables_x2 = ommx_instance.get_decision_variable(1)
+    decision_variables_x2 = ommx_instance.get_decision_variable_by_id(1)
     assert decision_variables_x2.id == 1
     assert decision_variables_x2.kind == DecisionVariable.CONTINUOUS
     assert decision_variables_x2.bound.lower == LOWER_BOUND
@@ -162,7 +162,7 @@ def test_no_objective_model():
     # Check the constraints
     assert len(ommx_instance.constraints) == 2
 
-    constraint1 = ommx_instance.get_constraint(0)
+    constraint1 = ommx_instance.get_constraint_by_id(0)
     assert constraint1.equality == Constraint.EQUAL_TO_ZERO
     assert constraint1.function.degree() == 1
     assert constraint1.function.constant_term == -5
@@ -171,7 +171,7 @@ def test_no_objective_model():
     assert constraint1_terms[0] == 1
     assert constraint1_terms[1] == 2
 
-    constraint2 = ommx_instance.get_constraint(1)
+    constraint2 = ommx_instance.get_constraint_by_id(1)
     assert constraint2.equality == Constraint.EQUAL_TO_ZERO
     assert constraint2.function.degree() == 1
     assert constraint2.function.constant_term == -10

--- a/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
+++ b/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
@@ -48,7 +48,7 @@ def test_milp():
     assert ommx_instance.sense == Instance.MINIMIZE
 
     # Check the decision variables
-    assert len(ommx_instance.decision_variables()) == 3
+    assert len(ommx_instance.decision_variables) == 3
     decision_variables_x1 = ommx_instance.get_decision_variable(0)
     assert decision_variables_x1.id == 0
     assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
@@ -78,7 +78,7 @@ def test_milp():
     assert linear_terms[2] == -3
 
     # Check the constraints
-    assert len(ommx_instance.constraints()) == 3
+    assert len(ommx_instance.constraints) == 3
 
     constraint1 = ommx_instance.get_constraint(0)
     assert constraint1.equality == Constraint.EQUAL_TO_ZERO
@@ -141,7 +141,7 @@ def test_no_objective_model():
     assert ommx_instance.sense == Instance.MAXIMIZE
 
     # Check the decision variables
-    assert len(ommx_instance.decision_variables()) == 2
+    assert len(ommx_instance.decision_variables) == 2
     decision_variables_x1 = ommx_instance.get_decision_variable(0)
     assert decision_variables_x1.id == 0
     assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
@@ -160,7 +160,7 @@ def test_no_objective_model():
     assert ommx_instance.objective.num_terms() == 0  # Zero function has 0 terms
 
     # Check the constraints
-    assert len(ommx_instance.constraints()) == 2
+    assert len(ommx_instance.constraints) == 2
 
     constraint1 = ommx_instance.get_constraint(0)
     assert constraint1.equality == Constraint.EQUAL_TO_ZERO

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -88,8 +88,8 @@ def test_convert_inequality_to_equality_with_integer_slack_trivial():
     instance.convert_inequality_to_equality_with_integer_slack(
         constraint_id=0, max_integer_range=32
     )
-    assert instance.get_constraints() == []
-    removed = instance.get_removed_constraints()[0]
+    assert instance.constraints == []
+    removed = instance.removed_constraints[0]
     assert removed.id == 0
 
 
@@ -133,8 +133,8 @@ def test_add_integer_slack_to_inequality_trivial():
     assert b is None
 
     # Check that the constraint is removed
-    assert instance.get_constraints() == []
-    removed = instance.get_removed_constraints()[0]
+    assert instance.constraints == []
+    removed = instance.removed_constraints[0]
     assert removed.id == 0
 
 

--- a/python/ommx-tests/tests/test_mps.py
+++ b/python/ommx-tests/tests/test_mps.py
@@ -86,7 +86,7 @@ def test_output():
     dvars_before = instance.decision_variables
     dvars_after = loaded.decision_variables
     assert len(dvars_before) == len(dvars_after)
-    for (b, a) in zip(dvars_before, dvars_after):
+    for b, a in zip(dvars_before, dvars_after):
         assert b.id == a.id
         # Note: MPS format does not preserve variable names (see Instance.write_mps docstring)
         # assert b.name == a.name  # Skip name check as it's not preserved
@@ -98,7 +98,7 @@ def test_output():
     constr_before = instance.constraints
     constr_after = loaded.constraints
     assert len(constr_before) == len(constr_after)
-    for (b, a) in zip(constr_before, constr_after):
+    for b, a in zip(constr_before, constr_after):
         assert b.id == a.id
         # Note: MPS format does not preserve constraint names (see Instance.write_mps docstring)
         # assert before.name == after.name  # Skip name check as it's not preserved

--- a/python/ommx-tests/tests/test_mps.py
+++ b/python/ommx-tests/tests/test_mps.py
@@ -11,9 +11,9 @@ def test_example_mps():
     instance = ommx.mps.load_file(str(test_dir / "objsense_max.mps.gz"))
 
     assert instance.raw.sense == Instance.MAXIMIZE  # OBJSENSE field is specified
-    dvars = instance.get_decision_variables()
+    dvars = instance.decision_variables
     dvars.sort(key=lambda x: x.name)
-    constraints = instance.get_constraints()
+    constraints = instance.constraints
     constraints.sort(key=lambda c: c.name or "")
 
     assert len(dvars) == 3
@@ -83,12 +83,10 @@ def test_output():
     loaded = ommx.mps.load_file(test_out_file)
 
     # convert to a format easier to test.
-    dvars_before = instance.raw.decision_variables
-    dvars_after = loaded.raw.decision_variables
-    assert dvars_before.keys() == dvars_after.keys()
-    for key in dvars_before.keys():
-        b = dvars_before[key]
-        a = dvars_after[key]
+    dvars_before = instance.decision_variables
+    dvars_after = loaded.decision_variables
+    assert len(dvars_before) == len(dvars_after)
+    for (b, a) in zip(dvars_before, dvars_after):
         assert b.id == a.id
         # Note: MPS format does not preserve variable names (see Instance.write_mps docstring)
         # assert b.name == a.name  # Skip name check as it's not preserved
@@ -97,19 +95,16 @@ def test_output():
         assert b.bound.upper == a.bound.upper
         assert b.subscripts == a.subscripts
 
-    constr_before = instance.raw.constraints
-    constr_after = loaded.raw.constraints
-    assert constr_before.keys() == constr_after.keys()
-
-    for key in constr_before.keys():
-        before = constr_before[key]
-        after = constr_after[key]
-        assert before.id == after.id
+    constr_before = instance.constraints
+    constr_after = loaded.constraints
+    assert len(constr_before) == len(constr_after)
+    for (b, a) in zip(constr_before, constr_after):
+        assert b.id == a.id
         # Note: MPS format does not preserve constraint names (see Instance.write_mps docstring)
         # assert before.name == after.name  # Skip name check as it's not preserved
-        assert before.equality == after.equality
-        assert before.subscripts == after.subscripts
-        assert before.function.almost_equal(after.function)
+        assert b.equality == a.equality
+        assert b.subscripts == a.subscripts
+        assert b.function.almost_equal(a.function)
 
     # same as above for objective function
-    assert instance.raw.objective.almost_equal(loaded.raw.objective)
+    assert instance.objective.almost_equal(loaded.objective)

--- a/python/ommx/ommx/_ommx_rust.pyi
+++ b/python/ommx/ommx/_ommx_rust.pyi
@@ -479,9 +479,18 @@ class Function:
 class Instance:
     sense: Sense
     objective: Function
-    decision_variables: builtins.dict[builtins.int, DecisionVariable]
-    constraints: builtins.dict[builtins.int, Constraint]
-    removed_constraints: builtins.dict[builtins.int, RemovedConstraint]
+    decision_variables: builtins.list[DecisionVariable]
+    r"""
+    List of all decision variables in the instance sorted by their IDs.
+    """
+    constraints: builtins.list[Constraint]
+    r"""
+    List of all decision variables in the instance sorted by their IDs.
+    """
+    removed_constraints: builtins.list[RemovedConstraint]
+    r"""
+    List of all removed constraints in the instance sorted by their IDs.
+    """
     description: typing.Optional[InstanceDescription]
     constraint_hints: ConstraintHints
     @staticmethod

--- a/python/ommx/ommx/_ommx_rust.pyi
+++ b/python/ommx/ommx/_ommx_rust.pyi
@@ -543,15 +543,19 @@ class Instance:
     def __deepcopy__(self, _memo: typing.Any) -> Instance: ...
     def as_minimization_problem(self) -> builtins.bool: ...
     def as_maximization_problem(self) -> builtins.bool: ...
-    def get_decision_variable(self, variable_id: builtins.int) -> DecisionVariable:
+    def get_decision_variable_by_id(
+        self, variable_id: builtins.int
+    ) -> DecisionVariable:
         r"""
         Get a specific decision variable by ID
         """
-    def get_constraint(self, constraint_id: builtins.int) -> Constraint:
+    def get_constraint_by_id(self, constraint_id: builtins.int) -> Constraint:
         r"""
         Get a specific constraint by ID
         """
-    def get_removed_constraint(self, constraint_id: builtins.int) -> RemovedConstraint:
+    def get_removed_constraint_by_id(
+        self, constraint_id: builtins.int
+    ) -> RemovedConstraint:
         r"""
         Get a specific removed constraint by ID
         """

--- a/python/ommx/ommx/_ommx_rust.pyi
+++ b/python/ommx/ommx/_ommx_rust.pyi
@@ -534,6 +534,18 @@ class Instance:
     def __deepcopy__(self, _memo: typing.Any) -> Instance: ...
     def as_minimization_problem(self) -> builtins.bool: ...
     def as_maximization_problem(self) -> builtins.bool: ...
+    def get_decision_variable(self, variable_id: builtins.int) -> DecisionVariable:
+        r"""
+        Get a specific decision variable by ID
+        """
+    def get_constraint(self, constraint_id: builtins.int) -> Constraint:
+        r"""
+        Get a specific constraint by ID
+        """
+    def get_removed_constraint(self, constraint_id: builtins.int) -> RemovedConstraint:
+        r"""
+        Get a specific removed constraint by ID
+        """
 
 class InstanceDescription:
     name: typing.Optional[builtins.str]

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -1860,7 +1860,7 @@ class ParametricInstance(UserAnnotationBase):
         """
         return [Parameter(raw) for raw in self.raw.parameters]
 
-    def get_parameter(self, parameter_id: int) -> Parameter:
+    def get_parameter_by_id(self, parameter_id: int) -> Parameter:
         """
         Get a parameter by ID.
         """
@@ -1878,7 +1878,7 @@ class ParametricInstance(UserAnnotationBase):
                 return v
         raise ValueError(f"Decision variable ID {variable_id} is not found")
 
-    def get_constraint(self, constraint_id: int) -> Constraint:
+    def get_constraint_by_id(self, constraint_id: int) -> Constraint:
         """
         Get a constraint by ID.
         """
@@ -1887,7 +1887,7 @@ class ParametricInstance(UserAnnotationBase):
                 return c
         raise ValueError(f"Constraint ID {constraint_id} is not found")
 
-    def get_removed_constraint(self, removed_constraint_id: int) -> RemovedConstraint:
+    def get_removed_constraint_by_id(self, removed_constraint_id: int) -> RemovedConstraint:
         """
         Get a removed constraint by ID.
         """

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -405,24 +405,24 @@ class Instance(UserAnnotationBase):
         """
         return [RemovedConstraint.from_raw(rc) for rc in self.raw.removed_constraints]
 
-    def get_decision_variable(self, variable_id: int) -> DecisionVariable:
+    def get_decision_variable_by_id(self, variable_id: int) -> DecisionVariable:
         """
         Get a decision variable by ID.
         """
-        return DecisionVariable(self.raw.get_decision_variable(variable_id))
+        return DecisionVariable(self.raw.get_decision_variable_by_id(variable_id))
 
-    def get_constraint(self, constraint_id: int) -> Constraint:
+    def get_constraint_by_id(self, constraint_id: int) -> Constraint:
         """
         Get a constraint by ID.
         """
-        return Constraint.from_raw(self.raw.get_constraint(constraint_id))
+        return Constraint.from_raw(self.raw.get_constraint_by_id(constraint_id))
 
-    def get_removed_constraint(self, removed_constraint_id: int) -> RemovedConstraint:
+    def get_removed_constraint_by_id(self, removed_constraint_id: int) -> RemovedConstraint:
         """
         Get a removed constraint by ID.
         """
         return RemovedConstraint.from_raw(
-            self.raw.get_removed_constraint(removed_constraint_id)
+            self.raw.get_removed_constraint_by_id(removed_constraint_id)
         )
 
     @property
@@ -722,7 +722,7 @@ class Instance(UserAnnotationBase):
 
         >>> instance.objective
         Function(-x3*x3 - 2*x3*x4 - 4*x3*x5 - 4*x3*x6 - 2*x3*x7 - 4*x3*x8 - x4*x4 - 4*x4*x5 - 4*x4*x6 - 2*x4*x7 - 4*x4*x8 - 4*x5*x5 - 8*x5*x6 - 4*x5*x7 - 8*x5*x8 - 4*x6*x6 - 4*x6*x7 - 8*x6*x8 - x7*x7 - 4*x7*x8 - 4*x8*x8 + 7*x3 + 7*x4 + 13*x5 + 13*x6 + 6*x7 + 12*x8 - 9)
-        >>> instance.get_removed_constraint(0)
+        >>> instance.get_removed_constraint_by_id(0)
         RemovedConstraint(x3 + x4 + 2*x5 + 2*x6 + x7 + 2*x8 - 3 == 0, reason=uniform_penalty_method)
 
         Solvers will return solutions which only contain log-encoded binary variables like:
@@ -1869,7 +1869,7 @@ class ParametricInstance(UserAnnotationBase):
                 return Parameter(p)
         raise ValueError(f"Parameter ID {parameter_id} is not found")
 
-    def get_decision_variable(self, variable_id: int) -> DecisionVariable:
+    def get_decision_variable_by_id(self, variable_id: int) -> DecisionVariable:
         """
         Get a decision variable by ID.
         """

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -417,7 +417,9 @@ class Instance(UserAnnotationBase):
         """
         return Constraint.from_raw(self.raw.get_constraint_by_id(constraint_id))
 
-    def get_removed_constraint_by_id(self, removed_constraint_id: int) -> RemovedConstraint:
+    def get_removed_constraint_by_id(
+        self, removed_constraint_id: int
+    ) -> RemovedConstraint:
         """
         Get a removed constraint by ID.
         """
@@ -1887,7 +1889,9 @@ class ParametricInstance(UserAnnotationBase):
                 return c
         raise ValueError(f"Constraint ID {constraint_id} is not found")
 
-    def get_removed_constraint_by_id(self, removed_constraint_id: int) -> RemovedConstraint:
+    def get_removed_constraint_by_id(
+        self, removed_constraint_id: int
+    ) -> RemovedConstraint:
         """
         Get a removed constraint by ID.
         """

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -95,65 +95,8 @@ Type alias for convertible types to :class:`Samples`.
 """
 
 
-class InstanceBase(ABC):
-    @abstractmethod
-    def get_decision_variables(self) -> list[DecisionVariable]: ...
-    @abstractmethod
-    def get_constraints(self) -> list[Constraint]: ...
-    @abstractmethod
-    def get_removed_constraints(self) -> list[RemovedConstraint]: ...
-
-    def get_decision_variable(self, variable_id: int) -> DecisionVariable:
-        """
-        Get a decision variable by ID.
-        """
-        for v in self.get_decision_variables():
-            if v.id == variable_id:
-                return v
-        raise ValueError(f"Decision variable ID {variable_id} is not found")
-
-    def get_constraint(self, constraint_id: int) -> Constraint:
-        """
-        Get a constraint by ID.
-        """
-        for c in self.get_constraints():
-            if c.id == constraint_id:
-                return c
-        raise ValueError(f"Constraint ID {constraint_id} is not found")
-
-    def get_removed_constraint(self, removed_constraint_id: int) -> RemovedConstraint:
-        """
-        Get a removed constraint by ID.
-        """
-        for rc in self.get_removed_constraints():
-            if rc.id == removed_constraint_id:
-                return rc
-        raise ValueError(f"Removed constraint ID {removed_constraint_id} is not found")
-
-    @property
-    def decision_variables_df(self) -> DataFrame:
-        df = DataFrame(v._as_pandas_entry() for v in self.get_decision_variables())
-        if not df.empty:
-            df = df.set_index("id")
-        return df
-
-    @property
-    def constraints_df(self) -> DataFrame:
-        df = DataFrame(c._as_pandas_entry() for c in self.get_constraints())
-        if not df.empty:
-            df = df.set_index("id")
-        return df
-
-    @property
-    def removed_constraints_df(self) -> DataFrame:
-        df = DataFrame(rc._as_pandas_entry() for rc in self.get_removed_constraints())
-        if not df.empty:
-            df = df.set_index("id")
-        return df
-
-
 @dataclass
-class Instance(InstanceBase, UserAnnotationBase):
+class Instance(UserAnnotationBase):
     """
     Idiomatic wrapper of ``ommx.v1.Instance`` protobuf message.
 
@@ -469,6 +412,54 @@ class Instance(InstanceBase, UserAnnotationBase):
                 self.raw.removed_constraints.items()
             )
         ]
+
+    def get_decision_variable(self, variable_id: int) -> DecisionVariable:
+        """
+        Get a decision variable by ID.
+        """
+        for v in self.get_decision_variables():
+            if v.id == variable_id:
+                return v
+        raise ValueError(f"Decision variable ID {variable_id} is not found")
+
+    def get_constraint(self, constraint_id: int) -> Constraint:
+        """
+        Get a constraint by ID.
+        """
+        for c in self.get_constraints():
+            if c.id == constraint_id:
+                return c
+        raise ValueError(f"Constraint ID {constraint_id} is not found")
+
+    def get_removed_constraint(self, removed_constraint_id: int) -> RemovedConstraint:
+        """
+        Get a removed constraint by ID.
+        """
+        for rc in self.get_removed_constraints():
+            if rc.id == removed_constraint_id:
+                return rc
+        raise ValueError(f"Removed constraint ID {removed_constraint_id} is not found")
+
+    @property
+    def decision_variables_df(self) -> DataFrame:
+        df = DataFrame(v._as_pandas_entry() for v in self.get_decision_variables())
+        if not df.empty:
+            df = df.set_index("id")
+        return df
+
+    @property
+    def constraints_df(self) -> DataFrame:
+        df = DataFrame(c._as_pandas_entry() for c in self.get_constraints())
+        if not df.empty:
+            df = df.set_index("id")
+        return df
+
+    @property
+    def removed_constraints_df(self) -> DataFrame:
+        df = DataFrame(rc._as_pandas_entry() for rc in self.get_removed_constraints())
+        if not df.empty:
+            df = df.set_index("id")
+        return df
 
     def evaluate(self, state: ToState) -> Solution:
         r"""
@@ -1720,7 +1711,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
 
 @dataclass
-class ParametricInstance(InstanceBase, UserAnnotationBase):
+class ParametricInstance(UserAnnotationBase):
     """
     Idiomatic wrapper of ``ommx.v1.ParametricInstance`` protobuf message.
 
@@ -1888,6 +1879,54 @@ class ParametricInstance(InstanceBase, UserAnnotationBase):
             if p.id == parameter_id:
                 return Parameter(p)
         raise ValueError(f"Parameter ID {parameter_id} is not found")
+
+    def get_decision_variable(self, variable_id: int) -> DecisionVariable:
+        """
+        Get a decision variable by ID.
+        """
+        for v in self.get_decision_variables():
+            if v.id == variable_id:
+                return v
+        raise ValueError(f"Decision variable ID {variable_id} is not found")
+
+    def get_constraint(self, constraint_id: int) -> Constraint:
+        """
+        Get a constraint by ID.
+        """
+        for c in self.get_constraints():
+            if c.id == constraint_id:
+                return c
+        raise ValueError(f"Constraint ID {constraint_id} is not found")
+
+    def get_removed_constraint(self, removed_constraint_id: int) -> RemovedConstraint:
+        """
+        Get a removed constraint by ID.
+        """
+        for rc in self.get_removed_constraints():
+            if rc.id == removed_constraint_id:
+                return rc
+        raise ValueError(f"Removed constraint ID {removed_constraint_id} is not found")
+
+    @property
+    def decision_variables_df(self) -> DataFrame:
+        df = DataFrame(v._as_pandas_entry() for v in self.get_decision_variables())
+        if not df.empty:
+            df = df.set_index("id")
+        return df
+
+    @property
+    def constraints_df(self) -> DataFrame:
+        df = DataFrame(c._as_pandas_entry() for c in self.get_constraints())
+        if not df.empty:
+            df = df.set_index("id")
+        return df
+
+    @property
+    def removed_constraints_df(self) -> DataFrame:
+        df = DataFrame(rc._as_pandas_entry() for rc in self.get_removed_constraints())
+        if not df.empty:
+            df = df.set_index("id")
+        return df
 
     @property
     def parameters(self) -> DataFrame:

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -131,21 +131,21 @@ class InstanceBase(ABC):
         raise ValueError(f"Removed constraint ID {removed_constraint_id} is not found")
 
     @property
-    def decision_variables(self) -> DataFrame:
+    def decision_variables_df(self) -> DataFrame:
         df = DataFrame(v._as_pandas_entry() for v in self.get_decision_variables())
         if not df.empty:
             df = df.set_index("id")
         return df
 
     @property
-    def constraints(self) -> DataFrame:
+    def constraints_df(self) -> DataFrame:
         df = DataFrame(c._as_pandas_entry() for c in self.get_constraints())
         if not df.empty:
             df = df.set_index("id")
         return df
 
     @property
-    def removed_constraints(self) -> DataFrame:
+    def removed_constraints_df(self) -> DataFrame:
         df = DataFrame(rc._as_pandas_entry() for rc in self.get_removed_constraints())
         if not df.empty:
             df = df.set_index("id")
@@ -729,7 +729,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
             * ``ommx.log_encode`` binary variables :math:`x_3, \ldots, x_8` introduced by :py:meth:`log_encode`.
 
-        >>> instance.decision_variables.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
+        >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper             name subscripts
         id
         0   Integer   -0.0    2.0                x        [0]
@@ -1495,7 +1495,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         Added binary variables are also appeared in :attr:`decision_variables`
 
-        >>> instance.decision_variables[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
+        >>> instance.decision_variables_df[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper             name subscripts
         id
         0   Integer   -0.0    3.0                x        [0]
@@ -1595,7 +1595,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         The slack variable is added to the decision variables with name `ommx.slack` and the constraint ID is stored in `subscripts`.
 
-        >>> instance.decision_variables[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
+        >>> instance.decision_variables_df[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper        name subscripts
         id
         0   Integer   -0.0    3.0           x        [0]
@@ -1669,7 +1669,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         The slack variable is added to the decision variables with name `ommx.slack` and the constraint ID is stored in `subscripts`.
 
-        >>> instance.decision_variables[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
+        >>> instance.decision_variables_df[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper        name subscripts
         id
         0   Integer   -0.0    3.0           x        [0]

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -386,32 +386,21 @@ class Instance(UserAnnotationBase):
 
     def get_decision_variables(self) -> list[DecisionVariable]:
         """
-        Get decision variables as a list of :class:`DecisionVariable` instances.
+        Get decision variables as a list of :class:`DecisionVariable` instances sorted by their IDs.
         """
-        return [
-            DecisionVariable(rust_dv)
-            for _, rust_dv in sorted(self.raw.decision_variables.items())
-        ]
+        return [DecisionVariable(dv) for dv in self.raw.decision_variables]
 
     def get_constraints(self) -> list[Constraint]:
         """
-        Get constraints as a list of :class:`Constraint` instances.
+        Get constraints as a list of :class:`Constraint` instances sorted by their IDs.
         """
-        return [
-            Constraint.from_raw(rust_constraint)
-            for _, rust_constraint in sorted(self.raw.constraints.items())
-        ]
+        return [Constraint.from_raw(c) for c in self.raw.constraints]
 
     def get_removed_constraints(self) -> list[RemovedConstraint]:
         """
         Get removed constraints as a list of :class:`RemovedConstraint` instances.
         """
-        return [
-            RemovedConstraint.from_raw(rust_removed_constraint)
-            for _, rust_removed_constraint in sorted(
-                self.raw.removed_constraints.items()
-            )
-        ]
+        return [RemovedConstraint.from_raw(rc) for rc in self.raw.removed_constraints]
 
     def get_decision_variable(self, variable_id: int) -> DecisionVariable:
         """

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -421,7 +421,9 @@ class Instance(UserAnnotationBase):
         """
         Get a removed constraint by ID.
         """
-        return RemovedConstraint.from_raw(self.raw.get_removed_constraint(removed_constraint_id))
+        return RemovedConstraint.from_raw(
+            self.raw.get_removed_constraint(removed_constraint_id)
+        )
 
     @property
     def decision_variables_df(self) -> DataFrame:

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -1495,7 +1495,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         Added binary variables are also appeared in :attr:`decision_variables`
 
-        >>> instance.decision_variables_df[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
+        >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper             name subscripts
         id
         0   Integer   -0.0    3.0                x        [0]
@@ -1595,7 +1595,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         The slack variable is added to the decision variables with name `ommx.slack` and the constraint ID is stored in `subscripts`.
 
-        >>> instance.decision_variables_df[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
+        >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper        name subscripts
         id
         0   Integer   -0.0    3.0           x        [0]
@@ -1669,7 +1669,7 @@ class Instance(InstanceBase, UserAnnotationBase):
 
         The slack variable is added to the decision variables with name `ommx.slack` and the constraint ID is stored in `subscripts`.
 
-        >>> instance.decision_variables_df[["kind", "lower", "upper", "name", "subscripts"]]  # doctest: +NORMALIZE_WHITESPACE
+        >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper        name subscripts
         id
         0   Integer   -0.0    3.0           x        [0]

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -193,7 +193,7 @@ impl Instance {
         ))
     }
 
-    pub fn random_state<'py>(&self, rng: &Rng) -> Result<crate::State> {
+    pub fn random_state(&self, rng: &Rng) -> Result<crate::State> {
         let strategy = self.0.arbitrary_state();
         let mut rng_guard = rng
             .lock()
@@ -209,7 +209,7 @@ impl Instance {
         num_samples = *ommx::random::SamplesParameters::default().num_samples(),
         max_sample_id = None
     ))]
-    pub fn random_samples<'py>(
+    pub fn random_samples(
         &self,
         rng: &Rng,
         num_different_samples: usize,

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -307,7 +307,7 @@ impl Instance {
     }
 
     /// Get a specific decision variable by ID
-    pub fn get_decision_variable(&self, variable_id: u64) -> PyResult<DecisionVariable> {
+    pub fn get_decision_variable_by_id(&self, variable_id: u64) -> PyResult<DecisionVariable> {
         self.0
             .decision_variables()
             .get(&VariableID::from(variable_id))
@@ -321,7 +321,7 @@ impl Instance {
     }
 
     /// Get a specific constraint by ID
-    pub fn get_constraint(&self, constraint_id: u64) -> PyResult<Constraint> {
+    pub fn get_constraint_by_id(&self, constraint_id: u64) -> PyResult<Constraint> {
         self.0
             .constraints()
             .get(&ConstraintID::from(constraint_id))
@@ -332,7 +332,7 @@ impl Instance {
     }
 
     /// Get a specific removed constraint by ID
-    pub fn get_removed_constraint(&self, constraint_id: u64) -> PyResult<RemovedConstraint> {
+    pub fn get_removed_constraint_by_id(&self, constraint_id: u64) -> PyResult<RemovedConstraint> {
         self.0
             .removed_constraints()
             .get(&ConstraintID::from(constraint_id))

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -5,6 +5,7 @@ use crate::{
 use anyhow::Result;
 use ommx::{ConstraintID, Evaluate, Message, Parse, VariableID};
 use pyo3::{
+    exceptions::PyKeyError,
     prelude::*,
     types::{PyBytes, PyDict},
     Bound, PyAny,
@@ -305,6 +306,48 @@ impl Instance {
 
     pub fn as_maximization_problem(&mut self) -> bool {
         self.0.as_maximization_problem()
+    }
+
+    /// Get a specific decision variable by ID
+    pub fn get_decision_variable(&self, variable_id: u64) -> PyResult<DecisionVariable> {
+        self.0
+            .decision_variables()
+            .get(&VariableID::from(variable_id))
+            .map(|var| DecisionVariable(var.clone()))
+            .ok_or_else(|| {
+                PyKeyError::new_err(format!(
+                    "Decision variable with ID {} not found",
+                    variable_id
+                ))
+            })
+    }
+
+    /// Get a specific constraint by ID
+    pub fn get_constraint(&self, constraint_id: u64) -> PyResult<Constraint> {
+        self.0
+            .constraints()
+            .get(&ConstraintID::from(constraint_id))
+            .map(|constraint| Constraint(constraint.clone()))
+            .ok_or_else(|| {
+                PyKeyError::new_err(format!(
+                    "Constraint with ID {} not found",
+                    constraint_id
+                ))
+            })
+    }
+
+    /// Get a specific removed constraint by ID
+    pub fn get_removed_constraint(&self, constraint_id: u64) -> PyResult<RemovedConstraint> {
+        self.0
+            .removed_constraints()
+            .get(&ConstraintID::from(constraint_id))
+            .map(|removed_constraint| RemovedConstraint(removed_constraint.clone()))
+            .ok_or_else(|| {
+                PyKeyError::new_err(format!(
+                    "Removed constraint with ID {} not found",
+                    constraint_id
+                ))
+            })
     }
 }
 

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -84,35 +84,33 @@ impl Instance {
         Ok(())
     }
 
+    /// List of all decision variables in the instance sorted by their IDs.
     #[getter]
-    pub fn decision_variables(&self) -> HashMap<u64, DecisionVariable> {
+    pub fn decision_variables(&self) -> Vec<DecisionVariable> {
         self.0
             .decision_variables()
             .iter()
-            .map(|(id, var)| (id.into_inner(), DecisionVariable(var.clone())))
+            .map(|(_, var)| DecisionVariable(var.clone()))
             .collect()
     }
 
+    /// List of all decision variables in the instance sorted by their IDs.
     #[getter]
-    pub fn constraints(&self) -> HashMap<u64, Constraint> {
+    pub fn constraints(&self) -> Vec<Constraint> {
         self.0
             .constraints()
             .iter()
-            .map(|(id, constraint)| (id.into_inner(), Constraint(constraint.clone())))
+            .map(|(_, constraint)| Constraint(constraint.clone()))
             .collect()
     }
 
+    /// List of all removed constraints in the instance sorted by their IDs.
     #[getter]
-    pub fn removed_constraints(&self) -> HashMap<u64, RemovedConstraint> {
+    pub fn removed_constraints(&self) -> Vec<RemovedConstraint> {
         self.0
             .removed_constraints()
             .iter()
-            .map(|(id, removed_constraint)| {
-                (
-                    id.into_inner(),
-                    RemovedConstraint(removed_constraint.clone()),
-                )
-            })
+            .map(|(_, removed_constraint)| RemovedConstraint(removed_constraint.clone()))
             .collect()
     }
 
@@ -329,10 +327,7 @@ impl Instance {
             .get(&ConstraintID::from(constraint_id))
             .map(|constraint| Constraint(constraint.clone()))
             .ok_or_else(|| {
-                PyKeyError::new_err(format!(
-                    "Constraint with ID {} not found",
-                    constraint_id
-                ))
+                PyKeyError::new_err(format!("Constraint with ID {} not found", constraint_id))
             })
     }
 


### PR DESCRIPTION
Changes
--------

Same changes are taken also for `constraints`, `removed_constraints` and `parameters` in `ParametricInstance`.

## `_ommx_rust.Instance`
- `decision_variables` property is changed to return `list[DecisionVariable]` instead of `dict[int, DecisionVariable]`, and assures sorted by the ID.
- `get_decision_variable_by_id(id)` method is added

## `ommx.v1.Instance`
- `Instance.decision_variables` property gets suffix `decision_variables_df`
  - This returns `pandas.DataFrame`, most data scientists calls it `df`.
- `Instance.get_decision_variables` method becomes `decision_variables` property
- `Instance.get_decision_variable(id)` is renamed to `get_decision_variable_by_id` and uses `raw.get_decision_variable_by_id(id)`
  - `ParametricInstance.get_decision_variable(id)` still search ID linearly. This will be fixed next PR. 
