### PR TITLE
Add substituted_value property to DecisionVariable

### DIFF
--- a/python/ommx/ommx/_ommx_rust.pyi
+++ b/python/ommx/ommx/_ommx_rust.pyi
@@ -186,6 +186,7 @@ class DecisionVariable:
     subscripts: builtins.list[builtins.int]
     parameters: builtins.dict[builtins.str, builtins.str]
     description: builtins.str
+    substituted_value: builtins.float
     def __new__(
         cls,
         id: builtins.int,

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -586,20 +586,25 @@ class Instance(UserAnnotationBase):
         Examples
         =========
 
-        .. doctest::
+        >>> from ommx.v1 import Instance, DecisionVariable
+        >>> x = DecisionVariable.binary(1)
+        >>> y = DecisionVariable.binary(2)
+        >>> instance = Instance.from_components(
+        ...     decision_variables=[x, y],
+        ...     objective=x + y,
+        ...     constraints=[x + y <= 1],
+        ...     sense=Instance.MINIMIZE
+        ... )
+        >>> new_instance = instance.partial_evaluate({1: 1})
+        >>> new_instance.objective
+        Function(x2 + 1)
 
-            >>> from ommx.v1 import Instance, DecisionVariable
-            >>> x = DecisionVariable.binary(1)
-            >>> y = DecisionVariable.binary(2)
-            >>> instance = Instance.from_components(
-            ...     decision_variables=[x, y],
-            ...     objective=x + y,
-            ...     constraints=[x + y <= 1],
-            ...     sense=Instance.MINIMIZE
-            ... )
-            >>> new_instance = instance.partial_evaluate({1: 1})
-            >>> new_instance.objective
-            Function(x2 + 1)
+        Substituted value is stored in the decision variable:
+
+        >>> x = new_instance.get_decision_variable_by_id(1)
+        >>> x.substituted_value
+        1.0
+
         """
         # Create a copy of the instance and call partial_evaluate on it
         # Note: partial_evaluate modifies the instance in place and returns bytes
@@ -2598,6 +2603,13 @@ class DecisionVariable(VariableBase):
     def upper(self) -> float:
         """Upper bound of the decision variable"""
         return self.raw.bound.upper
+
+    @property
+    def substituted_value(self) -> float:
+        """
+        The value of the decision variable fixed by `:py:attr:`~Instance.partial_evaluate` or presolvers.
+        """
+        return self.raw.substituted_value
 
     @property
     def subscripts(self) -> list[int]:

--- a/python/ommx/src/decision_variable.rs
+++ b/python/ommx/src/decision_variable.rs
@@ -84,6 +84,13 @@ impl DecisionVariable {
         self.0.metadata.description.clone().unwrap_or_default()
     }
 
+    #[getter]
+    pub fn substituted_value(&self) -> Result<f64> {
+        self.0.substituted_value().ok_or_else(|| {
+            anyhow::anyhow!("DecisionVariable(id={}) does not have a substituted value", self.id())
+        })
+    }
+
     #[staticmethod]
     #[pyo3(signature = (id, name=None, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
     pub fn binary(


### PR DESCRIPTION
- Add substituted_value getter to Rust DecisionVariable wrapper
- Return RuntimeError when substituted_value is not set
- Add Python property wrapper and documentation
- Update type stubs to include new property

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>