### PR TITLE
chore: silence constraint evaluate clippy warnings

### DIFF
--- a/rust/ommx/src/indicator_constraint/evaluate.rs
+++ b/rust/ommx/src/indicator_constraint/evaluate.rs
@@ -334,14 +334,14 @@ mod tests {
         let s2 = crate::SampleID::from(2);
 
         // Feasibility
-        assert_eq!(result.stage.feasible[&s0], true);
-        assert_eq!(result.stage.feasible[&s1], false);
-        assert_eq!(result.stage.feasible[&s2], true);
+        assert!(result.stage.feasible[&s0]);
+        assert!(!result.stage.feasible[&s1]);
+        assert!(result.stage.feasible[&s2]);
 
         // Indicator active
-        assert_eq!(result.stage.indicator_active[&s0], true);
-        assert_eq!(result.stage.indicator_active[&s1], true);
-        assert_eq!(result.stage.indicator_active[&s2], false);
+        assert!(result.stage.indicator_active[&s0]);
+        assert!(result.stage.indicator_active[&s1]);
+        assert!(!result.stage.indicator_active[&s2]);
     }
 
     // === Propagate tests ===

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -562,7 +562,7 @@ mod tests {
 
         let result = instance.convert_all_sos1_to_constraints().unwrap();
         assert_eq!(result.len(), 2);
-        for (_, new_ids) in &result {
+        for new_ids in result.values() {
             assert_eq!(new_ids.len(), 1); // all-binary: only cardinality
             assert!(instance.constraints().contains_key(&new_ids[0]));
         }

--- a/rust/ommx/src/one_hot_constraint/evaluate.rs
+++ b/rust/ommx/src/one_hot_constraint/evaluate.rs
@@ -278,9 +278,9 @@ mod tests {
         let s1 = crate::SampleID::from(1);
         let s2 = crate::SampleID::from(2);
 
-        assert_eq!(result.stage.feasible[&s0], true);
-        assert_eq!(result.stage.feasible[&s1], false);
-        assert_eq!(result.stage.feasible[&s2], false);
+        assert!(result.stage.feasible[&s0]);
+        assert!(!result.stage.feasible[&s1]);
+        assert!(!result.stage.feasible[&s2]);
 
         assert_eq!(result.stage.active_variable[&s0], Some(VariableID::from(1)));
         assert_eq!(result.stage.active_variable[&s1], None);

--- a/rust/ommx/src/sos1_constraint/evaluate.rs
+++ b/rust/ommx/src/sos1_constraint/evaluate.rs
@@ -250,9 +250,9 @@ mod tests {
         let s1 = crate::SampleID::from(1);
         let s2 = crate::SampleID::from(2);
 
-        assert_eq!(result.stage.feasible[&s0], true);
-        assert_eq!(result.stage.feasible[&s1], false);
-        assert_eq!(result.stage.feasible[&s2], true);
+        assert!(result.stage.feasible[&s0]);
+        assert!(!result.stage.feasible[&s1]);
+        assert!(result.stage.feasible[&s2]);
 
         assert_eq!(result.stage.active_variable[&s0], Some(VariableID::from(2)));
         assert_eq!(result.stage.active_variable[&s1], None);


### PR DESCRIPTION
## Summary

- Replace `assert_eq!(x, true|false)` with `assert!(x)` / `assert!(!x)` in `indicator_constraint/evaluate.rs`, `one_hot_constraint/evaluate.rs`, and `sos1_constraint/evaluate.rs` tests (12 warnings).
- Iterate `BTreeMap::values()` directly instead of `for (_, v) in &map` in the bulk-conversion test in `instance/sos1.rs` (1 warning).

## Test plan

- [x] `cargo test -p ommx --lib` — 424 tests pass (same as before)
- [x] `cargo clippy -p ommx --all-targets` — 0 warnings (was 13)

## Notes

- No behavioral changes; test-only refactor to silence pre-existing `clippy::bool_assert_comparison` and `clippy::for_kv_map` warnings flagged while working on #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)