### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: Benchmarks for Rust SDK

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -77,6 +77,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   protogen:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -128,6 +128,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/python-')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     needs: [linux, macos, windows, adapters, check-wheel]
     steps:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     strategy:
@@ -143,6 +146,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/python-')
     runs-on: ubuntu-latest
     needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -13,6 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write # Required for OIDC token exchange
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -6,6 +6,9 @@ on:
       - rust-*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -22,6 +25,9 @@ jobs:
   next_version:
     runs-on: ubuntu-latest
     needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_llms_md.yml
+++ b/.github/workflows/update_llms_md.yml
@@ -10,6 +10,10 @@ on:
       - "docs/en/**/*.ipynb"
       - "docs/en/_toc.yml"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   detect-and-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following the principle of least privilege, add explicit permissions blocks to all workflows:
- Read-only permissions for workflows that only need to checkout and test code
- Write permissions only where necessary (creating PRs, publishing releases)

This addresses security warnings about workflows without explicit permissions limits.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>