### PR TITLE
Add Propagate trait with unit propagation and Provenance tracking

### DIFF
--- a/python/ommx-pyscipopt-adapter/tests/test_sos1_partial_evaluate.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_sos1_partial_evaluate.py
@@ -38,9 +38,6 @@ def sos1_instance_setup():
     )
 
 
-@pytest.mark.skip(
-    reason="SOS1 variable partial_evaluate is deferred to the forget phase"
-)
 def test_adapter_handles_sos1_variable_fixed_nonzero(sos1_instance_setup):
     """Test that PySCIPOpt adapter handles instances when SOS1 variable is fixed to non-zero value."""
     instance = sos1_instance_setup
@@ -64,9 +61,6 @@ def test_adapter_handles_sos1_variable_fixed_nonzero(sos1_instance_setup):
     assert fixed_var.value == 5.0, "Fixed variable should have the specified value"
 
 
-@pytest.mark.skip(
-    reason="SOS1 variable partial_evaluate is deferred to the forget phase"
-)
 def test_adapter_handles_sos1_variable_fixed_to_zero(sos1_instance_setup):
     """Test adapter behavior when SOS1 variable is fixed to zero."""
     instance = sos1_instance_setup

--- a/python/ommx/src/constraint.rs
+++ b/python/ommx/src/constraint.rs
@@ -106,6 +106,7 @@ impl Constraint {
                 subscripts,
                 parameters: parameters.into_iter().collect(),
                 description,
+                provenance: None,
             },
             stage: ommx::CreatedData {
                 function: rust_function,

--- a/python/ommx/src/constraint.rs
+++ b/python/ommx/src/constraint.rs
@@ -106,7 +106,7 @@ impl Constraint {
                 subscripts,
                 parameters: parameters.into_iter().collect(),
                 description,
-                provenance: None,
+                provenance: Vec::new(),
             },
             stage: ommx::CreatedData {
                 function: rust_function,

--- a/python/ommx/src/indicator_constraint.rs
+++ b/python/ommx/src/indicator_constraint.rs
@@ -50,7 +50,7 @@ impl IndicatorConstraint {
             subscripts,
             parameters: parameters.into_iter().collect(),
             description,
-            provenance: None,
+            provenance: Vec::new(),
         };
         Ok(Self(ic))
     }

--- a/python/ommx/src/indicator_constraint.rs
+++ b/python/ommx/src/indicator_constraint.rs
@@ -50,6 +50,7 @@ impl IndicatorConstraint {
             subscripts,
             parameters: parameters.into_iter().collect(),
             description,
+            provenance: None,
         };
         Ok(Self(ic))
     }

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -68,11 +68,11 @@ impl From<ConstraintID> for u64 {
     }
 }
 
-/// Tracks the origin of a constraint that was created by transforming another constraint type.
+/// One step in a constraint's transformation history.
 ///
 /// For example, when an indicator constraint with indicator=1 is propagated,
-/// it is promoted to a regular `Constraint` with provenance recording the original
-/// indicator constraint ID.
+/// it is promoted to a regular `Constraint` with a provenance step recording
+/// the original indicator constraint ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Provenance {
     IndicatorConstraint(crate::IndicatorConstraintID),
@@ -87,9 +87,14 @@ pub struct ConstraintMetadata {
     pub subscripts: Vec<i64>,
     pub parameters: FnvHashMap<String, String>,
     pub description: Option<String>,
-    /// If this constraint was created by transforming another constraint type,
-    /// this records the original constraint's identity.
-    pub provenance: Option<Provenance>,
+    /// Chain of transformations that produced this constraint.
+    ///
+    /// Empty for constraints that were directly authored. When a constraint is
+    /// transformed from another (e.g. an indicator constraint promoted to a
+    /// regular constraint), a new [`Provenance`] entry is appended. Each entry
+    /// records the identity of the constraint that existed just before the
+    /// transformation. Older entries come first, newer last.
+    pub provenance: Vec<Provenance>,
 }
 
 /// A constraint parameterized by its lifecycle stage.

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -62,6 +62,12 @@ impl ConstraintID {
     }
 }
 
+impl From<ConstraintID> for u64 {
+    fn from(id: ConstraintID) -> Self {
+        id.0
+    }
+}
+
 /// Tracks the origin of a constraint that was created by transforming another constraint type.
 ///
 /// For example, when an indicator constraint with indicator=1 is propagated,

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -62,6 +62,18 @@ impl ConstraintID {
     }
 }
 
+/// Tracks the origin of a constraint that was created by transforming another constraint type.
+///
+/// For example, when an indicator constraint with indicator=1 is propagated,
+/// it is promoted to a regular `Constraint` with provenance recording the original
+/// indicator constraint ID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Provenance {
+    IndicatorConstraint(crate::IndicatorConstraintID),
+    OneHotConstraint(crate::OneHotConstraintID),
+    Sos1Constraint(crate::Sos1ConstraintID),
+}
+
 /// Auxiliary metadata for constraints (excluding essential id and equality)
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ConstraintMetadata {
@@ -69,6 +81,9 @@ pub struct ConstraintMetadata {
     pub subscripts: Vec<i64>,
     pub parameters: FnvHashMap<String, String>,
     pub description: Option<String>,
+    /// If this constraint was created by transforming another constraint type,
+    /// this records the original constraint's identity.
+    pub provenance: Option<Provenance>,
 }
 
 /// A constraint parameterized by its lifecycle stage.

--- a/rust/ommx/src/constraint/logical_memory.rs
+++ b/rust/ommx/src/constraint/logical_memory.rs
@@ -1,5 +1,6 @@
 use crate::constraint::{
-    Constraint, ConstraintID, ConstraintMetadata, Created, CreatedData, Equality, RemovedReason,
+    Constraint, ConstraintID, ConstraintMetadata, Created, CreatedData, Equality, Provenance,
+    RemovedReason,
 };
 use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
 use std::mem::size_of;
@@ -16,12 +17,19 @@ impl LogicalMemoryProfile for Equality {
     }
 }
 
+impl LogicalMemoryProfile for Provenance {
+    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
+        visitor.visit_leaf(path, size_of::<Provenance>());
+    }
+}
+
 crate::impl_logical_memory_profile! {
     ConstraintMetadata {
         name,
         subscripts,
         parameters,
         description,
+        provenance,
     }
 }
 

--- a/rust/ommx/src/constraint/parse.rs
+++ b/rust/ommx/src/constraint/parse.rs
@@ -51,6 +51,7 @@ impl Parse for v1::Constraint {
             subscripts: self.subscripts,
             parameters: self.parameters.into_iter().collect(),
             description: self.description,
+            provenance: None,
         };
         let function = self
             .function
@@ -150,6 +151,7 @@ impl Parse for v1::EvaluatedConstraint {
             subscripts: self.subscripts,
             parameters: self.parameters.into_iter().collect(),
             description: self.description,
+            provenance: None,
         };
 
         let feasible = match equality {
@@ -206,6 +208,7 @@ impl Parse for v1::SampledConstraint {
             subscripts: self.subscripts,
             parameters: self.parameters.into_iter().collect(),
             description: self.description,
+            provenance: None,
         };
 
         let removed_reason = self.removed_reason.map(|reason| RemovedReason {

--- a/rust/ommx/src/constraint/parse.rs
+++ b/rust/ommx/src/constraint/parse.rs
@@ -51,7 +51,7 @@ impl Parse for v1::Constraint {
             subscripts: self.subscripts,
             parameters: self.parameters.into_iter().collect(),
             description: self.description,
-            provenance: None,
+            provenance: Vec::new(),
         };
         let function = self
             .function
@@ -151,7 +151,7 @@ impl Parse for v1::EvaluatedConstraint {
             subscripts: self.subscripts,
             parameters: self.parameters.into_iter().collect(),
             description: self.description,
-            provenance: None,
+            provenance: Vec::new(),
         };
 
         let feasible = match equality {
@@ -208,7 +208,7 @@ impl Parse for v1::SampledConstraint {
             subscripts: self.subscripts,
             parameters: self.parameters.into_iter().collect(),
             description: self.description,
-            provenance: None,
+            provenance: Vec::new(),
         };
 
         let removed_reason = self.removed_reason.map(|reason| RemovedReason {

--- a/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_snapshot.snap
+++ b/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: rust/ommx/src/constraint/logical_memory.rs
-assertion_line: 91
 expression: folded
 ---
 Constraint.equality 1
@@ -8,5 +7,6 @@ Constraint.id 8
 Constraint.metadata;ConstraintMetadata.description;Option[stack] 24
 Constraint.metadata;ConstraintMetadata.name;Option[stack] 24
 Constraint.metadata;ConstraintMetadata.parameters;FnvHashMap[stack] 32
+Constraint.metadata;ConstraintMetadata.provenance;Option[stack] 16
 Constraint.metadata;ConstraintMetadata.subscripts;Vec[stack] 24
 Constraint.stage;CreatedData.function;Linear;PolynomialBase.terms 80

--- a/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_snapshot.snap
+++ b/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_snapshot.snap
@@ -7,6 +7,6 @@ Constraint.id 8
 Constraint.metadata;ConstraintMetadata.description;Option[stack] 24
 Constraint.metadata;ConstraintMetadata.name;Option[stack] 24
 Constraint.metadata;ConstraintMetadata.parameters;FnvHashMap[stack] 32
-Constraint.metadata;ConstraintMetadata.provenance;Option[stack] 16
+Constraint.metadata;ConstraintMetadata.provenance;Vec[stack] 24
 Constraint.metadata;ConstraintMetadata.subscripts;Vec[stack] 24
 Constraint.stage;CreatedData.function;Linear;PolynomialBase.terms 80

--- a/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_with_metadata_snapshot.snap
+++ b/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_with_metadata_snapshot.snap
@@ -7,7 +7,7 @@ Constraint.id 8
 Constraint.metadata;ConstraintMetadata.description 41
 Constraint.metadata;ConstraintMetadata.name 39
 Constraint.metadata;ConstraintMetadata.parameters;FnvHashMap[stack] 32
-Constraint.metadata;ConstraintMetadata.provenance;Option[stack] 16
+Constraint.metadata;ConstraintMetadata.provenance;Vec[stack] 24
 Constraint.metadata;ConstraintMetadata.subscripts 24
 Constraint.metadata;ConstraintMetadata.subscripts;Vec[stack] 24
 Constraint.stage;CreatedData.function;Linear;PolynomialBase.terms 56

--- a/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_with_metadata_snapshot.snap
+++ b/rust/ommx/src/constraint/snapshots/ommx__constraint__logical_memory__tests__constraint_with_metadata_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: rust/ommx/src/constraint/logical_memory.rs
-assertion_line: 105
 expression: folded
 ---
 Constraint.equality 1
@@ -8,6 +7,7 @@ Constraint.id 8
 Constraint.metadata;ConstraintMetadata.description 41
 Constraint.metadata;ConstraintMetadata.name 39
 Constraint.metadata;ConstraintMetadata.parameters;FnvHashMap[stack] 32
+Constraint.metadata;ConstraintMetadata.provenance;Option[stack] 16
 Constraint.metadata;ConstraintMetadata.subscripts 24
 Constraint.metadata;ConstraintMetadata.subscripts;Vec[stack] 24
 Constraint.stage;CreatedData.function;Linear;PolynomialBase.terms 56

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -40,7 +40,7 @@ use std::collections::BTreeMap;
 /// to define all stage types for regular constraints.
 pub trait ConstraintType {
     /// The ID type for this constraint family.
-    type ID: Clone + Copy + Ord + std::hash::Hash + std::fmt::Debug;
+    type ID: Clone + Copy + Ord + std::hash::Hash + std::fmt::Debug + From<u64> + Into<u64>;
     /// The constraint as defined in the problem.
     type Created: Evaluate<Output = Self::Evaluated, SampledOutput = Self::Sampled>
         + Clone
@@ -184,6 +184,25 @@ impl<T: ConstraintType> ConstraintCollection<T> {
     /// Mutable access to removed constraints.
     pub fn removed_mut(&mut self) -> &mut BTreeMap<T::ID, (T::Created, RemovedReason)> {
         &mut self.removed
+    }
+
+    /// Return an ID that is not used by any active or removed constraint in this collection.
+    pub fn unused_id(&self) -> T::ID {
+        let max_active: u64 = self
+            .active
+            .keys()
+            .last()
+            .copied()
+            .map(Into::into)
+            .unwrap_or(0);
+        let max_removed: u64 = self
+            .removed
+            .keys()
+            .last()
+            .copied()
+            .map(Into::into)
+            .unwrap_or(0);
+        T::ID::from(max_active.max(max_removed) + 1)
     }
 
     /// Consume the collection and return the active and removed maps.

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -189,14 +189,21 @@ impl<T: ConstraintType> ConstraintCollection<T> {
     /// Return an ID that is not used by any active or removed constraint in this collection.
     ///
     /// Returns `0` when the collection is empty, otherwise `max(existing id) + 1`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the maximum existing ID is `u64::MAX`, i.e. all IDs are exhausted.
     pub fn unused_id(&self) -> T::ID {
         let max_active = self.active.keys().last().copied().map(Into::into);
         let max_removed = self.removed.keys().last().copied().map(Into::into);
         let next = match (max_active, max_removed) {
             (None, None) => 0u64,
-            (Some(a), None) => a + 1,
-            (None, Some(r)) => r + 1,
-            (Some(a), Some(r)) => a.max(r) + 1,
+            (Some(a), None) => a.checked_add(1).expect("constraint ID space exhausted"),
+            (None, Some(r)) => r.checked_add(1).expect("constraint ID space exhausted"),
+            (Some(a), Some(r)) => a
+                .max(r)
+                .checked_add(1)
+                .expect("constraint ID space exhausted"),
         };
         T::ID::from(next)
     }

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -187,22 +187,18 @@ impl<T: ConstraintType> ConstraintCollection<T> {
     }
 
     /// Return an ID that is not used by any active or removed constraint in this collection.
+    ///
+    /// Returns `0` when the collection is empty, otherwise `max(existing id) + 1`.
     pub fn unused_id(&self) -> T::ID {
-        let max_active: u64 = self
-            .active
-            .keys()
-            .last()
-            .copied()
-            .map(Into::into)
-            .unwrap_or(0);
-        let max_removed: u64 = self
-            .removed
-            .keys()
-            .last()
-            .copied()
-            .map(Into::into)
-            .unwrap_or(0);
-        T::ID::from(max_active.max(max_removed) + 1)
+        let max_active = self.active.keys().last().copied().map(Into::into);
+        let max_removed = self.removed.keys().last().copied().map(Into::into);
+        let next = match (max_active, max_removed) {
+            (None, None) => 0u64,
+            (Some(a), None) => a + 1,
+            (None, Some(r)) => r + 1,
+            (Some(a), Some(r)) => a.max(r) + 1,
+        };
+        T::ID::from(next)
     }
 
     /// Consume the collection and return the active and removed maps.

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -23,6 +23,27 @@ pub trait Evaluate {
     fn required_ids(&self) -> VariableIDSet;
 }
 
+/// Unit propagation trait for constraint types.
+///
+/// Consumes `self` and returns the propagated result together with any
+/// additional variable fixings discovered during propagation.
+///
+/// The associated `Output` type varies per constraint:
+/// - `Self` for types that never change shape (e.g. regular `Constraint`)
+/// - `Option<Self>` for types that can be consumed (OneHot, SOS1)
+/// - A custom enum for types that can transform into a different constraint
+///   (e.g. `IndicatorConstraint` → `Constraint`)
+pub trait Propagate {
+    type Output;
+
+    /// Propagate variable fixings from `state` through this constraint.
+    ///
+    /// Returns `(output, additional_fixings)` where:
+    /// - `output` is the constraint after propagation (may be consumed or transformed)
+    /// - `additional_fixings` contains newly discovered variable values
+    fn propagate(self, state: &State, atol: crate::ATol) -> Result<(Self::Output, State)>;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -25,23 +25,31 @@ pub trait Evaluate {
 
 /// Unit propagation trait for constraint types.
 ///
-/// Consumes `self` and returns the propagated result together with any
-/// additional variable fixings discovered during propagation.
+/// Mutates `self` in-place and returns the propagation result together with
+/// any additional variable fixings discovered during propagation.
 ///
-/// The associated `Output` type varies per constraint:
-/// - `Self` for types that never change shape (e.g. regular `Constraint`)
-/// - `Option<Self>` for types that can be consumed (OneHot, SOS1)
-/// - A custom enum for types that can transform into a different constraint
-///   (e.g. `IndicatorConstraint` → `Constraint`)
+/// The associated `Transformed` type represents what the constraint becomes
+/// when it undergoes a type change (e.g. `IndicatorConstraint` → `Constraint`).
+/// When no type change occurs, `Transformed` is `()`.
+///
+/// Return value semantics:
+/// - `(None, state)` — constraint was modified in-place; it stays active.
+/// - `(Some(transformed), state)` — constraint was transformed into another type.
+///   The caller moves `self` to the removed set and handles the transformed value.
 pub trait Propagate {
-    type Output;
+    type Transformed;
 
     /// Propagate variable fixings from `state` through this constraint.
     ///
-    /// Returns `(output, additional_fixings)` where:
-    /// - `output` is the constraint after propagation (may be consumed or transformed)
-    /// - `additional_fixings` contains newly discovered variable values
-    fn propagate(self, state: &State, atol: crate::ATol) -> Result<(Self::Output, State)>;
+    /// Returns `(transformed, additional_fixings)` where:
+    /// - `transformed` is `None` if the constraint was only modified in-place,
+    ///   or `Some(T)` if the constraint was consumed/transformed.
+    /// - `additional_fixings` contains newly discovered variable values.
+    fn propagate(
+        &mut self,
+        state: &State,
+        atol: crate::ATol,
+    ) -> Result<(Option<Self::Transformed>, State)>;
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -23,33 +23,42 @@ pub trait Evaluate {
     fn required_ids(&self) -> VariableIDSet;
 }
 
+/// Outcome of [`Propagate::propagate`].
+///
+/// `self` is consumed by propagation; the variant decides where it ends up.
+/// Atomicity is the caller's responsibility: on error, the constraint is lost,
+/// so callers that need atomicity should clone before calling (or snapshot the
+/// containing structure).
+#[derive(Debug, Clone)]
+pub enum PropagateOutcome<Self_, Transformed> {
+    /// Constraint remains active (possibly shrunk / modified).
+    Active(Self_),
+    /// Constraint is fully determined by the state. Move to the removed set as-is.
+    Consumed(Self_),
+    /// Constraint transformed into another type (e.g. IndicatorConstraint → Constraint).
+    /// `original` goes to the removed set, `new` is the replacement.
+    Transformed { original: Self_, new: Transformed },
+}
+
 /// Unit propagation trait for constraint types.
 ///
-/// Mutates `self` in-place and returns the propagation result together with
-/// any additional variable fixings discovered during propagation.
+/// Consumes `self` and returns [`PropagateOutcome`] together with any
+/// additional variable fixings discovered during propagation.
 ///
-/// The associated `Transformed` type represents what the constraint becomes
-/// when it undergoes a type change (e.g. `IndicatorConstraint` → `Constraint`).
-/// When no type change occurs, `Transformed` is `()`.
-///
-/// Return value semantics:
-/// - `(None, state)` — constraint was modified in-place; it stays active.
-/// - `(Some(transformed), state)` — constraint was transformed into another type.
-///   The caller moves `self` to the removed set and handles the transformed value.
-pub trait Propagate {
+/// Atomicity note: on error, `self` is lost. Callers requiring atomicity must
+/// clone `self` before calling, or snapshot the containing structure.
+pub trait Propagate: Sized {
     type Transformed;
 
     /// Propagate variable fixings from `state` through this constraint.
     ///
-    /// Returns `(transformed, additional_fixings)` where:
-    /// - `transformed` is `None` if the constraint was only modified in-place,
-    ///   or `Some(T)` if the constraint was consumed/transformed.
-    /// - `additional_fixings` contains newly discovered variable values.
+    /// Returns `(outcome, additional_fixings)` where `additional_fixings`
+    /// contains newly discovered variable values.
     fn propagate(
-        &mut self,
+        self,
         state: &State,
         atol: crate::ATol,
-    ) -> Result<(Option<Self::Transformed>, State)>;
+    ) -> Result<(PropagateOutcome<Self, Self::Transformed>, State)>;
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/evaluate.rs
+++ b/rust/ommx/src/evaluate.rs
@@ -30,14 +30,14 @@ pub trait Evaluate {
 /// so callers that need atomicity should clone before calling (or snapshot the
 /// containing structure).
 #[derive(Debug, Clone)]
-pub enum PropagateOutcome<Self_, Transformed> {
+pub enum PropagateOutcome<T: Propagate> {
     /// Constraint remains active (possibly shrunk / modified).
-    Active(Self_),
+    Active(T),
     /// Constraint is fully determined by the state. Move to the removed set as-is.
-    Consumed(Self_),
+    Consumed(T),
     /// Constraint transformed into another type (e.g. IndicatorConstraint → Constraint).
     /// `original` goes to the removed set, `new` is the replacement.
-    Transformed { original: Self_, new: Transformed },
+    Transformed { original: T, new: T::Transformed },
 }
 
 /// Unit propagation trait for constraint types.
@@ -54,11 +54,8 @@ pub trait Propagate: Sized {
     ///
     /// Returns `(outcome, additional_fixings)` where `additional_fixings`
     /// contains newly discovered variable values.
-    fn propagate(
-        self,
-        state: &State,
-        atol: crate::ATol,
-    ) -> Result<(PropagateOutcome<Self, Self::Transformed>, State)>;
+    fn propagate(self, state: &State, atol: crate::ATol)
+        -> Result<(PropagateOutcome<Self>, State)>;
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -12,8 +12,8 @@ impl Propagate for IndicatorConstraint<Created> {
         let empty_state = crate::v1::State::default();
 
         if let Some(&indicator_value) = state.entries.get(&self.indicator_variable.into_inner()) {
-            if indicator_value > 1.0 - *atol {
-                // Indicator ON → promote inner constraint to regular Constraint.
+            if (indicator_value - 1.0).abs() < *atol {
+                // Indicator ON (~1) → promote inner constraint to regular Constraint.
                 // Clone the function so self (going to removed) retains its data.
                 let mut promoted_function = self.stage.function.clone();
                 promoted_function.partial_evaluate(state, atol)?;
@@ -35,7 +35,7 @@ impl Propagate for IndicatorConstraint<Created> {
                     empty_state,
                 ))
             } else if indicator_value.abs() < *atol {
-                // Indicator OFF → vacuously satisfied; the constraint is consumed.
+                // Indicator OFF (~0) → vacuously satisfied; the constraint is consumed.
                 Ok((PropagateOutcome::Consumed(self), empty_state))
             } else {
                 anyhow::bail!(
@@ -73,7 +73,18 @@ impl Evaluate for IndicatorConstraint<Created> {
                 )
             })?;
 
-        let indicator_on = *indicator_value > 1.0 - *atol;
+        let indicator_on = if (*indicator_value - 1.0).abs() < *atol {
+            true
+        } else if indicator_value.abs() < *atol {
+            false
+        } else {
+            anyhow::bail!(
+                "Indicator variable {:?} of indicator constraint {:?} has invalid value {} (must be 0 or 1)",
+                self.indicator_variable,
+                self.id,
+                indicator_value
+            );
+        };
 
         let feasible = if indicator_on {
             // Indicator ON → check constraint as usual
@@ -128,7 +139,19 @@ impl Evaluate for IndicatorConstraint<Created> {
                         self.id
                     )
                 })?;
-            let indicator_on = *indicator_value > 1.0 - *atol;
+            let indicator_on = if (*indicator_value - 1.0).abs() < *atol {
+                true
+            } else if indicator_value.abs() < *atol {
+                false
+            } else {
+                anyhow::bail!(
+                    "Indicator variable {:?} of indicator constraint {:?} has invalid value {} in sample {:?} (must be 0 or 1)",
+                    self.indicator_variable,
+                    self.id,
+                    indicator_value,
+                    sample_id
+                );
+            };
 
             let f = if indicator_on {
                 match self.equality {

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -19,8 +19,9 @@ impl Propagate for IndicatorConstraint<Created> {
                 promoted_function.partial_evaluate(state, atol)?;
 
                 let mut metadata = self.metadata.clone();
-                metadata.provenance =
-                    Some(crate::constraint::Provenance::IndicatorConstraint(self.id));
+                metadata
+                    .provenance
+                    .push(crate::constraint::Provenance::IndicatorConstraint(self.id));
 
                 let new = IndicatorPromote {
                     equality: self.equality,
@@ -380,9 +381,10 @@ mod tests {
         match outcome {
             PropagateOutcome::Transformed { original, new } => {
                 assert_eq!(new.equality, Equality::LessThanOrEqualToZero);
+                assert_eq!(new.metadata.provenance.len(), 1);
                 assert!(matches!(
-                    new.metadata.provenance,
-                    Some(crate::constraint::Provenance::IndicatorConstraint(id)) if id == IndicatorConstraintID::from(1)
+                    new.metadata.provenance[0],
+                    crate::constraint::Provenance::IndicatorConstraint(id) if id == IndicatorConstraintID::from(1)
                 ));
                 // Original indicator constraint preserved for removed set
                 assert_eq!(original.indicator_variable, VariableID::from(10));

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -22,16 +22,12 @@ impl Propagate for IndicatorConstraint<Created> {
                 metadata.provenance =
                     Some(crate::constraint::Provenance::IndicatorConstraint(self.id));
 
-                let constraint = crate::Constraint {
-                    id: crate::ConstraintID::from(self.id.into_inner()),
-                    equality: self.equality,
-                    metadata,
-                    stage: CreatedData {
-                        function: promoted_function,
-                    },
-                };
                 Ok((
-                    Some(IndicatorPropagateOutput::Promote(constraint)),
+                    Some(IndicatorPropagateOutput::Promote {
+                        equality: self.equality,
+                        function: promoted_function,
+                        metadata,
+                    }),
                     empty_state,
                 ))
             } else if indicator_value.abs() < *atol {
@@ -356,9 +352,16 @@ mod tests {
         let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
         match transformed {
-            Some(IndicatorPropagateOutput::Promote(constraint)) => {
-                assert_eq!(constraint.equality, Equality::LessThanOrEqualToZero);
-                assert_eq!(constraint.id, crate::ConstraintID::from(1));
+            Some(IndicatorPropagateOutput::Promote {
+                equality,
+                function: _,
+                metadata,
+            }) => {
+                assert_eq!(equality, Equality::LessThanOrEqualToZero);
+                assert!(matches!(
+                    metadata.provenance,
+                    Some(crate::constraint::Provenance::IndicatorConstraint(id)) if id == IndicatorConstraintID::from(1)
+                ));
             }
             _ => panic!("Expected Some(Promote)"),
         }
@@ -419,8 +422,8 @@ mod tests {
         let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
         match transformed {
-            Some(IndicatorPropagateOutput::Promote(constraint)) => {
-                let ids = constraint.stage.function.required_ids();
+            Some(IndicatorPropagateOutput::Promote { function, .. }) => {
+                let ids = function.required_ids();
                 assert!(!ids.contains(&VariableID::from(1))); // substituted
                 assert!(ids.contains(&VariableID::from(2))); // still free
             }

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -8,7 +8,7 @@ impl Propagate for IndicatorConstraint<Created> {
         mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(PropagateOutcome<Self, IndicatorPromote>, crate::v1::State)> {
+    ) -> anyhow::Result<(PropagateOutcome<Self>, crate::v1::State)> {
         let empty_state = crate::v1::State::default();
 
         if let Some(&indicator_value) = state.entries.get(&self.indicator_variable.into_inner()) {

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -1,5 +1,49 @@
 use super::*;
-use crate::{ATol, Evaluate, VariableIDSet};
+use crate::{ATol, Evaluate, Propagate, VariableIDSet};
+
+impl Propagate for IndicatorConstraint<Created> {
+    type Output = IndicatorPropagateOutput;
+
+    fn propagate(
+        mut self,
+        state: &crate::v1::State,
+        atol: ATol,
+    ) -> anyhow::Result<(Self::Output, crate::v1::State)> {
+        let empty_state = crate::v1::State::default();
+
+        if let Some(&indicator_value) = state.entries.get(&self.indicator_variable.into_inner()) {
+            if indicator_value > 1.0 - *atol {
+                // Indicator ON → promote inner constraint to regular Constraint
+                // Partial-evaluate the inner function first
+                self.stage.function.partial_evaluate(state, atol)?;
+
+                let constraint = crate::Constraint {
+                    id: crate::ConstraintID::from(self.id.into_inner()),
+                    equality: self.equality,
+                    metadata: self.metadata,
+                    stage: CreatedData {
+                        function: self.stage.function,
+                    },
+                };
+                Ok((IndicatorPropagateOutput::Promote(constraint), empty_state))
+            } else if indicator_value.abs() < *atol {
+                // Indicator OFF → vacuously satisfied
+                Ok((IndicatorPropagateOutput::Removed, empty_state))
+            } else {
+                anyhow::bail!(
+                    "Indicator variable {:?} of indicator constraint {:?} has invalid value {} (must be 0 or 1)",
+                    self.indicator_variable,
+                    self.id,
+                    indicator_value
+                );
+            }
+        } else {
+            // Indicator variable not in state — partial-evaluate inner function only
+            self.stage.function.partial_evaluate(state, atol)?;
+            Ok((IndicatorPropagateOutput::Active(self), empty_state))
+        }
+    }
+}
 
 impl Evaluate for IndicatorConstraint<Created> {
     type Output = EvaluatedIndicatorConstraint;
@@ -129,7 +173,7 @@ impl Evaluate for IndicatorConstraint<Created> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{coeff, linear, Evaluate, Function};
+    use crate::{coeff, linear, Evaluate, Function, Propagate};
     use std::collections::HashMap;
 
     #[test]
@@ -285,5 +329,94 @@ mod tests {
         assert_eq!(result.stage.indicator_active[&s0], true);
         assert_eq!(result.stage.indicator_active[&s1], true);
         assert_eq!(result.stage.indicator_active[&s2], false);
+    }
+
+    // === Propagate tests ===
+
+    #[test]
+    fn test_propagate_indicator_on_promotes() {
+        // x1 <= 5, indicator = x10
+        let ic = IndicatorConstraint::new(
+            IndicatorConstraintID::from(1),
+            VariableID::from(10),
+            Equality::LessThanOrEqualToZero,
+            Function::from(linear!(1) + coeff!(-5.0)),
+        );
+
+        // x10 = 1 → promote inner constraint
+        let state = crate::v1::State::from(HashMap::from([(10, 1.0)]));
+        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        assert!(additional.entries.is_empty());
+        match output {
+            IndicatorPropagateOutput::Promote(constraint) => {
+                assert_eq!(constraint.equality, Equality::LessThanOrEqualToZero);
+                assert_eq!(constraint.id, crate::ConstraintID::from(1));
+            }
+            _ => panic!("Expected Promote"),
+        }
+    }
+
+    #[test]
+    fn test_propagate_indicator_off_removed() {
+        let ic = IndicatorConstraint::new(
+            IndicatorConstraintID::from(1),
+            VariableID::from(10),
+            Equality::LessThanOrEqualToZero,
+            Function::from(linear!(1) + coeff!(-5.0)),
+        );
+
+        // x10 = 0 → removed
+        let state = crate::v1::State::from(HashMap::from([(10, 0.0)]));
+        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        assert!(additional.entries.is_empty());
+        assert!(matches!(output, IndicatorPropagateOutput::Removed));
+    }
+
+    #[test]
+    fn test_propagate_indicator_not_fixed_partial_evaluates_function() {
+        let ic = IndicatorConstraint::new(
+            IndicatorConstraintID::from(1),
+            VariableID::from(10),
+            Equality::LessThanOrEqualToZero,
+            Function::from(linear!(1) + linear!(2) + coeff!(-5.0)),
+        );
+
+        // x1 = 3 (not indicator), x10 not in state → Active with partial-evaluated function
+        let state = crate::v1::State::from(HashMap::from([(1, 3.0)]));
+        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        assert!(additional.entries.is_empty());
+        match output {
+            IndicatorPropagateOutput::Active(ic) => {
+                // x1 was substituted, only x2 remains in function
+                let ids = ic.stage.function.required_ids();
+                assert!(!ids.contains(&VariableID::from(1)));
+                assert!(ids.contains(&VariableID::from(2)));
+            }
+            _ => panic!("Expected Active"),
+        }
+    }
+
+    #[test]
+    fn test_propagate_indicator_on_with_function_partial_eval() {
+        // Both indicator fixed and function variables fixed
+        let ic = IndicatorConstraint::new(
+            IndicatorConstraintID::from(1),
+            VariableID::from(10),
+            Equality::LessThanOrEqualToZero,
+            Function::from(linear!(1) + linear!(2) + coeff!(-5.0)),
+        );
+
+        // x10=1, x1=3 → promote with x1 substituted in function
+        let state = crate::v1::State::from(HashMap::from([(10, 1.0), (1, 3.0)]));
+        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        assert!(additional.entries.is_empty());
+        match output {
+            IndicatorPropagateOutput::Promote(constraint) => {
+                let ids = constraint.stage.function.required_ids();
+                assert!(!ids.contains(&VariableID::from(1))); // substituted
+                assert!(ids.contains(&VariableID::from(2))); // still free
+            }
+            _ => panic!("Expected Promote"),
+        }
     }
 }

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -2,33 +2,38 @@ use super::*;
 use crate::{ATol, Evaluate, Propagate, VariableIDSet};
 
 impl Propagate for IndicatorConstraint<Created> {
-    type Output = IndicatorPropagateOutput;
+    type Transformed = IndicatorPropagateOutput;
 
     fn propagate(
-        mut self,
+        &mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(Self::Output, crate::v1::State)> {
+    ) -> anyhow::Result<(Option<IndicatorPropagateOutput>, crate::v1::State)> {
         let empty_state = crate::v1::State::default();
 
         if let Some(&indicator_value) = state.entries.get(&self.indicator_variable.into_inner()) {
             if indicator_value > 1.0 - *atol {
-                // Indicator ON → promote inner constraint to regular Constraint
-                // Partial-evaluate the inner function first
-                self.stage.function.partial_evaluate(state, atol)?;
+                // Indicator ON → promote inner constraint to regular Constraint.
+                // Clone the function so self (going to removed) retains its data.
+                let mut promoted_function = self.stage.function.clone();
+                promoted_function.partial_evaluate(state, atol)?;
 
                 let constraint = crate::Constraint {
                     id: crate::ConstraintID::from(self.id.into_inner()),
                     equality: self.equality,
-                    metadata: self.metadata,
+                    metadata: self.metadata.clone(),
                     stage: CreatedData {
-                        function: self.stage.function,
+                        function: promoted_function,
                     },
                 };
-                Ok((IndicatorPropagateOutput::Promote(constraint), empty_state))
+                Ok((
+                    Some(IndicatorPropagateOutput::Promote(constraint)),
+                    empty_state,
+                ))
             } else if indicator_value.abs() < *atol {
                 // Indicator OFF → vacuously satisfied
-                Ok((IndicatorPropagateOutput::Removed, empty_state))
+                // self not mutated — caller moves it to removed
+                Ok((Some(IndicatorPropagateOutput::Removed), empty_state))
             } else {
                 anyhow::bail!(
                     "Indicator variable {:?} of indicator constraint {:?} has invalid value {} (must be 0 or 1)",
@@ -38,9 +43,9 @@ impl Propagate for IndicatorConstraint<Created> {
                 );
             }
         } else {
-            // Indicator variable not in state — partial-evaluate inner function only
+            // Indicator variable not in state — partial-evaluate inner function in-place
             self.stage.function.partial_evaluate(state, atol)?;
-            Ok((IndicatorPropagateOutput::Active(self), empty_state))
+            Ok((None, empty_state))
         }
     }
 }
@@ -335,88 +340,93 @@ mod tests {
 
     #[test]
     fn test_propagate_indicator_on_promotes() {
-        // x1 <= 5, indicator = x10
-        let ic = IndicatorConstraint::new(
+        let mut ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + coeff!(-5.0)),
         );
 
-        // x10 = 1 → promote inner constraint
+        // x10 = 1 → transformed: promote inner constraint
         let state = crate::v1::State::from(HashMap::from([(10, 1.0)]));
-        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        match output {
-            IndicatorPropagateOutput::Promote(constraint) => {
+        match transformed {
+            Some(IndicatorPropagateOutput::Promote(constraint)) => {
                 assert_eq!(constraint.equality, Equality::LessThanOrEqualToZero);
                 assert_eq!(constraint.id, crate::ConstraintID::from(1));
             }
-            _ => panic!("Expected Promote"),
+            _ => panic!("Expected Some(Promote)"),
         }
+        // Original indicator constraint preserved for removed set
+        assert_eq!(ic.indicator_variable, VariableID::from(10));
     }
 
     #[test]
     fn test_propagate_indicator_off_removed() {
-        let ic = IndicatorConstraint::new(
+        let mut ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + coeff!(-5.0)),
         );
 
-        // x10 = 0 → removed
+        // x10 = 0 → transformed: removed
         let state = crate::v1::State::from(HashMap::from([(10, 0.0)]));
-        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        assert!(matches!(output, IndicatorPropagateOutput::Removed));
+        assert!(matches!(
+            transformed,
+            Some(IndicatorPropagateOutput::Removed)
+        ));
     }
 
     #[test]
     fn test_propagate_indicator_not_fixed_partial_evaluates_function() {
-        let ic = IndicatorConstraint::new(
+        let mut ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + linear!(2) + coeff!(-5.0)),
         );
 
-        // x1 = 3 (not indicator), x10 not in state → Active with partial-evaluated function
+        // x1 = 3 (not indicator) → in-place: function partial-evaluated
         let state = crate::v1::State::from(HashMap::from([(1, 3.0)]));
-        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        match output {
-            IndicatorPropagateOutput::Active(ic) => {
-                // x1 was substituted, only x2 remains in function
-                let ids = ic.stage.function.required_ids();
-                assert!(!ids.contains(&VariableID::from(1)));
-                assert!(ids.contains(&VariableID::from(2)));
-            }
-            _ => panic!("Expected Active"),
-        }
+        assert!(transformed.is_none()); // in-place
+                                        // ic's function was partial-evaluated
+        let ids = ic.stage.function.required_ids();
+        assert!(!ids.contains(&VariableID::from(1)));
+        assert!(ids.contains(&VariableID::from(2)));
     }
 
     #[test]
     fn test_propagate_indicator_on_with_function_partial_eval() {
-        // Both indicator fixed and function variables fixed
-        let ic = IndicatorConstraint::new(
+        let mut ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + linear!(2) + coeff!(-5.0)),
         );
 
-        // x10=1, x1=3 → promote with x1 substituted in function
+        // x10=1, x1=3 → promote with x1 substituted in promoted function
         let state = crate::v1::State::from(HashMap::from([(10, 1.0), (1, 3.0)]));
-        let (output, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        match output {
-            IndicatorPropagateOutput::Promote(constraint) => {
+        match transformed {
+            Some(IndicatorPropagateOutput::Promote(constraint)) => {
                 let ids = constraint.stage.function.required_ids();
                 assert!(!ids.contains(&VariableID::from(1))); // substituted
                 assert!(ids.contains(&VariableID::from(2))); // still free
             }
-            _ => panic!("Expected Promote"),
+            _ => panic!("Expected Some(Promote)"),
         }
+        // Original ic still has unmodified function (was cloned for promotion)
+        assert!(ic
+            .stage
+            .function
+            .required_ids()
+            .contains(&VariableID::from(1)));
     }
 }

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -18,10 +18,14 @@ impl Propagate for IndicatorConstraint<Created> {
                 let mut promoted_function = self.stage.function.clone();
                 promoted_function.partial_evaluate(state, atol)?;
 
+                let mut metadata = self.metadata.clone();
+                metadata.provenance =
+                    Some(crate::constraint::Provenance::IndicatorConstraint(self.id));
+
                 let constraint = crate::Constraint {
                     id: crate::ConstraintID::from(self.id.into_inner()),
                     equality: self.equality,
-                    metadata: self.metadata.clone(),
+                    metadata,
                     stage: CreatedData {
                         function: promoted_function,
                     },

--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -1,14 +1,14 @@
 use super::*;
-use crate::{ATol, Evaluate, Propagate, VariableIDSet};
+use crate::{ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet};
 
 impl Propagate for IndicatorConstraint<Created> {
-    type Transformed = IndicatorPropagateOutput;
+    type Transformed = IndicatorPromote;
 
     fn propagate(
-        &mut self,
+        mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(Option<IndicatorPropagateOutput>, crate::v1::State)> {
+    ) -> anyhow::Result<(PropagateOutcome<Self, IndicatorPromote>, crate::v1::State)> {
         let empty_state = crate::v1::State::default();
 
         if let Some(&indicator_value) = state.entries.get(&self.indicator_variable.into_inner()) {
@@ -22,18 +22,21 @@ impl Propagate for IndicatorConstraint<Created> {
                 metadata.provenance =
                     Some(crate::constraint::Provenance::IndicatorConstraint(self.id));
 
+                let new = IndicatorPromote {
+                    equality: self.equality,
+                    function: promoted_function,
+                    metadata,
+                };
                 Ok((
-                    Some(IndicatorPropagateOutput::Promote {
-                        equality: self.equality,
-                        function: promoted_function,
-                        metadata,
-                    }),
+                    PropagateOutcome::Transformed {
+                        original: self,
+                        new,
+                    },
                     empty_state,
                 ))
             } else if indicator_value.abs() < *atol {
-                // Indicator OFF → vacuously satisfied
-                // self not mutated — caller moves it to removed
-                Ok((Some(IndicatorPropagateOutput::Removed), empty_state))
+                // Indicator OFF → vacuously satisfied; the constraint is consumed.
+                Ok((PropagateOutcome::Consumed(self), empty_state))
             } else {
                 anyhow::bail!(
                     "Indicator variable {:?} of indicator constraint {:?} has invalid value {} (must be 0 or 1)",
@@ -45,7 +48,7 @@ impl Propagate for IndicatorConstraint<Created> {
         } else {
             // Indicator variable not in state — partial-evaluate inner function in-place
             self.stage.function.partial_evaluate(state, atol)?;
-            Ok((None, empty_state))
+            Ok((PropagateOutcome::Active(self), empty_state))
         }
     }
 }
@@ -178,7 +181,7 @@ impl Evaluate for IndicatorConstraint<Created> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{coeff, linear, Evaluate, Function, Propagate};
+    use crate::{coeff, linear, Evaluate, Function, Propagate, PropagateOutcome};
     use std::collections::HashMap;
 
     #[test]
@@ -340,100 +343,96 @@ mod tests {
 
     #[test]
     fn test_propagate_indicator_on_promotes() {
-        let mut ic = IndicatorConstraint::new(
+        let ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + coeff!(-5.0)),
         );
 
-        // x10 = 1 → transformed: promote inner constraint
+        // x10 = 1 → Transformed: promote inner constraint
         let state = crate::v1::State::from(HashMap::from([(10, 1.0)]));
-        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (outcome, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        match transformed {
-            Some(IndicatorPropagateOutput::Promote {
-                equality,
-                function: _,
-                metadata,
-            }) => {
-                assert_eq!(equality, Equality::LessThanOrEqualToZero);
+        match outcome {
+            PropagateOutcome::Transformed { original, new } => {
+                assert_eq!(new.equality, Equality::LessThanOrEqualToZero);
                 assert!(matches!(
-                    metadata.provenance,
+                    new.metadata.provenance,
                     Some(crate::constraint::Provenance::IndicatorConstraint(id)) if id == IndicatorConstraintID::from(1)
                 ));
+                // Original indicator constraint preserved for removed set
+                assert_eq!(original.indicator_variable, VariableID::from(10));
             }
-            _ => panic!("Expected Some(Promote)"),
+            _ => panic!("Expected Transformed"),
         }
-        // Original indicator constraint preserved for removed set
-        assert_eq!(ic.indicator_variable, VariableID::from(10));
     }
 
     #[test]
-    fn test_propagate_indicator_off_removed() {
-        let mut ic = IndicatorConstraint::new(
+    fn test_propagate_indicator_off_consumed() {
+        let ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + coeff!(-5.0)),
         );
 
-        // x10 = 0 → transformed: removed
+        // x10 = 0 → Consumed (vacuously satisfied)
         let state = crate::v1::State::from(HashMap::from([(10, 0.0)]));
-        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (outcome, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        assert!(matches!(
-            transformed,
-            Some(IndicatorPropagateOutput::Removed)
-        ));
+        assert!(matches!(outcome, PropagateOutcome::Consumed(_)));
     }
 
     #[test]
     fn test_propagate_indicator_not_fixed_partial_evaluates_function() {
-        let mut ic = IndicatorConstraint::new(
+        let ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + linear!(2) + coeff!(-5.0)),
         );
 
-        // x1 = 3 (not indicator) → in-place: function partial-evaluated
+        // x1 = 3 (not indicator) → Active: function partial-evaluated
         let state = crate::v1::State::from(HashMap::from([(1, 3.0)]));
-        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (outcome, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        assert!(transformed.is_none()); // in-place
-                                        // ic's function was partial-evaluated
-        let ids = ic.stage.function.required_ids();
-        assert!(!ids.contains(&VariableID::from(1)));
-        assert!(ids.contains(&VariableID::from(2)));
+        match outcome {
+            PropagateOutcome::Active(ic) => {
+                let ids = ic.stage.function.required_ids();
+                assert!(!ids.contains(&VariableID::from(1)));
+                assert!(ids.contains(&VariableID::from(2)));
+            }
+            _ => panic!("Expected Active"),
+        }
     }
 
     #[test]
     fn test_propagate_indicator_on_with_function_partial_eval() {
-        let mut ic = IndicatorConstraint::new(
+        let ic = IndicatorConstraint::new(
             IndicatorConstraintID::from(1),
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
             Function::from(linear!(1) + linear!(2) + coeff!(-5.0)),
         );
 
-        // x10=1, x1=3 → promote with x1 substituted in promoted function
+        // x10=1, x1=3 → Transformed with x1 substituted in promoted function
         let state = crate::v1::State::from(HashMap::from([(10, 1.0), (1, 3.0)]));
-        let (transformed, additional) = ic.propagate(&state, ATol::default()).unwrap();
+        let (outcome, additional) = ic.propagate(&state, ATol::default()).unwrap();
         assert!(additional.entries.is_empty());
-        match transformed {
-            Some(IndicatorPropagateOutput::Promote { function, .. }) => {
-                let ids = function.required_ids();
+        match outcome {
+            PropagateOutcome::Transformed { original, new } => {
+                let ids = new.function.required_ids();
                 assert!(!ids.contains(&VariableID::from(1))); // substituted
                 assert!(ids.contains(&VariableID::from(2))); // still free
+                                                             // Original ic still has unmodified function (was cloned for promotion)
+                assert!(original
+                    .stage
+                    .function
+                    .required_ids()
+                    .contains(&VariableID::from(1)));
             }
-            _ => panic!("Expected Some(Promote)"),
+            _ => panic!("Expected Transformed"),
         }
-        // Original ic still has unmodified function (was cloned for promotion)
-        assert!(ic
-            .stage
-            .function
-            .required_ids()
-            .contains(&VariableID::from(1)));
     }
 }

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -164,6 +164,20 @@ impl ConstraintType for IndicatorConstraint {
     type Sampled = SampledIndicatorConstraint;
 }
 
+// ===== Propagate output =====
+
+/// Result of propagating an indicator constraint.
+#[derive(Debug, Clone)]
+pub enum IndicatorPropagateOutput {
+    /// Indicator variable not fixed; constraint remains active.
+    /// Inner function may have been partial-evaluated.
+    Active(IndicatorConstraint<Created>),
+    /// Indicator = 1; inner constraint promoted to a regular `Constraint`.
+    Promote(crate::Constraint<Created>),
+    /// Indicator = 0; constraint vacuously satisfied, removed.
+    Removed,
+}
+
 // ===== Created stage =====
 
 impl IndicatorConstraint<Created> {

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -43,6 +43,12 @@ impl IndicatorConstraintID {
     }
 }
 
+impl From<IndicatorConstraintID> for u64 {
+    fn from(id: IndicatorConstraintID) -> Self {
+        id.0
+    }
+}
+
 /// An indicator constraint: `indicator_variable = 1 → f(x) <= 0` (or `= 0`).
 ///
 /// When the binary indicator variable is 0, the constraint is unconditionally satisfied.
@@ -172,8 +178,15 @@ impl ConstraintType for IndicatorConstraint {
 /// The "active/in-place" case is represented by `None` at the `Propagate` level.
 #[derive(Debug, Clone)]
 pub enum IndicatorPropagateOutput {
-    /// Indicator = 1; inner constraint promoted to a regular `Constraint`.
-    Promote(crate::Constraint<Created>),
+    /// Indicator = 1; inner constraint should be promoted to a regular `Constraint`.
+    ///
+    /// Contains the components needed to build the promoted constraint.
+    /// The caller (Instance) is responsible for assigning a unique `ConstraintID`.
+    Promote {
+        equality: Equality,
+        function: Function,
+        metadata: ConstraintMetadata,
+    },
     /// Indicator = 0; constraint vacuously satisfied, removed.
     Removed,
 }

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -166,12 +166,12 @@ impl ConstraintType for IndicatorConstraint {
 
 // ===== Propagate output =====
 
-/// Result of propagating an indicator constraint.
+/// The transformation result when an indicator constraint is consumed during propagation.
+///
+/// This is the `Transformed` type for `Propagate` impl on `IndicatorConstraint`.
+/// The "active/in-place" case is represented by `None` at the `Propagate` level.
 #[derive(Debug, Clone)]
 pub enum IndicatorPropagateOutput {
-    /// Indicator variable not fixed; constraint remains active.
-    /// Inner function may have been partial-evaluated.
-    Active(IndicatorConstraint<Created>),
     /// Indicator = 1; inner constraint promoted to a regular `Constraint`.
     Promote(crate::Constraint<Created>),
     /// Indicator = 0; constraint vacuously satisfied, removed.

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -172,23 +172,19 @@ impl ConstraintType for IndicatorConstraint {
 
 // ===== Propagate output =====
 
-/// The transformation result when an indicator constraint is consumed during propagation.
+/// Components of a regular constraint promoted from an indicator constraint
+/// (when the indicator variable is fixed to 1).
 ///
 /// This is the `Transformed` type for `Propagate` impl on `IndicatorConstraint`.
-/// The "active/in-place" case is represented by `None` at the `Propagate` level.
+/// The caller (Instance) assigns a unique `ConstraintID` for the new constraint.
+///
+/// Other propagation outcomes (indicator=0 → removed, no propagation → active)
+/// are represented at the [`PropagateOutcome`](crate::PropagateOutcome) level.
 #[derive(Debug, Clone)]
-pub enum IndicatorPropagateOutput {
-    /// Indicator = 1; inner constraint should be promoted to a regular `Constraint`.
-    ///
-    /// Contains the components needed to build the promoted constraint.
-    /// The caller (Instance) is responsible for assigning a unique `ConstraintID`.
-    Promote {
-        equality: Equality,
-        function: Function,
-        metadata: ConstraintMetadata,
-    },
-    /// Indicator = 0; constraint vacuously satisfied, removed.
-    Removed,
+pub struct IndicatorPromote {
+    pub equality: Equality,
+    pub function: Function,
+    pub metadata: ConstraintMetadata,
 }
 
 // ===== Created stage =====

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -240,19 +240,18 @@ impl Instance {
                             .active_mut()
                             .insert(id, ic);
                     }
-                    Some(IndicatorPropagateOutput::Promote(constraint)) => {
-                        // Validate no ConstraintID collision
-                        let cid = constraint.id;
-                        if self.constraint_collection.active().contains_key(&cid)
-                            || self.constraint_collection.removed().contains_key(&cid)
-                        {
-                            anyhow::bail!(
-                                "Cannot promote indicator constraint {:?}: \
-                                 ConstraintID {:?} already exists in constraint collection",
-                                id,
-                                cid
-                            );
-                        }
+                    Some(IndicatorPropagateOutput::Promote {
+                        equality,
+                        function,
+                        metadata,
+                    }) => {
+                        let cid = self.constraint_collection.unused_id();
+                        let constraint = crate::Constraint {
+                            id: cid,
+                            equality,
+                            metadata,
+                            stage: crate::CreatedData { function },
+                        };
                         self.constraint_collection
                             .active_mut()
                             .insert(cid, constraint);
@@ -624,11 +623,8 @@ mod tests {
         assert!(instance.indicator_constraint_collection.active().is_empty());
         assert_eq!(instance.indicator_constraint_collection.removed().len(), 1);
 
-        // A new regular constraint should be added with ConstraintID(100)
-        assert!(instance
-            .constraint_collection
-            .active()
-            .contains_key(&ConstraintID::from(100)));
+        // A new regular constraint should be added
+        assert_eq!(instance.constraint_collection.active().len(), 1);
     }
 
     #[test]

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -8,12 +8,17 @@ use std::collections::BTreeMap;
 /// Merge additional variable fixings from propagation into `expanded` state.
 ///
 /// Returns `Err` if any fixing conflicts with an existing value in `expanded`
-/// (outside of numerical tolerance), which indicates infeasibility discovered
-/// during propagation.
-fn merge_state(expanded: &mut v1::State, additional: v1::State, changed: &mut bool) -> Result<()> {
+/// (outside of `atol`), which indicates infeasibility discovered during
+/// propagation.
+fn merge_state(
+    expanded: &mut v1::State,
+    additional: v1::State,
+    atol: ATol,
+    changed: &mut bool,
+) -> Result<()> {
     for (var_id, value) in additional.entries {
         if let Some(&existing) = expanded.entries.get(&var_id) {
-            if (existing - value).abs() > *ATol::default() {
+            if (existing - value).abs() > *atol {
                 return Err(anyhow!(
                     "Conflicting variable fixings for ID={var_id}: \
                      existing={existing}, new={value}"
@@ -208,7 +213,7 @@ impl Instance {
             let one_hots = std::mem::take(self.one_hot_constraint_collection.active_mut());
             for (id, oh) in one_hots {
                 let (outcome, additional) = oh.propagate(&expanded, atol)?;
-                merge_state(&mut expanded, additional, &mut changed)?;
+                merge_state(&mut expanded, additional, atol, &mut changed)?;
                 match outcome {
                     PropagateOutcome::Active(oh) => {
                         self.one_hot_constraint_collection
@@ -233,7 +238,7 @@ impl Instance {
             let sos1s = std::mem::take(self.sos1_constraint_collection.active_mut());
             for (id, sos1) in sos1s {
                 let (outcome, additional) = sos1.propagate(&expanded, atol)?;
-                merge_state(&mut expanded, additional, &mut changed)?;
+                merge_state(&mut expanded, additional, atol, &mut changed)?;
                 match outcome {
                     PropagateOutcome::Active(sos1) => {
                         self.sos1_constraint_collection
@@ -257,7 +262,7 @@ impl Instance {
             let indicators = std::mem::take(self.indicator_constraint_collection.active_mut());
             for (id, ic) in indicators {
                 let (outcome, additional) = ic.propagate(&expanded, atol)?;
-                merge_state(&mut expanded, additional, &mut changed)?;
+                merge_state(&mut expanded, additional, atol, &mut changed)?;
                 match outcome {
                     PropagateOutcome::Active(ic) => {
                         self.indicator_constraint_collection

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -1,10 +1,32 @@
 use super::*;
 use crate::{
-    constraint::RemovedReason, indicator_constraint::IndicatorPropagateOutput, ATol, Evaluate,
-    Propagate, VariableIDSet,
+    constraint::RemovedReason, ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet,
 };
 use anyhow::{anyhow, Result};
 use std::collections::BTreeMap;
+
+/// Merge additional variable fixings from propagation into `expanded` state.
+///
+/// Returns `Err` if any fixing conflicts with an existing value in `expanded`
+/// (outside of numerical tolerance), which indicates infeasibility discovered
+/// during propagation.
+fn merge_state(expanded: &mut v1::State, additional: v1::State, changed: &mut bool) -> Result<()> {
+    for (var_id, value) in additional.entries {
+        if let Some(&existing) = expanded.entries.get(&var_id) {
+            if (existing - value).abs() > *ATol::default() {
+                return Err(anyhow!(
+                    "Conflicting variable fixings for ID={var_id}: \
+                     existing={existing}, new={value}"
+                ));
+            }
+            // Same value: nothing to do.
+        } else {
+            expanded.entries.insert(var_id, value);
+            *changed = true;
+        }
+    }
+    Ok(())
+}
 
 impl Evaluate for Instance {
     type Output = crate::Solution;
@@ -118,13 +140,17 @@ impl Evaluate for Instance {
     }
 
     fn partial_evaluate(&mut self, state: &v1::State, atol: ATol) -> Result<()> {
+        // Operate on a clone so that any failure leaves `self` unchanged (atomic).
+        // Propagation consumes constraints via `self` in `Propagate`, so even a
+        // partial failure would otherwise leave the Instance in an inconsistent state.
+        let mut working = self.clone();
+
         // Phase 1: Propagate through special constraints (unit propagation).
-        // This may discover additional variable fixings and consume/transform constraints.
-        let expanded_state = self.propagate_special_constraints(state, atol)?;
+        let expanded_state = working.propagate_special_constraints(state, atol)?;
 
         // Phase 2: Substitute fixed values into decision variables.
         for (id, value) in expanded_state.entries.iter() {
-            let Some(dv) = self.decision_variables.get_mut(&VariableID::from(*id)) else {
+            let Some(dv) = working.decision_variables.get_mut(&VariableID::from(*id)) else {
                 return Err(anyhow!("Unknown decision variable (ID={id}) in state."));
             };
             dv.substitute(*value, atol)?;
@@ -132,14 +158,19 @@ impl Evaluate for Instance {
 
         // Phase 3: Regular partial evaluation with expanded state.
         // Special constraint collections are already handled by propagation — not called again.
-        self.objective.partial_evaluate(&expanded_state, atol)?;
-        self.constraint_collection
+        working.objective.partial_evaluate(&expanded_state, atol)?;
+        working
+            .constraint_collection
             .partial_evaluate(&expanded_state, atol)?;
-        for named_function in self.named_functions.values_mut() {
+        for named_function in working.named_functions.values_mut() {
             named_function.partial_evaluate(&expanded_state, atol)?;
         }
-        self.decision_variable_dependency
+        working
+            .decision_variable_dependency
             .partial_evaluate(&expanded_state, atol)?;
+
+        // All operations succeeded; commit changes atomically.
+        *self = working;
         Ok(())
     }
 
@@ -175,96 +206,86 @@ impl Instance {
 
             // --- OneHot constraints ---
             let one_hots = std::mem::take(self.one_hot_constraint_collection.active_mut());
-            for (id, mut oh) in one_hots {
-                let (transformed, additional) = oh.propagate(&expanded, atol)?;
-                if !additional.entries.is_empty() {
-                    for (var_id, value) in additional.entries {
-                        expanded.entries.insert(var_id, value);
-                    }
-                    changed = true;
-                }
-                match transformed {
-                    None => {
-                        // In-place modification — keep active
+            for (id, oh) in one_hots {
+                let (outcome, additional) = oh.propagate(&expanded, atol)?;
+                merge_state(&mut expanded, additional, &mut changed)?;
+                match outcome {
+                    PropagateOutcome::Active(oh) => {
                         self.one_hot_constraint_collection
                             .active_mut()
                             .insert(id, oh);
                     }
-                    Some(()) => {
-                        // Transformed (consumed) — move original to removed
+                    PropagateOutcome::Consumed(oh) => {
                         self.one_hot_constraint_collection
                             .removed_mut()
                             .insert(id, (oh, propagation_reason.clone()));
+                    }
+                    PropagateOutcome::Transformed { original, new: () } => {
+                        // OneHot has no non-trivial transformation; treat as consumed.
+                        self.one_hot_constraint_collection
+                            .removed_mut()
+                            .insert(id, (original, propagation_reason.clone()));
                     }
                 }
             }
 
             // --- SOS1 constraints ---
             let sos1s = std::mem::take(self.sos1_constraint_collection.active_mut());
-            for (id, mut sos1) in sos1s {
-                let (transformed, additional) = sos1.propagate(&expanded, atol)?;
-                if !additional.entries.is_empty() {
-                    for (var_id, value) in additional.entries {
-                        expanded.entries.insert(var_id, value);
-                    }
-                    changed = true;
-                }
-                match transformed {
-                    None => {
+            for (id, sos1) in sos1s {
+                let (outcome, additional) = sos1.propagate(&expanded, atol)?;
+                merge_state(&mut expanded, additional, &mut changed)?;
+                match outcome {
+                    PropagateOutcome::Active(sos1) => {
                         self.sos1_constraint_collection
                             .active_mut()
                             .insert(id, sos1);
                     }
-                    Some(()) => {
+                    PropagateOutcome::Consumed(sos1) => {
                         self.sos1_constraint_collection
                             .removed_mut()
                             .insert(id, (sos1, propagation_reason.clone()));
+                    }
+                    PropagateOutcome::Transformed { original, new: () } => {
+                        self.sos1_constraint_collection
+                            .removed_mut()
+                            .insert(id, (original, propagation_reason.clone()));
                     }
                 }
             }
 
             // --- Indicator constraints ---
             let indicators = std::mem::take(self.indicator_constraint_collection.active_mut());
-            for (id, mut ic) in indicators {
-                let (transformed, additional) = ic.propagate(&expanded, atol)?;
-                if !additional.entries.is_empty() {
-                    for (var_id, value) in additional.entries {
-                        expanded.entries.insert(var_id, value);
-                    }
-                    changed = true;
-                }
-                match transformed {
-                    None => {
-                        // In-place — keep active
+            for (id, ic) in indicators {
+                let (outcome, additional) = ic.propagate(&expanded, atol)?;
+                merge_state(&mut expanded, additional, &mut changed)?;
+                match outcome {
+                    PropagateOutcome::Active(ic) => {
                         self.indicator_constraint_collection
                             .active_mut()
                             .insert(id, ic);
                     }
-                    Some(IndicatorPropagateOutput::Promote {
-                        equality,
-                        function,
-                        metadata,
-                    }) => {
-                        let cid = self.constraint_collection.unused_id();
-                        let constraint = crate::Constraint {
-                            id: cid,
-                            equality,
-                            metadata,
-                            stage: crate::CreatedData { function },
-                        };
-                        self.constraint_collection
-                            .active_mut()
-                            .insert(cid, constraint);
-                        // Move original indicator to removed (preserves full data)
+                    PropagateOutcome::Consumed(ic) => {
                         self.indicator_constraint_collection
                             .removed_mut()
                             .insert(id, (ic, propagation_reason.clone()));
                     }
-                    Some(IndicatorPropagateOutput::Removed) => {
-                        // Move original indicator to removed
+                    PropagateOutcome::Transformed { original, new } => {
+                        // Indicator=1 → promote inner constraint to regular constraint
+                        let cid = self.constraint_collection.unused_id();
+                        let constraint = crate::Constraint {
+                            id: cid,
+                            equality: new.equality,
+                            metadata: new.metadata,
+                            stage: crate::CreatedData {
+                                function: new.function,
+                            },
+                        };
+                        self.constraint_collection
+                            .active_mut()
+                            .insert(cid, constraint);
                         self.indicator_constraint_collection
                             .removed_mut()
-                            .insert(id, (ic, propagation_reason.clone()));
+                            .insert(id, (original, propagation_reason.clone()));
                     }
                 }
             }

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -225,12 +225,7 @@ impl Instance {
                             .removed_mut()
                             .insert(id, (oh, propagation_reason.clone()));
                     }
-                    PropagateOutcome::Transformed { original, new: () } => {
-                        // OneHot has no non-trivial transformation; treat as consumed.
-                        self.one_hot_constraint_collection
-                            .removed_mut()
-                            .insert(id, (original, propagation_reason.clone()));
-                    }
+                    PropagateOutcome::Transformed { new, .. } => match new {},
                 }
             }
 
@@ -250,11 +245,7 @@ impl Instance {
                             .removed_mut()
                             .insert(id, (sos1, propagation_reason.clone()));
                     }
-                    PropagateOutcome::Transformed { original, new: () } => {
-                        self.sos1_constraint_collection
-                            .removed_mut()
-                            .insert(id, (original, propagation_reason.clone()));
-                    }
+                    PropagateOutcome::Transformed { new, .. } => match new {},
                 }
             }
 

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -175,74 +175,72 @@ impl Instance {
 
             // --- OneHot constraints ---
             let one_hots = std::mem::take(self.one_hot_constraint_collection.active_mut());
-            for (id, oh) in one_hots {
-                let (output, additional) = oh.propagate(&expanded, atol)?;
+            for (id, mut oh) in one_hots {
+                let (transformed, additional) = oh.propagate(&expanded, atol)?;
                 if !additional.entries.is_empty() {
                     for (var_id, value) in additional.entries {
                         expanded.entries.insert(var_id, value);
                     }
                     changed = true;
                 }
-                match output {
-                    Some(shrunk) => {
+                match transformed {
+                    None => {
+                        // In-place modification — keep active
                         self.one_hot_constraint_collection
                             .active_mut()
-                            .insert(id, shrunk);
+                            .insert(id, oh);
                     }
-                    None => {
-                        // Constraint consumed — create a placeholder for removed set
-                        let placeholder =
-                            crate::OneHotConstraint::new(id, std::collections::BTreeSet::new());
+                    Some(()) => {
+                        // Transformed (consumed) — move original to removed
                         self.one_hot_constraint_collection
                             .removed_mut()
-                            .insert(id, (placeholder, propagation_reason.clone()));
+                            .insert(id, (oh, propagation_reason.clone()));
                     }
                 }
             }
 
             // --- SOS1 constraints ---
             let sos1s = std::mem::take(self.sos1_constraint_collection.active_mut());
-            for (id, sos1) in sos1s {
-                let (output, additional) = sos1.propagate(&expanded, atol)?;
+            for (id, mut sos1) in sos1s {
+                let (transformed, additional) = sos1.propagate(&expanded, atol)?;
                 if !additional.entries.is_empty() {
                     for (var_id, value) in additional.entries {
                         expanded.entries.insert(var_id, value);
                     }
                     changed = true;
                 }
-                match output {
-                    Some(shrunk) => {
+                match transformed {
+                    None => {
                         self.sos1_constraint_collection
                             .active_mut()
-                            .insert(id, shrunk);
+                            .insert(id, sos1);
                     }
-                    None => {
-                        let placeholder =
-                            crate::Sos1Constraint::new(id, std::collections::BTreeSet::new());
+                    Some(()) => {
                         self.sos1_constraint_collection
                             .removed_mut()
-                            .insert(id, (placeholder, propagation_reason.clone()));
+                            .insert(id, (sos1, propagation_reason.clone()));
                     }
                 }
             }
 
             // --- Indicator constraints ---
             let indicators = std::mem::take(self.indicator_constraint_collection.active_mut());
-            for (id, ic) in indicators {
-                let (output, additional) = ic.propagate(&expanded, atol)?;
+            for (id, mut ic) in indicators {
+                let (transformed, additional) = ic.propagate(&expanded, atol)?;
                 if !additional.entries.is_empty() {
                     for (var_id, value) in additional.entries {
                         expanded.entries.insert(var_id, value);
                     }
                     changed = true;
                 }
-                match output {
-                    IndicatorPropagateOutput::Active(ic) => {
+                match transformed {
+                    None => {
+                        // In-place — keep active
                         self.indicator_constraint_collection
                             .active_mut()
                             .insert(id, ic);
                     }
-                    IndicatorPropagateOutput::Promote(constraint) => {
+                    Some(IndicatorPropagateOutput::Promote(constraint)) => {
                         // Validate no ConstraintID collision
                         let cid = constraint.id;
                         if self.constraint_collection.active().contains_key(&cid)
@@ -258,27 +256,16 @@ impl Instance {
                         self.constraint_collection
                             .active_mut()
                             .insert(cid, constraint);
-                        // Also record indicator as removed
-                        let placeholder = crate::IndicatorConstraint::new(
-                            id,
-                            VariableID::from(0), // placeholder
-                            crate::constraint::Equality::EqualToZero,
-                            Function::Zero,
-                        );
+                        // Move original indicator to removed (preserves full data)
                         self.indicator_constraint_collection
                             .removed_mut()
-                            .insert(id, (placeholder, propagation_reason.clone()));
+                            .insert(id, (ic, propagation_reason.clone()));
                     }
-                    IndicatorPropagateOutput::Removed => {
-                        let placeholder = crate::IndicatorConstraint::new(
-                            id,
-                            VariableID::from(0),
-                            crate::constraint::Equality::EqualToZero,
-                            Function::Zero,
-                        );
+                    Some(IndicatorPropagateOutput::Removed) => {
+                        // Move original indicator to removed
                         self.indicator_constraint_collection
                             .removed_mut()
-                            .insert(id, (placeholder, propagation_reason.clone()));
+                            .insert(id, (ic, propagation_reason.clone()));
                     }
                 }
             }

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{ATol, Evaluate, VariableIDSet};
+use crate::{
+    constraint::RemovedReason, indicator_constraint::IndicatorPropagateOutput, ATol, Evaluate,
+    Propagate, VariableIDSet,
+};
 use anyhow::{anyhow, Result};
 use std::collections::BTreeMap;
 
@@ -115,75 +118,173 @@ impl Evaluate for Instance {
     }
 
     fn partial_evaluate(&mut self, state: &v1::State, atol: ATol) -> Result<()> {
-        let updated_state = state.clone();
+        // Phase 1: Propagate through special constraints (unit propagation).
+        // This may discover additional variable fixings and consume/transform constraints.
+        let expanded_state = self.propagate_special_constraints(state, atol)?;
 
-        // Validate that no indicator variable is being partially evaluated.
-        // This check must happen before any mutation to ensure the Instance
-        // is not left in an inconsistent state on error.
-        for ic in self.indicator_constraint_collection.active().values() {
-            if updated_state
-                .entries
-                .contains_key(&ic.indicator_variable.into_inner())
-            {
-                anyhow::bail!(
-                    "Cannot partially evaluate indicator variable {:?} of indicator constraint {:?}. \
-                     Fixing an indicator variable would change the constraint type.",
-                    ic.indicator_variable,
-                    ic.id
-                );
-            }
-        }
-
-        // Validate that no one-hot or SOS1 variable is being partially evaluated.
-        for oh in self.one_hot_constraint_collection.active().values() {
-            for var_id in &oh.variables {
-                if updated_state.entries.contains_key(&var_id.into_inner()) {
-                    anyhow::bail!(
-                        "Cannot partially evaluate variable {:?} of one-hot constraint {:?}. \
-                         Fixing a one-hot variable would change the constraint type.",
-                        var_id,
-                        oh.id
-                    );
-                }
-            }
-        }
-        for sos1 in self.sos1_constraint_collection.active().values() {
-            for var_id in &sos1.variables {
-                if updated_state.entries.contains_key(&var_id.into_inner()) {
-                    anyhow::bail!(
-                        "Cannot partially evaluate variable {:?} of SOS1 constraint {:?}. \
-                         Fixing a SOS1 variable would change the constraint type.",
-                        var_id,
-                        sos1.id
-                    );
-                }
-            }
-        }
-
-        // Then proceed with the regular partial evaluation using the updated state
-        for (id, value) in updated_state.entries.iter() {
+        // Phase 2: Substitute fixed values into decision variables.
+        for (id, value) in expanded_state.entries.iter() {
             let Some(dv) = self.decision_variables.get_mut(&VariableID::from(*id)) else {
                 return Err(anyhow!("Unknown decision variable (ID={id}) in state."));
             };
             dv.substitute(*value, atol)?;
         }
-        self.objective.partial_evaluate(&updated_state, atol)?;
+
+        // Phase 3: Regular partial evaluation with expanded state.
+        // Special constraint collections are already handled by propagation — not called again.
+        self.objective.partial_evaluate(&expanded_state, atol)?;
         self.constraint_collection
-            .partial_evaluate(&updated_state, atol)?;
-        // Indicator variable check already passed above, so this only
-        // partial_evaluates the function parts of indicator constraints.
-        self.indicator_constraint_collection
-            .partial_evaluate(&updated_state, atol)?;
+            .partial_evaluate(&expanded_state, atol)?;
         for named_function in self.named_functions.values_mut() {
-            named_function.partial_evaluate(&updated_state, atol)?;
+            named_function.partial_evaluate(&expanded_state, atol)?;
         }
         self.decision_variable_dependency
-            .partial_evaluate(&updated_state, atol)?;
+            .partial_evaluate(&expanded_state, atol)?;
         Ok(())
     }
 
     fn required_ids(&self) -> VariableIDSet {
         self.analyze_decision_variables().used().clone()
+    }
+}
+
+impl Instance {
+    /// Run unit propagation over special constraint types (OneHot, SOS1, Indicator).
+    ///
+    /// This is a fixed-point iteration: each constraint is propagated with the current
+    /// state, and any additional variable fixings are merged back into the state.
+    /// The loop continues until no new fixings are discovered.
+    ///
+    /// Consumed constraints are moved to the removed set.
+    /// Promoted indicator constraints are inserted into the regular constraint collection.
+    fn propagate_special_constraints(
+        &mut self,
+        state: &v1::State,
+        atol: ATol,
+    ) -> Result<v1::State> {
+        let mut expanded = state.clone();
+        let mut changed = true;
+
+        let propagation_reason = RemovedReason {
+            reason: "unit_propagation".to_string(),
+            parameters: Default::default(),
+        };
+
+        while changed {
+            changed = false;
+
+            // --- OneHot constraints ---
+            let one_hots = std::mem::take(self.one_hot_constraint_collection.active_mut());
+            for (id, oh) in one_hots {
+                let (output, additional) = oh.propagate(&expanded, atol)?;
+                if !additional.entries.is_empty() {
+                    for (var_id, value) in additional.entries {
+                        expanded.entries.insert(var_id, value);
+                    }
+                    changed = true;
+                }
+                match output {
+                    Some(shrunk) => {
+                        self.one_hot_constraint_collection
+                            .active_mut()
+                            .insert(id, shrunk);
+                    }
+                    None => {
+                        // Constraint consumed — create a placeholder for removed set
+                        let placeholder =
+                            crate::OneHotConstraint::new(id, std::collections::BTreeSet::new());
+                        self.one_hot_constraint_collection
+                            .removed_mut()
+                            .insert(id, (placeholder, propagation_reason.clone()));
+                    }
+                }
+            }
+
+            // --- SOS1 constraints ---
+            let sos1s = std::mem::take(self.sos1_constraint_collection.active_mut());
+            for (id, sos1) in sos1s {
+                let (output, additional) = sos1.propagate(&expanded, atol)?;
+                if !additional.entries.is_empty() {
+                    for (var_id, value) in additional.entries {
+                        expanded.entries.insert(var_id, value);
+                    }
+                    changed = true;
+                }
+                match output {
+                    Some(shrunk) => {
+                        self.sos1_constraint_collection
+                            .active_mut()
+                            .insert(id, shrunk);
+                    }
+                    None => {
+                        let placeholder =
+                            crate::Sos1Constraint::new(id, std::collections::BTreeSet::new());
+                        self.sos1_constraint_collection
+                            .removed_mut()
+                            .insert(id, (placeholder, propagation_reason.clone()));
+                    }
+                }
+            }
+
+            // --- Indicator constraints ---
+            let indicators = std::mem::take(self.indicator_constraint_collection.active_mut());
+            for (id, ic) in indicators {
+                let (output, additional) = ic.propagate(&expanded, atol)?;
+                if !additional.entries.is_empty() {
+                    for (var_id, value) in additional.entries {
+                        expanded.entries.insert(var_id, value);
+                    }
+                    changed = true;
+                }
+                match output {
+                    IndicatorPropagateOutput::Active(ic) => {
+                        self.indicator_constraint_collection
+                            .active_mut()
+                            .insert(id, ic);
+                    }
+                    IndicatorPropagateOutput::Promote(constraint) => {
+                        // Validate no ConstraintID collision
+                        let cid = constraint.id;
+                        if self.constraint_collection.active().contains_key(&cid)
+                            || self.constraint_collection.removed().contains_key(&cid)
+                        {
+                            anyhow::bail!(
+                                "Cannot promote indicator constraint {:?}: \
+                                 ConstraintID {:?} already exists in constraint collection",
+                                id,
+                                cid
+                            );
+                        }
+                        self.constraint_collection
+                            .active_mut()
+                            .insert(cid, constraint);
+                        // Also record indicator as removed
+                        let placeholder = crate::IndicatorConstraint::new(
+                            id,
+                            VariableID::from(0), // placeholder
+                            crate::constraint::Equality::EqualToZero,
+                            Function::Zero,
+                        );
+                        self.indicator_constraint_collection
+                            .removed_mut()
+                            .insert(id, (placeholder, propagation_reason.clone()));
+                    }
+                    IndicatorPropagateOutput::Removed => {
+                        let placeholder = crate::IndicatorConstraint::new(
+                            id,
+                            VariableID::from(0),
+                            crate::constraint::Equality::EqualToZero,
+                            Function::Zero,
+                        );
+                        self.indicator_constraint_collection
+                            .removed_mut()
+                            .insert(id, (placeholder, propagation_reason.clone()));
+                    }
+                }
+            }
+        }
+
+        Ok(expanded)
     }
 }
 
@@ -335,5 +436,252 @@ mod tests {
         assert!(used_ids.contains(&VariableID::from(5)));
         // x1 is not used in the named function
         assert!(!used_ids.contains(&VariableID::from(1)));
+    }
+
+    // === Unit propagation integration tests ===
+
+    #[test]
+    fn test_partial_evaluate_one_hot_propagation() {
+        use crate::{DecisionVariable, OneHotConstraint, OneHotConstraintID};
+        use maplit::btreemap;
+
+        // Binary variables x1, x2, x3 with OneHot{x1, x2, x3}
+        let decision_variables = btreemap! {
+            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+        };
+        let objective = Function::from(linear!(1) + linear!(2) + linear!(3));
+
+        let mut instance = Instance::new(
+            Sense::Minimize,
+            objective,
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let oh = OneHotConstraint::new(
+            OneHotConstraintID::from(1),
+            [1, 2, 3].into_iter().map(VariableID::from).collect(),
+        );
+        instance
+            .one_hot_constraint_collection
+            .active_mut()
+            .insert(OneHotConstraintID::from(1), oh);
+
+        // Fix x2 = 1 → OneHot propagation should fix x1=0, x3=0
+        let state = v1::State::from(HashMap::from([(2, 1.0)]));
+        instance.partial_evaluate(&state, ATol::default()).unwrap();
+
+        // All three variables should be substituted
+        assert_eq!(
+            instance.decision_variables[&VariableID::from(1)].substituted_value(),
+            Some(0.0)
+        );
+        assert_eq!(
+            instance.decision_variables[&VariableID::from(2)].substituted_value(),
+            Some(1.0)
+        );
+        assert_eq!(
+            instance.decision_variables[&VariableID::from(3)].substituted_value(),
+            Some(0.0)
+        );
+
+        // OneHot constraint should be consumed (moved to removed)
+        assert!(instance.one_hot_constraint_collection.active().is_empty());
+        assert_eq!(instance.one_hot_constraint_collection.removed().len(), 1);
+    }
+
+    #[test]
+    fn test_partial_evaluate_one_hot_unit_propagation() {
+        use crate::{DecisionVariable, OneHotConstraint, OneHotConstraintID};
+        use maplit::btreemap;
+
+        let decision_variables = btreemap! {
+            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+        };
+        let objective = Function::from(linear!(1) + linear!(2) + linear!(3));
+
+        let mut instance = Instance::new(
+            Sense::Minimize,
+            objective,
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let oh = OneHotConstraint::new(
+            OneHotConstraintID::from(1),
+            [1, 2, 3].into_iter().map(VariableID::from).collect(),
+        );
+        instance
+            .one_hot_constraint_collection
+            .active_mut()
+            .insert(OneHotConstraintID::from(1), oh);
+
+        // Fix x1=0, x2=0 → unit propagation: x3 must be 1
+        let state = v1::State::from(HashMap::from([(1, 0.0), (2, 0.0)]));
+        instance.partial_evaluate(&state, ATol::default()).unwrap();
+
+        assert_eq!(
+            instance.decision_variables[&VariableID::from(3)].substituted_value(),
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn test_partial_evaluate_cascade_one_hot_sos1() {
+        use crate::{
+            DecisionVariable, OneHotConstraint, OneHotConstraintID, Sos1Constraint,
+            Sos1ConstraintID,
+        };
+        use maplit::btreemap;
+
+        // x1, x2 in OneHot; x2, x3 in SOS1
+        // Fix x1=1 → OneHot propagates x2=0 → SOS1 shrinks (x2 removed)
+        let decision_variables = btreemap! {
+            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(3) => DecisionVariable::continuous(VariableID::from(3)),
+        };
+        let objective = Function::from(linear!(1) + linear!(2) + linear!(3));
+
+        let mut instance = Instance::new(
+            Sense::Minimize,
+            objective,
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let oh = OneHotConstraint::new(
+            OneHotConstraintID::from(1),
+            [1, 2].into_iter().map(VariableID::from).collect(),
+        );
+        instance
+            .one_hot_constraint_collection
+            .active_mut()
+            .insert(OneHotConstraintID::from(1), oh);
+
+        let sos1 = Sos1Constraint::new(
+            Sos1ConstraintID::from(1),
+            [2, 3].into_iter().map(VariableID::from).collect(),
+        );
+        instance
+            .sos1_constraint_collection
+            .active_mut()
+            .insert(Sos1ConstraintID::from(1), sos1);
+
+        // Fix x1=1 → OneHot: x2=0 → SOS1{x2,x3} shrinks to SOS1{x3}
+        let state = v1::State::from(HashMap::from([(1, 1.0)]));
+        instance.partial_evaluate(&state, ATol::default()).unwrap();
+
+        // x2 should be fixed to 0 by propagation
+        assert_eq!(
+            instance.decision_variables[&VariableID::from(2)].substituted_value(),
+            Some(0.0)
+        );
+
+        // OneHot consumed, SOS1 shrunk to just x3
+        assert!(instance.one_hot_constraint_collection.active().is_empty());
+        let sos1_active = instance.sos1_constraint_collection.active();
+        assert_eq!(sos1_active.len(), 1);
+        let remaining_sos1 = sos1_active.values().next().unwrap();
+        assert_eq!(remaining_sos1.variables.len(), 1);
+        assert!(remaining_sos1.variables.contains(&VariableID::from(3)));
+    }
+
+    #[test]
+    fn test_partial_evaluate_indicator_promotion() {
+        use crate::{constraint::Equality, DecisionVariable, IndicatorConstraintID};
+        use maplit::btreemap;
+
+        // x10 (indicator), x1, x2 (function variables)
+        let decision_variables = btreemap! {
+            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
+            VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
+            VariableID::from(10) => DecisionVariable::binary(VariableID::from(10)),
+        };
+        let objective = Function::from(linear!(1) + linear!(2));
+
+        let mut indicator_constraints = BTreeMap::new();
+        indicator_constraints.insert(
+            IndicatorConstraintID::from(100),
+            crate::IndicatorConstraint::new(
+                IndicatorConstraintID::from(100),
+                VariableID::from(10),
+                Equality::LessThanOrEqualToZero,
+                Function::from(linear!(1) + linear!(2) + coeff!(-5.0)),
+            ),
+        );
+
+        let instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(objective)
+            .decision_variables(decision_variables)
+            .constraints(BTreeMap::new())
+            .indicator_constraints(indicator_constraints)
+            .build()
+            .unwrap();
+
+        let mut instance = instance;
+
+        // Fix x10=1 → indicator promoted to regular constraint
+        let state = v1::State::from(HashMap::from([(10, 1.0)]));
+        instance.partial_evaluate(&state, ATol::default()).unwrap();
+
+        // Indicator constraint should be removed
+        assert!(instance.indicator_constraint_collection.active().is_empty());
+        assert_eq!(instance.indicator_constraint_collection.removed().len(), 1);
+
+        // A new regular constraint should be added with ConstraintID(100)
+        assert!(instance
+            .constraint_collection
+            .active()
+            .contains_key(&ConstraintID::from(100)));
+    }
+
+    #[test]
+    fn test_partial_evaluate_indicator_removed() {
+        use crate::{constraint::Equality, DecisionVariable, IndicatorConstraintID};
+        use maplit::btreemap;
+
+        let decision_variables = btreemap! {
+            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
+            VariableID::from(10) => DecisionVariable::binary(VariableID::from(10)),
+        };
+        let objective = Function::from(linear!(1));
+
+        let mut indicator_constraints = BTreeMap::new();
+        indicator_constraints.insert(
+            IndicatorConstraintID::from(1),
+            crate::IndicatorConstraint::new(
+                IndicatorConstraintID::from(1),
+                VariableID::from(10),
+                Equality::LessThanOrEqualToZero,
+                Function::from(linear!(1) + coeff!(-5.0)),
+            ),
+        );
+
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(objective)
+            .decision_variables(decision_variables)
+            .constraints(BTreeMap::new())
+            .indicator_constraints(indicator_constraints)
+            .build()
+            .unwrap();
+
+        // Fix x10=0 → indicator removed (vacuously satisfied)
+        let state = v1::State::from(HashMap::from([(10, 0.0)]));
+        instance.partial_evaluate(&state, ATol::default()).unwrap();
+
+        assert!(instance.indicator_constraint_collection.active().is_empty());
+        assert_eq!(instance.indicator_constraint_collection.removed().len(), 1);
+        // No new regular constraint should be added
+        assert!(instance.constraint_collection.active().is_empty());
     }
 }

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -250,6 +250,7 @@ mod tests {
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.description;Option[stack] 24
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.name;Option[stack] 24
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.parameters;FnvHashMap[stack] 32
+        Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.provenance;Option[stack] 16
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.subscripts;Vec[stack] 24
         Instance.constraint_collection;constraints;Constraint.stage;CreatedData.function;Linear;PolynomialBase.terms 80
         Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -250,7 +250,7 @@ mod tests {
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.description;Option[stack] 24
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.name;Option[stack] 24
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.parameters;FnvHashMap[stack] 32
-        Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.provenance;Option[stack] 16
+        Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.provenance;Vec[stack] 24
         Instance.constraint_collection;constraints;Constraint.metadata;ConstraintMetadata.subscripts;Vec[stack] 24
         Instance.constraint_collection;constraints;Constraint.stage;CreatedData.function;Linear;PolynomialBase.terms 80
         Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -316,7 +316,7 @@ pub use coefficient::*;
 pub use constraint::*;
 pub use constraint_type::*;
 pub use decision_variable::*;
-pub use evaluate::Evaluate;
+pub use evaluate::{Evaluate, Propagate};
 pub use function::*;
 pub use indicator_constraint::*;
 pub use infeasible_detected::*;

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -316,7 +316,7 @@ pub use coefficient::*;
 pub use constraint::*;
 pub use constraint_type::*;
 pub use decision_variable::*;
-pub use evaluate::{Evaluate, Propagate};
+pub use evaluate::{Evaluate, Propagate, PropagateOutcome};
 pub use function::*;
 pub use indicator_constraint::*;
 pub use infeasible_detected::*;

--- a/rust/ommx/src/one_hot_constraint/evaluate.rs
+++ b/rust/ommx/src/one_hot_constraint/evaluate.rs
@@ -8,7 +8,7 @@ impl Propagate for OneHotConstraint<Created> {
         mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(PropagateOutcome<Self, ()>, crate::v1::State)> {
+    ) -> anyhow::Result<(PropagateOutcome<Self>, crate::v1::State)> {
         let mut fixed_to_one: Option<VariableID> = None;
         let mut unfixed = BTreeSet::new();
 

--- a/rust/ommx/src/one_hot_constraint/evaluate.rs
+++ b/rust/ommx/src/one_hot_constraint/evaluate.rs
@@ -1,5 +1,72 @@
 use super::*;
-use crate::{ATol, Evaluate, VariableIDSet};
+use crate::{ATol, Evaluate, Propagate, VariableIDSet};
+
+impl Propagate for OneHotConstraint<Created> {
+    type Output = Option<Self>;
+
+    fn propagate(
+        mut self,
+        state: &crate::v1::State,
+        atol: ATol,
+    ) -> anyhow::Result<(Self::Output, crate::v1::State)> {
+        let mut fixed_to_one: Option<VariableID> = None;
+        let mut unfixed = BTreeSet::new();
+
+        for &var_id in &self.variables {
+            let Some(&value) = state.entries.get(&var_id.into_inner()) else {
+                unfixed.insert(var_id);
+                continue;
+            };
+
+            if (value - 1.0).abs() < *atol {
+                // Variable is ~1
+                if let Some(first) = fixed_to_one {
+                    anyhow::bail!(
+                        "Multiple variables fixed to 1 in one-hot constraint {:?}: {:?} and {:?}",
+                        self.id,
+                        first,
+                        var_id
+                    );
+                }
+                fixed_to_one = Some(var_id);
+            } else if value.abs() < *atol {
+                // Variable is ~0, removed from set
+            } else {
+                anyhow::bail!(
+                    "Variable {:?} in one-hot constraint {:?} fixed to invalid value {} (must be 0 or 1)",
+                    var_id,
+                    self.id,
+                    value
+                );
+            }
+        }
+
+        if fixed_to_one.is_some() {
+            // One variable is 1 → constraint satisfied, fix remaining unfixed to 0
+            let mut additional = crate::v1::State::default();
+            for var_id in &unfixed {
+                additional.entries.insert(var_id.into_inner(), 0.0);
+            }
+            Ok((None, additional))
+        } else if unfixed.is_empty() {
+            // All variables fixed to 0 → infeasible
+            anyhow::bail!(
+                "All variables in one-hot constraint {:?} are fixed to 0, constraint cannot be satisfied",
+                self.id
+            );
+        } else if unfixed.len() == 1 {
+            // Unit propagation: exactly one unfixed variable → must be 1
+            let var_id = *unfixed.iter().next().unwrap();
+            let mut additional = crate::v1::State::default();
+            additional.entries.insert(var_id.into_inner(), 1.0);
+            Ok((None, additional))
+        } else {
+            // Multiple unfixed variables remain, constraint still active
+            self.variables = unfixed;
+            Ok((Some(self), crate::v1::State::default()))
+        }
+    }
+}
 
 impl Evaluate for OneHotConstraint<Created> {
     type Output = EvaluatedOneHotConstraint;
@@ -113,7 +180,7 @@ fn check_one_hot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Evaluate;
+    use crate::{Evaluate, Propagate};
     use std::collections::HashMap;
 
     fn make_one_hot(id: u64, var_ids: &[u64]) -> OneHotConstraint {
@@ -237,5 +304,70 @@ mod tests {
         assert_eq!(result.stage.active_variable[&s0], Some(VariableID::from(1)));
         assert_eq!(result.stage.active_variable[&s1], None);
         assert_eq!(result.stage.active_variable[&s2], None);
+    }
+
+    // === Propagate tests ===
+
+    #[test]
+    fn test_propagate_var_one_fixes_rest() {
+        let c = make_one_hot(1, &[1, 2, 3]);
+        // x2=1 → x1=0, x3=0
+        let state = crate::v1::State::from(HashMap::from([(2, 1.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(output.is_none()); // constraint consumed
+        assert_eq!(additional.entries.get(&1), Some(&0.0));
+        assert_eq!(additional.entries.get(&3), Some(&0.0));
+        assert_eq!(additional.entries.len(), 2);
+    }
+
+    #[test]
+    fn test_propagate_var_zero_shrinks() {
+        let c = make_one_hot(1, &[1, 2, 3]);
+        // x1=0 → constraint shrinks to {x2, x3}
+        let state = crate::v1::State::from(HashMap::from([(1, 0.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        let shrunk = output.unwrap();
+        assert_eq!(shrunk.variables.len(), 2);
+        assert!(shrunk.variables.contains(&VariableID::from(2)));
+        assert!(shrunk.variables.contains(&VariableID::from(3)));
+        assert!(additional.entries.is_empty());
+    }
+
+    #[test]
+    fn test_propagate_unit_clause() {
+        let c = make_one_hot(1, &[1, 2, 3]);
+        // x1=0, x2=0 → only x3 unfixed → x3 must be 1
+        let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(output.is_none()); // constraint consumed
+        assert_eq!(additional.entries.get(&3), Some(&1.0));
+        assert_eq!(additional.entries.len(), 1);
+    }
+
+    #[test]
+    fn test_propagate_all_zeros_error() {
+        let c = make_one_hot(1, &[1, 2, 3]);
+        let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0), (3, 0.0)]));
+        let result = c.propagate(&state, ATol::default());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_propagate_multiple_ones_error() {
+        let c = make_one_hot(1, &[1, 2, 3]);
+        let state = crate::v1::State::from(HashMap::from([(1, 1.0), (2, 1.0)]));
+        let result = c.propagate(&state, ATol::default());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_propagate_no_overlap() {
+        let c = make_one_hot(1, &[1, 2, 3]);
+        // No variables in state overlap → constraint unchanged
+        let state = crate::v1::State::from(HashMap::from([(99, 5.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        let same = output.unwrap();
+        assert_eq!(same.variables.len(), 3);
+        assert!(additional.entries.is_empty());
     }
 }

--- a/rust/ommx/src/one_hot_constraint/evaluate.rs
+++ b/rust/ommx/src/one_hot_constraint/evaluate.rs
@@ -2,13 +2,13 @@ use super::*;
 use crate::{ATol, Evaluate, Propagate, VariableIDSet};
 
 impl Propagate for OneHotConstraint<Created> {
-    type Output = Option<Self>;
+    type Transformed = ();
 
     fn propagate(
-        mut self,
+        &mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(Self::Output, crate::v1::State)> {
+    ) -> anyhow::Result<(Option<()>, crate::v1::State)> {
         let mut fixed_to_one: Option<VariableID> = None;
         let mut unfixed = BTreeSet::new();
 
@@ -47,7 +47,8 @@ impl Propagate for OneHotConstraint<Created> {
             for var_id in &unfixed {
                 additional.entries.insert(var_id.into_inner(), 0.0);
             }
-            Ok((None, additional))
+            // self is not mutated — caller moves it to removed as-is
+            Ok((Some(()), additional))
         } else if unfixed.is_empty() {
             // All variables fixed to 0 → infeasible
             anyhow::bail!(
@@ -59,11 +60,12 @@ impl Propagate for OneHotConstraint<Created> {
             let var_id = *unfixed.iter().next().unwrap();
             let mut additional = crate::v1::State::default();
             additional.entries.insert(var_id.into_inner(), 1.0);
-            Ok((None, additional))
+            // self is not mutated — caller moves it to removed as-is
+            Ok((Some(()), additional))
         } else {
-            // Multiple unfixed variables remain, constraint still active
+            // Multiple unfixed variables remain — modify in-place
             self.variables = unfixed;
-            Ok((Some(self), crate::v1::State::default()))
+            Ok((None, crate::v1::State::default()))
         }
     }
 }
@@ -310,43 +312,45 @@ mod tests {
 
     #[test]
     fn test_propagate_var_one_fixes_rest() {
-        let c = make_one_hot(1, &[1, 2, 3]);
-        // x2=1 → x1=0, x3=0
+        let mut c = make_one_hot(1, &[1, 2, 3]);
+        // x2=1 → transformed (consumed), fix x1=0, x3=0
         let state = crate::v1::State::from(HashMap::from([(2, 1.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(output.is_none()); // constraint consumed
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_some()); // transformed = consumed
         assert_eq!(additional.entries.get(&1), Some(&0.0));
         assert_eq!(additional.entries.get(&3), Some(&0.0));
         assert_eq!(additional.entries.len(), 2);
+        // Original constraint preserved in c for removed set
+        assert_eq!(c.variables.len(), 3);
     }
 
     #[test]
     fn test_propagate_var_zero_shrinks() {
-        let c = make_one_hot(1, &[1, 2, 3]);
-        // x1=0 → constraint shrinks to {x2, x3}
+        let mut c = make_one_hot(1, &[1, 2, 3]);
+        // x1=0 → in-place shrink to {x2, x3}
         let state = crate::v1::State::from(HashMap::from([(1, 0.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        let shrunk = output.unwrap();
-        assert_eq!(shrunk.variables.len(), 2);
-        assert!(shrunk.variables.contains(&VariableID::from(2)));
-        assert!(shrunk.variables.contains(&VariableID::from(3)));
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_none()); // in-place
+        assert_eq!(c.variables.len(), 2);
+        assert!(c.variables.contains(&VariableID::from(2)));
+        assert!(c.variables.contains(&VariableID::from(3)));
         assert!(additional.entries.is_empty());
     }
 
     #[test]
     fn test_propagate_unit_clause() {
-        let c = make_one_hot(1, &[1, 2, 3]);
-        // x1=0, x2=0 → only x3 unfixed → x3 must be 1
+        let mut c = make_one_hot(1, &[1, 2, 3]);
+        // x1=0, x2=0 → only x3 unfixed → unit propagation: x3=1, constraint consumed
         let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(output.is_none()); // constraint consumed
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_some()); // transformed = consumed
         assert_eq!(additional.entries.get(&3), Some(&1.0));
         assert_eq!(additional.entries.len(), 1);
     }
 
     #[test]
     fn test_propagate_all_zeros_error() {
-        let c = make_one_hot(1, &[1, 2, 3]);
+        let mut c = make_one_hot(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0), (3, 0.0)]));
         let result = c.propagate(&state, ATol::default());
         assert!(result.is_err());
@@ -354,7 +358,7 @@ mod tests {
 
     #[test]
     fn test_propagate_multiple_ones_error() {
-        let c = make_one_hot(1, &[1, 2, 3]);
+        let mut c = make_one_hot(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(1, 1.0), (2, 1.0)]));
         let result = c.propagate(&state, ATol::default());
         assert!(result.is_err());
@@ -362,12 +366,12 @@ mod tests {
 
     #[test]
     fn test_propagate_no_overlap() {
-        let c = make_one_hot(1, &[1, 2, 3]);
-        // No variables in state overlap → constraint unchanged
+        let mut c = make_one_hot(1, &[1, 2, 3]);
+        // No variables in state overlap → in-place, no change
         let state = crate::v1::State::from(HashMap::from([(99, 5.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        let same = output.unwrap();
-        assert_eq!(same.variables.len(), 3);
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_none()); // in-place
+        assert_eq!(c.variables.len(), 3);
         assert!(additional.entries.is_empty());
     }
 }

--- a/rust/ommx/src/one_hot_constraint/evaluate.rs
+++ b/rust/ommx/src/one_hot_constraint/evaluate.rs
@@ -1,14 +1,14 @@
 use super::*;
-use crate::{ATol, Evaluate, Propagate, VariableIDSet};
+use crate::{ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet};
 
 impl Propagate for OneHotConstraint<Created> {
     type Transformed = ();
 
     fn propagate(
-        &mut self,
+        mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(Option<()>, crate::v1::State)> {
+    ) -> anyhow::Result<(PropagateOutcome<Self, ()>, crate::v1::State)> {
         let mut fixed_to_one: Option<VariableID> = None;
         let mut unfixed = BTreeSet::new();
 
@@ -47,8 +47,7 @@ impl Propagate for OneHotConstraint<Created> {
             for var_id in &unfixed {
                 additional.entries.insert(var_id.into_inner(), 0.0);
             }
-            // self is not mutated — caller moves it to removed as-is
-            Ok((Some(()), additional))
+            Ok((PropagateOutcome::Consumed(self), additional))
         } else if unfixed.is_empty() {
             // All variables fixed to 0 → infeasible
             anyhow::bail!(
@@ -60,12 +59,11 @@ impl Propagate for OneHotConstraint<Created> {
             let var_id = *unfixed.iter().next().unwrap();
             let mut additional = crate::v1::State::default();
             additional.entries.insert(var_id.into_inner(), 1.0);
-            // self is not mutated — caller moves it to removed as-is
-            Ok((Some(()), additional))
+            Ok((PropagateOutcome::Consumed(self), additional))
         } else {
-            // Multiple unfixed variables remain — modify in-place
+            // Multiple unfixed variables remain — modify and stay active
             self.variables = unfixed;
-            Ok((None, crate::v1::State::default()))
+            Ok((PropagateOutcome::Active(self), crate::v1::State::default()))
         }
     }
 }
@@ -182,7 +180,7 @@ fn check_one_hot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Evaluate, Propagate};
+    use crate::{Evaluate, Propagate, PropagateOutcome};
     use std::collections::HashMap;
 
     fn make_one_hot(id: u64, var_ids: &[u64]) -> OneHotConstraint {
@@ -312,45 +310,52 @@ mod tests {
 
     #[test]
     fn test_propagate_var_one_fixes_rest() {
-        let mut c = make_one_hot(1, &[1, 2, 3]);
-        // x2=1 → transformed (consumed), fix x1=0, x3=0
+        let c = make_one_hot(1, &[1, 2, 3]);
+        // x2=1 → Consumed, fix x1=0, x3=0
         let state = crate::v1::State::from(HashMap::from([(2, 1.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_some()); // transformed = consumed
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        match outcome {
+            PropagateOutcome::Consumed(original) => {
+                assert_eq!(original.variables.len(), 3);
+            }
+            _ => panic!("Expected Consumed"),
+        }
         assert_eq!(additional.entries.get(&1), Some(&0.0));
         assert_eq!(additional.entries.get(&3), Some(&0.0));
         assert_eq!(additional.entries.len(), 2);
-        // Original constraint preserved in c for removed set
-        assert_eq!(c.variables.len(), 3);
     }
 
     #[test]
     fn test_propagate_var_zero_shrinks() {
-        let mut c = make_one_hot(1, &[1, 2, 3]);
-        // x1=0 → in-place shrink to {x2, x3}
+        let c = make_one_hot(1, &[1, 2, 3]);
+        // x1=0 → Active (shrunk to {x2, x3})
         let state = crate::v1::State::from(HashMap::from([(1, 0.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_none()); // in-place
-        assert_eq!(c.variables.len(), 2);
-        assert!(c.variables.contains(&VariableID::from(2)));
-        assert!(c.variables.contains(&VariableID::from(3)));
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        match outcome {
+            PropagateOutcome::Active(c) => {
+                assert_eq!(c.variables.len(), 2);
+                assert!(c.variables.contains(&VariableID::from(2)));
+                assert!(c.variables.contains(&VariableID::from(3)));
+            }
+            _ => panic!("Expected Active"),
+        }
         assert!(additional.entries.is_empty());
     }
 
     #[test]
     fn test_propagate_unit_clause() {
-        let mut c = make_one_hot(1, &[1, 2, 3]);
+        let c = make_one_hot(1, &[1, 2, 3]);
         // x1=0, x2=0 → only x3 unfixed → unit propagation: x3=1, constraint consumed
         let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_some()); // transformed = consumed
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(matches!(outcome, PropagateOutcome::Consumed(_)));
         assert_eq!(additional.entries.get(&3), Some(&1.0));
         assert_eq!(additional.entries.len(), 1);
     }
 
     #[test]
     fn test_propagate_all_zeros_error() {
-        let mut c = make_one_hot(1, &[1, 2, 3]);
+        let c = make_one_hot(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0), (3, 0.0)]));
         let result = c.propagate(&state, ATol::default());
         assert!(result.is_err());
@@ -358,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_propagate_multiple_ones_error() {
-        let mut c = make_one_hot(1, &[1, 2, 3]);
+        let c = make_one_hot(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(1, 1.0), (2, 1.0)]));
         let result = c.propagate(&state, ATol::default());
         assert!(result.is_err());
@@ -366,12 +371,16 @@ mod tests {
 
     #[test]
     fn test_propagate_no_overlap() {
-        let mut c = make_one_hot(1, &[1, 2, 3]);
-        // No variables in state overlap → in-place, no change
+        let c = make_one_hot(1, &[1, 2, 3]);
+        // No variables in state overlap → Active (unchanged)
         let state = crate::v1::State::from(HashMap::from([(99, 5.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_none()); // in-place
-        assert_eq!(c.variables.len(), 3);
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        match outcome {
+            PropagateOutcome::Active(c) => {
+                assert_eq!(c.variables.len(), 3);
+            }
+            _ => panic!("Expected Active"),
+        }
         assert!(additional.entries.is_empty());
     }
 }

--- a/rust/ommx/src/one_hot_constraint/evaluate.rs
+++ b/rust/ommx/src/one_hot_constraint/evaluate.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet};
 
 impl Propagate for OneHotConstraint<Created> {
-    type Transformed = ();
+    type Transformed = std::convert::Infallible;
 
     fn propagate(
         mut self,

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -43,6 +43,12 @@ impl OneHotConstraintID {
     }
 }
 
+impl From<OneHotConstraintID> for u64 {
+    fn from(id: OneHotConstraintID) -> Self {
+        id.0
+    }
+}
+
 /// A one-hot constraint: exactly one variable in `variables` must be 1, the rest must be 0.
 ///
 /// This is a structural constraint — no explicit function or equality is stored.

--- a/rust/ommx/src/sos1_constraint/evaluate.rs
+++ b/rust/ommx/src/sos1_constraint/evaluate.rs
@@ -1,14 +1,14 @@
 use super::*;
-use crate::{ATol, Evaluate, Propagate, VariableIDSet};
+use crate::{ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet};
 
 impl Propagate for Sos1Constraint<Created> {
     type Transformed = ();
 
     fn propagate(
-        &mut self,
+        mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(Option<()>, crate::v1::State)> {
+    ) -> anyhow::Result<(PropagateOutcome<Self, ()>, crate::v1::State)> {
         let mut fixed_nonzero: Option<VariableID> = None;
         let mut unfixed = BTreeSet::new();
 
@@ -40,16 +40,17 @@ impl Propagate for Sos1Constraint<Created> {
             for var_id in &unfixed {
                 additional.entries.insert(var_id.into_inner(), 0.0);
             }
-            // self not mutated — caller moves it to removed
-            Ok((Some(()), additional))
+            Ok((PropagateOutcome::Consumed(self), additional))
         } else if unfixed.is_empty() {
             // All variables fixed to 0 → vacuously satisfied for SOS1
-            // self not mutated — caller moves it to removed
-            Ok((Some(()), crate::v1::State::default()))
+            Ok((
+                PropagateOutcome::Consumed(self),
+                crate::v1::State::default(),
+            ))
         } else {
-            // Multiple unfixed variables remain — modify in-place
+            // Multiple unfixed variables remain — modify and stay active
             self.variables = unfixed;
-            Ok((None, crate::v1::State::default()))
+            Ok((PropagateOutcome::Active(self), crate::v1::State::default()))
         }
     }
 }
@@ -159,7 +160,7 @@ fn check_sos1(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Evaluate, Propagate};
+    use crate::{Evaluate, Propagate, PropagateOutcome};
     use std::collections::HashMap;
 
     fn make_sos1(id: u64, var_ids: &[u64]) -> Sos1Constraint {
@@ -279,44 +280,51 @@ mod tests {
 
     #[test]
     fn test_propagate_nonzero_fixes_rest() {
-        let mut c = make_sos1(1, &[1, 2, 3]);
-        // x2=5.0 → transformed (consumed), fix x1=0, x3=0
+        let c = make_sos1(1, &[1, 2, 3]);
+        // x2=5.0 → Consumed, fix x1=0, x3=0
         let state = crate::v1::State::from(HashMap::from([(2, 5.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_some());
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        match outcome {
+            PropagateOutcome::Consumed(original) => {
+                assert_eq!(original.variables.len(), 3); // preserved
+            }
+            _ => panic!("Expected Consumed"),
+        }
         assert_eq!(additional.entries.get(&1), Some(&0.0));
         assert_eq!(additional.entries.get(&3), Some(&0.0));
         assert_eq!(additional.entries.len(), 2);
-        // Original preserved
-        assert_eq!(c.variables.len(), 3);
     }
 
     #[test]
     fn test_propagate_zero_shrinks() {
-        let mut c = make_sos1(1, &[1, 2, 3]);
-        // x1=0 → in-place shrink to {x2, x3}
+        let c = make_sos1(1, &[1, 2, 3]);
+        // x1=0 → Active (shrunk to {x2, x3})
         let state = crate::v1::State::from(HashMap::from([(1, 0.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_none()); // in-place
-        assert_eq!(c.variables.len(), 2);
-        assert!(c.variables.contains(&VariableID::from(2)));
-        assert!(c.variables.contains(&VariableID::from(3)));
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        match outcome {
+            PropagateOutcome::Active(c) => {
+                assert_eq!(c.variables.len(), 2);
+                assert!(c.variables.contains(&VariableID::from(2)));
+                assert!(c.variables.contains(&VariableID::from(3)));
+            }
+            _ => panic!("Expected Active"),
+        }
         assert!(additional.entries.is_empty());
     }
 
     #[test]
     fn test_propagate_all_zeros_satisfied() {
-        let mut c = make_sos1(1, &[1, 2, 3]);
-        // All zeros → transformed (vacuously satisfied)
+        let c = make_sos1(1, &[1, 2, 3]);
+        // All zeros → Consumed (vacuously satisfied)
         let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0), (3, 0.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_some()); // consumed
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(matches!(outcome, PropagateOutcome::Consumed(_)));
         assert!(additional.entries.is_empty());
     }
 
     #[test]
     fn test_propagate_multiple_nonzero_error() {
-        let mut c = make_sos1(1, &[1, 2, 3]);
+        let c = make_sos1(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(1, 1.0), (2, 2.0)]));
         let result = c.propagate(&state, ATol::default());
         assert!(result.is_err());
@@ -324,11 +332,15 @@ mod tests {
 
     #[test]
     fn test_propagate_no_overlap() {
-        let mut c = make_sos1(1, &[1, 2, 3]);
+        let c = make_sos1(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(99, 5.0)]));
-        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(transformed.is_none()); // in-place
-        assert_eq!(c.variables.len(), 3);
+        let (outcome, additional) = c.propagate(&state, ATol::default()).unwrap();
+        match outcome {
+            PropagateOutcome::Active(c) => {
+                assert_eq!(c.variables.len(), 3);
+            }
+            _ => panic!("Expected Active"),
+        }
         assert!(additional.entries.is_empty());
     }
 }

--- a/rust/ommx/src/sos1_constraint/evaluate.rs
+++ b/rust/ommx/src/sos1_constraint/evaluate.rs
@@ -8,7 +8,7 @@ impl Propagate for Sos1Constraint<Created> {
         mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(PropagateOutcome<Self, ()>, crate::v1::State)> {
+    ) -> anyhow::Result<(PropagateOutcome<Self>, crate::v1::State)> {
         let mut fixed_nonzero: Option<VariableID> = None;
         let mut unfixed = BTreeSet::new();
 

--- a/rust/ommx/src/sos1_constraint/evaluate.rs
+++ b/rust/ommx/src/sos1_constraint/evaluate.rs
@@ -2,13 +2,13 @@ use super::*;
 use crate::{ATol, Evaluate, Propagate, VariableIDSet};
 
 impl Propagate for Sos1Constraint<Created> {
-    type Output = Option<Self>;
+    type Transformed = ();
 
     fn propagate(
-        mut self,
+        &mut self,
         state: &crate::v1::State,
         atol: ATol,
-    ) -> anyhow::Result<(Self::Output, crate::v1::State)> {
+    ) -> anyhow::Result<(Option<()>, crate::v1::State)> {
         let mut fixed_nonzero: Option<VariableID> = None;
         let mut unfixed = BTreeSet::new();
 
@@ -40,14 +40,16 @@ impl Propagate for Sos1Constraint<Created> {
             for var_id in &unfixed {
                 additional.entries.insert(var_id.into_inner(), 0.0);
             }
-            Ok((None, additional))
+            // self not mutated — caller moves it to removed
+            Ok((Some(()), additional))
         } else if unfixed.is_empty() {
             // All variables fixed to 0 → vacuously satisfied for SOS1
-            Ok((None, crate::v1::State::default()))
+            // self not mutated — caller moves it to removed
+            Ok((Some(()), crate::v1::State::default()))
         } else {
-            // Multiple unfixed variables remain, constraint still active
+            // Multiple unfixed variables remain — modify in-place
             self.variables = unfixed;
-            Ok((Some(self), crate::v1::State::default()))
+            Ok((None, crate::v1::State::default()))
         }
     }
 }
@@ -277,42 +279,44 @@ mod tests {
 
     #[test]
     fn test_propagate_nonzero_fixes_rest() {
-        let c = make_sos1(1, &[1, 2, 3]);
-        // x2=5.0 → x1=0, x3=0
+        let mut c = make_sos1(1, &[1, 2, 3]);
+        // x2=5.0 → transformed (consumed), fix x1=0, x3=0
         let state = crate::v1::State::from(HashMap::from([(2, 5.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(output.is_none());
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_some());
         assert_eq!(additional.entries.get(&1), Some(&0.0));
         assert_eq!(additional.entries.get(&3), Some(&0.0));
         assert_eq!(additional.entries.len(), 2);
+        // Original preserved
+        assert_eq!(c.variables.len(), 3);
     }
 
     #[test]
     fn test_propagate_zero_shrinks() {
-        let c = make_sos1(1, &[1, 2, 3]);
-        // x1=0 → constraint shrinks to {x2, x3}
+        let mut c = make_sos1(1, &[1, 2, 3]);
+        // x1=0 → in-place shrink to {x2, x3}
         let state = crate::v1::State::from(HashMap::from([(1, 0.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        let shrunk = output.unwrap();
-        assert_eq!(shrunk.variables.len(), 2);
-        assert!(shrunk.variables.contains(&VariableID::from(2)));
-        assert!(shrunk.variables.contains(&VariableID::from(3)));
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_none()); // in-place
+        assert_eq!(c.variables.len(), 2);
+        assert!(c.variables.contains(&VariableID::from(2)));
+        assert!(c.variables.contains(&VariableID::from(3)));
         assert!(additional.entries.is_empty());
     }
 
     #[test]
     fn test_propagate_all_zeros_satisfied() {
-        let c = make_sos1(1, &[1, 2, 3]);
-        // All zeros → vacuously satisfied (unlike OneHot)
+        let mut c = make_sos1(1, &[1, 2, 3]);
+        // All zeros → transformed (vacuously satisfied)
         let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0), (3, 0.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        assert!(output.is_none()); // consumed
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_some()); // consumed
         assert!(additional.entries.is_empty());
     }
 
     #[test]
     fn test_propagate_multiple_nonzero_error() {
-        let c = make_sos1(1, &[1, 2, 3]);
+        let mut c = make_sos1(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(1, 1.0), (2, 2.0)]));
         let result = c.propagate(&state, ATol::default());
         assert!(result.is_err());
@@ -320,11 +324,11 @@ mod tests {
 
     #[test]
     fn test_propagate_no_overlap() {
-        let c = make_sos1(1, &[1, 2, 3]);
+        let mut c = make_sos1(1, &[1, 2, 3]);
         let state = crate::v1::State::from(HashMap::from([(99, 5.0)]));
-        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
-        let same = output.unwrap();
-        assert_eq!(same.variables.len(), 3);
+        let (transformed, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(transformed.is_none()); // in-place
+        assert_eq!(c.variables.len(), 3);
         assert!(additional.entries.is_empty());
     }
 }

--- a/rust/ommx/src/sos1_constraint/evaluate.rs
+++ b/rust/ommx/src/sos1_constraint/evaluate.rs
@@ -1,5 +1,56 @@
 use super::*;
-use crate::{ATol, Evaluate, VariableIDSet};
+use crate::{ATol, Evaluate, Propagate, VariableIDSet};
+
+impl Propagate for Sos1Constraint<Created> {
+    type Output = Option<Self>;
+
+    fn propagate(
+        mut self,
+        state: &crate::v1::State,
+        atol: ATol,
+    ) -> anyhow::Result<(Self::Output, crate::v1::State)> {
+        let mut fixed_nonzero: Option<VariableID> = None;
+        let mut unfixed = BTreeSet::new();
+
+        for &var_id in &self.variables {
+            let Some(&value) = state.entries.get(&var_id.into_inner()) else {
+                unfixed.insert(var_id);
+                continue;
+            };
+
+            if value.abs() < *atol {
+                // Variable is ~0, removed from set
+            } else {
+                // Variable is non-zero
+                if let Some(first) = fixed_nonzero {
+                    anyhow::bail!(
+                        "Multiple variables fixed to non-zero in SOS1 constraint {:?}: {:?} and {:?}",
+                        self.id,
+                        first,
+                        var_id
+                    );
+                }
+                fixed_nonzero = Some(var_id);
+            }
+        }
+
+        if fixed_nonzero.is_some() {
+            // One variable is non-zero → constraint satisfied, fix remaining unfixed to 0
+            let mut additional = crate::v1::State::default();
+            for var_id in &unfixed {
+                additional.entries.insert(var_id.into_inner(), 0.0);
+            }
+            Ok((None, additional))
+        } else if unfixed.is_empty() {
+            // All variables fixed to 0 → vacuously satisfied for SOS1
+            Ok((None, crate::v1::State::default()))
+        } else {
+            // Multiple unfixed variables remain, constraint still active
+            self.variables = unfixed;
+            Ok((Some(self), crate::v1::State::default()))
+        }
+    }
+}
 
 impl Evaluate for Sos1Constraint<Created> {
     type Output = EvaluatedSos1Constraint;
@@ -106,7 +157,7 @@ fn check_sos1(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Evaluate;
+    use crate::{Evaluate, Propagate};
     use std::collections::HashMap;
 
     fn make_sos1(id: u64, var_ids: &[u64]) -> Sos1Constraint {
@@ -220,5 +271,60 @@ mod tests {
         assert_eq!(result.stage.active_variable[&s0], Some(VariableID::from(2)));
         assert_eq!(result.stage.active_variable[&s1], None);
         assert_eq!(result.stage.active_variable[&s2], None);
+    }
+
+    // === Propagate tests ===
+
+    #[test]
+    fn test_propagate_nonzero_fixes_rest() {
+        let c = make_sos1(1, &[1, 2, 3]);
+        // x2=5.0 → x1=0, x3=0
+        let state = crate::v1::State::from(HashMap::from([(2, 5.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(output.is_none());
+        assert_eq!(additional.entries.get(&1), Some(&0.0));
+        assert_eq!(additional.entries.get(&3), Some(&0.0));
+        assert_eq!(additional.entries.len(), 2);
+    }
+
+    #[test]
+    fn test_propagate_zero_shrinks() {
+        let c = make_sos1(1, &[1, 2, 3]);
+        // x1=0 → constraint shrinks to {x2, x3}
+        let state = crate::v1::State::from(HashMap::from([(1, 0.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        let shrunk = output.unwrap();
+        assert_eq!(shrunk.variables.len(), 2);
+        assert!(shrunk.variables.contains(&VariableID::from(2)));
+        assert!(shrunk.variables.contains(&VariableID::from(3)));
+        assert!(additional.entries.is_empty());
+    }
+
+    #[test]
+    fn test_propagate_all_zeros_satisfied() {
+        let c = make_sos1(1, &[1, 2, 3]);
+        // All zeros → vacuously satisfied (unlike OneHot)
+        let state = crate::v1::State::from(HashMap::from([(1, 0.0), (2, 0.0), (3, 0.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        assert!(output.is_none()); // consumed
+        assert!(additional.entries.is_empty());
+    }
+
+    #[test]
+    fn test_propagate_multiple_nonzero_error() {
+        let c = make_sos1(1, &[1, 2, 3]);
+        let state = crate::v1::State::from(HashMap::from([(1, 1.0), (2, 2.0)]));
+        let result = c.propagate(&state, ATol::default());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_propagate_no_overlap() {
+        let c = make_sos1(1, &[1, 2, 3]);
+        let state = crate::v1::State::from(HashMap::from([(99, 5.0)]));
+        let (output, additional) = c.propagate(&state, ATol::default()).unwrap();
+        let same = output.unwrap();
+        assert_eq!(same.variables.len(), 3);
+        assert!(additional.entries.is_empty());
     }
 }

--- a/rust/ommx/src/sos1_constraint/evaluate.rs
+++ b/rust/ommx/src/sos1_constraint/evaluate.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet};
 
 impl Propagate for Sos1Constraint<Created> {
-    type Transformed = ();
+    type Transformed = std::convert::Infallible;
 
     fn propagate(
         mut self,

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -43,6 +43,12 @@ impl Sos1ConstraintID {
     }
 }
 
+impl From<Sos1ConstraintID> for u64 {
+    fn from(id: Sos1ConstraintID) -> Self {
+        id.0
+    }
+}
+
 /// A SOS1 (Special Ordered Set type 1) constraint: at most one variable can be non-zero.
 ///
 /// This is a structural constraint — no explicit function or equality is stored.


### PR DESCRIPTION
## Summary

Implement unit propagation for special constraint types (OneHot, SOS1, Indicator) via a new `Propagate` trait, with atomic `Instance::partial_evaluate`.

## Design

### `Propagate` trait

```rust
pub enum PropagateOutcome<T: Propagate> {
    /// Constraint remains active (possibly shrunk / modified).
    Active(T),
    /// Constraint is fully determined by the state. Move to removed set as-is.
    Consumed(T),
    /// Constraint transformed into another type (e.g. Indicator → Constraint).
    /// `original` goes to removed set, `new` is the replacement.
    Transformed { original: T, new: T::Transformed },
}

pub trait Propagate: Sized {
    type Transformed;
    fn propagate(
        self,
        state: &State,
        atol: ATol,
    ) -> Result<(PropagateOutcome<Self>, State)>;
}
```

`Propagate` consumes `self` and returns the outcome + additional variable fixings. Atomicity is the caller's responsibility — individual impls may lose `self` on error (see below for how `Instance` handles this).

### Per-constraint propagation

| Constraint | `Transformed` | Key behaviors |
|-----------|---------------|---------------|
| OneHotConstraint | `()` | var=1 → Consumed (fix rest to 0); all=0 → Err; exactly one unfixed → unit clause (Consumed, fix to 1); otherwise Active (shrunk) |
| Sos1Constraint | `()` | var≠0 → Consumed (fix rest to 0); all=0 → Consumed (vacuous); multiple≠0 → Err; otherwise Active (shrunk) |
| IndicatorConstraint | `IndicatorPromote` | indicator=1 → Transformed (promote inner to regular Constraint); indicator=0 → Consumed; otherwise Active (function partial-evaluated) |

### Atomic `Instance::partial_evaluate`

Since `Propagate::propagate` consumes `self` and loses it on error, Instance-level atomicity is guaranteed via the clone/commit pattern:

```rust
fn partial_evaluate(&mut self, state, atol) -> Result<()> {
    let mut working = self.clone();  // snapshot
    // all fallible operations on `working`:
    working.propagate_special_constraints(...)?;
    working.objective.partial_evaluate(...)?;
    // ...
    *self = working;  // commit atomically
    Ok(())
}
```

On any failure, `self` is unchanged.

### Conflict detection in propagation fixed-point

`merge_state` detects when two propagated fixings disagree (e.g. one says x=0, another x=1 within tolerance) and returns an error rather than silently overwriting.

### Provenance tracking

`ConstraintMetadata.provenance: Option<Provenance>` records that a constraint was promoted from an indicator constraint. Used when indicator=1 triggers the `Transformed` path.

### ID allocation

`ConstraintCollection::unused_id()` allocates a fresh ID (`max(existing id) + 1`, or `0` if empty) for promoted constraints so they don't collide with existing IDs.

### Strict indicator value validation

Indicator variable values are validated to be within tolerance of 0 or 1. Values like `2.0` no longer silently accepted as ON.

## Test plan

- [x] `cargo test -p ommx` — 462 unit tests + 53 doc tests pass
- [x] `cargo clippy -p ommx` — clean
- [x] `cargo fmt --check` — clean
- [x] Tests per constraint type: Active / Consumed / Transformed / error paths
- [x] Indicator: on-promotes, off-consumed, not-fixed partial-eval, on-with-function-partial-eval

🤖 Generated with [Claude Code](https://claude.com/claude-code)