### PR TITLE
docs: Add pure Python modules to API reference

### DIFF
--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -58,6 +58,7 @@ python_use_unqualified_type_names = True
 # -- AutoAPI settings (adapters only) ----------------------------------------
 
 autoapi_dirs = [
+    python_root / "ommx",
     python_root / "ommx-python-mip-adapter",
     python_root / "ommx-pyscipopt-adapter",
     python_root / "ommx-highs-adapter",
@@ -71,7 +72,14 @@ autoapi_options = [
 ]
 autoapi_member_order = "groupwise"
 autoapi_file_patterns = ["*.pyi", "*.py"]
-autoapi_ignore = ["**/tests/**", "**/conftest.py"]
+autoapi_ignore = [
+    "**/tests/**",
+    "**/conftest.py",
+    "**/ommx/v1/**",
+    "**/ommx/artifact/**",
+    "**/ommx/_ommx_rust/**",
+    "**/pywasmcross/**",
+]
 autoapi_add_toctree_entry = False
 
 # -- Intersphinx Configuration -----------------------------------------------

--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -55,7 +55,7 @@ html_static_path = []
 add_module_names = False
 python_use_unqualified_type_names = True
 
-# -- AutoAPI settings (adapters only) ----------------------------------------
+# -- AutoAPI settings --------------------------------------------------------
 
 autoapi_dirs = [
     python_root / "ommx",

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -10,6 +10,18 @@ Core
    api/ommx.v1
    api/ommx.artifact
 
+Utilities
+---------
+
+.. toctree::
+   :maxdepth: 3
+
+   autoapi/ommx/adapter/index
+   autoapi/ommx/dataset/index
+   autoapi/ommx/testing/index
+   autoapi/ommx/mps/index
+   autoapi/ommx/qplib/index
+
 Adapters
 --------
 

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -14,7 +14,7 @@ Utilities
 ---------
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
 
    autoapi/ommx/adapter/index
    autoapi/ommx/dataset/index
@@ -26,7 +26,7 @@ Adapters
 --------
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
 
    autoapi/ommx_python_mip_adapter/index
    autoapi/ommx_pyscipopt_adapter/index


### PR DESCRIPTION
## Summary

- Add `ommx.adapter`, `ommx.dataset`, `ommx.testing`, `ommx.mps`, and `ommx.qplib` to the API reference using sphinx-autoapi
- Exclude Rust-generated modules (`v1/`, `artifact/`, `_ommx_rust/`) from autoapi since they are already documented via pyo3-stub-gen docgen
- Add a "Utilities" section to the index between Core and Adapters

## Context

After PRs #779 and #782 moved `ommx.v1` and `ommx.artifact` to Rust re-exports with pyo3-stub-gen docgen, the remaining pure Python modules (`adapter.py`, `dataset.py`, `testing.py`, `mps.py`, `qplib.py`) were missing from the API reference. This PR adds them back using autoapi, which coexists with pyo3-stub-gen docgen.

## Test plan

- [ ] Verify `sphinx-build` succeeds without new errors
- [ ] Check that adapter, dataset, testing, mps, qplib pages render correctly
- [ ] Confirm ommx.v1 and ommx.artifact pages are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)