### PR TITLE
Change `SampleSet.best_feasible` APIs to raise errors instead of returning `None`

### DIFF
--- a/python/ommx/ommx/_ommx_rust.pyi
+++ b/python/ommx/ommx/_ommx_rust.pyi
@@ -739,11 +739,11 @@ class Rng:
         """
 
 class SampleSet:
-    best_feasible_id: typing.Optional[builtins.int]
-    best_feasible_relaxed_id: typing.Optional[builtins.int]
-    best_feasible: typing.Optional[Solution]
-    best_feasible_relaxed: typing.Optional[Solution]
-    best_feasible_unrelaxed: typing.Optional[Solution]
+    best_feasible_id: builtins.int
+    best_feasible_relaxed_id: builtins.int
+    best_feasible: Solution
+    best_feasible_relaxed: Solution
+    best_feasible_unrelaxed: Solution
     objectives: builtins.dict[builtins.int, builtins.float]
     r"""
     Get objectives for all samples

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -58,20 +58,16 @@ class SamplerAdapter(SolverAdapter):
 
     @classmethod
     def solve(cls, ommx_instance: Instance, **kwargs) -> Solution:
-        solution = cls.sample(ommx_instance, **kwargs).best_feasible
-        if solution is None:
-            raise NoFeasibleSample("No feasible sample found by the sampler.")
-        return solution
+        sample_set = cls.sample(ommx_instance, **kwargs)
+        return sample_set.best_feasible
 
     @property
     def solver_input(self) -> SamplerInput:
         return self.sampler_input
 
     def decode(self, data: SamplerOutput) -> Solution:
-        solution = self.decode_to_sampleset(data).best_feasible
-        if solution is None:
-            raise NoFeasibleSample("No feasible sample found by the sampler.")
-        return solution
+        sample_set = self.decode_to_sampleset(data)
+        return sample_set.best_feasible
 
 
 class InfeasibleDetected(Exception):
@@ -79,12 +75,4 @@ class InfeasibleDetected(Exception):
 
 
 class UnboundedDetected(Exception):
-    pass
-
-
-class NoFeasibleSample(Exception):
-    """
-    Exception raised when no feasible solution is found by SamplerAdapter.
-    """
-
     pass

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -4177,61 +4177,79 @@ class SampleSet(UserAnnotationBase):
         return Solution(solution)
 
     @property
-    def best_feasible_id(self) -> int | None:
+    def best_feasible_id(self) -> int:
         """
         Get the sample ID of the best feasible solution.
-        Returns None if no feasible solution exists.
+
+        Raises
+        ------
+        RuntimeError
+            If no feasible solution exists.
         """
         return self.raw.best_feasible_id
 
     @property
-    def best_feasible_relaxed_id(self) -> int | None:
+    def best_feasible_relaxed_id(self) -> int:
         """
         Get the sample ID of the best feasible solution without relaxation.
-        Returns None if no feasible solution exists.
+
+        Raises
+        ------
+        RuntimeError
+            If no feasible solution exists.
         """
         return self.raw.best_feasible_relaxed_id
 
     @property
-    def best_feasible_unrelaxed_id(self) -> int | None:
+    def best_feasible_unrelaxed_id(self) -> int:
         """
         Get the sample ID of the best feasible solution without relaxation.
-        Returns None if no feasible solution exists.
+
+        Raises
+        ------
+        RuntimeError
+            If no feasible solution exists.
         """
-        return self.best_feasible_unrelaxed_id
+        return self.best_feasible_id
 
     @property
-    def best_feasible(self) -> Solution | None:
+    def best_feasible(self) -> Solution:
         """
-        Get the best feasible solution
+        Get the best feasible solution.
+
+        Raises
+        ------
+        RuntimeError
+            If no feasible solution exists.
         """
         solution = self.raw.best_feasible
-        if solution is not None:
-            return Solution(solution)
-        else:
-            return None
+        return Solution(solution)
 
     @property
-    def best_feasible_relaxed(self) -> Solution | None:
+    def best_feasible_relaxed(self) -> Solution:
         """
-        Get the best feasible solution without relaxation
+        Get the best feasible solution without relaxation.
+
+        Raises
+        ------
+        RuntimeError
+            If no feasible solution exists.
         """
         solution = self.raw.best_feasible_relaxed
-        if solution is not None:
-            return Solution(solution)
-        else:
-            return None
+        return Solution(solution)
 
     @property
-    def best_feasible_unrelaxed(self) -> Solution | None:
+    def best_feasible_unrelaxed(self) -> Solution:
         """
-        Get the best feasible solution without relaxation
+        Get the best feasible solution without relaxation.
+
+        Raises
+        ------
+        RuntimeError
+            If no feasible solution exists.
         """
         solution = self.raw.best_feasible_unrelaxed
-        if solution is not None:
-            return Solution(solution)
-        else:
-            return None
+        return Solution(solution)
 
 
 @dataclass

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -4210,7 +4210,7 @@ class SampleSet(UserAnnotationBase):
         RuntimeError
             If no feasible solution exists.
         """
-        return self.best_feasible_id
+        return self.best_feasible_unrelaxed_id
 
     @property
     def best_feasible(self) -> Solution:

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -67,27 +67,27 @@ impl SampleSet {
     }
 
     #[getter]
-    pub fn best_feasible_id(&self) -> Option<u64> {
-        self.0.best_feasible_id().map(|id| id.into_inner())
+    pub fn best_feasible_id(&self) -> Result<u64> {
+        Ok(self.0.best_feasible_id()?.into_inner())
     }
 
     #[getter]
-    pub fn best_feasible_relaxed_id(&self) -> Option<u64> {
-        self.0.best_feasible_relaxed_id().map(|id| id.into_inner())
+    pub fn best_feasible_relaxed_id(&self) -> Result<u64> {
+        Ok(self.0.best_feasible_relaxed_id()?.into_inner())
     }
 
     #[getter]
-    pub fn best_feasible(&self) -> Option<Solution> {
-        self.0.best_feasible().map(Solution)
+    pub fn best_feasible(&self) -> Result<Solution> {
+        Ok(Solution(self.0.best_feasible()?))
     }
 
     #[getter]
-    pub fn best_feasible_relaxed(&self) -> Option<Solution> {
-        self.0.best_feasible_relaxed().map(Solution)
+    pub fn best_feasible_relaxed(&self) -> Result<Solution> {
+        Ok(Solution(self.0.best_feasible_relaxed()?))
     }
 
     #[getter]
-    pub fn best_feasible_unrelaxed(&self) -> Option<Solution> {
+    pub fn best_feasible_unrelaxed(&self) -> Result<Solution> {
         // Exactly the same as best_feasible
         self.best_feasible()
     }


### PR DESCRIPTION
- Add NoFeasibleSolution/NoFeasibleSolutionRelaxed errors to SampleSetError
- Update best_feasible_id, best_feasible_relaxed_id to return Result<SampleID, SampleSetError>
- Update best_feasible, best_feasible_relaxed to return Result<Solution, SampleSetError>
- Update PyO3 bindings to return anyhow::Result and let PyO3 convert to Python exceptions
- Update Python SDK to raise RuntimeError instead of returning None
- Remove NoFeasibleSample exception from adapter classes
- Regenerate stub files to reflect new return types

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>