### PR TITLE
Broaden tracing span coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "pyo3-tracing-opentelemetry",
  "serde-pyobject",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -2147,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-tracing-opentelemetry"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9653bcd0c9cbc8330b02e1b7239a879a04ee1fe09e83c6f8f3f421ddcb08ebe9"
+checksum = "af5a0530c5bfa1f2e02ef047c31fab60a33d692068b60fb3357feea9c192dd03"
 dependencies = [
  "anyhow",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ prost-build = "0.12.0"
 quote = "1.0.40"
 pyo3 = { version = "0.27.2", features = ["anyhow", "multiple-pymethods"] }
 pyo3-stub-gen = "0.22.1"
-pyo3-tracing-opentelemetry = "0.1.2"
+pyo3-tracing-opentelemetry = "0.2.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde-pyobject = "0.8.0"
 serde_json = "1.0.149"

--- a/python/ommx-tests/tests/test_tracing.py
+++ b/python/ommx-tests/tests/test_tracing.py
@@ -128,6 +128,65 @@ def test_trace_context_propagation() -> None:
     )
 
 
+def test_evaluate_emits_rust_span_under_python_parent() -> None:
+    """``Instance.evaluate`` forwards the Rust ``Instance::evaluate`` span,
+    and it attaches under the Python parent span via trace-context propagation."""
+    exporter = get_test_exporter()
+    provider = get_test_provider()
+    exporter.clear()
+
+    tracer = trace.get_tracer("ommx-tracing-test")
+    x = DecisionVariable.binary(0)
+    y = DecisionVariable.binary(1)
+    instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x + y,
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+
+    with tracer.start_as_current_span("python_parent") as parent_span:
+        parent_trace_id = parent_span.get_span_context().trace_id
+        instance.evaluate({0: 1.0, 1: 0.0})
+
+    provider.force_flush()
+    rust_spans = [s for s in exporter.spans if s.name == "evaluate"]
+    assert rust_spans, (
+        f"No 'evaluate' span exported. Got: {[s.name for s in exporter.spans]}"
+    )
+    for s in rust_spans:
+        assert s.context is not None
+        assert s.context.trace_id == parent_trace_id
+
+
+def test_to_qubo_emits_pipeline_spans() -> None:
+    """``Instance.to_qubo`` exercises the nested QUBO conversion pipeline,
+    producing the expected span names on the Rust side."""
+    exporter = get_test_exporter()
+    provider = get_test_provider()
+    exporter.clear()
+
+    x = [DecisionVariable.binary(i) for i in range(3)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={},
+        sense=Instance.MINIMIZE,
+    )
+
+    instance.to_qubo()
+
+    provider.force_flush()
+    names = {s.name for s in exporter.spans}
+    # The PyO3 pipeline wrapper and the Rust-side formatter both emit spans.
+    assert "qubo_hubo_pipeline" in names, (
+        f"Missing 'qubo_hubo_pipeline' span. Got: {sorted(names)}"
+    )
+    assert "as_qubo_format" in names, (
+        f"Missing 'as_qubo_format' span. Got: {sorted(names)}"
+    )
+
+
 def test_tracing_info_event_captured_on_rust_span() -> None:
     """``tracing::info!`` inside ``reduce_capabilities`` becomes a span event
     on the Rust span, not a separate span."""

--- a/python/ommx/Cargo.toml
+++ b/python/ommx/Cargo.toml
@@ -40,3 +40,4 @@ pyo3-tracing-opentelemetry.workspace = true
 pyo3.workspace = true
 serde-pyobject.workspace = true
 serde_json.workspace = true
+tracing.workspace = true

--- a/python/ommx/src/artifact.rs
+++ b/python/ommx/src/artifact.rs
@@ -184,7 +184,8 @@ impl PyArtifact {
     }
 
     /// Look up a layer descriptor by digest.
-    pub fn get_layer_descriptor(&mut self, digest: &str) -> Result<PyDescriptor> {
+    pub fn get_layer_descriptor(&mut self, py: Python<'_>, digest: &str) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let layers = self.0.layers()?;
         for layer in layers {
             if layer.digest() == digest {
@@ -200,6 +201,7 @@ impl PyArtifact {
         py: Python<'py>,
         digest_or_descriptor: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyBytes>> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let digest: String = if let Ok(desc) = digest_or_descriptor.extract::<PyRef<PyDescriptor>>()
         {
             desc.digest()
@@ -218,8 +220,8 @@ impl PyArtifact {
     /// Raises `ValueError` if no instance layer is found.
     /// For multiple instance layers, use {meth}`get_instance` with a descriptor.
     #[getter(instance)]
-    pub fn instance_(&mut self) -> Result<crate::Instance> {
-        Ok(self.get_instance(None)?)
+    pub fn instance_(&mut self, py: Python<'_>) -> Result<crate::Instance> {
+        Ok(self.get_instance(py, None)?)
     }
 
     /// The first solution layer in the artifact.
@@ -227,8 +229,8 @@ impl PyArtifact {
     /// Raises `ValueError` if no solution layer is found.
     /// For multiple solution layers, use {meth}`get_solution` with a descriptor.
     #[getter(solution)]
-    pub fn solution_(&mut self) -> Result<crate::Solution> {
-        Ok(self.get_solution(None)?)
+    pub fn solution_(&mut self, py: Python<'_>) -> Result<crate::Solution> {
+        Ok(self.get_solution(py, None)?)
     }
 
     /// The first parametric instance layer in the artifact.
@@ -236,8 +238,8 @@ impl PyArtifact {
     /// Raises `ValueError` if no parametric instance layer is found.
     /// For multiple parametric instance layers, use {meth}`get_parametric_instance` with a descriptor.
     #[getter(parametric_instance)]
-    pub fn parametric_instance_(&mut self) -> Result<crate::ParametricInstance> {
-        Ok(self.get_parametric_instance(None)?)
+    pub fn parametric_instance_(&mut self, py: Python<'_>) -> Result<crate::ParametricInstance> {
+        Ok(self.get_parametric_instance(py, None)?)
     }
 
     /// The first sample set layer in the artifact.
@@ -245,8 +247,8 @@ impl PyArtifact {
     /// Raises `ValueError` if no sample set layer is found.
     /// For multiple sample set layers, use {meth}`get_sample_set` with a descriptor.
     #[getter(sample_set)]
-    pub fn sample_set_(&mut self) -> Result<crate::SampleSet> {
-        Ok(self.get_sample_set(None)?)
+    pub fn sample_set_(&mut self, py: Python<'_>) -> Result<crate::SampleSet> {
+        Ok(self.get_sample_set(py, None)?)
     }
 
     /// Get the layer object corresponding to the descriptor.
@@ -260,6 +262,7 @@ impl PyArtifact {
         py: Python<'py>,
         descriptor: &PyDescriptor,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let media_type = descriptor.media_type();
         match media_type.as_str() {
             "application/org.ommx.v1.instance" => {
@@ -297,7 +300,12 @@ impl PyArtifact {
     ///
     /// Raises `ValueError` if no instance layer is found.
     #[pyo3(signature = (descriptor = None))]
-    pub fn get_instance(&mut self, descriptor: Option<&PyDescriptor>) -> PyResult<crate::Instance> {
+    pub fn get_instance(
+        &mut self,
+        py: Python<'_>,
+        descriptor: Option<&PyDescriptor>,
+    ) -> PyResult<crate::Instance> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         match descriptor {
             Some(desc) => self
                 .get_instance_inner(desc)
@@ -328,7 +336,12 @@ impl PyArtifact {
     ///
     /// Raises `ValueError` if no solution layer is found.
     #[pyo3(signature = (descriptor = None))]
-    pub fn get_solution(&mut self, descriptor: Option<&PyDescriptor>) -> PyResult<crate::Solution> {
+    pub fn get_solution(
+        &mut self,
+        py: Python<'_>,
+        descriptor: Option<&PyDescriptor>,
+    ) -> PyResult<crate::Solution> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         match descriptor {
             Some(desc) => self
                 .get_solution_inner(desc)
@@ -361,8 +374,10 @@ impl PyArtifact {
     #[pyo3(signature = (descriptor = None))]
     pub fn get_parametric_instance(
         &mut self,
+        py: Python<'_>,
         descriptor: Option<&PyDescriptor>,
     ) -> PyResult<crate::ParametricInstance> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         match descriptor {
             Some(desc) => self
                 .get_parametric_instance_inner(desc)
@@ -395,8 +410,10 @@ impl PyArtifact {
     #[pyo3(signature = (descriptor = None))]
     pub fn get_sample_set(
         &mut self,
+        py: Python<'_>,
         descriptor: Option<&PyDescriptor>,
     ) -> PyResult<crate::SampleSet> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         match descriptor {
             Some(desc) => self
                 .get_sample_set_inner(desc)
@@ -426,6 +443,7 @@ impl PyArtifact {
         py: Python<'py>,
         descriptor: &PyDescriptor,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         self.get_ndarray_inner(py, descriptor)
     }
 
@@ -435,6 +453,7 @@ impl PyArtifact {
         py: Python<'py>,
         descriptor: &PyDescriptor,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         assert_media_type(descriptor, "application/vnd.apache.parquet")?;
         let blob = self
             .0
@@ -452,6 +471,7 @@ impl PyArtifact {
         py: Python<'py>,
         descriptor: &PyDescriptor,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         assert_media_type(descriptor, "application/json")?;
         let blob = self
             .0
@@ -713,7 +733,12 @@ impl PyArtifactBuilder {
     /// test instance
     ///
     /// ```
-    pub fn add_instance(&mut self, instance: &crate::Instance) -> Result<PyDescriptor> {
+    pub fn add_instance(
+        &mut self,
+        py: Python<'_>,
+        instance: &crate::Instance,
+    ) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let blob = instance.inner.to_bytes();
         self.0.add_layer(
             "application/org.ommx.v1.instance",
@@ -725,8 +750,10 @@ impl PyArtifactBuilder {
     /// Add a {class}`~ommx.v1.ParametricInstance` to the artifact with annotations.
     pub fn add_parametric_instance(
         &mut self,
+        py: Python<'_>,
         instance: &crate::ParametricInstance,
     ) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let blob = instance.inner.to_bytes();
         self.0.add_layer(
             "application/org.ommx.v1.parametric-instance",
@@ -736,7 +763,12 @@ impl PyArtifactBuilder {
     }
 
     /// Add a {class}`~ommx.v1.Solution` to the artifact with annotations.
-    pub fn add_solution(&mut self, solution: &crate::Solution) -> Result<PyDescriptor> {
+    pub fn add_solution(
+        &mut self,
+        py: Python<'_>,
+        solution: &crate::Solution,
+    ) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let blob = solution.inner.to_bytes();
         self.0.add_layer(
             "application/org.ommx.v1.solution",
@@ -746,7 +778,12 @@ impl PyArtifactBuilder {
     }
 
     /// Add a {class}`~ommx.v1.SampleSet` to the artifact with annotations.
-    pub fn add_sample_set(&mut self, sample_set: &crate::SampleSet) -> Result<PyDescriptor> {
+    pub fn add_sample_set(
+        &mut self,
+        py: Python<'_>,
+        sample_set: &crate::SampleSet,
+    ) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let blob = sample_set.inner.to_bytes();
         self.0.add_layer(
             "application/org.ommx.v1.sample-set",
@@ -778,6 +815,7 @@ impl PyArtifactBuilder {
         annotation_namespace: &str,
         annotations: Option<&Bound<pyo3::types::PyDict>>,
     ) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let io = py.import("io")?;
         let numpy = py.import("numpy")?;
         let bytes_io = io.call_method0("BytesIO")?;
@@ -807,6 +845,7 @@ impl PyArtifactBuilder {
         annotation_namespace: &str,
         annotations: Option<&Bound<pyo3::types::PyDict>>,
     ) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(df.py());
         let blob: Vec<u8> = df.call_method0("to_parquet")?.extract()?;
         let ann = build_annotations(annotation_namespace, annotations)?;
         self.0
@@ -833,6 +872,7 @@ impl PyArtifactBuilder {
         annotation_namespace: &str,
         annotations: Option<&Bound<pyo3::types::PyDict>>,
     ) -> Result<PyDescriptor> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let json = py.import("json")?;
         let blob_str: String = json.call_method1("dumps", (obj,))?.extract()?;
         let ann = build_annotations(annotation_namespace, annotations)?;

--- a/python/ommx/src/dataset.rs
+++ b/python/ommx/src/dataset.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
-pub fn miplib2017_instance_annotations() -> HashMap<String, HashMap<String, String>> {
+pub fn miplib2017_instance_annotations(py: Python<'_>) -> HashMap<String, HashMap<String, String>> {
+    let _guard = crate::TRACING.attach_parent_context(py);
     ommx::dataset::miplib2017::instance_annotations()
         .into_iter()
         .map(|(instance, annotations)| (instance, annotations.into_inner()))
@@ -12,7 +13,8 @@ pub fn miplib2017_instance_annotations() -> HashMap<String, HashMap<String, Stri
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
-pub fn qplib_instance_annotations() -> HashMap<String, HashMap<String, String>> {
+pub fn qplib_instance_annotations(py: Python<'_>) -> HashMap<String, HashMap<String, String>> {
+    let _guard = crate::TRACING.attach_parent_context(py);
     ommx::dataset::qplib::instance_annotations()
         .into_iter()
         .map(|(instance, annotations)| (instance, annotations.into_inner()))

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -430,6 +430,7 @@ impl Instance {
     }
 
     pub fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let buf = self.inner.to_bytes();
         PyBytes::new(py, &buf)
     }
@@ -459,6 +460,7 @@ impl Instance {
     }
 
     pub fn as_qubo_format<'py>(&self, py: Python<'py>) -> Result<(Bound<'py, PyDict>, f64)> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let (qubo, constant) = self.inner.as_qubo_format()?;
         Ok((
             serde_pyobject::to_pyobject(py, &qubo)?
@@ -469,6 +471,7 @@ impl Instance {
     }
 
     pub fn as_hubo_format<'py>(&self, py: Python<'py>) -> Result<(Bound<'py, PyDict>, f64)> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let (hubo, constant) = self.inner.as_hubo_format()?;
         Ok((
             serde_pyobject::to_pyobject(py, &hubo)?
@@ -550,7 +553,7 @@ impl Instance {
             penalty_weights,
             inequality_integer_slack_max_range,
         )?;
-        self.log_encode(BTreeSet::new())?;
+        self.log_encode(py, BTreeSet::new())?;
         let result = self.as_qubo_format(py)?;
         if is_converted {
             self.as_maximization_problem();
@@ -599,7 +602,7 @@ impl Instance {
             penalty_weights,
             inequality_integer_slack_max_range,
         )?;
-        self.log_encode(BTreeSet::new())?;
+        self.log_encode(py, BTreeSet::new())?;
         let result = self.as_hubo_format(py)?;
         if is_converted {
             self.as_maximization_problem();
@@ -661,7 +664,8 @@ impl Instance {
     /// >>> pi.removed_constraints[1]
     /// RemovedConstraint(x1 + x2 - 1 == 0, reason=ommx.Instance.penalty_method, parameter_id=4)
     /// ```
-    pub fn penalty_method(&self) -> Result<ParametricInstance> {
+    pub fn penalty_method(&self, py: Python<'_>) -> Result<ParametricInstance> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let parametric_instance = self.inner.clone().penalty_method()?;
         Ok(ParametricInstance {
             inner: parametric_instance,
@@ -725,7 +729,8 @@ impl Instance {
     /// >>> p.name
     /// 'uniform_penalty_weight'
     /// ```
-    pub fn uniform_penalty_method(&self) -> Result<ParametricInstance> {
+    pub fn uniform_penalty_method(&self, py: Python<'_>) -> Result<ParametricInstance> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let parametric_instance = self.inner.clone().uniform_penalty_method()?;
         Ok(ParametricInstance {
             inner: parametric_instance,
@@ -1397,7 +1402,12 @@ impl Instance {
     /// Function(x1 + x3 + 2*x4 + x5 + 2*x6)
     /// ```
     #[pyo3(signature = (decision_variable_ids=BTreeSet::new()))]
-    pub fn log_encode(&mut self, decision_variable_ids: BTreeSet<u64>) -> Result<()> {
+    pub fn log_encode(
+        &mut self,
+        py: Python<'_>,
+        decision_variable_ids: BTreeSet<u64>,
+    ) -> Result<()> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let ids: BTreeSet<u64> = if decision_variable_ids.is_empty() {
             // Auto-detect: find all used integer decision variables
             let analysis = self.inner.analyze_decision_variables();
@@ -1952,7 +1962,8 @@ impl Instance {
     }
 
     #[staticmethod]
-    pub fn load_mps(path: String) -> Result<Self> {
+    pub fn load_mps(py: Python<'_>, path: String) -> Result<Self> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let instance = ommx::mps::load(path)?;
         Ok(Self {
             inner: instance,
@@ -1961,13 +1972,15 @@ impl Instance {
     }
 
     #[pyo3(signature = (path, compress = true))]
-    pub fn save_mps(&self, path: String, compress: bool) -> Result<()> {
+    pub fn save_mps(&self, py: Python<'_>, path: String, compress: bool) -> Result<()> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         ommx::mps::save(&self.inner, path, compress)?;
         Ok(())
     }
 
     #[staticmethod]
-    pub fn load_qplib(path: String) -> Result<Self> {
+    pub fn load_qplib(py: Python<'_>, path: String) -> Result<Self> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         let instance = ommx::qplib::load(path)?;
         Ok(Self {
             inner: instance,
@@ -2033,6 +2046,7 @@ impl Instance {
     }
 
     /// Shared pipeline for to_qubo/to_hubo: handle inequality constraints, apply penalty method.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn qubo_hubo_pipeline(
         &mut self,
         uniform_penalty_weight: Option<f64>,

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -26,6 +26,7 @@ crate::annotations::impl_instance_annotations!(
 impl ParametricInstance {
     #[staticmethod]
     pub fn from_bytes(bytes: &Bound<PyBytes>) -> Result<Self> {
+        let _guard = crate::TRACING.attach_parent_context(bytes.py());
         let inner = ommx::ParametricInstance::from_bytes(bytes.as_bytes())?;
         Ok(Self {
             inner,
@@ -34,6 +35,7 @@ impl ParametricInstance {
     }
 
     pub fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         PyBytes::new(py, &self.inner.to_bytes())
     }
 

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -92,6 +92,7 @@ crate::annotations::impl_solution_annotations!(SampleSet, "org.ommx.v1.sample-se
 impl SampleSet {
     #[staticmethod]
     pub fn from_bytes(bytes: &Bound<PyBytes>) -> Result<Self> {
+        let _guard = crate::TRACING.attach_parent_context(bytes.py());
         Ok(Self {
             inner: ommx::SampleSet::from_bytes(bytes.as_bytes())?,
             annotations: HashMap::new(),
@@ -99,6 +100,7 @@ impl SampleSet {
     }
 
     pub fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         PyBytes::new(py, &self.inner.to_bytes())
     }
 

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -27,6 +27,7 @@ crate::annotations::impl_solution_annotations!(Solution, "org.ommx.v1.solution")
 impl Solution {
     #[staticmethod]
     pub fn from_bytes(bytes: &Bound<PyBytes>) -> Result<Self> {
+        let _guard = crate::TRACING.attach_parent_context(bytes.py());
         Ok(Self {
             inner: ommx::Solution::from_bytes(bytes.as_bytes())?,
             annotations: HashMap::new(),
@@ -34,6 +35,7 @@ impl Solution {
     }
 
     pub fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        let _guard = crate::TRACING.attach_parent_context(py);
         PyBytes::new(py, &self.inner.to_bytes())
     }
 

--- a/rust/ommx/src/artifact.rs
+++ b/rust/ommx/src/artifact.rs
@@ -298,6 +298,7 @@ impl<Base: Image> Artifact<Base> {
             .collect())
     }
 
+    #[tracing::instrument(skip_all, fields(digest = %digest))]
     pub fn get_layer(&mut self, digest: &Digest) -> Result<(Descriptor, Vec<u8>)> {
         for (desc, blob) in self.0.get_layers()? {
             if desc.digest() == digest {
@@ -307,6 +308,7 @@ impl<Base: Image> Artifact<Base> {
         bail!("Layer of digest {} not found", digest)
     }
 
+    #[tracing::instrument(skip_all, fields(digest = %digest))]
     pub fn get_solution(&mut self, digest: &Digest) -> Result<(v1::State, SolutionAnnotations)> {
         let (desc, blob) = self.get_layer(digest)?;
         ensure!(
@@ -320,6 +322,7 @@ impl<Base: Image> Artifact<Base> {
         ))
     }
 
+    #[tracing::instrument(skip_all, fields(digest = %digest))]
     pub fn get_sample_set(
         &mut self,
         digest: &Digest,
@@ -336,6 +339,7 @@ impl<Base: Image> Artifact<Base> {
         ))
     }
 
+    #[tracing::instrument(skip_all, fields(digest = %digest))]
     pub fn get_instance(&mut self, digest: &Digest) -> Result<(v1::Instance, InstanceAnnotations)> {
         let (desc, blob) = self.get_layer(digest)?;
         ensure!(
@@ -349,6 +353,7 @@ impl<Base: Image> Artifact<Base> {
         ))
     }
 
+    #[tracing::instrument(skip_all, fields(digest = %digest))]
     pub fn get_parametric_instance(
         &mut self,
         digest: &Digest,

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -37,6 +37,7 @@ impl Evaluate for Instance {
     type Output = crate::Solution;
     type SampledOutput = crate::SampleSet;
 
+    #[tracing::instrument(skip_all)]
     fn evaluate(&self, state: &v1::State, atol: ATol) -> Result<Self::Output> {
         let state = self
             .analyze_decision_variables()
@@ -82,6 +83,7 @@ impl Evaluate for Instance {
         Ok(solution)
     }
 
+    #[tracing::instrument(skip_all)]
     fn evaluate_samples(
         &self,
         samples: &crate::Sampled<v1::State>,
@@ -146,6 +148,7 @@ impl Evaluate for Instance {
             .build()?)
     }
 
+    #[tracing::instrument(skip_all)]
     fn partial_evaluate(&mut self, state: &v1::State, atol: ATol) -> Result<()> {
         // Operate on a clone so that any failure leaves `self` unchanged (atomic).
         // Propagation consumes constraints via `self` in `Propagate`, so even a

--- a/rust/ommx/src/instance/log_encode.rs
+++ b/rust/ommx/src/instance/log_encode.rs
@@ -78,6 +78,7 @@ fn log_encoding_coefficients(bound: Bound) -> Result<(Vec<Coefficient>, f64), Lo
 
 impl Instance {
     /// Encode an integer decision variable into binary decision variables.
+    #[tracing::instrument(skip(self))]
     pub fn log_encode(&mut self, id: VariableID) -> Result<Linear, LogEncodingError> {
         let v = self
             .decision_variables

--- a/rust/ommx/src/instance/qubo.rs
+++ b/rust/ommx/src/instance/qubo.rs
@@ -14,6 +14,7 @@ impl Instance {
     ///   - TODO: Binary encoding will be added.
     /// - The degree of the objective is at most 2.
     ///
+    #[tracing::instrument(skip_all)]
     pub fn as_qubo_format(&self) -> Result<(BTreeMap<BinaryIdPair, f64>, f64)> {
         if self.sense() == Sense::Maximize {
             bail!("QUBO format is only for minimization problems.");
@@ -63,6 +64,7 @@ impl Instance {
     /// - The objective function uses only binary decision variables.
     ///   - TODO: Binary encoding will be added.
     ///
+    #[tracing::instrument(skip_all)]
     pub fn as_hubo_format(&self) -> Result<(BTreeMap<BinaryIds, f64>, f64)> {
         if self.sense() == Sense::Maximize {
             bail!("HUBO format is only for minimization problems.");

--- a/rust/ommx/src/mps.rs
+++ b/rust/ommx/src/mps.rs
@@ -66,12 +66,14 @@ use parser::*;
 use std::{io::Read, path::Path};
 
 /// Reads and parses the MPS file from the given [`Read`] source with automatic gzipped detection.
+#[tracing::instrument(skip_all)]
 pub fn parse(reader: impl Read) -> anyhow::Result<crate::Instance> {
     let mps_data = Mps::parse(reader)?;
     convert::convert(mps_data)
 }
 
 /// Reads and parses the file at the given path. Gzipped files are automatically detected and decompressed.
+#[tracing::instrument(skip_all, fields(path = %path.as_ref().display()))]
 pub fn load(path: impl AsRef<Path>) -> anyhow::Result<crate::Instance> {
     let mps_data = Mps::load(path)?;
     convert::convert(mps_data)
@@ -85,6 +87,10 @@ pub fn load(path: impl AsRef<Path>) -> anyhow::Result<crate::Instance> {
 /// ----------
 /// Only linear problems are supported. See [`format()`] for detailed information about information loss,
 /// removed constraints handling, and variable filtering behavior.
+#[tracing::instrument(
+    skip_all,
+    fields(path = %out_path.as_ref().display(), compress),
+)]
 pub fn save(
     instance: &crate::Instance,
     out_path: impl AsRef<Path>,

--- a/rust/ommx/src/mps.rs
+++ b/rust/ommx/src/mps.rs
@@ -73,7 +73,10 @@ pub fn parse(reader: impl Read) -> anyhow::Result<crate::Instance> {
 }
 
 /// Reads and parses the file at the given path. Gzipped files are automatically detected and decompressed.
-#[tracing::instrument(skip_all, fields(path = %path.as_ref().display()))]
+//
+// Note: the caller's path is intentionally not recorded as a span field to
+// avoid leaking local directory structure through exported telemetry.
+#[tracing::instrument(skip_all)]
 pub fn load(path: impl AsRef<Path>) -> anyhow::Result<crate::Instance> {
     let mps_data = Mps::load(path)?;
     convert::convert(mps_data)
@@ -87,10 +90,9 @@ pub fn load(path: impl AsRef<Path>) -> anyhow::Result<crate::Instance> {
 /// ----------
 /// Only linear problems are supported. See [`format()`] for detailed information about information loss,
 /// removed constraints handling, and variable filtering behavior.
-#[tracing::instrument(
-    skip_all,
-    fields(path = %out_path.as_ref().display(), compress),
-)]
+// Note: the caller's output path is intentionally not recorded as a span
+// field to avoid leaking local directory structure through exported telemetry.
+#[tracing::instrument(skip_all, fields(compress))]
 pub fn save(
     instance: &crate::Instance,
     out_path: impl AsRef<Path>,

--- a/rust/ommx/src/qplib.rs
+++ b/rust/ommx/src/qplib.rs
@@ -8,7 +8,10 @@ pub use parser::QplibFile;
 use std::{io::Read, path::Path};
 
 /// Reads and parses the file into a [`Instance`].
-#[tracing::instrument(skip_all, fields(path = %path.as_ref().display()))]
+//
+// Note: the caller's path is intentionally not recorded as a span field to
+// avoid leaking local directory structure through exported telemetry.
+#[tracing::instrument(skip_all)]
 pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Instance> {
     let data = QplibFile::load(path)?;
     let converted = convert::convert(data)?;

--- a/rust/ommx/src/qplib.rs
+++ b/rust/ommx/src/qplib.rs
@@ -8,6 +8,7 @@ pub use parser::QplibFile;
 use std::{io::Read, path::Path};
 
 /// Reads and parses the file into a [`Instance`].
+#[tracing::instrument(skip_all, fields(path = %path.as_ref().display()))]
 pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Instance> {
     let data = QplibFile::load(path)?;
     let converted = convert::convert(data)?;
@@ -15,6 +16,7 @@ pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Instance> {
 }
 
 /// Parses QPLIB data from a reader into a [`Instance`].
+#[tracing::instrument(skip_all)]
 pub fn parse(reader: impl Read) -> anyhow::Result<Instance> {
     let data = QplibFile::parse(reader)?;
     let converted = convert::convert(data)?;


### PR DESCRIPTION
Part of #817 (PR3).

Extends tracing instrumentation to the remaining meaningful entry points called out in the tracking issue. Users now get Rust spans from a much wider surface — serialization, QUBO conversion, evaluation, MPS/QPLIB I/O, and artifact reads — when they configure an OpenTelemetry `TracerProvider` on the Python side.

## Changes

### Dependency bump
- `pyo3-tracing-opentelemetry` 0.1.2 → 0.2.0 (dynamic span-processor resolution)

### PyO3 entries — `attach_parent_context`
- Serialization: `Solution/SampleSet/ParametricInstance.{from_bytes, to_bytes}`, `Instance.to_bytes`
- Conversion: `Instance.{penalty_method, uniform_penalty_method, as_qubo_format, as_hubo_format, log_encode}`
- File I/O: `Instance.{load_mps, save_mps, load_qplib}`
- `ArtifactBuilder.add_*` (instance, parametric_instance, solution, sample_set, ndarray, dataframe, json)
- `PyArtifact` getters and `get_*` methods (instance, solution, parametric_instance, sample_set, ndarray, dataframe, json, layer, blob, layer_descriptor)
- `miplib2017_instance_annotations`, `qplib_instance_annotations`

### Rust `#[tracing::instrument]`
- `Instance::{evaluate, evaluate_samples, partial_evaluate}`
- `Instance::{as_qubo_format, as_hubo_format, log_encode}` and `qubo_hubo_pipeline` (the PyO3-side helper)
- `mps::{parse, load, save}`, `qplib::{parse, load}`
- Artifact blob reads: `Artifact::{get_layer, get_solution, get_sample_set, get_instance, get_parametric_instance}`

## Tests

Two new end-to-end tests in `python/ommx-tests/tests/test_tracing.py`:

- `test_evaluate_emits_rust_span_under_python_parent` — asserts `Instance.evaluate` produces the `evaluate` Rust span and that its `trace_id` matches the Python parent span (context propagation).
- `test_to_qubo_emits_pipeline_spans` — asserts `Instance.to_qubo` exercises the nested pipeline and emits both `qubo_hubo_pipeline` and `as_qubo_format` spans.

## Test plan

- [x] `task rust:test` green
- [x] `task python:test` green (197 tests total, 5 tracing tests)
- [x] `cargo clippy -p ommx -p _ommx_rust` clean
- [x] `task format` applied

## Follow-ups (separate PRs under #817)

- PR4: Jupyter cell magic `%%ommx_trace` (text tree + Chrome Trace JSON download)
- PR5: Documentation (OTel setup guide, span naming rules, troubleshooting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)