### PR TITLE
Drop v1_ext helpers with domain equivalents (Batches A+B+C)

### DIFF
--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -10,7 +10,7 @@ use approx::AbsDiffEq;
 use num::Zero;
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry as HashMapEntry, BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{hash_map::Entry as HashMapEntry, BTreeMap, BTreeSet, HashMap},
 };
 
 impl Instance {
@@ -50,20 +50,6 @@ impl Instance {
         Ok(())
     }
 
-    pub fn get_kinds(&self) -> HashMap<VariableID, Kind> {
-        self.decision_variables
-            .iter()
-            .map(|dv| (VariableID::from(dv.id), dv.kind()))
-            .collect()
-    }
-
-    pub fn defined_ids(&self) -> BTreeSet<u64> {
-        self.decision_variables
-            .iter()
-            .map(|dv| dv.id)
-            .collect::<BTreeSet<_>>()
-    }
-
     pub fn constraint_ids(&self) -> BTreeSet<u64> {
         self.constraints.iter().map(|c| c.id).collect()
     }
@@ -92,47 +78,6 @@ impl Instance {
             removed_reason,
             removed_reason_parameters,
         });
-        Ok(())
-    }
-
-    /// Execute all validations for this instance
-    pub fn validate(&self) -> Result<()> {
-        self.validate_decision_variable_ids()?;
-        self.validate_constraint_ids()?;
-        Ok(())
-    }
-
-    /// Validate that all decision variable IDs used in the instance are defined.
-    pub fn validate_decision_variable_ids(&self) -> Result<()> {
-        let used_ids = self.required_ids();
-        let mut defined_ids = VariableIDSet::default();
-        for dv in &self.decision_variables {
-            if !defined_ids.insert(dv.id.into()) {
-                bail!("Duplicated definition of decision variable ID: {}", dv.id);
-            }
-        }
-        if !used_ids.is_subset(&defined_ids) {
-            let undefined_ids = used_ids.difference(&defined_ids).collect::<Vec<_>>();
-            bail!("Undefined decision variable IDs: {:?}", undefined_ids);
-        }
-        Ok(())
-    }
-
-    /// Test all constraints and removed constraints have unique IDs.
-    pub fn validate_constraint_ids(&self) -> Result<()> {
-        let mut map = HashSet::new();
-        for c in &self.constraints {
-            if !map.insert(c.id) {
-                bail!("Duplicated constraint ID: {}", c.id);
-            }
-        }
-        for c in &self.removed_constraints {
-            if let Some(c) = &c.constraint {
-                if !map.insert(c.id) {
-                    bail!("Duplicated constraint ID: {}", c.id);
-                }
-            }
-        }
         Ok(())
     }
 }
@@ -393,15 +338,6 @@ fn eval_dependencies(
 mod tests {
     use super::*;
     use crate::v1::{Linear, State};
-    use proptest::prelude::*;
-
-    proptest! {
-        #[test]
-        fn test_instance_arbitrary_any(instance in Instance::arbitrary()) {
-            instance.validate().unwrap();
-        }
-
-    }
 
     #[test]
     fn test_eval_dependencies() {

--- a/rust/ommx/src/v1_ext/instance.rs
+++ b/rust/ommx/src/v1_ext/instance.rs
@@ -75,6 +75,26 @@ impl Instance {
             .collect()
     }
 
+    pub fn relax_constraint(
+        &mut self,
+        constraint_id: u64,
+        removed_reason: String,
+        removed_reason_parameters: HashMap<String, String>,
+    ) -> Result<()> {
+        let index = self
+            .constraints
+            .iter()
+            .position(|c| c.id == constraint_id)
+            .with_context(|| format!("Constraint ID {constraint_id} not found"))?;
+        let c = self.constraints.remove(index);
+        self.removed_constraints.push(crate::v1::RemovedConstraint {
+            constraint: Some(c),
+            removed_reason,
+            removed_reason_parameters,
+        });
+        Ok(())
+    }
+
     /// Execute all validations for this instance
     pub fn validate(&self) -> Result<()> {
         self.validate_decision_variable_ids()?;
@@ -113,88 +133,6 @@ impl Instance {
                 }
             }
         }
-        Ok(())
-    }
-
-    pub fn binary_ids(&self) -> VariableIDSet {
-        self.decision_variables
-            .iter()
-            .filter(|dv| dv.kind() == Kind::Binary)
-            .map(|dv| dv.id.into())
-            .collect()
-    }
-
-    pub fn relax_constraint(
-        &mut self,
-        constraint_id: u64,
-        removed_reason: String,
-        removed_reason_parameters: HashMap<String, String>,
-    ) -> Result<()> {
-        let index = self
-            .constraints
-            .iter()
-            .position(|c| c.id == constraint_id)
-            .with_context(|| format!("Constraint ID {constraint_id} not found"))?;
-        let c = self.constraints.remove(index);
-        self.removed_constraints.push(crate::v1::RemovedConstraint {
-            constraint: Some(c),
-            removed_reason,
-            removed_reason_parameters,
-        });
-        Ok(())
-    }
-
-    pub fn restore_constraint(&mut self, constraint_id: u64) -> Result<()> {
-        let index = self
-            .removed_constraints
-            .iter()
-            .position(|c| c.constraint.as_ref().is_some_and(|c| c.id == constraint_id))
-            .with_context(|| format!("Constraint ID {constraint_id} not found"))?;
-        let c = self.removed_constraints.remove(index).constraint.unwrap();
-        self.constraints.push(c);
-        Ok(())
-    }
-
-    /// Convert the instance into a minimization problem.
-    ///
-    /// This is based on the fact that maximization problem with negative objective function is equivalent to minimization problem.
-    pub fn as_minimization_problem(&mut self) {
-        if self.sense() == Sense::Minimize {
-            return;
-        }
-        self.sense = Sense::Minimize as i32;
-        self.objective = Some(-self.objective().into_owned());
-    }
-
-    pub fn as_maximization_problem(&mut self) {
-        if self.sense() == Sense::Maximize {
-            return;
-        }
-        self.sense = Sense::Maximize as i32;
-        self.objective = Some(-self.objective().into_owned());
-    }
-
-    /// Substitute dependent decision variables with given [Function]s.
-    pub fn substitute(&mut self, replacement: HashMap<u64, Function>) -> Result<()> {
-        if let Some(obj) = self.objective.as_mut() {
-            *obj = obj.substitute(&replacement)?;
-        }
-        for c in &mut self.constraints {
-            if let Some(f) = c.function.as_mut() {
-                *f = f.substitute(&replacement)?;
-            }
-        }
-        for c in &mut self.removed_constraints {
-            if let Some(c) = &mut c.constraint {
-                if let Some(f) = c.function.as_mut() {
-                    *f = f.substitute(&replacement)?;
-                }
-            }
-        }
-        for (_id, f) in self.decision_variable_dependency.iter_mut() {
-            *f = f.substitute(&replacement)?;
-        }
-        self.decision_variable_dependency.extend(replacement);
         Ok(())
     }
 }
@@ -454,10 +392,7 @@ fn eval_dependencies(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        v1::{Linear, State},
-        Evaluate,
-    };
+    use crate::v1::{Linear, State};
     use proptest::prelude::*;
 
     proptest! {
@@ -466,17 +401,6 @@ mod tests {
             instance.validate().unwrap();
         }
 
-        /// Compare the result of partial_evaluate and substitute with `Function::Constant`.
-        #[test]
-        fn substitute_fixed_value(instance in Instance::arbitrary(), value in -3.0..3.0) {
-            for id in instance.defined_ids() {
-                let mut partially_evaluated = instance.clone();
-                partially_evaluated.partial_evaluate(&State { entries: [(id, value)].into_iter().collect() }, crate::ATol::default()).unwrap();
-                let mut substituted = instance.clone();
-                substituted.substitute([(id, Function::from(value))].into_iter().collect()).unwrap();
-                prop_assert!(partially_evaluated.abs_diff_eq(&substituted, crate::ATol::default()));
-            }
-        }
     }
 
     #[test]

--- a/rust/ommx/src/v1_ext/parametric_instance.rs
+++ b/rust/ommx/src/v1_ext/parametric_instance.rs
@@ -1,9 +1,9 @@
 use crate::{
-    v1::{Function, Instance, Parameters, ParametricInstance, State},
-    Evaluate, VariableIDSet,
+    v1::{Instance, Parameters, ParametricInstance, State},
+    Evaluate,
 };
 use anyhow::{bail, Result};
-use std::{borrow::Cow, collections::BTreeSet};
+use std::collections::BTreeSet;
 
 impl From<Instance> for ParametricInstance {
     fn from(
@@ -89,78 +89,6 @@ impl ParametricInstance {
             named_functions: self.named_functions,
         })
     }
-
-    pub fn objective(&self) -> Cow<'_, Function> {
-        match &self.objective {
-            Some(f) => Cow::Borrowed(f),
-            None => Cow::Owned(Function::default()),
-        }
-    }
-
-    /// Used decision variable and parameter IDs in the objective and constraints.
-    pub fn used_ids(&self) -> Result<VariableIDSet> {
-        let mut used_ids = self.objective().required_ids();
-        for c in &self.constraints {
-            used_ids.extend(c.function().required_ids());
-        }
-        Ok(used_ids)
-    }
-
-    /// Defined decision variable IDs. These IDs may not be used in the objective and constraints.
-    pub fn defined_decision_variable_ids(&self) -> VariableIDSet {
-        self.decision_variables
-            .iter()
-            .map(|dv| dv.id.into())
-            .collect()
-    }
-
-    /// Defined parameter IDs. These IDs may not be used in the objective and constraints.
-    pub fn defined_parameter_ids(&self) -> VariableIDSet {
-        self.parameters.iter().map(|p| p.id.into()).collect()
-    }
-
-    pub fn validate(&self) -> Result<()> {
-        self.validate_ids()?;
-        self.validate_constraint_ids()?;
-        Ok(())
-    }
-
-    pub fn validate_ids(&self) -> Result<()> {
-        let mut ids = VariableIDSet::default();
-        for dv in &self.decision_variables {
-            if !ids.insert(dv.id.into()) {
-                bail!("Duplicate decision variable ID: {}", dv.id);
-            }
-        }
-        for p in &self.parameters {
-            if !ids.insert(p.id.into()) {
-                bail!("Duplicate parameter ID: {}", p.id);
-            }
-        }
-        let used_ids = self.used_ids()?;
-        if !used_ids.is_subset(&ids) {
-            let sub = used_ids.difference(&ids).collect::<BTreeSet<_>>();
-            bail!("Undefined ID is used: {:?}", sub);
-        }
-        Ok(())
-    }
-
-    pub fn validate_constraint_ids(&self) -> Result<()> {
-        let mut ids = BTreeSet::new();
-        for c in &self.constraints {
-            if !ids.insert(c.id) {
-                bail!("Duplicate constraint ID: {}", c.id);
-            }
-        }
-        for c in &self.removed_constraints {
-            if let Some(c) = c.constraint.as_ref() {
-                if !ids.insert(c.id) {
-                    bail!("Duplicate removed constraint ID: {}", c.id);
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -181,9 +109,5 @@ mod tests {
             );
         }
 
-        #[test]
-        fn validate(pi in ParametricInstance::arbitrary()) {
-            pi.validate().unwrap();
-        }
     }
 }

--- a/rust/ommx/src/v1_ext/sample_set.rs
+++ b/rust/ommx/src/v1_ext/sample_set.rs
@@ -1,11 +1,11 @@
 use crate::v1::{
-    instance::Sense, sampled_values::SampledValuesEntry, samples::SamplesEntry, SampleSet,
-    SampledValues, Samples, Solution, State,
+    sampled_values::SampledValuesEntry, samples::SamplesEntry, SampleSet, SampledValues, Samples,
+    Solution, State,
 };
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{bail, Context, Result};
 use approx::AbsDiffEq;
 use ordered_float::OrderedFloat;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
 impl From<HashMap<OrderedFloat<f64>, Vec<u64>>> for SampledValues {
     fn from(map: HashMap<OrderedFloat<f64>, Vec<u64>>) -> Self {
@@ -174,7 +174,7 @@ impl SampleSet {
             .context("SampleSet lacks objectives")
     }
 
-    pub fn feasible_relaxed(&self) -> &HashMap<u64, bool> {
+    fn feasible_relaxed_map(&self) -> &HashMap<u64, bool> {
         if self.feasible_relaxed.is_empty() {
             &self.feasible
         } else {
@@ -182,7 +182,7 @@ impl SampleSet {
         }
     }
 
-    pub fn feasible_unrelaxed(&self) -> &HashMap<u64, bool> {
+    fn feasible_unrelaxed_map(&self) -> &HashMap<u64, bool> {
         if self.feasible_relaxed.is_empty() {
             #[allow(deprecated)]
             &self.feasible_unrelaxed
@@ -191,76 +191,12 @@ impl SampleSet {
         }
     }
 
-    pub fn num_samples(&self) -> Result<usize> {
-        let objectives = self.objectives()?;
-        ensure!(
-            objectives.len() == self.feasible_relaxed().len()
-                && objectives.len() == self.feasible_unrelaxed().len(),
-            "SampleSet has inconsistent number of objectives and feasibility"
-        );
-        Ok(objectives.len())
-    }
-
-    pub fn sample_ids(&self) -> BTreeSet<u64> {
-        self.feasible_relaxed().keys().cloned().collect()
-    }
-
-    pub fn feasible_ids(&self) -> BTreeSet<u64> {
-        self.feasible_relaxed()
-            .iter()
-            .filter_map(|(id, is_feasible)| is_feasible.then_some(*id))
-            .collect()
-    }
-
-    pub fn feasible_unrelaxed_ids(&self) -> BTreeSet<u64> {
-        self.feasible_unrelaxed()
-            .iter()
-            .filter_map(|(id, is_feasible)| is_feasible.then_some(*id))
-            .collect()
-    }
-
-    /// Find the best ID in terms of the total objective value.
-    fn best(&self, ids: impl Iterator<Item = u64>) -> Result<u64> {
-        let objectives = self.objectives()?;
-        let obj = ids
-            .map(|id| {
-                Ok((
-                    id,
-                    objectives
-                        .get(id)
-                        .context(format!("SampleSet lacks objective for sample ID={id}"))?,
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let sense = Sense::try_from(self.sense).context("Invalid sense")?;
-        obj.iter()
-            .min_by(|(_, a), (_, b)| {
-                if sense == Sense::Minimize {
-                    a.total_cmp(b)
-                } else {
-                    b.total_cmp(a)
-                }
-            })
-            .map(|(id, _)| *id)
-            .context("No feasible solution found in SampleSet")
-    }
-
-    pub fn best_feasible_id(&self) -> Result<u64> {
-        self.best(self.feasible_ids().into_iter())
-    }
-
-    pub fn best_feasible_unrelaxed_id(&self) -> Result<u64> {
-        self.best(self.feasible_unrelaxed_ids().into_iter())
-    }
-
-    pub fn best_feasible(&self) -> Result<Solution> {
-        self.get(self.best_feasible_id()?)
-    }
-
-    pub fn best_feasible_unrelaxed(&self) -> Result<Solution> {
-        self.get(self.best_feasible_unrelaxed_id()?)
-    }
-
+    /// Extract the [`Solution`] for a specific sample ID.
+    ///
+    /// Retained solely for the v1_ext proptest that compares
+    /// `v1::Instance::evaluate_samples` with single-sample
+    /// `v1::Instance::evaluate`. Will go away when those tests are
+    /// migrated to the domain layer (see issue #802).
     pub fn get(&self, sample_id: u64) -> Result<Solution> {
         let mut decision_variables = Vec::new();
         let mut state = State::default();
@@ -292,12 +228,15 @@ impl SampleSet {
                 format!("SampleSet lacks objective for sample with ID={sample_id}")
             })?,
             decision_variables,
-            feasible_relaxed: Some(*self.feasible_relaxed().get(&sample_id).with_context(
+            feasible_relaxed: Some(*self.feasible_relaxed_map().get(&sample_id).with_context(
                 || format!("SampleSet lacks feasibility for sample with ID={sample_id}"),
             )?),
-            feasible: *self.feasible_unrelaxed().get(&sample_id).with_context(|| {
-                format!("SampleSet lacks unrelaxed feasibility for sample with ID={sample_id}")
-            })?,
+            feasible: *self
+                .feasible_unrelaxed_map()
+                .get(&sample_id)
+                .with_context(|| {
+                    format!("SampleSet lacks unrelaxed feasibility for sample with ID={sample_id}")
+                })?,
             evaluated_constraints,
             ..Default::default()
         })


### PR DESCRIPTION
Part of #802 — Batches A, B, and C.

## Summary

Delete helpers from \`v1_ext/\` that either have direct equivalents on the domain \`ommx::*\` types or have no callers anywhere after the slack/QUBO/HUBO/log_encode migration in #801.

Net delta: **3 files changed, 24 insertions, 301 deletions**.

### Commit 1 — Batch A: v1::Instance helpers with domain equivalents

| Removed | Domain equivalent |
|---------|-------------------|
| \`binary_ids\` | \`instance/analysis.rs:252\` |
| \`restore_constraint\` | \`instance/pass.rs:23\` |
| \`as_minimization_problem\` / \`as_maximization_problem\` | \`instance/convert.rs:12,28\` |
| \`substitute\` | \`substitute::substitute\` (generic) |

Also drops the v1_ext-internal \`substitute_fixed_value\` proptest that was the last caller of \`v1::Instance::substitute\`.

### Commit 2 — Batch B+C: further dead code in v1_ext

**v1::Instance** (last callers were v1_ext tests):
- \`get_kinds\`, \`defined_ids\`, \`validate\`, \`validate_decision_variable_ids\`, \`validate_constraint_ids\`

**v1::ParametricInstance** (last callers were v1_ext tests):
- \`objective\`, \`used_ids\`, \`defined_decision_variable_ids\`, \`defined_parameter_ids\`, \`validate\`, \`validate_ids\`, \`validate_constraint_ids\`

**v1::SampleSet** — 10 helpers; 8 have direct domain equivalents on \`ommx::SampleSet\`, the remaining 2 (\`num_samples\`, \`feasible_relaxed\`/\`feasible_unrelaxed\` map accessors) were purely internal wiring whose only consumers were the other 8:
- \`feasible_relaxed\`, \`feasible_unrelaxed\` (internal map accessors)
- \`num_samples\` (no domain equivalent needed — never used externally)
- \`sample_ids\`, \`feasible_ids\`, \`feasible_unrelaxed_ids\` → domain \`sample_set.rs:176,180,194\`
- \`best_feasible_id\`, \`best_feasible_unrelaxed_id\`, \`best_feasible\`, \`best_feasible_unrelaxed\` → domain \`sample_set.rs:294,312,331,336\`

Also drops the v1_ext proptests \`test_instance_arbitrary_any\` and the ParametricInstance \`validate\` proptest.

### Retained (deferred to later batches of #802)

- \`v1::Instance::relax_constraint\` — still called by \`rust/ommx/src/random/instance.rs:194\` (Batch D — random generator rewrite)
- \`v1::Instance::{objective, get_bounds, check_bound, constraint_ids, removed_constraint_ids}\` — still used by \`impl Evaluate for v1::Instance\` or by v1_ext proptests that exercise v1 evaluation chains
- \`v1::ParametricInstance::with_parameters\` — still called from \`python/ommx/src/instance.rs\`
- \`v1::SampleSet::get\` — still used by the \`evaluate_samples\` v1_ext proptest (now backed by private helpers \`objectives\`, \`feasible_relaxed_map\`, \`feasible_unrelaxed_map\`)

### Note on Batch C

Issue #802's Batch C originally proposed porting a set of accessors (\`Function::as_constant\`, \`Instance::check_bound\`, \`Linear/Quadratic/Polynomial::{degree, as_constant, get_constant}\`, etc.) to the domain. Audit confirmed all of them have **zero external callers** — so porting was unnecessary. The leaf accessors will be dropped together with their internal-v1_ext consumers in later batches.

## Test plan

- [x] \`cargo test -p ommx --lib\` — 477 passed
- [x] \`cargo check -p _ommx_rust\` — Python bindings still compile
- [x] \`task python:ommx:test\` — 37 passed
- [x] \`task python:ommx-openjij-adapter:test\` — 30 passed + pyright/ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)