### PR TITLE
Normalize `-0.0` to `0.0` in `Bound`

### DIFF
--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -400,7 +400,7 @@ class OMMXHighsAdapter(SolverAdapter):
         <...>
         >>> state = adapter.decode_to_state(model)
         >>> state.entries
-        {1: -0.0}
+        {1: 0.0}
         """
         status = data.getModelStatus()
         if status == highspy.HighsModelStatus.kNotset:

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -242,7 +242,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
             >>> ommx_state = adapter.decode_to_state(model)
             >>> ommx_state.entries
-            {1: 0.0}
+            {1: -0.0}
 
         """
         if data.getStatus() == "unknown":

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -242,7 +242,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
             >>> ommx_state = adapter.decode_to_state(model)
             >>> ommx_state.entries
-            {1: -0.0}
+            {1: 0.0}
 
         """
         if data.getStatus() == "unknown":

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -749,9 +749,9 @@ class Instance(UserAnnotationBase):
         >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper             name subscripts
         id
-        0   Integer   -0.0    2.0                x        [0]
-        1   Integer   -0.0    2.0                x        [1]
-        2   Integer   -0.0    3.0       ommx.slack        [0]
+        0   Integer    0.0    2.0                x        [0]
+        1   Integer    0.0    2.0                x        [1]
+        2   Integer    0.0    3.0       ommx.slack        [0]
         3    Binary    0.0    1.0  ommx.log_encode     [0, 0]
         4    Binary    0.0    1.0  ommx.log_encode     [0, 1]
         5    Binary    0.0    1.0  ommx.log_encode     [1, 0]
@@ -783,9 +783,9 @@ class Instance(UserAnnotationBase):
         >>> solution.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper             name subscripts  value
         id                                                          
-        0   Integer   -0.0    2.0                x        [0]    2.0
-        1   Integer   -0.0    2.0                x        [1]    0.0
-        2   Integer   -0.0    3.0       ommx.slack        [0]    1.0
+        0   Integer    0.0    2.0                x        [0]    2.0
+        1   Integer    0.0    2.0                x        [1]    0.0
+        2   Integer    0.0    3.0       ommx.slack        [0]    1.0
         3    Binary    0.0    1.0  ommx.log_encode     [0, 0]    1.0
         4    Binary    0.0    1.0  ommx.log_encode     [0, 1]    1.0
         5    Binary    0.0    1.0  ommx.log_encode     [1, 0]    0.0
@@ -1515,9 +1515,9 @@ class Instance(UserAnnotationBase):
         >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper             name subscripts
         id
-        0   Integer   -0.0    3.0                x        [0]
-        1   Integer   -0.0    3.0                x        [1]
-        2   Integer   -0.0    3.0                x        [2]
+        0   Integer    0.0    3.0                x        [0]
+        1   Integer    0.0    3.0                x        [1]
+        2   Integer    0.0    3.0                x        [2]
         3    Binary    0.0    1.0  ommx.log_encode     [0, 0]
         4    Binary    0.0    1.0  ommx.log_encode     [0, 1]
         5    Binary    0.0    1.0  ommx.log_encode     [2, 0]
@@ -1657,10 +1657,10 @@ class Instance(UserAnnotationBase):
         >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper        name subscripts
         id
-        0   Integer   -0.0    3.0           x        [0]
-        1   Integer   -0.0    3.0           x        [1]
-        2   Integer   -0.0    3.0           x        [2]
-        3   Integer   -0.0    5.0  ommx.slack        [0]
+        0   Integer    0.0    3.0           x        [0]
+        1   Integer    0.0    3.0           x        [1]
+        2   Integer    0.0    3.0           x        [2]
+        3   Integer    0.0    5.0  ommx.slack        [0]
 
         """
         self.raw.convert_inequality_to_equality_with_integer_slack(
@@ -1731,10 +1731,10 @@ class Instance(UserAnnotationBase):
         >>> instance.decision_variables_df.dropna(axis=1, how="all")  # doctest: +NORMALIZE_WHITESPACE
                kind  lower  upper        name subscripts
         id
-        0   Integer   -0.0    3.0           x        [0]
-        1   Integer   -0.0    3.0           x        [1]
-        2   Integer   -0.0    3.0           x        [2]
-        3   Integer   -0.0    2.0  ommx.slack        [0]
+        0   Integer    0.0    3.0           x        [0]
+        1   Integer    0.0    3.0           x        [1]
+        2   Integer    0.0    3.0           x        [2]
+        3   Integer    0.0    2.0  ommx.slack        [0]
 
         In this case, the slack variable only take :math:`s = \{ 0, 1, 2 \}`,
         and thus the residual error is not disappear for :math:`x_0 = x_1 = 1` case :math:`f(x) + b \cdot x = 1 + 2 \cdot 1 + 2 \cdot s - 4 = 2s - 1`.

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -374,7 +374,12 @@ impl Bound {
     /// ```
     pub fn as_integer_bound(&self, atol: crate::ATol) -> Option<Self> {
         let lower = if self.lower.is_finite() {
-            (self.lower - atol).ceil()
+            let out = (self.lower - atol).ceil();
+            if out == 0.0 {
+                0.0 // Avoid negative zero
+            } else {
+                out
+            }
         } else {
             self.lower
         };

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -591,6 +591,12 @@ mod tests {
     }
 
     #[test]
+    fn minus_zero() {
+        let bound = Bound::new(-0.1, 1.1).unwrap();
+        insta::assert_snapshot!(bound.as_integer_bound(ATol::default()).unwrap(), @"[0, 1]");
+    }
+
+    #[test]
     fn bound_pow() {
         insta::assert_debug_snapshot!(Bound::new(2.0, 3.0).unwrap().pow(2), @"Bound[4, 9]");
         insta::assert_debug_snapshot!(Bound::new(2.0, 3.0).unwrap().pow(3), @"Bound[8, 27]");


### PR DESCRIPTION
Resolve #510. The root cause is `f64::ceil` keeps its sign, e.g. `(-0.1_f64).ceil()` returns `-0.0` instead of `0.0`. 