### PR TITLE
Auto-convert unsupported constraint types in SolverAdapter

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -7191,38 +7191,6 @@
               "deprecated": null
             },
             {
-              "name": "check_capabilities",
-              "doc": "Check that the adapter's supported capabilities cover this instance's requirements.\n\n`supported` is a set of `AdditionalCapability` flags.\n\nRaises an error if the instance uses constraint types not in `supported`.",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "supported",
-                      "type_": {
-                        "display": "set[AdditionalCapability]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "AdditionalCapability",
-                            "link_target": null,
-                            "children": []
-                          }
-                        ]
-                      },
-                      "default": null
-                    }
-                  ],
-                  "return_type": {
-                    "display": "None",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
               "name": "convert_all_indicators_to_constraints",
               "doc": "Convert every active indicator constraint to regular constraints using Big-M.\n\nSee {meth}`~ommx.v1.Instance.convert_indicator_to_constraint` for the\nconversion rule. Returns a dict mapping each original indicator ID to the\nlist of regular constraint IDs it produced.\n\nAtomic: every active indicator is validated up front, and only if every\none is convertible are the conversions applied. If any indicator fails\nvalidation (non-finite bound on a required side), no mutation happens and\nthe instance is left untouched.",
               "signatures": [
@@ -8267,7 +8235,7 @@
             },
             {
               "name": "reduce_capabilities",
-              "doc": "Convert constraint types not in `supported` into regular constraints.\n\nFor every capability in ``required_capabilities() - supported``, the\ncorresponding bulk conversion is invoked\n(:meth:`convert_all_indicators_to_constraints`,\n:meth:`convert_all_one_hots_to_constraints`, or\n:meth:`convert_all_sos1_to_constraints`). The instance is mutated in\nplace and its :meth:`required_capabilities` becomes a subset of\n``supported`` on success.\n\nReturns the list of :class:`AdditionalCapability` values that were\nactually converted, in the fixed order ``Indicator``, ``OneHot``,\n``Sos1``. Empty when nothing needed conversion.\n\nRaises if any underlying Big-M conversion fails (e.g. a SOS1 variable\nwith a non-finite bound).",
+              "doc": "Convert constraint types not in `supported` into regular constraints.\n\nFor every capability in :attr:`required_capabilities` not in\n``supported``, the corresponding bulk conversion is invoked\n(:meth:`convert_all_indicators_to_constraints`,\n:meth:`convert_all_one_hots_to_constraints`, or\n:meth:`convert_all_sos1_to_constraints`). The instance is mutated in\nplace and :attr:`required_capabilities` becomes a subset of\n``supported`` on success.\n\nReturns the list of :class:`AdditionalCapability` values that were\nactually converted, in the fixed order ``Indicator``, ``OneHot``,\n``Sos1``. Empty when nothing needed conversion.\n\nRaises if any underlying Big-M conversion fails (e.g. a SOS1 variable\nwith a non-finite bound).",
               "signatures": [
                 {
                   "parameters": [
@@ -9226,6 +9194,23 @@
                 "display": "DataFrame",
                 "link_target": null,
                 "children": []
+              },
+              "is_property": true,
+              "is_readonly": true
+            },
+            {
+              "name": "required_capabilities",
+              "doc": "The non-standard constraint capabilities this instance currently uses.\n\nReturns the set of :class:`AdditionalCapability` values corresponding to\nthe active (non-removed) constraint collections the instance contains.\nAn empty set means the instance only uses regular constraints.\n\nCallers can diff this against an adapter's\n``ADDITIONAL_CAPABILITIES`` to see what would be converted, or use\n:meth:`reduce_capabilities` to perform the conversion.",
+              "type_": {
+                "display": "set[AdditionalCapability]",
+                "link_target": null,
+                "children": [
+                  {
+                    "display": "AdditionalCapability",
+                    "link_target": null,
+                    "children": []
+                  }
+                ]
               },
               "is_property": true,
               "is_readonly": true

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -7256,6 +7256,28 @@
               "deprecated": null
             },
             {
+              "name": "convert_all_one_hots_to_constraints",
+              "doc": "Convert every active one-hot constraint to a regular equality constraint.\n\nSee {meth}`~ommx.v1.Instance.convert_one_hot_to_constraint` for the conversion rule.\nReturns the IDs of the newly created regular constraints.\n\n# Examples\n\n```python\n>>> from ommx.v1 import Instance, DecisionVariable, OneHotConstraint\n>>> x = [DecisionVariable.binary(i) for i in range(4)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     one_hot_constraints={\n...         1: OneHotConstraint(variables=[0, 1]),\n...         2: OneHotConstraint(variables=[2, 3]),\n...     },\n...     sense=Instance.MINIMIZE,\n... )\n>>> instance.convert_all_one_hots_to_constraints()\n[0, 1]\n>>> instance.one_hot_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 - 1 == 0), 1: Constraint(x2 + x3 - 1 == 0)}\n```",
+              "signatures": [
+                {
+                  "parameters": [],
+                  "return_type": {
+                    "display": "list[int]",
+                    "link_target": null,
+                    "children": [
+                      {
+                        "display": "int",
+                        "link_target": null,
+                        "children": []
+                      }
+                    ]
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
               "name": "convert_all_sos1_to_constraints",
               "doc": "Convert every active SOS1 constraint to regular constraints using Big-M.\n\nSee {meth}`~ommx.v1.Instance.convert_sos1_to_constraints` for the conversion\nrule. Returns a dict mapping each original SOS1 ID to the list of regular\nconstraint IDs it produced.\n\nAtomic: every active SOS1 is validated up front, and only if every one is\nconvertible are the conversions applied. If any SOS1 fails validation\n(unsupported kind, non-finite bound, domain excludes 0, etc.), no mutation\nhappens and the instance is left untouched.\n\n# Examples\n\n```python\n>>> from ommx.v1 import Instance, DecisionVariable, Sos1Constraint\n>>> x = [DecisionVariable.binary(i) for i in range(4)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     sos1_constraints={\n...         1: Sos1Constraint(variables=[0, 1]),\n...         2: Sos1Constraint(variables=[2, 3]),\n...     },\n...     sense=Instance.MINIMIZE,\n... )\n>>> instance.convert_all_sos1_to_constraints()\n{1: [0], 2: [1]}\n>>> instance.sos1_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 - 1 <= 0), 1: Constraint(x2 + x3 - 1 <= 0)}\n```",
               "signatures": [
@@ -7375,28 +7397,6 @@
                     "display": "int",
                     "link_target": null,
                     "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "convert_one_hots_to_constraints",
-              "doc": "Convert every active one-hot constraint to a regular equality constraint.\n\nSee {meth}`~ommx.v1.Instance.convert_one_hot_to_constraint` for the conversion rule.\nReturns the IDs of the newly created regular constraints.\n\n# Examples\n\n```python\n>>> from ommx.v1 import Instance, DecisionVariable, OneHotConstraint\n>>> x = [DecisionVariable.binary(i) for i in range(4)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     one_hot_constraints={\n...         1: OneHotConstraint(variables=[0, 1]),\n...         2: OneHotConstraint(variables=[2, 3]),\n...     },\n...     sense=Instance.MINIMIZE,\n... )\n>>> instance.convert_one_hots_to_constraints()\n[0, 1]\n>>> instance.one_hot_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 - 1 == 0), 1: Constraint(x2 + x3 - 1 == 0)}\n```",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "list[int]",
-                    "link_target": null,
-                    "children": [
-                      {
-                        "display": "int",
-                        "link_target": null,
-                        "children": []
-                      }
-                    ]
                   }
                 }
               ],
@@ -8259,6 +8259,44 @@
                     "display": "bool",
                     "link_target": null,
                     "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
+              "name": "reduce_capabilities",
+              "doc": "Convert constraint types not in `supported` into regular constraints.\n\nFor every capability in ``required_capabilities() - supported``, the\ncorresponding bulk conversion is invoked\n(:meth:`convert_all_indicators_to_constraints`,\n:meth:`convert_all_one_hots_to_constraints`, or\n:meth:`convert_all_sos1_to_constraints`). The instance is mutated in\nplace and its :meth:`required_capabilities` becomes a subset of\n``supported`` on success.\n\nReturns the list of :class:`AdditionalCapability` values that were\nactually converted, in the fixed order ``Indicator``, ``OneHot``,\n``Sos1``. Empty when nothing needed conversion.\n\nRaises if any underlying Big-M conversion fails (e.g. a SOS1 variable\nwith a non-finite bound).",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "supported",
+                      "type_": {
+                        "display": "set[AdditionalCapability]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "AdditionalCapability",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "list[AdditionalCapability]",
+                    "link_target": null,
+                    "children": [
+                      {
+                        "display": "AdditionalCapability",
+                        "link_target": null,
+                        "children": []
+                      }
+                    ]
                   }
                 }
               ],

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -8235,7 +8235,7 @@
             },
             {
               "name": "reduce_capabilities",
-              "doc": "Convert constraint types not in `supported` into regular constraints.\n\nFor every capability in :attr:`required_capabilities` not in\n``supported``, the corresponding bulk conversion is invoked\n(:meth:`convert_all_indicators_to_constraints`,\n:meth:`convert_all_one_hots_to_constraints`, or\n:meth:`convert_all_sos1_to_constraints`). The instance is mutated in\nplace and :attr:`required_capabilities` becomes a subset of\n``supported`` on success.\n\nReturns the list of :class:`AdditionalCapability` values that were\nactually converted, in the fixed order ``Indicator``, ``OneHot``,\n``Sos1``. Empty when nothing needed conversion.\n\nRaises if any underlying Big-M conversion fails (e.g. a SOS1 variable\nwith a non-finite bound).",
+              "doc": "Convert constraint types not in `supported` into regular constraints.\n\nFor every capability in :attr:`required_capabilities` not in\n``supported``, the corresponding bulk conversion is invoked\n(:meth:`convert_all_indicators_to_constraints`,\n:meth:`convert_all_one_hots_to_constraints`, or\n:meth:`convert_all_sos1_to_constraints`). The instance is mutated in\nplace and :attr:`required_capabilities` becomes a subset of\n``supported`` on success.\n\nReturns the set of :class:`AdditionalCapability` values that were\nactually converted. Empty when nothing needed conversion.\n\nRaises if any underlying Big-M conversion fails (e.g. a SOS1 variable\nwith a non-finite bound).",
               "signatures": [
                 {
                   "parameters": [
@@ -8256,7 +8256,7 @@
                     }
                   ],
                   "return_type": {
-                    "display": "list[AdditionalCapability]",
+                    "display": "set[AdditionalCapability]",
                     "link_target": null,
                     "children": [
                       {

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -65,7 +65,7 @@ df = solution.indicator_constraints_df.join(solution.indicator_removed_reasons_d
 
 ### Adapter Capability model ([#790](https://github.com/Jij-Inc/ommx/pull/790))
 
-As specialized constraint types (such as {class}`~ommx.v1.IndicatorConstraint`) are added and support varies across solvers, an Adapter Capability model has been introduced. Adapters declare their supported capabilities via `ADDITIONAL_CAPABILITIES`, and {meth}`Instance.check_capabilities() <ommx.v1.Instance.check_capabilities>` validates that the problem is compatible before solving.
+As specialized constraint types (such as {class}`~ommx.v1.IndicatorConstraint`) are added and support varies across solvers, an Adapter Capability model has been introduced. Adapters declare their supported capabilities via `ADDITIONAL_CAPABILITIES`, and {meth}`Instance.reduce_capabilities() <ommx.v1.Instance.reduce_capabilities>` converts any constraint type outside that set into regular constraints (Big-M for indicator / SOS1, linear equality for one-hot) before solving. Callers can inspect {attr}`Instance.required_capabilities <ommx.v1.Instance.required_capabilities>` to see which non-standard types an instance currently carries.
 
 ```python
 from ommx.v1 import AdditionalCapability
@@ -75,7 +75,7 @@ class MySolverAdapter(SolverAdapter):
     ADDITIONAL_CAPABILITIES = frozenset({AdditionalCapability.Indicator})
 ```
 
-Currently, the PySCIPOpt Adapter declares indicator constraint support. **Each OMMX Adapter will need changes to support Python SDK 3.0.0** — specifically, calling `super().__init__(instance)` for automatic capability checking.
+Currently, the PySCIPOpt Adapter declares indicator and SOS1 support. **Each OMMX Adapter will need changes to support Python SDK 3.0.0** — specifically, calling `super().__init__(instance)` so that unsupported capabilities are converted automatically.
 
 ## 3.0.0 Alpha 1
 

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -63,7 +63,7 @@ df = solution.constraints_df.join(solution.removed_reasons_df)
 df = solution.indicator_constraints_df.join(solution.indicator_removed_reasons_df)
 ```
 
-### Adapter Capability model ([#790](https://github.com/Jij-Inc/ommx/pull/790))
+### Adapter Capability model ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 
 As specialized constraint types (such as {class}`~ommx.v1.IndicatorConstraint`) are added and support varies across solvers, an Adapter Capability model has been introduced. Adapters declare their supported capabilities via `ADDITIONAL_CAPABILITIES`, and {meth}`Instance.reduce_capabilities() <ommx.v1.Instance.reduce_capabilities>` converts any constraint type outside that set into regular constraints (Big-M for indicator / SOS1, linear equality for one-hot) before solving. Callers can inspect {attr}`Instance.required_capabilities <ommx.v1.Instance.required_capabilities>` to see which non-standard types an instance currently carries.
 

--- a/docs/en/tutorial/implement_adapter.md
+++ b/docs/en/tutorial/implement_adapter.md
@@ -285,8 +285,8 @@ class SolverAdapter(ABC):
     ADDITIONAL_CAPABILITIES: set[AdditionalCapability] = set()
 
     def __init__(self, ommx_instance: Instance):
-        """Checks constraint capabilities. Subclasses must call super().__init__()."""
-        ommx_instance.check_capabilities(self.ADDITIONAL_CAPABILITIES)
+        """Reduce the instance to supported capabilities. Subclasses must call super().__init__()."""
+        ommx_instance.reduce_capabilities(self.ADDITIONAL_CAPABILITIES)
 
     @classmethod
     @abstractmethod
@@ -310,14 +310,16 @@ This abstract base class assumes the following two use cases:
 
 #### Constraint Capability Declaration
 
-Each adapter must declare which constraint types it supports via the `ADDITIONAL_CAPABILITIES` class attribute. The base class automatically checks that the given `Instance` only uses supported constraint types when `super().__init__()` is called. Available capabilities are:
+Each adapter must declare which constraint types it supports via the `ADDITIONAL_CAPABILITIES` class attribute. The base class automatically converts any constraint type **not** in that set into regular constraints when `super().__init__()` is called (Big-M for indicator / SOS1, linear equality for one-hot), and logs each conversion at `INFO` level. Available capabilities are:
 
 - `AdditionalCapability.Indicator`: Indicator constraints (`binvar = 1 → f(x) <= 0`)
+- `AdditionalCapability.OneHot`: Exactly one of a set of binary variables is 1
+- `AdditionalCapability.Sos1`: At most one of a set of variables is non-zero
 
-If the adapter does not override `ADDITIONAL_CAPABILITIES`, only standard constraints are supported by default. If an `Instance` contains unsupported constraint types, an error is raised automatically.
+If the adapter does not override `ADDITIONAL_CAPABILITIES`, only standard constraints are kept and all non-standard types are converted automatically. Use {attr}`Instance.required_capabilities <ommx.v1.Instance.required_capabilities>` to inspect which non-standard types an instance currently holds.
 
 ```{important}
-Subclasses **must** call `super().__init__(ommx_instance)` in their `__init__` method to enable the automatic constraint capability check.
+Subclasses **must** call `super().__init__(ommx_instance)` in their `__init__` method to enable the automatic constraint conversion. The instance is mutated in place.
 ```
 
 Using the functions prepared so far, you can implement it as follows:
@@ -334,7 +336,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
         self,
         ommx_instance: Instance,
     ):
-        super().__init__(ommx_instance)  # Check constraint capabilities
+        super().__init__(ommx_instance)  # Auto-convert unsupported capabilities
         self.instance = ommx_instance
         self.model = pyscipopt.Model()
         self.model.hideOutput()
@@ -501,7 +503,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     ommx_instance: Instance
     
     def __init__(self, ommx_instance: Instance):
-        super().__init__(ommx_instance)  # Check constraint capabilities
+        super().__init__(ommx_instance)  # Auto-convert unsupported capabilities
         self.ommx_instance = ommx_instance
 
     # Perform sampling

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -65,7 +65,7 @@ df = solution.indicator_constraints_df.join(solution.indicator_removed_reasons_d
 
 ### Adapter Capabilityモデル ([#790](https://github.com/Jij-Inc/ommx/pull/790))
 
-{class}`~ommx.v1.IndicatorConstraint` のような特殊な制約型が追加されソルバー毎に対応・未対応が分かれるため、Adapter Capabilityモデルが導入されました。Adapterは `ADDITIONAL_CAPABILITIES` でサポートするCapabilityを宣言し、{meth}`Instance.check_capabilities() <ommx.v1.Instance.check_capabilities>` で問題の互換性を検証します。
+{class}`~ommx.v1.IndicatorConstraint` のような特殊な制約型が追加されソルバー毎に対応・未対応が分かれるため、Adapter Capabilityモデルが導入されました。Adapterは `ADDITIONAL_CAPABILITIES` でサポートするCapabilityを宣言し、{meth}`Instance.reduce_capabilities() <ommx.v1.Instance.reduce_capabilities>` がその集合に含まれない制約タイプを通常の制約へ変換（indicator/SOS1 は Big-M、one-hot は線形等式）してから solver に渡します。`Instance` が現在保持している非標準制約タイプは {attr}`Instance.required_capabilities <ommx.v1.Instance.required_capabilities>` で確認できます。
 
 ```python
 from ommx.v1 import AdditionalCapability
@@ -75,7 +75,7 @@ class MySolverAdapter(SolverAdapter):
     ADDITIONAL_CAPABILITIES = frozenset({AdditionalCapability.Indicator})
 ```
 
-現在、PySCIPOpt AdapterがIndicator Constraintのサポートを宣言しています。**各OMMX AdapterはPython SDK 3.0.0に対応する際に変更が必要になります。** 具体的には、Capability自動チェックのために `super().__init__(instance)` を呼び出す必要があります。
+現在、PySCIPOpt Adapter が Indicator 制約と SOS1 のサポートを宣言しています。**各OMMX AdapterはPython SDK 3.0.0に対応する際に変更が必要になります。** 具体的には、未サポートの Capability を自動変換するために `super().__init__(instance)` を呼び出す必要があります。
 
 ## 3.0.0 Alpha 1
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -63,7 +63,7 @@ df = solution.constraints_df.join(solution.removed_reasons_df)
 df = solution.indicator_constraints_df.join(solution.indicator_removed_reasons_df)
 ```
 
-### Adapter Capabilityモデル ([#790](https://github.com/Jij-Inc/ommx/pull/790))
+### Adapter Capabilityモデル ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 
 {class}`~ommx.v1.IndicatorConstraint` のような特殊な制約型が追加されソルバー毎に対応・未対応が分かれるため、Adapter Capabilityモデルが導入されました。Adapterは `ADDITIONAL_CAPABILITIES` でサポートするCapabilityを宣言し、{meth}`Instance.reduce_capabilities() <ommx.v1.Instance.reduce_capabilities>` がその集合に含まれない制約タイプを通常の制約へ変換（indicator/SOS1 は Big-M、one-hot は線形等式）してから solver に渡します。`Instance` が現在保持している非標準制約タイプは {attr}`Instance.required_capabilities <ommx.v1.Instance.required_capabilities>` で確認できます。
 

--- a/docs/ja/tutorial/implement_adapter.md
+++ b/docs/ja/tutorial/implement_adapter.md
@@ -281,8 +281,8 @@ class SolverAdapter(ABC):
     ADDITIONAL_CAPABILITIES: set[AdditionalCapability] = set()
 
     def __init__(self, ommx_instance: Instance):
-        """制約の互換性をチェックする。サブクラスは super().__init__() を呼ぶ必要がある。"""
-        ommx_instance.check_capabilities(self.ADDITIONAL_CAPABILITIES)
+        """サポート外の制約タイプを通常制約に変換する。サブクラスは super().__init__() を呼ぶ必要がある。"""
+        ommx_instance.reduce_capabilities(self.ADDITIONAL_CAPABILITIES)
 
     @classmethod
     @abstractmethod
@@ -306,14 +306,16 @@ class SolverAdapter(ABC):
 
 #### 制約タイプの Capability 宣言
 
-各アダプターは `ADDITIONAL_CAPABILITIES` クラス属性で、サポートする制約タイプを宣言する必要があります。基底クラスは `super().__init__()` の呼び出し時に、与えられた `Instance` がサポートされている制約タイプのみを使用していることを自動的にチェックします。利用可能な capability は以下の通りです：
+各アダプターは `ADDITIONAL_CAPABILITIES` クラス属性で、サポートする制約タイプを宣言します。基底クラスは `super().__init__()` の呼び出し時に、宣言されていない制約タイプを通常の制約へ自動的に変換します（indicator/SOS1 は Big-M、one-hot は線形等式）。変換が行われた capability は `INFO` レベルでログ出力されます。利用可能な capability は以下の通りです：
 
 - `AdditionalCapability.Indicator`: インジケーター制約 (`binvar = 1 → f(x) <= 0`)
+- `AdditionalCapability.OneHot`: バイナリ変数集合のうち丁度1つが1
+- `AdditionalCapability.Sos1`: 変数集合のうち高々1つが非ゼロ
 
-`ADDITIONAL_CAPABILITIES` をオーバーライドしない場合、デフォルトでは通常の制約のみがサポートされます。`Instance` がサポートされていない制約タイプを含む場合、自動的にエラーが発生します。
+`ADDITIONAL_CAPABILITIES` をオーバーライドしない場合、デフォルトでは通常の制約のみが維持され、非標準の制約タイプは全て自動変換されます。`Instance` が現在保持している非標準制約タイプを調べるには {attr}`Instance.required_capabilities <ommx.v1.Instance.required_capabilities>` を使用してください。
 
 ```{important}
-サブクラスは `__init__` メソッドで **必ず** `super().__init__(ommx_instance)` を呼び出してください。これにより、制約 capability の自動チェックが有効になります。
+サブクラスは `__init__` メソッドで **必ず** `super().__init__(ommx_instance)` を呼び出してください。これにより、制約の自動変換が有効になります。`Instance` はこの呼び出しで in-place に書き換えられる点に注意してください。
 ```
 
 ここまでで用意した関数を使って次のように実装することができます：
@@ -330,7 +332,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
         self,
         ommx_instance: Instance,
     ):
-        super().__init__(ommx_instance)  # 制約 capability のチェック
+        super().__init__(ommx_instance)  # サポート外の制約タイプを自動変換
         self.instance = ommx_instance
         self.model = pyscipopt.Model()
         self.model.hideOutput()
@@ -495,7 +497,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     ommx_instance: Instance
     
     def __init__(self, ommx_instance: Instance):
-        super().__init__(ommx_instance)  # 制約 capability のチェック
+        super().__init__(ommx_instance)  # サポート外の制約タイプを自動変換
         self.ommx_instance = ommx_instance
 
     # サンプリングを行う

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -1376,6 +1376,19 @@ class Instance:
         Dict of all removed SOS1 constraints in the instance keyed by their IDs.
         """
     @property
+    def required_capabilities(self) -> builtins.set[AdditionalCapability]:
+        r"""
+        The non-standard constraint capabilities this instance currently uses.
+
+        Returns the set of :class:`AdditionalCapability` values corresponding to
+        the active (non-removed) constraint collections the instance contains.
+        An empty set means the instance only uses regular constraints.
+
+        Callers can diff this against an adapter's
+        ``ADDITIONAL_CAPABILITIES`` to see what would be converted, or use
+        :meth:`reduce_capabilities` to perform the conversion.
+        """
+    @property
     def removed_constraints(self) -> builtins.dict[builtins.int, RemovedConstraint]:
         r"""
         Dict of all removed constraints in the instance keyed by their IDs.
@@ -1510,26 +1523,18 @@ class Instance:
         True
         ```
         """
-    def check_capabilities(self, supported: builtins.set[AdditionalCapability]) -> None:
-        r"""
-        Check that the adapter's supported capabilities cover this instance's requirements.
-
-        `supported` is a set of `AdditionalCapability` flags.
-
-        Raises an error if the instance uses constraint types not in `supported`.
-        """
     def reduce_capabilities(
         self, supported: builtins.set[AdditionalCapability]
     ) -> builtins.list[AdditionalCapability]:
         r"""
         Convert constraint types not in `supported` into regular constraints.
 
-        For every capability in ``required_capabilities() - supported``, the
-        corresponding bulk conversion is invoked
+        For every capability in :attr:`required_capabilities` not in
+        ``supported``, the corresponding bulk conversion is invoked
         (:meth:`convert_all_indicators_to_constraints`,
         :meth:`convert_all_one_hots_to_constraints`, or
         :meth:`convert_all_sos1_to_constraints`). The instance is mutated in
-        place and its :meth:`required_capabilities` becomes a subset of
+        place and :attr:`required_capabilities` becomes a subset of
         ``supported`` on success.
 
         Returns the list of :class:`AdditionalCapability` values that were

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -1518,6 +1518,27 @@ class Instance:
 
         Raises an error if the instance uses constraint types not in `supported`.
         """
+    def reduce_capabilities(
+        self, supported: builtins.set[AdditionalCapability]
+    ) -> builtins.list[AdditionalCapability]:
+        r"""
+        Convert constraint types not in `supported` into regular constraints.
+
+        For every capability in ``required_capabilities() - supported``, the
+        corresponding bulk conversion is invoked
+        (:meth:`convert_all_indicators_to_constraints`,
+        :meth:`convert_all_one_hots_to_constraints`, or
+        :meth:`convert_all_sos1_to_constraints`). The instance is mutated in
+        place and its :meth:`required_capabilities` becomes a subset of
+        ``supported`` on success.
+
+        Returns the list of :class:`AdditionalCapability` values that were
+        actually converted, in the fixed order ``Indicator``, ``OneHot``,
+        ``Sos1``. Empty when nothing needed conversion.
+
+        Raises if any underlying Big-M conversion fails (e.g. a SOS1 variable
+        with a non-finite bound).
+        """
     def to_bytes(self) -> bytes: ...
     def required_ids(self) -> builtins.set[builtins.int]:
         r"""
@@ -2034,7 +2055,7 @@ class Instance:
         {1: RemovedOneHotConstraint(OneHotConstraint(exactly one of {x0, x1, x2} = 1), reason=ommx.Instance.convert_one_hot_to_constraint, constraint_id=0)}
         ```
         """
-    def convert_one_hots_to_constraints(self) -> builtins.list[builtins.int]:
+    def convert_all_one_hots_to_constraints(self) -> builtins.list[builtins.int]:
         r"""
         Convert every active one-hot constraint to a regular equality constraint.
 
@@ -2056,7 +2077,7 @@ class Instance:
         ...     },
         ...     sense=Instance.MINIMIZE,
         ... )
-        >>> instance.convert_one_hots_to_constraints()
+        >>> instance.convert_all_one_hots_to_constraints()
         [0, 1]
         >>> instance.one_hot_constraints
         {}

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -1525,7 +1525,7 @@ class Instance:
         """
     def reduce_capabilities(
         self, supported: builtins.set[AdditionalCapability]
-    ) -> builtins.list[AdditionalCapability]:
+    ) -> builtins.set[AdditionalCapability]:
         r"""
         Convert constraint types not in `supported` into regular constraints.
 
@@ -1537,9 +1537,8 @@ class Instance:
         place and :attr:`required_capabilities` becomes a subset of
         ``supported`` on success.
 
-        Returns the list of :class:`AdditionalCapability` values that were
-        actually converted, in the fixed order ``Indicator``, ``OneHot``,
-        ``Sos1``. Empty when nothing needed conversion.
+        Returns the set of :class:`AdditionalCapability` values that were
+        actually converted. Empty when nothing needed conversion.
 
         Raises if any underlying Big-M conversion fails (e.g. a SOS1 variable
         with a non-finite bound).

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -1,10 +1,6 @@
-import logging
 from abc import ABC, abstractmethod
 from typing import Any
 from ommx.v1 import Instance, Solution, SampleSet, AdditionalCapability
-
-
-logger = logging.getLogger(__name__)
 
 
 SolverInput = Any
@@ -32,8 +28,8 @@ class SolverAdapter(ABC):
     Subclasses must call ``super().__init__(ommx_instance)`` so that any
     constraint types the adapter does not support are automatically converted
     into regular constraints (Big-M for indicator / SOS1, linear equality for
-    one-hot). Conversions mutate ``ommx_instance`` in place and are logged at
-    ``INFO`` level.
+    one-hot). Conversions mutate ``ommx_instance`` in place and are emitted
+    at ``INFO`` level from the Rust SDK via ``pyo3-log``.
     """
 
     ADDITIONAL_CAPABILITIES: frozenset[AdditionalCapability] = frozenset()
@@ -43,15 +39,9 @@ class SolverAdapter(ABC):
 
         Subclasses must call ``super().__init__()``. Any constraint type not in
         ``ADDITIONAL_CAPABILITIES`` is converted to regular constraints in place
-        on ``ommx_instance``; each converted capability is logged at ``INFO``.
+        on ``ommx_instance``.
         """
-        converted = ommx_instance.reduce_capabilities(set(self.ADDITIONAL_CAPABILITIES))
-        for cap in converted:
-            logger.info(
-                "%s does not support %s; converted to regular constraints",
-                type(self).__name__,
-                cap.name,
-            )
+        ommx_instance.reduce_capabilities(set(self.ADDITIONAL_CAPABILITIES))
 
     @classmethod
     @abstractmethod

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -1,6 +1,10 @@
+import logging
 from abc import ABC, abstractmethod
 from typing import Any
 from ommx.v1 import Instance, Solution, SampleSet, AdditionalCapability
+
+
+logger = logging.getLogger(__name__)
 
 
 SolverInput = Any
@@ -21,17 +25,33 @@ class SolverAdapter(ABC):
     Available capabilities:
 
     - ``AdditionalCapability.Indicator``: binvar = 1 → f(x) <= 0
+    - ``AdditionalCapability.OneHot``: exactly one of a set of binary variables is 1
+    - ``AdditionalCapability.Sos1``: at most one of a set of variables is non-zero
 
     The default is an empty set (standard constraints only).
-    Subclasses must call ``super().__init__(ommx_instance)`` to enable
-    automatic constraint capability checking.
+    Subclasses must call ``super().__init__(ommx_instance)`` so that any
+    constraint types the adapter does not support are automatically converted
+    into regular constraints (Big-M for indicator / SOS1, linear equality for
+    one-hot). Conversions mutate ``ommx_instance`` in place and are logged at
+    ``INFO`` level.
     """
 
     ADDITIONAL_CAPABILITIES: frozenset[AdditionalCapability] = frozenset()
 
     def __init__(self, ommx_instance: Instance):
-        """Check constraint capabilities. Subclasses must call super().__init__()."""
-        ommx_instance.check_capabilities(set(self.ADDITIONAL_CAPABILITIES))
+        """Reduce the instance to the adapter's supported capabilities.
+
+        Subclasses must call ``super().__init__()``. Any constraint type not in
+        ``ADDITIONAL_CAPABILITIES`` is converted to regular constraints in place
+        on ``ommx_instance``; each converted capability is logged at ``INFO``.
+        """
+        converted = ommx_instance.reduce_capabilities(set(self.ADDITIONAL_CAPABILITIES))
+        for cap in converted:
+            logger.info(
+                "%s does not support %s; converted to regular constraints",
+                type(self).__name__,
+                cap.name,
+            )
 
     @classmethod
     @abstractmethod

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -369,18 +369,16 @@ impl Instance {
     /// place and :attr:`required_capabilities` becomes a subset of
     /// ``supported`` on success.
     ///
-    /// Returns the list of :class:`AdditionalCapability` values that were
-    /// actually converted, in the fixed order ``Indicator``, ``OneHot``,
-    /// ``Sos1``. Empty when nothing needed conversion.
+    /// Returns the set of :class:`AdditionalCapability` values that were
+    /// actually converted. Empty when nothing needed conversion.
     ///
     /// Raises if any underlying Big-M conversion fails (e.g. a SOS1 variable
     /// with a non-finite bound).
     pub fn reduce_capabilities(
         &mut self,
         supported: std::collections::HashSet<crate::AdditionalCapability>,
-    ) -> anyhow::Result<Vec<crate::AdditionalCapability>> {
-        let rust_supported: fnv::FnvHashSet<ommx::AdditionalCapability> =
-            supported.into_iter().map(|c| c.into()).collect();
+    ) -> anyhow::Result<std::collections::HashSet<crate::AdditionalCapability>> {
+        let rust_supported: ommx::Capabilities = supported.into_iter().map(|c| c.into()).collect();
         let converted = self.inner.reduce_capabilities(&rust_supported)?;
         Ok(converted.into_iter().map(|c| c.into()).collect())
     }

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -341,29 +341,32 @@ impl Instance {
             .collect()
     }
 
-    /// Check that the adapter's supported capabilities cover this instance's requirements.
+    /// The non-standard constraint capabilities this instance currently uses.
     ///
-    /// `supported` is a set of `AdditionalCapability` flags.
+    /// Returns the set of :class:`AdditionalCapability` values corresponding to
+    /// the active (non-removed) constraint collections the instance contains.
+    /// An empty set means the instance only uses regular constraints.
     ///
-    /// Raises an error if the instance uses constraint types not in `supported`.
-    pub fn check_capabilities(
-        &self,
-        supported: std::collections::HashSet<crate::AdditionalCapability>,
-    ) -> anyhow::Result<()> {
-        let rust_supported: fnv::FnvHashSet<ommx::AdditionalCapability> =
-            supported.into_iter().map(|c| c.into()).collect();
-        self.inner.check_capabilities(&rust_supported)?;
-        Ok(())
+    /// Callers can diff this against an adapter's
+    /// ``ADDITIONAL_CAPABILITIES`` to see what would be converted, or use
+    /// :meth:`reduce_capabilities` to perform the conversion.
+    #[getter]
+    pub fn required_capabilities(&self) -> std::collections::HashSet<crate::AdditionalCapability> {
+        self.inner
+            .required_capabilities()
+            .into_iter()
+            .map(|c| c.into())
+            .collect()
     }
 
     /// Convert constraint types not in `supported` into regular constraints.
     ///
-    /// For every capability in ``required_capabilities() - supported``, the
-    /// corresponding bulk conversion is invoked
+    /// For every capability in :attr:`required_capabilities` not in
+    /// ``supported``, the corresponding bulk conversion is invoked
     /// (:meth:`convert_all_indicators_to_constraints`,
     /// :meth:`convert_all_one_hots_to_constraints`, or
     /// :meth:`convert_all_sos1_to_constraints`). The instance is mutated in
-    /// place and its :meth:`required_capabilities` becomes a subset of
+    /// place and :attr:`required_capabilities` becomes a subset of
     /// ``supported`` on success.
     ///
     /// Returns the list of :class:`AdditionalCapability` values that were

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -356,6 +356,32 @@ impl Instance {
         Ok(())
     }
 
+    /// Convert constraint types not in `supported` into regular constraints.
+    ///
+    /// For every capability in ``required_capabilities() - supported``, the
+    /// corresponding bulk conversion is invoked
+    /// (:meth:`convert_all_indicators_to_constraints`,
+    /// :meth:`convert_all_one_hots_to_constraints`, or
+    /// :meth:`convert_all_sos1_to_constraints`). The instance is mutated in
+    /// place and its :meth:`required_capabilities` becomes a subset of
+    /// ``supported`` on success.
+    ///
+    /// Returns the list of :class:`AdditionalCapability` values that were
+    /// actually converted, in the fixed order ``Indicator``, ``OneHot``,
+    /// ``Sos1``. Empty when nothing needed conversion.
+    ///
+    /// Raises if any underlying Big-M conversion fails (e.g. a SOS1 variable
+    /// with a non-finite bound).
+    pub fn reduce_capabilities(
+        &mut self,
+        supported: std::collections::HashSet<crate::AdditionalCapability>,
+    ) -> anyhow::Result<Vec<crate::AdditionalCapability>> {
+        let rust_supported: fnv::FnvHashSet<ommx::AdditionalCapability> =
+            supported.into_iter().map(|c| c.into()).collect();
+        let converted = self.inner.reduce_capabilities(&rust_supported)?;
+        Ok(converted.into_iter().map(|c| c.into()).collect())
+    }
+
     /// Dict of all removed constraints in the instance keyed by their IDs.
     #[getter]
     pub fn removed_constraints(&self) -> BTreeMap<u64, RemovedConstraint> {
@@ -1091,15 +1117,15 @@ impl Instance {
     /// ...     },
     /// ...     sense=Instance.MINIMIZE,
     /// ... )
-    /// >>> instance.convert_one_hots_to_constraints()
+    /// >>> instance.convert_all_one_hots_to_constraints()
     /// [0, 1]
     /// >>> instance.one_hot_constraints
     /// {}
     /// >>> instance.constraints
     /// {0: Constraint(x0 + x1 - 1 == 0), 1: Constraint(x2 + x3 - 1 == 0)}
     /// ```
-    pub fn convert_one_hots_to_constraints(&mut self) -> Result<Vec<u64>> {
-        let ids = self.inner.convert_one_hots_to_constraints()?;
+    pub fn convert_all_one_hots_to_constraints(&mut self) -> Result<Vec<u64>> {
+        let ids = self.inner.convert_all_one_hots_to_constraints()?;
         Ok(ids.into_iter().map(|id| id.into_inner()).collect())
     }
 

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -243,7 +243,8 @@ impl Instance {
     ///
     /// Returns the set of capabilities that were converted, in a stable order
     /// (`Indicator`, `OneHot`, `Sos1`). The set is empty when nothing needed
-    /// conversion.
+    /// conversion. Each conversion is also emitted as an `INFO`-level
+    /// [`log`] record so it surfaces through `pyo3-log` on the Python side.
     ///
     /// Errors if any underlying conversion fails (e.g. SOS1 / indicator with
     /// non-finite bounds). Each per-type conversion is atomic, but this method
@@ -291,6 +292,9 @@ impl Instance {
                 }
             };
             if converted_any {
+                log::info!(
+                    "reduce_capabilities: {cap:?} is not in supported capabilities; converted to regular constraints"
+                );
                 converted.push(cap);
             }
         }

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -58,13 +58,6 @@ pub enum AdditionalCapability {
     Sos1,
 }
 
-/// Error returned when an Instance contains unsupported constraint types.
-#[derive(Debug, Clone, thiserror::Error)]
-#[error("Unsupported constraint types: {unsupported:?}")]
-pub struct UnsupportedCapabilities {
-    pub unsupported: Vec<AdditionalCapability>,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub enum Sense {
     #[default]
@@ -88,7 +81,10 @@ pub enum Sense {
 /// are distinct and do not conflict. Uniqueness is only required within the same type
 /// (i.e. active and removed constraints of the same type must have disjoint IDs).
 ///
-/// Adapter compatibility is checked via [`AdditionalCapability`] and [`Instance::check_capabilities`].
+/// Adapter compatibility is expressed via [`AdditionalCapability`]. Callers can read
+/// [`Instance::required_capabilities`] to see which non-standard types the instance
+/// carries, and use [`Instance::reduce_capabilities`] to convert unsupported types
+/// into regular constraints.
 ///
 /// Invariants
 /// -----------
@@ -235,24 +231,6 @@ impl Instance {
             caps.insert(AdditionalCapability::Sos1);
         }
         caps
-    }
-
-    /// Check that the given supported capabilities cover all constraint types in this instance.
-    ///
-    /// Only active constraints are checked (see [`Self::required_capabilities`]).
-    ///
-    /// Returns an error listing unsupported constraint types if any are found.
-    pub fn check_capabilities(
-        &self,
-        supported: &fnv::FnvHashSet<AdditionalCapability>,
-    ) -> Result<(), UnsupportedCapabilities> {
-        let required = self.required_capabilities();
-        let unsupported: Vec<_> = required.difference(supported).copied().collect();
-        if unsupported.is_empty() {
-            Ok(())
-        } else {
-            Err(UnsupportedCapabilities { unsupported })
-        }
     }
 
     /// Convert constraint types not in `supported` into regular constraints.

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -254,6 +254,70 @@ impl Instance {
             Err(UnsupportedCapabilities { unsupported })
         }
     }
+
+    /// Convert constraint types not in `supported` into regular constraints.
+    ///
+    /// For every capability in `required_capabilities() - supported`, call the
+    /// corresponding bulk conversion (`convert_all_indicators_to_constraints`,
+    /// `convert_all_one_hots_to_constraints`, or `convert_all_sos1_to_constraints`).
+    /// After this call, the instance's [`Self::required_capabilities`] is a
+    /// subset of `supported`.
+    ///
+    /// Returns the set of capabilities that were converted, in a stable order
+    /// (`Indicator`, `OneHot`, `Sos1`). The set is empty when nothing needed
+    /// conversion.
+    ///
+    /// Errors if any underlying conversion fails (e.g. SOS1 / indicator with
+    /// non-finite bounds). Each per-type conversion is atomic, but this method
+    /// is **not** atomic across types: earlier conversions are not rolled back
+    /// if a later one fails. Callers that need cross-type atomicity should
+    /// validate / clone up front.
+    pub fn reduce_capabilities(
+        &mut self,
+        supported: &fnv::FnvHashSet<AdditionalCapability>,
+    ) -> anyhow::Result<Vec<AdditionalCapability>> {
+        let mut converted = Vec::new();
+        // Iterate in a fixed order so logs / callers see deterministic output.
+        for cap in [
+            AdditionalCapability::Indicator,
+            AdditionalCapability::OneHot,
+            AdditionalCapability::Sos1,
+        ] {
+            if supported.contains(&cap) {
+                continue;
+            }
+            let converted_any = match cap {
+                AdditionalCapability::Indicator => {
+                    if self.indicator_constraint_collection.active().is_empty() {
+                        false
+                    } else {
+                        self.convert_all_indicators_to_constraints()?;
+                        true
+                    }
+                }
+                AdditionalCapability::OneHot => {
+                    if self.one_hot_constraint_collection.active().is_empty() {
+                        false
+                    } else {
+                        self.convert_all_one_hots_to_constraints()?;
+                        true
+                    }
+                }
+                AdditionalCapability::Sos1 => {
+                    if self.sos1_constraint_collection.active().is_empty() {
+                        false
+                    } else {
+                        self.convert_all_sos1_to_constraints()?;
+                        true
+                    }
+                }
+            };
+            if converted_any {
+                converted.push(cap);
+            }
+        }
+        Ok(converted)
+    }
 }
 
 /// Optimization problem instance with parameters
@@ -356,5 +420,209 @@ impl ParametricInstance {
         &self,
     ) -> &BTreeMap<crate::Sos1ConstraintID, (Sos1Constraint, RemovedReason)> {
         self.sos1_constraint_collection.removed()
+    }
+}
+
+#[cfg(test)]
+mod reduce_capabilities_tests {
+    use super::*;
+    use crate::{
+        indicator_constraint::{IndicatorConstraint, IndicatorConstraintID},
+        linear,
+        one_hot_constraint::{OneHotConstraint, OneHotConstraintID},
+        sos1_constraint::{Sos1Constraint, Sos1ConstraintID},
+        Bound, DecisionVariable, Equality, Function, Kind, VariableID,
+    };
+    use maplit::btreemap;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    /// Build an instance with one of each non-standard constraint type, suitable
+    /// for Big-M conversion (binary variables have bound [0, 1]).
+    fn instance_with_all_capabilities() -> Instance {
+        let decision_variables = btreemap! {
+            VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
+            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+        };
+        let one_hot = OneHotConstraint::new(
+            [VariableID::from(0), VariableID::from(1)]
+                .into_iter()
+                .collect(),
+        );
+        let sos1 = Sos1Constraint::new(
+            [VariableID::from(2), VariableID::from(3)]
+                .into_iter()
+                .collect(),
+        );
+        // Indicator: y=1 => x0 <= 0 (trivially satisfied since x0 in [0,1], upper=1>0 emits upper Big-M)
+        let indicator = IndicatorConstraint::new(
+            VariableID::from(1),
+            Equality::LessThanOrEqualToZero,
+            Function::from(linear!(0)),
+        );
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(linear!(0)))
+            .decision_variables(decision_variables)
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(1),
+                indicator,
+            )]))
+            .one_hot_constraints(BTreeMap::from([(OneHotConstraintID::from(1), one_hot)]))
+            .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(1), sos1)]))
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn noop_when_all_required_are_supported() {
+        // Every required capability is in `supported` → nothing converted,
+        // instance left untouched.
+        let mut instance = instance_with_all_capabilities();
+        let supported: fnv::FnvHashSet<_> = [
+            AdditionalCapability::Indicator,
+            AdditionalCapability::OneHot,
+            AdditionalCapability::Sos1,
+        ]
+        .into_iter()
+        .collect();
+        let before_indicators = instance.indicator_constraints().clone();
+        let before_one_hots = instance.one_hot_constraints().clone();
+        let before_sos1 = instance.sos1_constraints().clone();
+
+        let converted = instance.reduce_capabilities(&supported).unwrap();
+
+        assert!(converted.is_empty());
+        assert_eq!(instance.indicator_constraints(), &before_indicators);
+        assert_eq!(instance.one_hot_constraints(), &before_one_hots);
+        assert_eq!(instance.sos1_constraints(), &before_sos1);
+    }
+
+    #[test]
+    fn converts_only_unsupported_capabilities() {
+        // Supported = {Sos1}: Indicator and OneHot must be converted, SOS1 kept.
+        // Return order is fixed: Indicator, OneHot, Sos1.
+        let mut instance = instance_with_all_capabilities();
+        let supported: fnv::FnvHashSet<_> = [AdditionalCapability::Sos1].into_iter().collect();
+
+        let converted = instance.reduce_capabilities(&supported).unwrap();
+
+        assert_eq!(
+            converted,
+            vec![
+                AdditionalCapability::Indicator,
+                AdditionalCapability::OneHot
+            ]
+        );
+        assert!(instance.indicator_constraints().is_empty());
+        assert!(instance.one_hot_constraints().is_empty());
+        assert!(!instance.sos1_constraints().is_empty());
+        // required_capabilities is now a subset of supported.
+        assert!(instance.required_capabilities().is_subset(&supported));
+    }
+
+    #[test]
+    fn empty_supported_converts_everything() {
+        // No capabilities supported → all three are converted and return in fixed order.
+        let mut instance = instance_with_all_capabilities();
+        let supported = fnv::FnvHashSet::default();
+
+        let converted = instance.reduce_capabilities(&supported).unwrap();
+
+        assert_eq!(
+            converted,
+            vec![
+                AdditionalCapability::Indicator,
+                AdditionalCapability::OneHot,
+                AdditionalCapability::Sos1,
+            ]
+        );
+        assert!(instance.required_capabilities().is_empty());
+    }
+
+    #[test]
+    fn skips_capabilities_that_are_not_required() {
+        // Instance has only a OneHot. Empty `supported` → only OneHot is reported
+        // as converted; Indicator / SOS1 aren't in the returned list since they
+        // were never present to begin with.
+        let decision_variables = btreemap! {
+            VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
+            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+        };
+        let one_hot = OneHotConstraint::new(
+            [VariableID::from(0), VariableID::from(1)]
+                .into_iter()
+                .collect(),
+        );
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(linear!(0)))
+            .decision_variables(decision_variables)
+            .constraints(BTreeMap::new())
+            .one_hot_constraints(BTreeMap::from([(OneHotConstraintID::from(1), one_hot)]))
+            .build()
+            .unwrap();
+        let supported = fnv::FnvHashSet::default();
+
+        let converted = instance.reduce_capabilities(&supported).unwrap();
+
+        assert_eq!(converted, vec![AdditionalCapability::OneHot]);
+        assert!(instance.one_hot_constraints().is_empty());
+    }
+
+    #[test]
+    fn conversion_failure_is_propagated() {
+        // SOS1 over a continuous variable with infinite bound cannot be Big-M
+        // converted; reduce_capabilities surfaces the underlying error.
+        let dv = DecisionVariable::continuous(VariableID::from(0));
+        let sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect::<BTreeSet<_>>());
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(linear!(0)))
+            .decision_variables(btreemap! { VariableID::from(0) => dv })
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(1), sos1)]))
+            .build()
+            .unwrap();
+        let supported = fnv::FnvHashSet::default();
+
+        let err = instance.reduce_capabilities(&supported).unwrap_err();
+        assert!(err.to_string().contains("non-finite"));
+    }
+
+    #[test]
+    fn integer_sos1_converts_with_new_indicator() {
+        // A single SOS1 over an integer variable with finite bound [-2, 3]:
+        // reduce_capabilities should invoke the SOS1 Big-M conversion which
+        // allocates a fresh binary indicator.
+        let dv = DecisionVariable::new(
+            VariableID::from(0),
+            Kind::Integer,
+            Bound::new(-2.0, 3.0).unwrap(),
+            None,
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect::<BTreeSet<_>>());
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(linear!(0)))
+            .decision_variables(btreemap! { VariableID::from(0) => dv })
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(1), sos1)]))
+            .build()
+            .unwrap();
+
+        let converted = instance
+            .reduce_capabilities(&fnv::FnvHashSet::default())
+            .unwrap();
+
+        assert_eq!(converted, vec![AdditionalCapability::Sos1]);
+        // Fresh binary indicator was allocated → decision variable count went up.
+        assert_eq!(instance.decision_variables.len(), 2);
+        assert!(instance.sos1_constraints().is_empty());
+        assert!(!instance.constraints().is_empty());
     }
 }

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -48,7 +48,11 @@ use std::collections::BTreeMap;
 /// Standard constraints (`f(x) = 0` or `f(x) <= 0`) are always supported by all adapters
 /// and do not need a capability flag. This enum only lists capabilities that adapters
 /// must explicitly opt in to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// The [`PartialOrd`] / [`Ord`] derives follow variant declaration order
+/// (`Indicator < OneHot < Sos1`), which is also the order in which
+/// [`Capabilities`] iterates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AdditionalCapability {
     /// Indicator constraints: binvar = 1 → f(x) <= 0
     Indicator,
@@ -57,6 +61,12 @@ pub enum AdditionalCapability {
     /// SOS1 constraints: at most one of a set of variables can be non-zero
     Sos1,
 }
+
+/// A set of [`AdditionalCapability`] flags.
+///
+/// Always represented as a [`BTreeSet`] so iteration, formatting, and
+/// comparison are deterministic and sorted by variant order.
+pub type Capabilities = std::collections::BTreeSet<AdditionalCapability>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub enum Sense {
@@ -219,8 +229,8 @@ impl Instance {
     /// Only **active** constraints are considered. Removed (relaxed) constraints are excluded
     /// because they are not passed to solver adapters — adapters only need to handle
     /// constraint types that are actively part of the problem.
-    pub fn required_capabilities(&self) -> fnv::FnvHashSet<AdditionalCapability> {
-        let mut caps = fnv::FnvHashSet::default();
+    pub fn required_capabilities(&self) -> Capabilities {
+        let mut caps = Capabilities::new();
         if !self.indicator_constraint_collection.active().is_empty() {
             caps.insert(AdditionalCapability::Indicator);
         }
@@ -241,10 +251,11 @@ impl Instance {
     /// After this call, the instance's [`Self::required_capabilities`] is a
     /// subset of `supported`.
     ///
-    /// Returns the set of capabilities that were converted, in a stable order
-    /// (`Indicator`, `OneHot`, `Sos1`). The set is empty when nothing needed
-    /// conversion. Each conversion is also emitted as an `INFO`-level
-    /// [`log`] record so it surfaces through `pyo3-log` on the Python side.
+    /// Returns the set of capabilities that were actually converted. Iteration
+    /// order follows [`Capabilities`]'s sorted order (`Indicator`, `OneHot`,
+    /// `Sos1`). The set is empty when nothing needed conversion. Each
+    /// conversion is also emitted as an `INFO`-level [`log`] record so it
+    /// surfaces through `pyo3-log` on the Python side.
     ///
     /// Errors if any underlying conversion fails (e.g. SOS1 / indicator with
     /// non-finite bounds). Each per-type conversion is atomic, but this method
@@ -253,9 +264,9 @@ impl Instance {
     /// validate / clone up front.
     pub fn reduce_capabilities(
         &mut self,
-        supported: &fnv::FnvHashSet<AdditionalCapability>,
-    ) -> anyhow::Result<Vec<AdditionalCapability>> {
-        let mut converted = Vec::new();
+        supported: &Capabilities,
+    ) -> anyhow::Result<Capabilities> {
+        let mut converted = Capabilities::new();
         // Iterate in a fixed order so logs / callers see deterministic output.
         for cap in [
             AdditionalCapability::Indicator,
@@ -295,7 +306,7 @@ impl Instance {
                 log::info!(
                     "reduce_capabilities: {cap:?} is not in supported capabilities; converted to regular constraints"
                 );
-                converted.push(cap);
+                converted.insert(cap);
             }
         }
         Ok(converted)
@@ -463,7 +474,7 @@ mod reduce_capabilities_tests {
         // Every required capability is in `supported` → nothing converted,
         // instance left untouched.
         let mut instance = instance_with_all_capabilities();
-        let supported: fnv::FnvHashSet<_> = [
+        let supported: Capabilities = [
             AdditionalCapability::Indicator,
             AdditionalCapability::OneHot,
             AdditionalCapability::Sos1,
@@ -485,19 +496,18 @@ mod reduce_capabilities_tests {
     #[test]
     fn converts_only_unsupported_capabilities() {
         // Supported = {Sos1}: Indicator and OneHot must be converted, SOS1 kept.
-        // Return order is fixed: Indicator, OneHot, Sos1.
         let mut instance = instance_with_all_capabilities();
-        let supported: fnv::FnvHashSet<_> = [AdditionalCapability::Sos1].into_iter().collect();
+        let supported: Capabilities = [AdditionalCapability::Sos1].into_iter().collect();
 
         let converted = instance.reduce_capabilities(&supported).unwrap();
 
-        assert_eq!(
-            converted,
-            vec![
-                AdditionalCapability::Indicator,
-                AdditionalCapability::OneHot
-            ]
-        );
+        let expected: Capabilities = [
+            AdditionalCapability::Indicator,
+            AdditionalCapability::OneHot,
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(converted, expected);
         assert!(instance.indicator_constraints().is_empty());
         assert!(instance.one_hot_constraints().is_empty());
         assert!(!instance.sos1_constraints().is_empty());
@@ -507,27 +517,27 @@ mod reduce_capabilities_tests {
 
     #[test]
     fn empty_supported_converts_everything() {
-        // No capabilities supported → all three are converted and return in fixed order.
+        // No capabilities supported → all three are converted.
         let mut instance = instance_with_all_capabilities();
-        let supported = fnv::FnvHashSet::default();
+        let supported = Capabilities::new();
 
         let converted = instance.reduce_capabilities(&supported).unwrap();
 
-        assert_eq!(
-            converted,
-            vec![
-                AdditionalCapability::Indicator,
-                AdditionalCapability::OneHot,
-                AdditionalCapability::Sos1,
-            ]
-        );
+        let expected: Capabilities = [
+            AdditionalCapability::Indicator,
+            AdditionalCapability::OneHot,
+            AdditionalCapability::Sos1,
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(converted, expected);
         assert!(instance.required_capabilities().is_empty());
     }
 
     #[test]
     fn skips_capabilities_that_are_not_required() {
         // Instance has only a OneHot. Empty `supported` → only OneHot is reported
-        // as converted; Indicator / SOS1 aren't in the returned list since they
+        // as converted; Indicator / SOS1 aren't in the returned set since they
         // were never present to begin with.
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
@@ -546,11 +556,12 @@ mod reduce_capabilities_tests {
             .one_hot_constraints(BTreeMap::from([(OneHotConstraintID::from(1), one_hot)]))
             .build()
             .unwrap();
-        let supported = fnv::FnvHashSet::default();
+        let supported = Capabilities::new();
 
         let converted = instance.reduce_capabilities(&supported).unwrap();
 
-        assert_eq!(converted, vec![AdditionalCapability::OneHot]);
+        let expected: Capabilities = [AdditionalCapability::OneHot].into_iter().collect();
+        assert_eq!(converted, expected);
         assert!(instance.one_hot_constraints().is_empty());
     }
 
@@ -568,7 +579,7 @@ mod reduce_capabilities_tests {
             .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(1), sos1)]))
             .build()
             .unwrap();
-        let supported = fnv::FnvHashSet::default();
+        let supported = Capabilities::new();
 
         let err = instance.reduce_capabilities(&supported).unwrap_err();
         assert!(err.to_string().contains("non-finite"));
@@ -597,11 +608,10 @@ mod reduce_capabilities_tests {
             .build()
             .unwrap();
 
-        let converted = instance
-            .reduce_capabilities(&fnv::FnvHashSet::default())
-            .unwrap();
+        let converted = instance.reduce_capabilities(&Capabilities::new()).unwrap();
 
-        assert_eq!(converted, vec![AdditionalCapability::Sos1]);
+        let expected: Capabilities = [AdditionalCapability::Sos1].into_iter().collect();
+        assert_eq!(converted, expected);
         // Fresh binary indicator was allocated → decision variable count went up.
         assert_eq!(instance.decision_variables.len(), 2);
         assert!(instance.sos1_constraints().is_empty());

--- a/rust/ommx/src/instance/one_hot.rs
+++ b/rust/ommx/src/instance/one_hot.rs
@@ -73,7 +73,7 @@ impl Instance {
     /// See [`Self::convert_one_hot_to_constraint`] for the conversion rule.
     /// Returns the IDs of the newly created regular constraints in ascending
     /// order of the original one-hot constraint IDs.
-    pub fn convert_one_hots_to_constraints(&mut self) -> Result<Vec<ConstraintID>> {
+    pub fn convert_all_one_hots_to_constraints(&mut self) -> Result<Vec<ConstraintID>> {
         let ids: Vec<_> = self
             .one_hot_constraint_collection
             .active()
@@ -198,7 +198,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let new_ids = instance.convert_one_hots_to_constraints().unwrap();
+        let new_ids = instance.convert_all_one_hots_to_constraints().unwrap();
         assert_eq!(new_ids.len(), 2);
         assert!(instance.one_hot_constraints().is_empty());
         assert_eq!(instance.removed_one_hot_constraints().len(), 2);

--- a/rust/ommx/src/instance/qubo.rs
+++ b/rust/ommx/src/instance/qubo.rs
@@ -1,6 +1,6 @@
 use super::{Instance, Sense};
 use crate::{BinaryIdPair, BinaryIds, Evaluate};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use std::collections::BTreeMap;
 
 impl Instance {
@@ -21,8 +21,12 @@ impl Instance {
         if !self.constraints().is_empty() {
             bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
         }
-        self.check_capabilities(&fnv::FnvHashSet::default())
-            .context("QUBO format does not support these constraint types. Convert via penalty method or equivalent first.")?;
+        let non_standard = self.required_capabilities();
+        if !non_standard.is_empty() {
+            bail!(
+                "QUBO format does not support these constraint types: {non_standard:?}. Convert via penalty method or equivalent first."
+            );
+        }
         if !self
             .objective()
             .required_ids()
@@ -66,8 +70,12 @@ impl Instance {
         if !self.constraints().is_empty() {
             bail!("The instance still has constraints. Use penalty method or other way to translate into unconstrained problem first.");
         }
-        self.check_capabilities(&fnv::FnvHashSet::default())
-            .context("HUBO format does not support these constraint types. Convert via penalty method or equivalent first.")?;
+        let non_standard = self.required_capabilities();
+        if !non_standard.is_empty() {
+            bail!(
+                "HUBO format does not support these constraint types: {non_standard:?}. Convert via penalty method or equivalent first."
+            );
+        }
         if !self
             .objective()
             .required_ids()


### PR DESCRIPTION
## Summary

- Add `Instance::reduce_capabilities(supported)` in the Rust SDK. For every capability in `required_capabilities() - supported`, it invokes the corresponding bulk conversion (`convert_all_indicators_to_constraints`, `convert_all_one_hots_to_constraints`, `convert_all_sos1_to_constraints`) and returns the list of converted capabilities.
- Switch `SolverAdapter.__init__` from `check_capabilities` (which rejected unsupported types) to `reduce_capabilities`. Unsupported capabilities are now converted to regular constraints in place, and each conversion is logged at `INFO` level.
- Remove `Instance::check_capabilities` and the `UnsupportedCapabilities` error from the Rust SDK (and `Instance.check_capabilities` from the Python binding). Internal callers in `as_qubo_format` / `as_hubo_format` now use `required_capabilities()` directly with an inline bail. Expose `Instance.required_capabilities` as a property on the Python binding so callers can diff it against an adapter's `ADDITIONAL_CAPABILITIES` themselves.
- Rename `convert_one_hots_to_constraints` → `convert_all_one_hots_to_constraints` so the bulk-conversion API is uniform across all three capability types.
- Update the implement-adapter tutorial (en / ja) and the 3.0 release notes to describe the new flow.

## Motivation

Previously, declaring `ADDITIONAL_CAPABILITIES` on an adapter meant rejecting any instance whose constraint types weren't in the declared set. Since regular constraints are always supported and we already have Big-M / linear-equality conversions for indicator, one-hot, and SOS1, rejection was unnecessarily strict. The new behavior lets every adapter accept any instance by automatically degrading unsupported capabilities into regular constraints.

The resulting conversions are visible on the instance via `removed_indicator_constraints` / `removed_one_hot_constraints` / `removed_sos1_constraints` (each has a `reason` and a `constraint_ids` parameter pointing to the generated regular constraints), plus an `INFO` log line per converted capability.

## Notes

- `reduce_capabilities` mutates the instance in place, matching the existing `convert_*` APIs.
- Each per-type `convert_all_*` is atomic, but `reduce_capabilities` is not atomic *across* types: earlier conversions aren't rolled back if a later one fails.
- SOS1 / indicator conversion can still fail (non-finite bounds, semi-continuous / semi-integer variables, domain excluding 0); those errors now surface from the adapter's `__init__` rather than from a separate capability check.
- **Breaking**: `Instance.check_capabilities` is removed. Callers that relied on it should either use `reduce_capabilities` (to auto-convert) or read `required_capabilities` and diff against their supported set manually.

## Test plan

- [x] `task rust:test` — 438 + 44 doctests pass, including 6 new tests for `reduce_capabilities` (no-op, partial conversion, full conversion, unrequired capability skipped, error propagation, integer SOS1 with fresh indicator)
- [x] `task python:test` — all adapter and core SDK tests pass
- [x] `task rust:clippy` — clean
- [x] `task format` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)