### PR TITLE
Add numpy scalar type support to ToFunction type alias

### DIFF
--- a/python/ommx-tests/tests/test_function.py
+++ b/python/ommx-tests/tests/test_function.py
@@ -1,5 +1,7 @@
 # FIXME: Use test case generator like Hypothesis
 
+import numpy as np
+
 from ommx.v1 import Linear, DecisionVariable, Quadratic, Polynomial, Function
 
 
@@ -272,3 +274,17 @@ def test_function_terms_polynomial():
         (8,): 9.0,
         (): 10.0,
     }
+
+
+def test_function_from_numpy_int64():
+    """numpy.int64 should be accepted as a constant value."""
+    i = np.int64(3)
+    f = Function(i)
+    assert_eq(f, Function(3))
+
+
+def test_function_from_numpy_float64():
+    """numpy.float64 should be accepted as a constant value."""
+    x = np.float64(2.5)
+    f = Function(x)
+    assert_eq(f, Function(2.5))

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -5,6 +5,7 @@ import builtins
 import collections.abc
 import datetime
 import enum
+import numpy
 import os
 import pandas
 import pathlib
@@ -71,6 +72,8 @@ __all__ = [
 ToFunction: TypeAlias = (
     builtins.int
     | builtins.float
+    | numpy.integer
+    | numpy.floating
     | DecisionVariable
     | Parameter
     | Linear

--- a/python/ommx/src/function.rs
+++ b/python/ommx/src/function.rs
@@ -126,12 +126,44 @@ impl<'py> FromPyObject<'_, 'py> for Function {
 
 pyo3_stub_gen::impl_py_runtime_type!(Function);
 
-// Type alias: ToFunction = int | float | DecisionVariable | Linear | Quadratic | Polynomial | Function
-// i64 and f64 have PyStubType/PyRuntimeType provided by pyo3-stub-gen builtins
+// Marker types for numpy scalar types in stubs
+macro_rules! numpy_stub_marker {
+    ($marker:ident, $numpy_name:expr, $numpy_attr:expr) => {
+        pub struct $marker;
+        impl pyo3_stub_gen::PyStubType for $marker {
+            fn type_output() -> pyo3_stub_gen::TypeInfo {
+                pyo3_stub_gen::TypeInfo {
+                    name: format!("numpy.{}", $numpy_name),
+                    source_module: None,
+                    import: std::collections::HashSet::from(["numpy".into()]),
+                    type_refs: std::collections::HashMap::new(),
+                }
+            }
+        }
+        impl pyo3_stub_gen::runtime::PyRuntimeType for $marker {
+            fn runtime_type_object(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+                let numpy = py.import("numpy")?;
+                numpy.getattr($numpy_attr)
+            }
+        }
+    };
+}
+numpy_stub_marker!(NumpyInteger, "integer", "integer");
+numpy_stub_marker!(NumpyFloating, "floating", "floating");
+
+// Type alias: ToFunction = int | float | numpy.integer | numpy.floating | DecisionVariable | ...
 pyo3_stub_gen::type_alias!(
     "ommx._ommx_rust",
-    ToFunction =
-        i64 | f64 | DecisionVariable | Parameter | Linear | Quadratic | Polynomial | Function
+    ToFunction = i64
+        | f64
+        | NumpyInteger
+        | NumpyFloating
+        | DecisionVariable
+        | Parameter
+        | Linear
+        | Quadratic
+        | Polynomial
+        | Function
 );
 
 // Manual stub for __iadd__ (PyO3 returns () but Python returns self)


### PR DESCRIPTION
## Summary
- Add `numpy.integer` and `numpy.floating` to the `ToFunction` type alias so that `Function(numpy.int64(3))` passes pyright
- Add regression tests for `Function` creation from `numpy.int64` and `numpy.float64` (was a `TypeError` in v2.5.1)

## Test plan
- [x] `test_function_from_numpy_int64` and `test_function_from_numpy_float64` pass
- [x] `pyright` passes with no errors on `test_function.py`
- [x] Verified the bug on `python-2.5.1` tag: `Function(numpy.int64(3))` → `TypeError: Cannot create Function from int64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)