### PR TITLE
openjij: Fix inverted sign in obj function in maximization problems

### DIFF
--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -248,7 +248,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
         if self._instance_prepared:
             return
 
-        self.ommx_instance.as_minimization_problem()
+        is_converted = self.ommx_instance.as_minimization_problem()
 
         continuous_variables = [
             var.id
@@ -311,6 +311,9 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
             self._qubo = qubo
 
         self._instance_prepared = True
+
+        if is_converted:
+            self.ommx_instance.as_maximization_problem()
 
 
 @deprecated("Renamed to `decode_to_samples`")

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -180,6 +180,10 @@ def test_sample(instance, ans):
         instance, num_reads=1, uniform_penalty_weight=3.1, seed=999
     )
     assert sample_set.extract_decision_variables("x", 0) == ans
+    # at least for our test cases the maximization problems should all be getting results >= 0
+    # -- this is to avoid a bug where objective function values were coming back with the sign inverted
+    if instance.sense == Instance.MAXIMIZE:
+        assert sample_set.objectives[0] > 0
 
 
 @pytest.mark.parametrize(
@@ -202,6 +206,10 @@ def test_solve(instance, ans):
         instance, num_reads=1, uniform_penalty_weight=3.1, seed=999
     )
     assert solution.extract_decision_variables("x") == ans
+    # at least for our test cases the maximization problems should all be getting results >= 0
+    # -- this is to avoid a bug where objective function values were coming back with the sign inverted
+    if instance.sense == Instance.MAXIMIZE:
+        assert solution.objective > 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- When sampling maximization problems with the openjij adapter, the objective function values were being returned negative when they should be positive, and vice versa.
- This was due to converting them to minimization problems when generating qubo/hubo, but never converting back before evaluating the results.