### PR TITLE
MPS output does not handle `f64::INFINITY` in `Bound` correctly

### DIFF
--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -276,7 +276,7 @@ class Instance(UserAnnotationBase):
     def write_mps(self, path: str):
         self.save_mps(path)
 
-    def save_mps(self, path: str):
+    def save_mps(self, path: str, *, compress=True):
         """
         Outputs the instance as an MPS file.
 
@@ -284,7 +284,7 @@ class Instance(UserAnnotationBase):
         - Only linear problems are supported.
         - Various forms of metadata, like problem description and variable/constraint names, are not preserved.
         """
-        self.raw.save_mps(path)
+        self.raw.save_mps(path, compress=compress)
 
     @staticmethod
     def load_qplib(path: str) -> Instance:

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -280,7 +280,7 @@ class Instance(UserAnnotationBase):
         """
         Outputs the instance as an MPS file.
 
-        - The outputted file is compressed by gzip.
+        - The outputted file is optionally compressed by gzip, depending on the value of the `compress` parameter (default: True).
         - Only linear problems are supported.
         - Various forms of metadata, like problem description and variable/constraint names, are not preserved.
         """


### PR DESCRIPTION
## Summary

This PR improves the MPS format output to properly handle infinite bounds using standard MPS specifiers and adds comprehensive unit tests.

### Changes

1. **Add `compress` parameter to `Instance.save_mps()` method** 
   - Allows users to optionally disable gzip compression when saving MPS files
   - Default is `compress=True` to maintain backward compatibility

2. **Fix infinite bound representation in MPS format**
   - Previously, infinite bounds were written as literal `inf` and `-inf` values, which is not standard MPS format
   - Now uses proper MPS bound specifiers:
     - `FR` (free) for unbounded variables `(-inf, +inf)`
     - `PL` (plus infinity) for variables with upper bound = `+inf`
     - `MI` (minus infinity) for variables with lower bound = `-inf`
   - Finite bounds continue to use `UP`/`LO` (continuous) or `UI`/`LI` (integer/binary)

3. **Add comprehensive unit tests for `write_bounds` function**
   - Test unbounded variables (`Bound::unbounded()`)
   - Test semi-infinite bounds (`Bound::positive()`, `Bound::negative()`)
   - Test integer and binary variable types
   - Test mixed bound types in a single instance
   - All tests use insta snapshot testing for exact output verification

### Example Output Changes

Before:
```
BOUNDS
  UP BND1    OMMX_VAR_0  inf
  LO BND1    OMMX_VAR_0  -inf
```

After:
```
BOUNDS
  FR BND1    OMMX_VAR_0
```

For semi-infinite bounds:
```
BOUNDS
  PL BND1    OMMX_VAR_0      # For [0, +inf)
  LO BND1    OMMX_VAR_0  0
  
  MI BND1    OMMX_VAR_1      # For (-inf, 0]
  UP BND1    OMMX_VAR_1  0
```

### Testing

All new unit tests pass and verify the correct MPS format output for various bound types.