### PR TITLE
Bug in substituted value consistency check

### DIFF
--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -281,7 +281,7 @@ pub enum DecisionVariableError {
         bound: Bound,
     },
 
-    #[error("Substituted value for ID={id} cannot be overwrite: previous={previous_value}, new={new_value}, atol={atol:?}")]
+    #[error("Substituted value for ID={id} cannot be overwritten: previous={previous_value}, new={new_value}, atol={atol:?}")]
     SubstitutedValueOverwrite {
         id: VariableID,
         previous_value: f64,

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -232,7 +232,8 @@ impl DecisionVariable {
         }
         match self.kind {
             Kind::Integer | Kind::Binary | Kind::SemiInteger => {
-                if value.fract().abs() >= atol {
+                let rounded = value.round();
+                if (rounded - value).abs() >= atol {
                     return Err(err());
                 }
             }
@@ -260,6 +261,7 @@ impl DecisionVariable {
                     id: self.id,
                     previous_value,
                     new_value,
+                    atol,
                 });
             }
         } else {
@@ -279,11 +281,12 @@ pub enum DecisionVariableError {
         bound: Bound,
     },
 
-    #[error("Substituted value for ID={id} cannot be overwrite: previous={previous_value}, new={new_value}")]
+    #[error("Substituted value for ID={id} cannot be overwrite: previous={previous_value}, new={new_value}, atol={atol:?}")]
     SubstitutedValueOverwrite {
         id: VariableID,
         previous_value: f64,
         new_value: f64,
+        atol: ATol,
     },
 
     #[error("Substituted value for ID={id} is inconsistent: kind={kind:?}, bound={bound}, substituted_value={substituted_value}, atol={atol:?}")]
@@ -331,11 +334,10 @@ impl EvaluatedDecisionVariable {
         // Check consistency with existing substituted_value if present
         if let Some(substituted_value) = decision_variable.substituted_value {
             if (substituted_value - value).abs() > *atol {
-                return Err(DecisionVariableError::SubstitutedValueInconsistent {
+                return Err(DecisionVariableError::SubstitutedValueOverwrite {
                     id: decision_variable.id,
-                    kind: decision_variable.kind,
-                    bound: decision_variable.bound,
-                    substituted_value,
+                    previous_value: substituted_value,
+                    new_value: value,
                     atol,
                 });
             }
@@ -383,11 +385,10 @@ impl SampledDecisionVariable {
             // Check that all sample values are consistent with substituted_value
             for (_, &sample_value) in samples.iter() {
                 if (substituted_value - sample_value).abs() > *atol {
-                    return Err(DecisionVariableError::SubstitutedValueInconsistent {
+                    return Err(DecisionVariableError::SubstitutedValueOverwrite {
                         id: decision_variable.id,
-                        kind: decision_variable.kind,
-                        bound: decision_variable.bound,
-                        substituted_value,
+                        previous_value: substituted_value,
+                        new_value: sample_value,
                         atol,
                     });
                 }

--- a/rust/ommx/src/instance/analysis.rs
+++ b/rust/ommx/src/instance/analysis.rs
@@ -226,7 +226,8 @@ impl DecisionVariableAnalysis {
 }
 
 fn check_integer(id: VariableID, value: f64, atol: ATol) -> Result<(), StateValidationError> {
-    if value.fract().abs() > atol {
+    let rounded = value.round();
+    if (rounded - value).abs() > atol {
         return Err(StateValidationError::NotAnInteger { id, value });
     }
     Ok(())

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -284,7 +284,7 @@ mod tests {
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
-        Substituted value for ID=1 is inconsistent: kind=Continuous, bound=[0, 10], substituted_value=3, atol=ATol(1e-6)
+        Substituted value for ID=1 cannot be overwrite: previous=3, new=2, atol=ATol(1e-6)
         "###);
     }
 

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -284,7 +284,7 @@ mod tests {
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
-        Substituted value for ID=1 cannot be overwrite: previous=3, new=2, atol=ATol(1e-6)
+        Substituted value for ID=1 cannot be overwritten: previous=3, new=2, atol=ATol(1e-6)
         "###);
     }
 


### PR DESCRIPTION
For integer variable, `1.000000001` is consistent, but `0.99999999999` becomes inconsistent wrongly.