### PR TITLE
Port QUBO/HUBO and slack helpers to the domain Instance

### DIFF
--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -4,7 +4,7 @@ use crate::{
     Rng, SampleSet, Samples, Sense, Solution, State, VariableBound,
 };
 use anyhow::Result;
-use ommx::{ConstraintID, Evaluate, NamedFunctionID, Parse, VariableID};
+use ommx::{ConstraintID, Evaluate, NamedFunctionID, VariableID};
 use pyo3::{
     exceptions::PyKeyError,
     prelude::*,
@@ -386,8 +386,7 @@ impl Instance {
     }
 
     pub fn as_qubo_format<'py>(&self, py: Python<'py>) -> Result<(Bound<'py, PyDict>, f64)> {
-        let inner: ommx::v1::Instance = self.inner.clone().into();
-        let (qubo, constant) = inner.as_qubo_format()?;
+        let (qubo, constant) = self.inner.as_qubo_format()?;
         Ok((
             serde_pyobject::to_pyobject(py, &qubo)?
                 .extract()
@@ -397,8 +396,7 @@ impl Instance {
     }
 
     pub fn as_hubo_format<'py>(&self, py: Python<'py>) -> Result<(Bound<'py, PyDict>, f64)> {
-        let inner: ommx::v1::Instance = self.inner.clone().into();
-        let (hubo, constant) = inner.as_hubo_format()?;
+        let (hubo, constant) = self.inner.as_hubo_format()?;
         Ok((
             serde_pyobject::to_pyobject(py, &hubo)?
                 .extract()
@@ -1118,13 +1116,12 @@ impl Instance {
         constraint_id: u64,
         max_integer_range: u64,
     ) -> Result<()> {
-        let mut inner: ommx::v1::Instance = self.inner.clone().into();
-        inner.convert_inequality_to_equality_with_integer_slack(
-            constraint_id,
-            max_integer_range,
-            ommx::ATol::default(),
-        )?;
-        self.inner = Parse::parse(inner, &())?;
+        self.inner
+            .convert_inequality_to_equality_with_integer_slack(
+                constraint_id,
+                max_integer_range,
+                ommx::ATol::default(),
+            )?;
         Ok(())
     }
 
@@ -1180,9 +1177,9 @@ impl Instance {
         constraint_id: u64,
         slack_upper_bound: u64,
     ) -> Result<Option<f64>> {
-        let mut inner: ommx::v1::Instance = self.inner.clone().into();
-        let result = inner.add_integer_slack_to_inequality(constraint_id, slack_upper_bound)?;
-        self.inner = Parse::parse(inner, &())?;
+        let result = self
+            .inner
+            .add_integer_slack_to_inequality(constraint_id, slack_upper_bound)?;
         Ok(result)
     }
 

--- a/rust/ommx/src/function.rs
+++ b/rust/ommx/src/function.rs
@@ -9,6 +9,7 @@ mod add;
 mod approx;
 mod arbitrary;
 mod evaluate;
+mod evaluate_bound;
 mod logical_memory;
 mod mul;
 mod parse;
@@ -206,7 +207,9 @@ impl Function {
     pub fn content_factor(&self) -> anyhow::Result<Coefficient> {
         match self {
             Function::Zero => Ok(Coefficient::one()),
-            Function::Constant(c) => Ok(c.inv()),
+            // The factor must be positive so that multiplying it preserves the sign of
+            // the constraint, matching `PolynomialBase::content_factor` for Linear/Quadratic/Polynomial.
+            Function::Constant(c) => Ok(c.inv().abs()),
             Function::Linear(l) => l.content_factor(),
             Function::Quadratic(q) => q.content_factor(),
             Function::Polynomial(p) => p.content_factor(),

--- a/rust/ommx/src/function/evaluate_bound.rs
+++ b/rust/ommx/src/function/evaluate_bound.rs
@@ -53,13 +53,16 @@ mod tests {
 
     #[test]
     fn bound_of_quadratic_with_squared_term() {
-        // f = x1*x1 with x1 in [-2, 3] → [0, 9]
+        // f = x1*x1 with x1 in [-2, 3].
+        //
+        // `Function::evaluate_bound` collapses the monomial via `MonomialDyn::chunks()`
+        // into `Bound::pow(2)`. For an even exponent across zero, `Bound::pow` uses
+        // sound interval-power semantics and yields [0, max(|-2|^2, 3^2)] = [0, 9],
+        // not a naive interval-square [-6, 9].
         let f = Function::from(quadratic!(1, 1));
         let mut bounds = Bounds::new();
         bounds.insert(VariableID::from(1), Bound::new(-2.0, 3.0).unwrap());
-        // Interval arithmetic gives [-2, 3]^2 = [-6, 9] since the chunks() exponent
-        // treats x1^2 as pow(2). This matches `v1::Function::evaluate_bound` semantics.
-        let expected = Bound::new(-2.0, 3.0).unwrap().pow(2);
+        let expected = Bound::new(0.0, 9.0).unwrap();
         assert_eq!(f.evaluate_bound(&bounds), expected);
     }
 

--- a/rust/ommx/src/function/evaluate_bound.rs
+++ b/rust/ommx/src/function/evaluate_bound.rs
@@ -1,0 +1,71 @@
+use super::*;
+use crate::{Bound, Bounds};
+use num::Zero;
+
+impl Function {
+    /// Compute the interval bound of this function given variable bounds.
+    ///
+    /// Missing IDs in `bounds` are treated as `Bound::default()` (unbounded).
+    pub fn evaluate_bound(&self, bounds: &Bounds) -> Bound {
+        let mut bound = Bound::zero();
+        for (ids, coefficient) in self.iter() {
+            let value = coefficient.into_inner();
+            if ids.is_empty() {
+                bound += value;
+                continue;
+            }
+            let mut cur = Bound::new(1.0, 1.0).unwrap();
+            for (id, exp) in ids.chunks() {
+                let b = bounds.get(&id).cloned().unwrap_or_default();
+                cur *= b.pow(exp as u8);
+                if cur == Bound::default() {
+                    return Bound::default();
+                }
+            }
+            bound += value * cur;
+        }
+        bound
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coeff, linear, quadratic, Bound, VariableID};
+
+    #[test]
+    fn bound_of_constant() {
+        let f = Function::Constant(coeff!(3.5));
+        assert_eq!(
+            f.evaluate_bound(&Bounds::new()),
+            Bound::new(3.5, 3.5).unwrap()
+        );
+    }
+
+    #[test]
+    fn bound_of_linear() {
+        // f = 2*x1 + 3 with x1 in [0, 2]
+        let f = Function::from(coeff!(2.0) * linear!(1) + coeff!(3.0));
+        let mut bounds = Bounds::new();
+        bounds.insert(VariableID::from(1), Bound::new(0.0, 2.0).unwrap());
+        assert_eq!(f.evaluate_bound(&bounds), Bound::new(3.0, 7.0).unwrap());
+    }
+
+    #[test]
+    fn bound_of_quadratic_with_squared_term() {
+        // f = x1*x1 with x1 in [-2, 3] → [0, 9]
+        let f = Function::from(quadratic!(1, 1));
+        let mut bounds = Bounds::new();
+        bounds.insert(VariableID::from(1), Bound::new(-2.0, 3.0).unwrap());
+        // Interval arithmetic gives [-2, 3]^2 = [-6, 9] since the chunks() exponent
+        // treats x1^2 as pow(2). This matches `v1::Function::evaluate_bound` semantics.
+        let expected = Bound::new(-2.0, 3.0).unwrap().pow(2);
+        assert_eq!(f.evaluate_bound(&bounds), expected);
+    }
+
+    #[test]
+    fn bound_missing_id_is_unbounded() {
+        let f = Function::from(linear!(1));
+        assert_eq!(f.evaluate_bound(&Bounds::new()), Bound::default());
+    }
+}

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -15,9 +15,11 @@ mod parametric_builder;
 mod parse;
 mod pass;
 mod penalty;
+mod qubo;
 mod reduce_binary_power;
 mod serialize;
 mod setter;
+mod slack;
 mod stats;
 mod substitute;
 

--- a/rust/ommx/src/instance/qubo.rs
+++ b/rust/ommx/src/instance/qubo.rs
@@ -1,6 +1,6 @@
 use super::{Instance, Sense};
 use crate::{BinaryIdPair, BinaryIds, Evaluate};
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::collections::BTreeMap;
 
 impl Instance {
@@ -21,6 +21,8 @@ impl Instance {
         if !self.constraints().is_empty() {
             bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
         }
+        self.check_capabilities(&fnv::FnvHashSet::default())
+            .context("QUBO format does not support these constraint types. Convert via penalty method or equivalent first.")?;
         if !self
             .objective()
             .required_ids()
@@ -64,6 +66,8 @@ impl Instance {
         if !self.constraints().is_empty() {
             bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
         }
+        self.check_capabilities(&fnv::FnvHashSet::default())
+            .context("HUBO format does not support these constraint types. Convert via penalty method or equivalent first.")?;
         if !self
             .objective()
             .required_ids()
@@ -173,6 +177,37 @@ mod tests {
         .unwrap();
         let err = instance.as_qubo_format().unwrap_err();
         assert!(err.to_string().contains("non-binary"));
+    }
+
+    #[test]
+    fn qubo_rejects_instances_with_one_hot_constraints() {
+        use crate::{OneHotConstraint, OneHotConstraintID};
+        use std::collections::BTreeSet;
+
+        let mut instance = Instance::new(
+            Sense::Minimize,
+            linear!(1).into(),
+            binary_vars([1, 2]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let one_hot = OneHotConstraint::new(
+            OneHotConstraintID::from(0),
+            [VariableID::from(1), VariableID::from(2)]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+        );
+        instance
+            .one_hot_constraint_collection
+            .active_mut()
+            .insert(OneHotConstraintID::from(0), one_hot);
+
+        let err = instance.as_qubo_format().unwrap_err();
+        let msg = err.to_string() + " " + &err.root_cause().to_string();
+        assert!(
+            msg.contains("QUBO") || msg.contains("Unsupported"),
+            "expected rejection message, got: {msg}"
+        );
     }
 
     #[test]

--- a/rust/ommx/src/instance/qubo.rs
+++ b/rust/ommx/src/instance/qubo.rs
@@ -1,0 +1,212 @@
+use super::{Instance, Sense};
+use crate::{BinaryIdPair, BinaryIds, Evaluate};
+use anyhow::{bail, Result};
+use std::collections::BTreeMap;
+
+impl Instance {
+    /// Create QUBO (Quadratic Unconstrained Binary Optimization) dictionary from the instance.
+    ///
+    /// Before calling this method, you should check that this instance is suitable for QUBO:
+    ///
+    /// - This instance has no constraints
+    ///   - Use penalty method (TODO: ALM will be added) to convert into an unconstrained problem.
+    /// - The objective function uses only binary decision variables.
+    ///   - TODO: Binary encoding will be added.
+    /// - The degree of the objective is at most 2.
+    ///
+    pub fn as_qubo_format(&self) -> Result<(BTreeMap<BinaryIdPair, f64>, f64)> {
+        if self.sense() == Sense::Maximize {
+            bail!("QUBO format is only for minimization problems.");
+        }
+        if !self.constraints().is_empty() {
+            bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
+        }
+        if !self
+            .objective()
+            .required_ids()
+            .is_subset(&self.binary_ids())
+        {
+            bail!("The objective function uses non-binary decision variables.");
+        }
+        let mut constant = 0.0;
+        let mut quad: BTreeMap<BinaryIdPair, f64> = BTreeMap::new();
+        for (ids, coefficient) in self.objective().iter() {
+            let c = coefficient.into_inner();
+            if c.abs() <= f64::EPSILON {
+                continue;
+            }
+            if ids.is_empty() {
+                constant += c;
+            } else {
+                let key = BinaryIdPair::try_from(ids)?;
+                let value = quad.entry(key).and_modify(|v| *v += c).or_insert(c);
+                if value.abs() < f64::EPSILON {
+                    quad.remove(&key);
+                }
+            }
+        }
+        Ok((quad, constant))
+    }
+
+    /// Create HUBO (Higher-Order Unconstrained Binary Optimization) dictionary from the instance.
+    ///
+    /// Before calling this method, you should check that this instance is suitable for HUBO:
+    ///
+    /// - This instance has no constraints
+    ///   - Use penalty method (TODO: ALM will be added) to convert into an unconstrained problem.
+    /// - The objective function uses only binary decision variables.
+    ///   - TODO: Binary encoding will be added.
+    ///
+    pub fn as_hubo_format(&self) -> Result<(BTreeMap<BinaryIds, f64>, f64)> {
+        if self.sense() == Sense::Maximize {
+            bail!("HUBO format is only for minimization problems.");
+        }
+        if !self.constraints().is_empty() {
+            bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
+        }
+        if !self
+            .objective()
+            .required_ids()
+            .is_subset(&self.binary_ids())
+        {
+            bail!("The objective function uses non-binary decision variables.");
+        }
+        let mut constant = 0.0;
+        let mut hubo: BTreeMap<BinaryIds, f64> = BTreeMap::new();
+        for (ids, coefficient) in self.objective().iter() {
+            let c = coefficient.into_inner();
+            if c.abs() <= f64::EPSILON {
+                continue;
+            }
+            if ids.is_empty() {
+                constant += c;
+            } else {
+                let key = BinaryIds::from(ids);
+                let value = hubo.entry(key.clone()).and_modify(|v| *v += c).or_insert(c);
+                if value.abs() < f64::EPSILON {
+                    hubo.remove(&key);
+                }
+            }
+        }
+        Ok((hubo, constant))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coeff, linear, quadratic, DecisionVariable, Function, VariableID};
+    use maplit::btreemap;
+    use std::collections::BTreeMap;
+
+    fn binary_vars(ids: impl IntoIterator<Item = u64>) -> BTreeMap<VariableID, DecisionVariable> {
+        ids.into_iter()
+            .map(|i| {
+                let id = VariableID::from(i);
+                (id, DecisionVariable::binary(id))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn qubo_from_quadratic_objective() {
+        // min x1 + 2*x2 + 3*x1*x2 with binary x1, x2
+        let objective = Function::from(linear!(1))
+            + Function::from(coeff!(2.0) * linear!(2))
+            + Function::from(coeff!(3.0) * quadratic!(1, 2));
+        let instance = Instance::new(
+            Sense::Minimize,
+            objective,
+            binary_vars([1, 2]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let (quad, constant) = instance.as_qubo_format().unwrap();
+        assert_eq!(constant, 0.0);
+        assert_eq!(quad.get(&BinaryIdPair(1, 1)), Some(&1.0));
+        assert_eq!(quad.get(&BinaryIdPair(2, 2)), Some(&2.0));
+        assert_eq!(quad.get(&BinaryIdPair(1, 2)), Some(&3.0));
+    }
+
+    #[test]
+    fn qubo_rejects_maximization() {
+        let instance = Instance::new(
+            Sense::Maximize,
+            linear!(1).into(),
+            binary_vars([1]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let err = instance.as_qubo_format().unwrap_err();
+        assert!(err.to_string().contains("minimization"));
+    }
+
+    #[test]
+    fn qubo_rejects_instances_with_constraints() {
+        let constraints = btreemap! {
+            crate::ConstraintID::from(0) =>
+                crate::Constraint::equal_to_zero(crate::ConstraintID::from(0), linear!(1).into()),
+        };
+        let instance = Instance::new(
+            Sense::Minimize,
+            linear!(1).into(),
+            binary_vars([1]),
+            constraints,
+        )
+        .unwrap();
+        let err = instance.as_qubo_format().unwrap_err();
+        assert!(err.to_string().contains("constraints"));
+    }
+
+    #[test]
+    fn qubo_rejects_non_binary_decision_variables() {
+        let mut dv = binary_vars([1]);
+        let id = VariableID::from(2);
+        dv.insert(id, DecisionVariable::integer(id));
+        let instance = Instance::new(
+            Sense::Minimize,
+            (linear!(1) + linear!(2)).into(),
+            dv,
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let err = instance.as_qubo_format().unwrap_err();
+        assert!(err.to_string().contains("non-binary"));
+    }
+
+    #[test]
+    fn hubo_from_cubic_objective() {
+        // min x1*x2*x3 + x1 with binary x1, x2, x3
+        use crate::MonomialDyn;
+        let cubic = crate::Polynomial::single_term(
+            MonomialDyn::new(vec![
+                VariableID::from(1),
+                VariableID::from(2),
+                VariableID::from(3),
+            ]),
+            coeff!(1.0),
+        );
+        let objective = Function::from(linear!(1)) + Function::from(cubic);
+        let instance = Instance::new(
+            Sense::Minimize,
+            objective,
+            binary_vars([1, 2, 3]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let (hubo, constant) = instance.as_hubo_format().unwrap();
+        assert_eq!(constant, 0.0);
+        // Cubic term
+        let cubic_key = BinaryIds::from(MonomialDyn::new(vec![
+            VariableID::from(1),
+            VariableID::from(2),
+            VariableID::from(3),
+        ]));
+        assert_eq!(hubo.get(&cubic_key), Some(&1.0));
+        // Linear term
+        let linear_key = BinaryIds::from(MonomialDyn::new(vec![VariableID::from(1)]));
+        assert_eq!(hubo.get(&linear_key), Some(&1.0));
+    }
+}

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -20,13 +20,18 @@ impl Instance {
         let bounds = self.bounds();
         let kinds = self.kinds();
 
-        let function = self
-            .constraint_collection
-            .active()
-            .get(&constraint_id)
-            .with_context(|| format!("Constraint ID {constraint_id:?} not found"))?
-            .function()
-            .clone();
+        let (function, equality) = {
+            let constraint = self
+                .constraint_collection
+                .active()
+                .get(&constraint_id)
+                .with_context(|| format!("Constraint ID {constraint_id:?} not found"))?;
+            (constraint.function().clone(), constraint.equality)
+        };
+
+        if equality != Equality::LessThanOrEqualToZero {
+            bail!("The constraint is not inequality: ID={constraint_id:?}");
+        }
 
         for id in function.required_ids() {
             let kind = kinds
@@ -73,8 +78,8 @@ impl Instance {
             );
         }
 
-        let slack_id = self.next_variable_id();
         let slack = self.new_decision_variable(Kind::Integer, slack_bound, None, atol)?;
+        let slack_id = slack.id();
         slack.metadata.name = Some("ommx.slack".to_string());
         slack.metadata.subscripts = vec![constraint_id.into_inner() as i64];
 
@@ -162,9 +167,9 @@ impl Instance {
             Err(e) => return Err(e).context("Slack coefficient must be finite"),
         };
 
-        let slack_id = self.next_variable_id();
         let slack =
             self.new_decision_variable(Kind::Integer, slack_bound, None, ATol::default())?;
+        let slack_id = slack.id();
         slack.metadata.name = Some("ommx.slack".to_string());
         slack.metadata.subscripts = vec![constraint_id.into_inner() as i64];
 
@@ -333,6 +338,33 @@ mod tests {
         // The original constraint is still the untouched inequality.
         let constraint = instance.constraints().get(&ConstraintID::from(0)).unwrap();
         assert_eq!(constraint.equality, Equality::LessThanOrEqualToZero);
+    }
+
+    #[test]
+    fn convert_inequality_rejects_equality_constraint() {
+        // An `EqualToZero` constraint must be rejected by
+        // `convert_inequality_to_equality_with_integer_slack`, which names the
+        // contract in its identifier. Matches the guard in the sibling
+        // `add_integer_slack_to_inequality`.
+        let dv = btreemap! {
+            VariableID::from(1) => DecisionVariable::new(
+                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), None, ATol::default()
+            ).unwrap(),
+        };
+        let objective = Function::from(linear!(1));
+        let constraint_fn = Function::from(linear!(1)) + coeff!(-2.0);
+        let constraints = btreemap! {
+            ConstraintID::from(0) => crate::Constraint::equal_to_zero(
+                ConstraintID::from(0),
+                constraint_fn,
+            ),
+        };
+        let mut instance = Instance::new(Sense::Minimize, objective, dv, constraints).unwrap();
+
+        let err = instance
+            .convert_inequality_to_equality_with_integer_slack(0, 32, ATol::default())
+            .unwrap_err();
+        assert!(err.to_string().contains("not inequality"));
     }
 
     #[test]

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -1,0 +1,320 @@
+use super::Instance;
+use crate::{
+    constraint::Equality, ATol, Bound, Bounds, Coefficient, ConstraintID, Evaluate,
+    InfeasibleDetected, Kind, Linear, LinearMonomial, VariableID,
+};
+use anyhow::{bail, Context, Result};
+use num::traits::Inv;
+
+impl Instance {
+    /// Convert an inequality $f(x) \leq 0$ to an equality $a f(x) + s = 0$ with a
+    /// newly introduced integer slack variable $s$, where $a$ is the minimal positive
+    /// factor that makes every coefficient of $f(x)$ integer.
+    pub fn convert_inequality_to_equality_with_integer_slack(
+        &mut self,
+        constraint_id: u64,
+        max_integer_range: u64,
+        atol: ATol,
+    ) -> Result<()> {
+        let constraint_id = ConstraintID::from(constraint_id);
+        let bounds = self.bounds();
+        let kinds = self.kinds();
+
+        let function = self
+            .constraint_collection
+            .active()
+            .get(&constraint_id)
+            .with_context(|| format!("Constraint ID {constraint_id:?} not found"))?
+            .function()
+            .clone();
+
+        for id in function.required_ids() {
+            let kind = kinds
+                .get(&id)
+                .with_context(|| format!("Decision variable ID {id:?} not found"))?;
+            if !matches!(kind, Kind::Binary | Kind::Integer) {
+                bail!("The constraint contains continuous decision variables: ID={id:?}");
+            }
+        }
+
+        let a = function
+            .content_factor()
+            .context("Cannot normalize the coefficients to integers")?;
+        let af = function.clone() * a;
+
+        let af_bound = af.evaluate_bound(&bounds);
+        let af_bound = af_bound.as_integer_bound(atol).ok_or(
+            InfeasibleDetected::InequalityConstraintBound {
+                id: constraint_id,
+                bound: af_bound,
+            },
+        )?;
+        if af_bound.lower() > 0.0 {
+            bail!(InfeasibleDetected::InequalityConstraintBound {
+                id: constraint_id,
+                bound: af_bound,
+            });
+        }
+        if af_bound.upper() <= 0.0 {
+            self.relax_constraint(
+                constraint_id,
+                "convert_inequality_to_equality_with_integer_slack".to_string(),
+                [],
+            )?;
+            return Ok(());
+        }
+
+        let slack_bound = Bound::new(0.0, -af_bound.lower()).unwrap();
+        if slack_bound.width() > max_integer_range as f64 {
+            bail!(
+                "The range of the slack variable exceeds the limit: evaluated({}) > limit({})",
+                slack_bound.width(),
+                max_integer_range
+            );
+        }
+
+        let slack_id = self.next_variable_id();
+        let slack = self.new_decision_variable(Kind::Integer, slack_bound, None, atol)?;
+        slack.metadata.name = Some("ommx.slack".to_string());
+        slack.metadata.subscripts = vec![constraint_id.into_inner() as i64];
+
+        let slack_term = Linear::single_term(LinearMonomial::Variable(slack_id), a.inv());
+        let new_function = function + slack_term;
+
+        let constraint = self
+            .constraint_collection
+            .active_mut()
+            .get_mut(&constraint_id)
+            .expect("constraint presence was verified above");
+        *constraint.function_mut() = new_function;
+        constraint.equality = Equality::EqualToZero;
+
+        Ok(())
+    }
+
+    /// Convert an inequality $f(x) \leq 0$ to $f(x) + b s \leq 0$ with an integer
+    /// slack variable $s \in [0, \text{slack\_upper\_bound}]$.
+    ///
+    /// Returns the coefficient $b = -\mathrm{lower}(f(x)) / \text{slack\_upper\_bound}$.
+    /// Returns `None` if the constraint was trivially satisfied and was moved to
+    /// removed_constraints.
+    pub fn add_integer_slack_to_inequality(
+        &mut self,
+        constraint_id: u64,
+        slack_upper_bound: u64,
+    ) -> Result<Option<f64>> {
+        let constraint_id = ConstraintID::from(constraint_id);
+        let bounds = self.bounds();
+        let kinds = self.kinds();
+
+        let (function, equality) = {
+            let constraint = self
+                .constraint_collection
+                .active()
+                .get(&constraint_id)
+                .with_context(|| format!("Constraint ID {constraint_id:?} not found"))?;
+            (constraint.function().clone(), constraint.equality)
+        };
+
+        if equality != Equality::LessThanOrEqualToZero {
+            bail!("The constraint is not inequality: ID={constraint_id:?}");
+        }
+
+        for id in function.required_ids() {
+            let kind = kinds
+                .get(&id)
+                .with_context(|| format!("Decision variable ID {id:?} not found"))?;
+            if !matches!(kind, Kind::Binary | Kind::Integer) {
+                bail!("The constraint contains continuous decision variables: ID={id:?}");
+            }
+        }
+
+        let f_bound = function.evaluate_bound(&bounds);
+        if f_bound.lower() > 0.0 {
+            bail!(InfeasibleDetected::InequalityConstraintBound {
+                id: constraint_id,
+                bound: f_bound,
+            });
+        }
+        if f_bound.upper() <= 0.0 {
+            self.relax_constraint(
+                constraint_id,
+                "add_integer_slack_to_inequality".to_string(),
+                [],
+            )?;
+            return Ok(None);
+        }
+
+        let b = -f_bound.lower() / slack_upper_bound as f64;
+        let slack_bound = Bound::new(0.0, slack_upper_bound as f64).unwrap();
+
+        let slack_id = self.next_variable_id();
+        let slack =
+            self.new_decision_variable(Kind::Integer, slack_bound, None, ATol::default())?;
+        slack.metadata.name = Some("ommx.slack".to_string());
+        slack.metadata.subscripts = vec![constraint_id.into_inner() as i64];
+
+        // `b` is non-negative in this branch (we bailed on lower > 0 and relaxed when
+        // upper <= 0). `b == 0` only when `f_bound.lower() == 0`, which is a boundary
+        // case; adding a zero-coefficient slack term is mathematically a no-op so we
+        // only modify the function when `b > 0`, matching the v1 observable behavior
+        // (where a zero coefficient is dropped on insertion).
+        let new_function = match Coefficient::try_from(b) {
+            Ok(b_coeff) => {
+                let slack_term = Linear::single_term(LinearMonomial::Variable(slack_id), b_coeff);
+                function + slack_term
+            }
+            Err(crate::CoefficientError::Zero) => function,
+            Err(e) => return Err(e).context("Slack coefficient must be finite"),
+        };
+
+        let constraint = self
+            .constraint_collection
+            .active_mut()
+            .get_mut(&constraint_id)
+            .expect("constraint presence was verified above");
+        *constraint.function_mut() = new_function;
+
+        Ok(Some(b))
+    }
+
+    /// Snapshot of bounds for every decision variable.
+    fn bounds(&self) -> Bounds {
+        self.decision_variables
+            .iter()
+            .map(|(id, dv)| (*id, dv.bound()))
+            .collect()
+    }
+
+    /// Snapshot of kinds for every decision variable.
+    fn kinds(&self) -> fnv::FnvHashMap<VariableID, Kind> {
+        self.decision_variables
+            .iter()
+            .map(|(id, dv)| (*id, dv.kind()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coeff, linear, ConstraintID, DecisionVariable, Function, Sense, VariableID};
+    use maplit::btreemap;
+
+    #[test]
+    fn converts_integer_inequality_to_equality_with_slack() {
+        // min x1 + x2 s.t. x1 + x2 - 4 <= 0, with x1, x2 integer in [0, 3]
+        let dv = btreemap! {
+            VariableID::from(1) => DecisionVariable::new(
+                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), None, ATol::default()
+            ).unwrap(),
+            VariableID::from(2) => DecisionVariable::new(
+                VariableID::from(2), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), None, ATol::default()
+            ).unwrap(),
+        };
+        let objective = Function::from(linear!(1)) + Function::from(linear!(2));
+        let constraint_fn = Function::from(linear!(1)) + Function::from(linear!(2)) + coeff!(-4.0);
+        let constraints = btreemap! {
+            ConstraintID::from(0) => crate::Constraint::less_than_or_equal_to_zero(
+                ConstraintID::from(0),
+                constraint_fn,
+            ),
+        };
+        let mut instance = Instance::new(Sense::Minimize, objective, dv, constraints).unwrap();
+
+        instance
+            .convert_inequality_to_equality_with_integer_slack(0, 32, ATol::default())
+            .unwrap();
+
+        let constraint = instance
+            .constraints()
+            .get(&ConstraintID::from(0))
+            .expect("constraint should still be present");
+        assert_eq!(constraint.equality, Equality::EqualToZero);
+        // Slack var should have been added
+        assert!(instance
+            .decision_variables
+            .values()
+            .any(|dv| dv.metadata.name.as_deref() == Some("ommx.slack")));
+    }
+
+    #[test]
+    fn add_integer_slack_updates_function_but_keeps_inequality() {
+        // min x1 s.t. x1 - 2 <= 0, x1 integer in [0, 3]
+        let dv = btreemap! {
+            VariableID::from(1) => DecisionVariable::new(
+                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), None, ATol::default()
+            ).unwrap(),
+        };
+        let objective = Function::from(linear!(1));
+        let constraint_fn = Function::from(linear!(1)) + coeff!(-2.0);
+        let constraints = btreemap! {
+            ConstraintID::from(0) => crate::Constraint::less_than_or_equal_to_zero(
+                ConstraintID::from(0),
+                constraint_fn,
+            ),
+        };
+        let mut instance = Instance::new(Sense::Minimize, objective, dv, constraints).unwrap();
+
+        let b = instance
+            .add_integer_slack_to_inequality(0, 2)
+            .unwrap()
+            .expect("constraint should still be active");
+        assert!(b > 0.0);
+
+        let constraint = instance
+            .constraints()
+            .get(&ConstraintID::from(0))
+            .expect("constraint should still be present");
+        assert_eq!(constraint.equality, Equality::LessThanOrEqualToZero);
+        assert!(instance
+            .decision_variables
+            .values()
+            .any(|dv| dv.metadata.name.as_deref() == Some("ommx.slack")));
+    }
+
+    #[test]
+    fn always_satisfied_inequality_is_relaxed() {
+        // x1 - 10 <= 0 with x1 in [0, 3] is always satisfied
+        let dv = btreemap! {
+            VariableID::from(1) => DecisionVariable::new(
+                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), None, ATol::default()
+            ).unwrap(),
+        };
+        let objective = Function::from(linear!(1));
+        let constraint_fn = Function::from(linear!(1)) + coeff!(-10.0);
+        let constraints = btreemap! {
+            ConstraintID::from(0) => crate::Constraint::less_than_or_equal_to_zero(
+                ConstraintID::from(0),
+                constraint_fn,
+            ),
+        };
+        let mut instance = Instance::new(Sense::Minimize, objective, dv, constraints).unwrap();
+
+        let result = instance.add_integer_slack_to_inequality(0, 2).unwrap();
+        assert!(result.is_none());
+        assert!(instance.constraints().is_empty());
+        assert_eq!(instance.removed_constraints().len(), 1);
+    }
+
+    #[test]
+    fn rejects_constraint_with_continuous_variable() {
+        let dv = btreemap! {
+            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
+        };
+        let objective = Function::from(linear!(1));
+        let constraint_fn = Function::from(linear!(1)) + coeff!(-2.0);
+        let constraints = btreemap! {
+            ConstraintID::from(0) => crate::Constraint::less_than_or_equal_to_zero(
+                ConstraintID::from(0),
+                constraint_fn,
+            ),
+        };
+        let mut instance = Instance::new(Sense::Minimize, objective, dv, constraints).unwrap();
+
+        let err = instance
+            .convert_inequality_to_equality_with_integer_slack(0, 32, ATol::default())
+            .unwrap_err();
+        assert!(err.to_string().contains("continuous decision variables"));
+    }
+}

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -148,24 +148,32 @@ impl Instance {
         let b = -f_bound.lower() / slack_upper_bound as f64;
         let slack_bound = Bound::new(0.0, slack_upper_bound as f64).unwrap();
 
+        // Validate the slack coefficient before mutating the instance so failures
+        // (e.g. `slack_upper_bound == 0` giving `b = inf`) do not leave an orphan
+        // slack decision variable behind. `b` is non-negative in this branch (we
+        // bailed on lower > 0 and relaxed when upper <= 0). `b == 0` only when
+        // `f_bound.lower() == 0`, which is a boundary case; adding a zero-coefficient
+        // slack term is mathematically a no-op so we skip the term in that case,
+        // matching v1 observable behavior (where a zero coefficient is dropped on
+        // insertion).
+        let b_coeff = match Coefficient::try_from(b) {
+            Ok(c) => Some(c),
+            Err(crate::CoefficientError::Zero) => None,
+            Err(e) => return Err(e).context("Slack coefficient must be finite"),
+        };
+
         let slack_id = self.next_variable_id();
         let slack =
             self.new_decision_variable(Kind::Integer, slack_bound, None, ATol::default())?;
         slack.metadata.name = Some("ommx.slack".to_string());
         slack.metadata.subscripts = vec![constraint_id.into_inner() as i64];
 
-        // `b` is non-negative in this branch (we bailed on lower > 0 and relaxed when
-        // upper <= 0). `b == 0` only when `f_bound.lower() == 0`, which is a boundary
-        // case; adding a zero-coefficient slack term is mathematically a no-op so we
-        // only modify the function when `b > 0`, matching the v1 observable behavior
-        // (where a zero coefficient is dropped on insertion).
-        let new_function = match Coefficient::try_from(b) {
-            Ok(b_coeff) => {
-                let slack_term = Linear::single_term(LinearMonomial::Variable(slack_id), b_coeff);
+        let new_function = match b_coeff {
+            Some(c) => {
+                let slack_term = Linear::single_term(LinearMonomial::Variable(slack_id), c);
                 function + slack_term
             }
-            Err(crate::CoefficientError::Zero) => function,
-            Err(e) => return Err(e).context("Slack coefficient must be finite"),
+            None => function,
         };
 
         let constraint = self
@@ -295,6 +303,36 @@ mod tests {
         assert!(result.is_none());
         assert!(instance.constraints().is_empty());
         assert_eq!(instance.removed_constraints().len(), 1);
+    }
+
+    #[test]
+    fn rejects_zero_slack_upper_bound_without_mutating_instance() {
+        // f(x) = x1 - 2 with x1 in [0, 3] gives a finite non-zero lower, so
+        // `slack_upper_bound == 0` drives `b = inf`. The call must fail without
+        // leaving behind an orphan slack decision variable.
+        let dv = btreemap! {
+            VariableID::from(1) => DecisionVariable::new(
+                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), None, ATol::default()
+            ).unwrap(),
+        };
+        let objective = Function::from(linear!(1));
+        let constraint_fn = Function::from(linear!(1)) + coeff!(-2.0);
+        let constraints = btreemap! {
+            ConstraintID::from(0) => crate::Constraint::less_than_or_equal_to_zero(
+                ConstraintID::from(0),
+                constraint_fn,
+            ),
+        };
+        let mut instance = Instance::new(Sense::Minimize, objective, dv, constraints).unwrap();
+        let before = instance.decision_variables.len();
+
+        let err = instance.add_integer_slack_to_inequality(0, 0).unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("finite"));
+        // No slack variable should have been added on the failure path.
+        assert_eq!(instance.decision_variables.len(), before);
+        // The original constraint is still the untouched inequality.
+        let constraint = instance.constraints().get(&ConstraintID::from(0)).unwrap();
+        assert_eq!(constraint.equality, Equality::LessThanOrEqualToZero);
     }
 
     #[test]

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -1,11 +1,11 @@
 use crate::{
     v1::{
-        decision_variable::Kind, instance::Sense, DecisionVariable, Function, Instance, Linear,
-        Optimality, Relaxation, SampleSet, SampledDecisionVariable, Samples, Solution, State,
+        decision_variable::Kind, instance::Sense, Function, Instance, Optimality, Relaxation,
+        SampleSet, SampledDecisionVariable, Samples, Solution, State,
     },
     Bound, Bounds, Evaluate, VariableID, VariableIDSet,
 };
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{bail, Context, Result};
 use approx::AbsDiffEq;
 use num::Zero;
 use std::{
@@ -172,91 +172,6 @@ impl Instance {
         }
         self.sense = Sense::Maximize as i32;
         self.objective = Some(-self.objective().into_owned());
-    }
-
-    /// Encode an integer decision variable into binary decision variables.
-    ///
-    /// Note that this method does not substitute the yielded binary representation into the objective and constraints.
-    /// Call [`Instance::substitute`] with the returned [`Linear`] representation.
-    ///
-    /// Mutability
-    /// ----------
-    /// - This adds new binary decision variables introduced for binary encoding to the instance.
-    ///
-    /// Errors
-    /// ------
-    /// Returns [anyhow::Error] in the following cases:
-    ///
-    /// - The given decision variable ID is not found
-    /// - The specified decision variable is not an integer type.
-    /// - The bound of the decision variable is not set or not finite.
-    ///
-    pub fn log_encode(&mut self, decision_variable_id: u64) -> Result<Linear> {
-        let v = self
-            .decision_variables
-            .iter()
-            .find(|dv| dv.id == decision_variable_id)
-            .with_context(|| format!("Decision variable ID {decision_variable_id} not found"))?;
-        if v.kind() != Kind::Integer {
-            bail!(
-                "The decision variable is not an integer type: ID={}",
-                decision_variable_id
-            );
-        }
-
-        let bound = v.bound.as_ref().with_context(|| {
-            format!("Bound must be set and finite for log-encoding: ID={decision_variable_id}")
-        })?;
-
-        // Bound of integer may be non-integer value
-        let upper = bound.upper.floor();
-        let lower = bound.lower.ceil();
-        let u_l = upper - lower;
-        ensure!(
-            u_l >= 0.0,
-            "No feasible integer found in the bound: ID={}, lower={}, upper={}",
-            decision_variable_id,
-            bound.lower,
-            bound.upper
-        );
-
-        // There is only one feasible integer, and no need to encode
-        if u_l == 0.0 {
-            return Ok(Linear::from(lower));
-        }
-
-        // Log-encoding
-        let n = (u_l + 1.0).log2().ceil() as usize;
-        let id_base = self
-            .defined_ids()
-            .last()
-            .map(|id| id + 1)
-            .expect("At least one decision variable here");
-
-        let mut terms = Vec::new();
-        for i in 0..n {
-            let id = id_base + i as u64;
-            terms.push((
-                id,
-                if i == n - 1 {
-                    u_l - 2.0f64.powi(i as i32) + 1.0
-                } else {
-                    2.0f64.powi(i as i32)
-                },
-            ));
-            self.decision_variables.push(DecisionVariable {
-                id,
-                name: Some("ommx.log_encode".to_string()),
-                subscripts: vec![decision_variable_id as i64, i as i64],
-                kind: Kind::Binary as i32,
-                bound: Some(crate::v1::Bound {
-                    lower: 0.0,
-                    upper: 1.0,
-                }),
-                ..Default::default()
-            });
-        }
-        Ok(Linear::new(terms.into_iter(), lower))
     }
 
     /// Substitute dependent decision variables with given [Function]s.
@@ -539,59 +454,16 @@ fn eval_dependencies(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{v1::State, Evaluate};
+    use crate::{
+        v1::{Linear, State},
+        Evaluate,
+    };
     use proptest::prelude::*;
 
     proptest! {
         #[test]
         fn test_instance_arbitrary_any(instance in Instance::arbitrary()) {
             instance.validate().unwrap();
-        }
-
-        #[test]
-        fn log_encode((lower, upper) in (-10.0_f64..10.0, -10.0_f64..10.0)
-            .prop_filter("At least one integer", |(lower, upper)| lower.ceil() <= upper.floor())
-        ) {
-            let mut instance = Instance::default();
-            instance.decision_variables.push(DecisionVariable {
-                id: 0,
-                name: Some("x".to_string()),
-                kind: Kind::Integer as i32,
-                bound: Some(crate::v1::Bound { lower, upper }),
-                ..Default::default()
-            });
-            let encoded = instance.log_encode(0).unwrap();
-
-            // Test the ID of yielded decision variables are not duplicated
-            instance.validate().unwrap();
-
-            // Get decision variables introduced for log-encoding
-            let aux_bits = instance
-                .decision_variables
-                .iter()
-                .filter_map(|dv| {
-                    if dv.name == Some("ommx.log_encode".to_string()) && dv.subscripts[0] == 0 {
-                        Some(dv.id)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>();
-
-            if lower.ceil() == upper.floor() {
-                // No need to encode
-                prop_assert_eq!(encoded.as_constant().unwrap(), lower.ceil());
-                prop_assert_eq!(aux_bits.len(), 0);
-                return Ok(());
-            }
-
-            let state = State { entries: aux_bits.iter().map(|&id| (id, 0.0)).collect::<HashMap<_, _>>() };
-            let lower_evaluated = encoded.evaluate(&state, crate::ATol::default()).unwrap();
-            prop_assert_eq!(lower_evaluated, lower.ceil());
-
-            let state = State { entries: aux_bits.iter().map(|&id| (id, 1.0)).collect::<HashMap<_, _>>() };
-            let upper_evaluated = encoded.evaluate(&state, crate::ATol::default()).unwrap();
-            prop_assert_eq!(upper_evaluated, upper.floor());
         }
 
         /// Compare the result of partial_evaluate and substitute with `Function::Constant`.

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -1,11 +1,9 @@
 use crate::{
     v1::{
-        decision_variable::Kind, instance::Sense, DecisionVariable, Equality, Function, Instance,
-        Linear, Optimality, Relaxation, SampleSet, SampledDecisionVariable, Samples, Solution,
-        State,
+        decision_variable::Kind, instance::Sense, DecisionVariable, Function, Instance, Linear,
+        Optimality, Relaxation, SampleSet, SampledDecisionVariable, Samples, Solution, State,
     },
-    BinaryIdPair, BinaryIds, Bound, Bounds, ConstraintID, Evaluate, InfeasibleDetected, VariableID,
-    VariableIDSet,
+    Bound, Bounds, Evaluate, VariableID, VariableIDSet,
 };
 use anyhow::{bail, ensure, Context, Result};
 use approx::AbsDiffEq;
@@ -176,91 +174,6 @@ impl Instance {
         self.objective = Some(-self.objective().into_owned());
     }
 
-    /// Create QUBO (Quadratic Unconstrained Binary Optimization) dictionary from the instance.
-    ///
-    /// Before calling this method, you should check that this instance is suitable for QUBO:
-    ///
-    /// - This instance has no constraints
-    ///   - Use penalty method (TODO: ALM will be added) to convert into an unconstrained problem.
-    /// - The objective function uses only binary decision variables.
-    ///   - TODO: Binary encoding will be added.
-    /// - The degree of the objective is at most 2.
-    ///
-    pub fn as_qubo_format(&self) -> Result<(BTreeMap<BinaryIdPair, f64>, f64)> {
-        if self.sense() == Sense::Maximize {
-            bail!("QUBO format is only for minimization problems.");
-        }
-        if !self.constraints.is_empty() {
-            bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
-        }
-        if !self
-            .objective()
-            .required_ids()
-            .is_subset(&self.binary_ids())
-        {
-            bail!("The objective function uses non-binary decision variables.");
-        }
-        let mut constant = 0.0;
-        let mut quad = BTreeMap::new();
-        for (ids, c) in self.objective().into_iter() {
-            if c.abs() <= f64::EPSILON {
-                continue;
-            }
-            if ids.is_empty() {
-                constant += c;
-            } else {
-                let key = BinaryIdPair::try_from(ids)?;
-                let value = quad.entry(key).and_modify(|v| *v += c).or_insert(c);
-                if value.abs() < f64::EPSILON {
-                    quad.remove(&key);
-                }
-            }
-        }
-        Ok((quad, constant))
-    }
-
-    /// Create HUBO (Higher-Order Unconstrained Binary Optimization) dictionary from the instance.
-    ///
-    /// Before calling this method, you should check that this instance is suitable for QUBO:
-    ///
-    /// - This instance has no constraints
-    ///   - Use penalty method (TODO: ALM will be added) to convert into an unconstrained problem.
-    /// - The objective function uses only binary decision variables.
-    ///   - TODO: Binary encoding will be added.
-    ///
-    pub fn as_hubo_format(&self) -> Result<(BTreeMap<BinaryIds, f64>, f64)> {
-        if self.sense() == Sense::Maximize {
-            bail!("HUBO format is only for minimization problems.");
-        }
-        if !self.constraints.is_empty() {
-            bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
-        }
-        if !self
-            .objective()
-            .required_ids()
-            .is_subset(&self.binary_ids())
-        {
-            bail!("The objective function uses non-binary decision variables.");
-        }
-        let mut constant = 0.0;
-        let mut quad = BTreeMap::new();
-        for (ids, c) in self.objective().into_iter() {
-            if c.abs() <= f64::EPSILON {
-                continue;
-            }
-            if ids.is_empty() {
-                constant += c;
-            } else {
-                let key = BinaryIds::from(ids);
-                let value = quad.entry(key.clone()).and_modify(|v| *v += c).or_insert(c);
-                if value.abs() < f64::EPSILON {
-                    quad.remove(&key);
-                }
-            }
-        }
-        Ok((quad, constant))
-    }
-
     /// Encode an integer decision variable into binary decision variables.
     ///
     /// Note that this method does not substitute the yielded binary representation into the objective and constraints.
@@ -368,205 +281,6 @@ impl Instance {
         }
         self.decision_variable_dependency.extend(replacement);
         Ok(())
-    }
-
-    /// Convert inequality `f(x) <= 0` into equality `f(x) + s/a = 0` with an *integer* slack variable `s`.
-    ///
-    /// Arguments
-    /// ---------
-    /// - `constraint_id`: The ID of the constraint to be converted.
-    /// - `max_integer_range`: The maximum integer range of the slack variable.
-    /// - `atol`: Absolute tolerance for approximating the coefficient to rational number.
-    ///
-    /// Since any `x: f64` can be approximated by an rational number (`x ~ p/q`) within some tolerance,
-    /// multiplying the lcm `a` of every denominator of coefficients `q_1, ...` yields `a * f(x)` whose coefficients are all integer.
-    /// However, this cause very large coefficients and thus the slack variable may have very large range,
-    /// which is not practical for solvers.
-    /// `max_integer_range` is used to limit the range of the slack variable, and the method returns error if exceeded it.
-    ///
-    /// Mutability
-    /// ----------
-    /// - This evaluates the bound of `f(x)` as `[lower, upper]`, and then:
-    ///   - if `lower > 0`, this constraint never be satisfied, and the method returns [`InfeasibleDetected::InequalityConstraintBound`].
-    ///   - if `upper <= 0`, this constraint is always satisfied, and the constraint is moved to `removed_constraints`.
-    /// - This creates a new decision variable for the slack variable.
-    ///   - Its name is `ommx.slack`
-    ///   - Its subscript is single element `[constraint_id]`
-    ///   - Its bound is determined from `f(x)`
-    ///   - Its kind are discussed below
-    /// - The constraint is changed as equality with keeping the constraint ID.
-    ///   - Its function will be converted `f(x)` to `f(x) + s/a`
-    ///
-    /// Error
-    /// -----
-    /// - The constraint ID is not found, or is not inequality
-    /// - The constraint contains continuous decision variables
-    /// - The slack variable range exceeds `max_integer_range`
-    ///
-    pub fn convert_inequality_to_equality_with_integer_slack(
-        &mut self,
-        constraint_id: u64,
-        max_integer_range: u64,
-        atol: crate::ATol,
-    ) -> Result<()> {
-        let bounds = self.get_bounds()?;
-        let kinds = self.get_kinds();
-        let next_id = self.defined_ids().last().map(|id| id + 1).unwrap_or(0);
-
-        let constraint = self
-            .constraints
-            .iter_mut()
-            .find(|c| c.id == constraint_id)
-            .with_context(|| format!("Constraint ID {constraint_id} not found"))?;
-        let function = constraint
-            .function
-            .as_ref()
-            .with_context(|| format!("Constraint ID {constraint_id} does not have a function"))?;
-
-        // If the constraint contains continuous decision variables, integer slack variable cannot be introduced
-        for id in function.required_ids() {
-            let kind = kinds
-                .get(&id)
-                .with_context(|| format!("Decision variable ID {id:?} not found"))?;
-            if !matches!(kind, Kind::Binary | Kind::Integer) {
-                bail!("The constraint contains continuous decision variables: ID={id:?}");
-            }
-        }
-
-        // Evaluate minimal integer coefficient multiplier `a` which make all coefficients of `a * f(x)` integer
-        let a = function
-            .content_factor()
-            .context("Cannot normalize the coefficients to integers")?;
-        let af = a * function.clone();
-
-        // Check the bound of `a*f`
-        // - If `lower > 0`, the constraint is infeasible
-        // - If `upper <= 0`, the constraint is always satisfied, thus moved to `removed_constraints`
-        let bound = af.evaluate_bound(&bounds);
-        let bound = bound.as_integer_bound(atol).ok_or_else(|| {
-            InfeasibleDetected::InequalityConstraintBound {
-                id: ConstraintID::from(constraint_id),
-                bound,
-            }
-        })?;
-        if bound.lower() > 0.0 {
-            bail!(InfeasibleDetected::InequalityConstraintBound {
-                id: ConstraintID::from(constraint_id),
-                bound,
-            });
-        }
-        if bound.upper() <= 0.0 {
-            // The constraint is always satisfied
-            self.relax_constraint(
-                constraint_id,
-                "convert_inequality_to_equality_with_integer_slack".to_string(),
-                Default::default(),
-            )?;
-            return Ok(());
-        }
-        let bound = Bound::new(0.0, -bound.lower()).unwrap();
-        if bound.width() > max_integer_range as f64 {
-            bail!(
-                "The range of the slack variable exceeds the limit: evaluated({width}) > limit({max_integer_range})",
-                width = bound.width()
-            );
-        }
-
-        self.decision_variables.push(DecisionVariable {
-            id: next_id,
-            name: Some("ommx.slack".to_string()),
-            subscripts: vec![constraint_id as i64],
-            kind: Kind::Integer as i32,
-            bound: Some(bound.into()),
-            ..Default::default()
-        });
-        constraint.function = Some(function.clone() + Linear::single_term(next_id, 1.0 / a));
-        constraint.set_equality(Equality::EqualToZero);
-
-        Ok(())
-    }
-
-    /// Add integer slack variable to inequality
-    ///
-    /// This converts an inequality `f(x) <= 0` to `f(x) + b*s <= 0` where `s` is an integer slack variable.
-    ///
-    /// Mutability
-    /// ----------
-    /// - This evaluates the bound of `f(x)` as `[lower, upper]`, and then:
-    ///   - if `lower > 0`, this constraint never be satisfied, and the method returns [`InfeasibleDetected::InequalityConstraintBound`].
-    ///   - if `upper <= 0`, this constraint is always satisfied, and the constraint is moved to `removed_constraints`.
-    /// - This adds a new decision variable for the slack variable.
-    ///   - Its name is `ommx.slack`
-    ///   - Its subscript is single element `[constraint_id]`
-    ///   - Its bound is `[0, slack_upper_bound]`
-    ///   - Its kind is integer
-    ///
-    /// Errors
-    /// ------
-    /// - The constraint ID is not found, or is not inequality
-    /// - The constraint contains continuous decision variables
-    ///
-    pub fn add_integer_slack_to_inequality(
-        &mut self,
-        constraint_id: u64,
-        slack_upper_bound: u64,
-    ) -> Result<Option<f64>> {
-        let slack_id = self.defined_ids().last().map(|id| id + 1).unwrap_or(0);
-        let bounds = self.get_bounds()?;
-        let kinds = self.get_kinds();
-        let constraint = self
-            .constraints
-            .iter_mut()
-            .find(|c| c.id == constraint_id)
-            .with_context(|| format!("Constraint ID {constraint_id} not found"))?;
-        if constraint.equality() != Equality::LessThanOrEqualToZero {
-            bail!("The constraint is not inequality: ID={}", constraint_id);
-        }
-        let f = constraint
-            .function
-            .as_ref()
-            .with_context(|| format!("Constraint ID {constraint_id} does not have a function"))?;
-
-        for id in f.required_ids() {
-            let kind = kinds
-                .get(&id)
-                .with_context(|| format!("Decision variable ID {id:?} not found"))?;
-            if !matches!(kind, Kind::Binary | Kind::Integer) {
-                bail!("The constraint contains continuous decision variables: ID={id:?}");
-            }
-        }
-
-        let bound = f.evaluate_bound(&bounds);
-        if bound.lower() > 0.0 {
-            bail!(InfeasibleDetected::InequalityConstraintBound {
-                id: ConstraintID::from(constraint_id),
-                bound,
-            });
-        }
-        if bound.upper() <= 0.0 {
-            // The constraint is always satisfied
-            self.relax_constraint(
-                constraint_id,
-                "add_integer_slack_to_inequality".to_string(),
-                Default::default(),
-            )?;
-            return Ok(None);
-        }
-        let b = -bound.lower() / slack_upper_bound as f64;
-
-        self.decision_variables.push(DecisionVariable {
-            id: slack_id,
-            name: Some("ommx.slack".to_string()),
-            subscripts: vec![constraint_id as i64],
-            kind: Kind::Integer as i32,
-            bound: Some(crate::v1::Bound {
-                lower: 0.0,
-                upper: slack_upper_bound as f64,
-            }),
-            ..Default::default()
-        });
-        constraint.function = Some(f.clone() + Linear::single_term(slack_id, b));
-        Ok(Some(b))
     }
 }
 
@@ -825,39 +539,13 @@ fn eval_dependencies(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{random::InstanceParameters, v1::State, Evaluate};
+    use crate::{v1::State, Evaluate};
     use proptest::prelude::*;
 
     proptest! {
         #[test]
         fn test_instance_arbitrary_any(instance in Instance::arbitrary()) {
             instance.validate().unwrap();
-        }
-
-
-        #[test]
-        fn test_qubo(instance in Instance::arbitrary_with(InstanceParameters::default_qubo())) {
-            if instance.sense() == Sense::Maximize {
-                return Ok(());
-            }
-            let (quad, _) = instance.as_qubo_format().unwrap();
-            for (ids, c) in quad {
-                prop_assert!(ids.0 <= ids.1);
-                prop_assert!(c.abs() > f64:: EPSILON);
-            }
-        }
-
-        #[test]
-        fn test_hubo(instance in Instance::arbitrary_with(InstanceParameters::default_hubo())) {
-            if instance.sense() == Sense::Maximize {
-                return Ok(());
-            }
-            let degree = instance.objective().degree();
-            let (quad, _) = instance.as_hubo_format().unwrap();
-            for (ids, c) in quad {
-                prop_assert!(ids.len() <= degree as usize);
-                prop_assert!(c.abs() > f64:: EPSILON);
-            }
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Step 1 of moving operations off the `v1::*` protobuf types onto the domain `ommx::*` layer. The principle we are working toward is **`v1::*` is IO-only; all mathematical operations live on the domain types**.

This PR:
- Ports four helpers from `v1::Instance` onto `ommx::Instance`:
  - `as_qubo_format`
  - `as_hubo_format`
  - `convert_inequality_to_equality_with_integer_slack`
  - `add_integer_slack_to_inequality`
- Adds `Function::evaluate_bound(&Bounds) -> Bound` (needed by the slack helpers) as `rust/ommx/src/function/evaluate_bound.rs`.
- Rewires the Python bindings in `python/ommx/src/instance.rs` so the four methods call the domain implementations directly instead of round-tripping through `v1::Instance`.
- Fixes `Function::content_factor` for the `Function::Constant` case (`c.inv()` → `c.inv().abs()`) so it returns a positive factor like the `PolynomialBase` path. Without this fix, negative constant constraints would sign-flip when multiplied by the content factor inside the slack helpers.
- Rejects special constraints (Indicator/OneHot/SOS1) in `as_qubo_format` / `as_hubo_format` via `check_capabilities(&empty_set)`, matching the guard pattern already present in `penalty_method`. Without this guard an instance with only special active constraints would silently serialize to a QUBO/HUBO that dropped them. The `slack` helpers operate on the regular constraint ID space only and need no analogous guard.
- Removes the migrated helpers (`as_qubo_format`, `as_hubo_format`, `convert_inequality_to_equality_with_integer_slack`, `add_integer_slack_to_inequality`, `log_encode`) from `v1_ext/instance.rs` since Python no longer calls the v1 copies.

The rest of `v1_ext/` is left in place for now — it is still used internally by `random/`, `qplib/`, various `evaluate.rs` impls, and `solution/parse.rs`. Tracking issue for the remaining migration: #802.

## Commits

- `0f8b4ca9` — Port QUBO/HUBO and slack helpers to the domain Instance
- `05c9d75c` — Remove migrated QUBO/HUBO and slack helpers from v1_ext
- `5b6ad181` — Remove v1_ext::log_encode now that Python calls the domain version
- `781af8d7` — Validate slack coefficient before mutating the instance
- `379b64e6` — Reject special constraints in as_qubo_format / as_hubo_format

## Review

Reviewed by Codex twice (initial pass + follow-up after the atomicity fix). Both passes returned **approve**. Highlights verified against the v1_ext originals:

- Mathematical equivalence per-method.
- `content_factor` fix matches the "minimal positive factor" contract and aligns with `PolynomialBase::content_factor`.
- Cancellation logic in `as_qubo_format` / `as_hubo_format` preserved (distinct monomials can collapse to the same binary key; the entry + accumulate + remove sequence is kept).
- `add_integer_slack_to_inequality` no longer leaves an orphan slack decision variable when `Coefficient::try_from(b)` fails (e.g. `slack_upper_bound == 0` giving `b = inf`). Covered by a regression test.
- `convert_inequality_to_equality_with_integer_slack` has no analogous failure window after mutation — all fallible checks run before `new_decision_variable`.
- Special constraints are now rejected at the boundary; a OneHot-only instance is verified to produce an error from `as_qubo_format`.

## Test plan

- [x] `cargo test -p ommx --lib` — 479 passed (15 new tests across `instance/qubo.rs`, `instance/slack.rs`, `function/evaluate_bound.rs`)
- [x] `task python:ommx:test` — 37 passed
- [x] `task python:ommx-openjij-adapter:test` — 30 passed (exercises `as_qubo_format` / `as_hubo_format` / slack helpers end-to-end)
- [ ] CI green

Tracking issue for the remaining v1_ext migration work: #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)