### PR TITLE
Add %%ommx_trace Jupyter cell magic

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -21,6 +21,7 @@ Utilities
    ../autoapi/ommx/testing/index
    ../autoapi/ommx/mps/index
    ../autoapi/ommx/qplib/index
+   ../autoapi/ommx/tracing/index
 
 Adapters
 --------

--- a/python/ommx-tests/tests/test_tracing_magic.py
+++ b/python/ommx-tests/tests/test_tracing_magic.py
@@ -373,3 +373,68 @@ def test_load_ipython_extension_registers_magic(ipython_shell):
     rendering."""
     ipython_shell.extension_manager.load_extension("ommx.tracing")
     assert "ommx_trace" in ipython_shell.magics_manager.magics["cell"]
+
+
+def test_run_cell_with_trace_starts_a_fresh_trace(ipython_shell, cell_collector):
+    """The cell root span must *not* inherit an ambient trace context.
+
+    If ``start_as_current_span`` is called without detaching from the
+    current context, any ambient span (from another extension,
+    instrumentation library, or leftover ``with`` block in the user
+    namespace) bleeds into the cell's ``trace_id`` and the collector
+    captures unrelated spans. This test installs an ambient span,
+    emits a sibling span under it, runs a traced cell, and asserts
+    the cell's rendered tree contains only the cell's own spans.
+    """
+    _setup.reset_for_testing()
+    try:
+        outer_tracer = trace.get_tracer("ommx-tracing-magic-test.ambient")
+        with outer_tracer.start_as_current_span("ambient_parent") as ambient:
+            ambient_trace_id = ambient.get_span_context().trace_id
+            cell_collector.begin_capture(ambient_trace_id)
+            # A sibling span on the ambient trace — must stay out of
+            # the cell's output.
+            with outer_tracer.start_as_current_span("ambient_sibling"):
+                pass
+
+            html, exc = run_cell_with_trace(
+                ipython_shell,
+                "ommx_isolation_sentinel = 1",
+            )
+
+        assert exc is None
+        assert ipython_shell.user_ns.pop("ommx_isolation_sentinel") == 1
+        # The cell got a fresh trace, so neither ``ambient_sibling``
+        # nor the still-open ``ambient_parent`` leak into the rendered
+        # tree.
+        assert "ambient_sibling" not in html
+        assert "ambient_parent" not in html
+        assert "ommx_trace_cell" in html
+        # Defensive: spans produced on the ambient trace are still
+        # captured by the ambient-trace collector slot — they didn't
+        # silently migrate into the cell's slot.
+        ambient_spans = cell_collector.end_capture(ambient_trace_id)
+        assert "ambient_sibling" in {s.name for s in ambient_spans}
+    finally:
+        _setup.reset_for_testing()
+
+
+def test_run_cell_with_trace_supports_top_level_await(ipython_shell):
+    """Using ``shell.run_cell`` (rather than ``shell.ex``) preserves the
+    full IPython cell pipeline, including top-level ``await`` — so
+    ``%%ommx_trace`` stays observational for async cells."""
+    _setup.reset_for_testing()
+    try:
+        ipython_shell.user_ns.pop("ommx_await_sentinel", None)
+        html, exc = run_cell_with_trace(
+            ipython_shell,
+            "import asyncio\n"
+            "async def _probe():\n"
+            "    return 99\n"
+            "ommx_await_sentinel = await _probe()\n",
+        )
+        assert exc is None, exc
+        assert ipython_shell.user_ns["ommx_await_sentinel"] == 99
+        assert "ommx_trace_cell" in html
+    finally:
+        _setup.reset_for_testing()

--- a/python/ommx-tests/tests/test_tracing_magic.py
+++ b/python/ommx-tests/tests/test_tracing_magic.py
@@ -330,9 +330,10 @@ def test_run_cell_with_trace_exec_user_code(ipython_shell):
 
 
 def test_run_cell_with_trace_reports_cell_exceptions(ipython_shell):
-    """A cell that raises still produces HTML output. ``run_cell`` handles
-    the traceback display; we only need to see the exception surfaced on
-    the return tuple for programmatic inspection."""
+    """A cell that raises still produces HTML output. The caller
+    (``register_magic``) is responsible for re-raising so failure
+    semantics propagate to outer automation; :func:`run_cell_with_trace`
+    itself surfaces the exception on the return tuple."""
     _setup.reset_for_testing()
     try:
         html, exc = run_cell_with_trace(
@@ -344,6 +345,23 @@ def test_run_cell_with_trace_reports_cell_exceptions(ipython_shell):
         # The root span closes even when the cell body raised, so its
         # name must appear in the rendered text tree.
         assert "ommx_trace_cell" in html
+    finally:
+        _setup.reset_for_testing()
+
+
+def test_magic_reraises_cell_exception(ipython_shell):
+    """The registered ``%%ommx_trace`` magic must propagate exceptions
+    from the cell body; otherwise notebook automation
+    (``nbconvert --execute``, papermill) would silently treat failed
+    traced cells as successful."""
+    import pytest
+
+    _setup.reset_for_testing()
+    try:
+        ipython_shell.extension_manager.load_extension("ommx.tracing")
+        magic_fn = ipython_shell.magics_manager.magics["cell"]["ommx_trace"]
+        with pytest.raises(ValueError, match="boom"):
+            magic_fn("", "raise ValueError('boom')")
     finally:
         _setup.reset_for_testing()
 

--- a/python/ommx-tests/tests/test_tracing_magic.py
+++ b/python/ommx-tests/tests/test_tracing_magic.py
@@ -1,0 +1,328 @@
+"""End-to-end tests for ``ommx.tracing`` (the ``%%ommx_trace`` cell magic).
+
+The magic is supposed to:
+
+1. Wrap a cell in a single OTel root span.
+2. Collect every span emitted during the cell (including Rust spans
+   forwarded by ``pyo3-tracing-opentelemetry``).
+3. Render a text tree and attach a Chrome Trace JSON download link.
+
+These tests exercise the collector and renderers directly for focused
+unit coverage, then drive the full magic through an ``IPython`` shell
+to verify the integration end-to-end.
+
+The session-scoped ``TracerProvider`` installed by :mod:`conftest` is
+reused throughout: OTel refuses to swap providers once set, so tests
+share the same one and distinguish runs by ``trace_id``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+import urllib.parse
+
+import pytest
+from opentelemetry import trace
+
+from ommx.tracing import _setup
+from ommx.tracing._collector import _CellSpanCollector
+from ommx.tracing._magic import run_cell_with_trace
+from ommx.tracing._render import (
+    chrome_trace_json,
+    render_cell_output_html,
+    render_text_tree,
+    to_chrome_trace,
+)
+
+from conftest import get_test_provider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_collector():
+    """A collector attached to the session provider for the test's use.
+
+    Each test gets its own collector instance so ``pop_trace`` does not
+    have to guard against spans from previous tests. The collector is
+    left attached for the session — we cannot remove processors from an
+    SDK provider without reaching into private attributes, and the
+    session exporter continues to receive spans regardless, so this only
+    costs a little per-span work.
+    """
+    _setup.reset_for_testing()
+    provider = get_test_provider()
+    collector = _CellSpanCollector()
+    provider.add_span_processor(collector)
+    yield collector
+    _setup.reset_for_testing()
+
+
+def _run_and_collect(collector: _CellSpanCollector, cell_fn):
+    """Run ``cell_fn`` inside a fresh root span and return its spans.
+
+    Uses the global tracer so trace-context propagation matches what the
+    real cell magic does.
+    """
+    tracer = trace.get_tracer("ommx-tracing-magic-test")
+    with tracer.start_as_current_span("root") as root:
+        trace_id = root.get_span_context().trace_id
+        cell_fn(tracer)
+    return collector.pop_trace(trace_id)
+
+
+# ---------------------------------------------------------------------------
+# Collector
+# ---------------------------------------------------------------------------
+
+
+def test_collector_groups_spans_by_trace_id(fresh_collector):
+    """``pop_trace`` returns exactly the spans tagged with that ``trace_id``."""
+    tracer = trace.get_tracer("ommx-tracing-magic-test")
+
+    with tracer.start_as_current_span("cell_a") as a:
+        trace_id_a = a.get_span_context().trace_id
+        with tracer.start_as_current_span("child_a"):
+            pass
+    with tracer.start_as_current_span("cell_b") as b:
+        trace_id_b = b.get_span_context().trace_id
+
+    assert trace_id_a != trace_id_b
+    spans_a = fresh_collector.pop_trace(trace_id_a)
+    spans_b = fresh_collector.pop_trace(trace_id_b)
+    assert sorted(s.name for s in spans_a) == ["cell_a", "child_a"]
+    assert sorted(s.name for s in spans_b) == ["cell_b"]
+
+    # Second pop for the same trace returns an empty list — the collector
+    # must not accumulate state.
+    assert fresh_collector.pop_trace(trace_id_a) == []
+
+
+def test_collector_is_threadsafe(fresh_collector):
+    """The collector is called from exporter threads; concurrent writes
+    must not lose spans or corrupt the internal dict."""
+    tracer = trace.get_tracer("ommx-tracing-magic-test")
+
+    root_trace_ids: list[int] = []
+
+    def worker():
+        with tracer.start_as_current_span("worker_root") as root:
+            root_trace_ids.append(root.get_span_context().trace_id)
+            for _ in range(20):
+                with tracer.start_as_current_span("work"):
+                    time.sleep(0.0001)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # One root span + 20 inner spans per worker = 21 per thread.
+    total = sum(len(fresh_collector.pop_trace(tid)) for tid in root_trace_ids)
+    assert total == 4 * 21
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_tree_reflects_nesting(fresh_collector):
+    """Children appear indented under their parent, not as siblings."""
+
+    def cell(tracer):
+        with tracer.start_as_current_span("outer"):
+            with tracer.start_as_current_span("inner"):
+                pass
+
+    spans = _run_and_collect(fresh_collector, cell)
+    tree = render_text_tree(spans)
+
+    # ``root`` is the cell's root; ``outer`` is a child; ``inner`` is a
+    # grandchild. The indent on ``inner`` must be strictly greater than
+    # on ``outer`` for the tree to be useful.
+    outer_line = next(line for line in tree.splitlines() if "outer" in line)
+    inner_line = next(line for line in tree.splitlines() if "inner" in line)
+    outer_indent = len(outer_line) - len(outer_line.lstrip())
+    inner_indent = len(inner_line) - len(inner_line.lstrip())
+    assert inner_indent > outer_indent
+
+
+def test_render_text_tree_handles_empty():
+    assert render_text_tree([]) == "(no spans)"
+
+
+def test_chrome_trace_is_valid_json_with_X_events(fresh_collector):
+    """Chrome-trace JSON must parse, every event has ``ph: 'X'``, and
+    durations are in microseconds (positive integers)."""
+
+    def cell(tracer):
+        with tracer.start_as_current_span("work") as span:
+            span.set_attribute("batch_size", 42)
+
+    spans = _run_and_collect(fresh_collector, cell)
+    payload = chrome_trace_json(spans)
+    parsed = json.loads(payload)
+
+    assert parsed["displayTimeUnit"] == "ms"
+    events = parsed["traceEvents"]
+    # Two events: the synthetic ``root`` and the inner ``work`` span.
+    assert {e["name"] for e in events} == {"root", "work"}
+    for ev in events:
+        assert ev["ph"] == "X"
+        assert isinstance(ev["ts"], int) and ev["ts"] > 0
+        assert isinstance(ev["dur"], int) and ev["dur"] >= 1
+
+    work = next(e for e in events if e["name"] == "work")
+    assert work["args"]["batch_size"] == 42
+
+
+def test_chrome_trace_skips_open_spans():
+    """Spans without an ``end_time`` must be omitted — they would emit a
+    zero-duration event and confuse Perfetto."""
+    from typing import cast
+
+    from opentelemetry.sdk.trace import ReadableSpan
+
+    class _Fake:
+        name = "still_running"
+        start_time = 1_000_000_000
+        end_time = None
+        attributes: dict = {}
+
+    # The renderer only touches ``start_time``/``end_time``/``attributes``/
+    # ``name``; a duck-typed stand-in is enough. Cast through ``ReadableSpan``
+    # to keep pyright quiet without materializing a full span.
+    result = to_chrome_trace([cast(ReadableSpan, _Fake())])
+    assert result["traceEvents"] == []
+
+
+def test_cell_html_contains_download_link(fresh_collector):
+    """The HTML blob must carry a base64 data URL the browser can download."""
+
+    def cell(tracer):
+        with tracer.start_as_current_span("work"):
+            pass
+
+    spans = _run_and_collect(fresh_collector, cell)
+    html = render_cell_output_html(spans, download_filename="cell.json")
+
+    assert "<pre>" in html
+    assert 'download="cell.json"' in html
+
+    # Extract the data URL payload and make sure it roundtrips as JSON.
+    marker = 'href="data:application/json;base64,'
+    start = html.index(marker) + len(marker)
+    end = html.index('"', start)
+    b64 = html[start:end]
+    decoded = base64.b64decode(urllib.parse.unquote(b64)).decode("utf-8")
+    parsed = json.loads(decoded)
+    assert parsed["traceEvents"]
+
+
+# ---------------------------------------------------------------------------
+# Setup: installing the collector onto the session provider
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_collector_installed_is_idempotent():
+    """Repeated calls must return the same cached collector so we do not
+    keep appending processors to the provider across magic invocations."""
+    _setup.reset_for_testing()
+    try:
+        first = _setup.ensure_collector_installed()
+        second = _setup.ensure_collector_installed()
+        assert first is second
+    finally:
+        _setup.reset_for_testing()
+
+
+def test_ensure_collector_does_not_replace_existing_processors():
+    """Pre-existing span processors continue to see spans after the
+    collector is installed."""
+    from conftest import get_test_exporter
+
+    exporter = get_test_exporter()
+    exporter.clear()
+    _setup.reset_for_testing()
+    try:
+        _setup.ensure_collector_installed()
+
+        tracer = trace.get_tracer("ommx-tracing-magic-test")
+        with tracer.start_as_current_span("verify"):
+            pass
+
+        get_test_provider().force_flush()
+        assert any(s.name == "verify" for s in exporter.spans), (
+            "The pre-existing session exporter stopped receiving spans "
+            "after the cell collector was attached."
+        )
+    finally:
+        _setup.reset_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through an IPython shell
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ipython_shell():
+    from IPython.testing.globalipapp import get_ipython
+
+    shell = get_ipython()
+    assert shell is not None
+    return shell
+
+
+def test_run_cell_with_trace_exec_user_code(ipython_shell):
+    """The cell body actually runs in the user namespace — the assignment
+    becomes visible to subsequent cells."""
+    _setup.reset_for_testing()
+    try:
+        ipython_shell.user_ns.pop("ommx_trace_test_sentinel", None)
+
+        html, exc = run_cell_with_trace(
+            ipython_shell,
+            "ommx_trace_test_sentinel = 7",
+        )
+
+        assert exc is None
+        assert ipython_shell.user_ns["ommx_trace_test_sentinel"] == 7
+        assert "Download Chrome Trace JSON" in html
+    finally:
+        _setup.reset_for_testing()
+
+
+def test_run_cell_with_trace_reports_cell_exceptions(ipython_shell):
+    """A cell that raises still produces HTML output, and the exception
+    is reported back to the caller so IPython can show a traceback."""
+    _setup.reset_for_testing()
+    try:
+        html, exc = run_cell_with_trace(
+            ipython_shell,
+            "raise ValueError('boom')",
+        )
+        assert isinstance(exc, ValueError)
+        assert "boom" in str(exc)
+        # The root span closes even when the cell body raised, so its
+        # name must appear in the rendered text tree.
+        assert "ommx_trace_cell" in html
+    finally:
+        _setup.reset_for_testing()
+
+
+def test_load_ipython_extension_registers_magic(ipython_shell):
+    """After ``%load_ext ommx.tracing`` the shell knows about
+    ``%%ommx_trace``. We check the magic registry directly rather than
+    parsing cell output, to avoid depending on IPython's HTML
+    rendering."""
+    ipython_shell.extension_manager.load_extension("ommx.tracing")
+    assert "ommx_trace" in ipython_shell.magics_manager.magics["cell"]

--- a/python/ommx-tests/tests/test_tracing_magic.py
+++ b/python/ommx-tests/tests/test_tracing_magic.py
@@ -3,8 +3,8 @@
 The magic is supposed to:
 
 1. Wrap a cell in a single OTel root span.
-2. Collect every span emitted during the cell (including Rust spans
-   forwarded by ``pyo3-tracing-opentelemetry``).
+2. Collect only that cell's spans (including Rust spans forwarded by
+   ``pyo3-tracing-opentelemetry``).
 3. Render a text tree and attach a Chrome Trace JSON download link.
 
 These tests exercise the collector and renderers directly for focused
@@ -41,40 +41,47 @@ from conftest import get_test_provider
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def fresh_collector():
-    """A collector attached to the session provider for the test's use.
+# A single collector is attached to the session provider and reused by every
+# test to avoid piling ``SpanProcessor`` instances on the provider each run.
+# The collector only retains spans for traces opened via ``begin_capture``,
+# so between-test state only lives inside ``_active_traces`` /
+# ``_spans_by_trace`` — both cleared in the fixture below.
+_SESSION_COLLECTOR: _CellSpanCollector | None = None
 
-    Each test gets its own collector instance so ``pop_trace`` does not
-    have to guard against spans from previous tests. The collector is
-    left attached for the session — we cannot remove processors from an
-    SDK provider without reaching into private attributes, and the
-    session exporter continues to receive spans regardless, so this only
-    costs a little per-span work.
+
+@pytest.fixture
+def cell_collector():
+    """Return a session-wide collector with per-test state cleared.
+
+    Rebuilding the collector every test attaches a new ``SpanProcessor``
+    to the SDK provider — OTel does not expose a clean removal API, so
+    those processors would accumulate. Reuse is both cheaper and
+    exercises the real long-lived notebook behaviour.
     """
+    global _SESSION_COLLECTOR
     _setup.reset_for_testing()
-    provider = get_test_provider()
-    collector = _CellSpanCollector()
-    provider.add_span_processor(collector)
-    yield collector
+    if _SESSION_COLLECTOR is None:
+        _SESSION_COLLECTOR = _CellSpanCollector()
+        get_test_provider().add_span_processor(_SESSION_COLLECTOR)
+    # Drop any leftover state from a previous test.
+    _SESSION_COLLECTOR.shutdown()
+    yield _SESSION_COLLECTOR
     _setup.reset_for_testing()
+    _SESSION_COLLECTOR.shutdown()
 
 
 def _run_and_collect(collector: _CellSpanCollector, cell_fn):
-    """Run ``cell_fn`` inside a fresh root span and return its spans.
-
-    Uses the global tracer so trace-context propagation matches what the
-    real cell magic does.
-    """
+    """Run ``cell_fn`` under a root span, using ``begin/end_capture``."""
     tracer = trace.get_tracer("ommx-tracing-magic-test")
     with tracer.start_as_current_span("root") as root:
         trace_id = root.get_span_context().trace_id
+        collector.begin_capture(trace_id)
         cell_fn(tracer)
-    return collector.pop_trace(trace_id)
+    return collector.end_capture(trace_id)
 
 
 # ---------------------------------------------------------------------------
@@ -82,41 +89,58 @@ def _run_and_collect(collector: _CellSpanCollector, cell_fn):
 # ---------------------------------------------------------------------------
 
 
-def test_collector_groups_spans_by_trace_id(fresh_collector):
-    """``pop_trace`` returns exactly the spans tagged with that ``trace_id``."""
+def test_collector_captures_only_active_traces(cell_collector):
+    """Spans outside a ``begin_capture`` window are dropped immediately —
+    this is the guard that keeps memory bounded in long-lived notebooks."""
     tracer = trace.get_tracer("ommx-tracing-magic-test")
 
-    with tracer.start_as_current_span("cell_a") as a:
-        trace_id_a = a.get_span_context().trace_id
-        with tracer.start_as_current_span("child_a"):
+    # Emit a span with no capture open. It must not be retained.
+    with tracer.start_as_current_span("background"):
+        pass
+
+    # Now open a capture and emit a span — this one should be kept.
+    with tracer.start_as_current_span("cell") as cell:
+        trace_id = cell.get_span_context().trace_id
+        cell_collector.begin_capture(trace_id)
+        with tracer.start_as_current_span("inner"):
             pass
-    with tracer.start_as_current_span("cell_b") as b:
-        trace_id_b = b.get_span_context().trace_id
 
-    assert trace_id_a != trace_id_b
-    spans_a = fresh_collector.pop_trace(trace_id_a)
-    spans_b = fresh_collector.pop_trace(trace_id_b)
-    assert sorted(s.name for s in spans_a) == ["cell_a", "child_a"]
-    assert sorted(s.name for s in spans_b) == ["cell_b"]
-
-    # Second pop for the same trace returns an empty list — the collector
-    # must not accumulate state.
-    assert fresh_collector.pop_trace(trace_id_a) == []
+    captured = cell_collector.end_capture(trace_id)
+    captured_names = sorted(s.name for s in captured)
+    # ``background`` was dropped; ``cell`` + ``inner`` were kept.
+    assert captured_names == ["cell", "inner"]
+    assert not cell_collector._spans_by_trace  # noqa: SLF001 - test-only reach-in
 
 
-def test_collector_is_threadsafe(fresh_collector):
-    """The collector is called from exporter threads; concurrent writes
-    must not lose spans or corrupt the internal dict."""
+def test_collector_pop_is_single_use(cell_collector):
+    """``end_capture`` removes the entries and discards the trace_id from
+    the active set, so a second call returns empty."""
     tracer = trace.get_tracer("ommx-tracing-magic-test")
 
-    root_trace_ids: list[int] = []
+    with tracer.start_as_current_span("cell") as cell:
+        trace_id = cell.get_span_context().trace_id
+        cell_collector.begin_capture(trace_id)
+
+    first = cell_collector.end_capture(trace_id)
+    second = cell_collector.end_capture(trace_id)
+    assert len(first) == 1
+    assert second == []
+
+
+def test_collector_is_threadsafe(cell_collector):
+    """``on_end`` is called from exporter threads; concurrent captures
+    must not lose spans or corrupt internal state."""
+    tracer = trace.get_tracer("ommx-tracing-magic-test")
+    captured: list[int] = []
 
     def worker():
         with tracer.start_as_current_span("worker_root") as root:
-            root_trace_ids.append(root.get_span_context().trace_id)
+            tid = root.get_span_context().trace_id
+            cell_collector.begin_capture(tid)
             for _ in range(20):
                 with tracer.start_as_current_span("work"):
                     time.sleep(0.0001)
+        captured.append(len(cell_collector.end_capture(tid)))
 
     threads = [threading.Thread(target=worker) for _ in range(4)]
     for t in threads:
@@ -124,9 +148,8 @@ def test_collector_is_threadsafe(fresh_collector):
     for t in threads:
         t.join()
 
-    # One root span + 20 inner spans per worker = 21 per thread.
-    total = sum(len(fresh_collector.pop_trace(tid)) for tid in root_trace_ids)
-    assert total == 4 * 21
+    # Each worker sees its root + 20 inner = 21 spans.
+    assert captured == [21] * 4
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +157,7 @@ def test_collector_is_threadsafe(fresh_collector):
 # ---------------------------------------------------------------------------
 
 
-def test_render_text_tree_reflects_nesting(fresh_collector):
+def test_render_text_tree_reflects_nesting(cell_collector):
     """Children appear indented under their parent, not as siblings."""
 
     def cell(tracer):
@@ -142,12 +165,9 @@ def test_render_text_tree_reflects_nesting(fresh_collector):
             with tracer.start_as_current_span("inner"):
                 pass
 
-    spans = _run_and_collect(fresh_collector, cell)
+    spans = _run_and_collect(cell_collector, cell)
     tree = render_text_tree(spans)
 
-    # ``root`` is the cell's root; ``outer`` is a child; ``inner`` is a
-    # grandchild. The indent on ``inner`` must be strictly greater than
-    # on ``outer`` for the tree to be useful.
     outer_line = next(line for line in tree.splitlines() if "outer" in line)
     inner_line = next(line for line in tree.splitlines() if "inner" in line)
     outer_indent = len(outer_line) - len(outer_line.lstrip())
@@ -159,7 +179,7 @@ def test_render_text_tree_handles_empty():
     assert render_text_tree([]) == "(no spans)"
 
 
-def test_chrome_trace_is_valid_json_with_X_events(fresh_collector):
+def test_chrome_trace_is_valid_json_with_X_events(cell_collector):
     """Chrome-trace JSON must parse, every event has ``ph: 'X'``, and
     durations are in microseconds (positive integers)."""
 
@@ -167,7 +187,7 @@ def test_chrome_trace_is_valid_json_with_X_events(fresh_collector):
         with tracer.start_as_current_span("work") as span:
             span.set_attribute("batch_size", 42)
 
-    spans = _run_and_collect(fresh_collector, cell)
+    spans = _run_and_collect(cell_collector, cell)
     payload = chrome_trace_json(spans)
     parsed = json.loads(payload)
 
@@ -204,20 +224,19 @@ def test_chrome_trace_skips_open_spans():
     assert result["traceEvents"] == []
 
 
-def test_cell_html_contains_download_link(fresh_collector):
+def test_cell_html_contains_download_link(cell_collector):
     """The HTML blob must carry a base64 data URL the browser can download."""
 
     def cell(tracer):
         with tracer.start_as_current_span("work"):
             pass
 
-    spans = _run_and_collect(fresh_collector, cell)
+    spans = _run_and_collect(cell_collector, cell)
     html = render_cell_output_html(spans, download_filename="cell.json")
 
     assert "<pre>" in html
     assert 'download="cell.json"' in html
 
-    # Extract the data URL payload and make sure it roundtrips as JSON.
     marker = 'href="data:application/json;base64,'
     start = html.index(marker) + len(marker)
     end = html.index('"', start)
@@ -225,6 +244,15 @@ def test_cell_html_contains_download_link(fresh_collector):
     decoded = base64.b64decode(urllib.parse.unquote(b64)).decode("utf-8")
     parsed = json.loads(decoded)
     assert parsed["traceEvents"]
+
+
+def test_cell_html_escapes_download_filename_for_attribute():
+    """A filename containing a quote must not break out of the
+    ``download`` attribute — otherwise arbitrary HTML could be injected."""
+    html = render_cell_output_html([], download_filename='"><script>alert(1)</script>')
+    assert "<script>" not in html
+    # Raw quote must not terminate the attribute prematurely.
+    assert 'download=""><script>' not in html
 
 
 # ---------------------------------------------------------------------------
@@ -302,8 +330,9 @@ def test_run_cell_with_trace_exec_user_code(ipython_shell):
 
 
 def test_run_cell_with_trace_reports_cell_exceptions(ipython_shell):
-    """A cell that raises still produces HTML output, and the exception
-    is reported back to the caller so IPython can show a traceback."""
+    """A cell that raises still produces HTML output. ``run_cell`` handles
+    the traceback display; we only need to see the exception surfaced on
+    the return tuple for programmatic inspection."""
     _setup.reset_for_testing()
     try:
         html, exc = run_cell_with_trace(

--- a/python/ommx/ommx/tracing/__init__.py
+++ b/python/ommx/ommx/tracing/__init__.py
@@ -15,9 +15,11 @@ plus a download link for the full trace in Chrome Trace Event Format.
 The public surface is intentionally tiny:
 
 * :func:`load_ipython_extension` — wired by ``%load_ext ommx.tracing``;
-  installs the ``%%ommx_trace`` cell magic and attaches a collector to
-  the active OpenTelemetry ``TracerProvider`` (creating one if none
-  exists).
+  registers the ``%%ommx_trace`` cell magic. The collector itself is
+  attached to the active OpenTelemetry ``TracerProvider`` lazily, on
+  the first traced cell, so ``%load_ext`` stays cheap and cannot fail
+  due to provider state that is still being configured further up the
+  notebook.
 * :func:`unload_ipython_extension` — pair for ``%unload_ext``. Kept as a
   no-op because IPython magics cannot be cleanly unregistered without
   disturbing user state; leaving the collector installed costs nothing.

--- a/python/ommx/ommx/tracing/__init__.py
+++ b/python/ommx/ommx/tracing/__init__.py
@@ -1,0 +1,62 @@
+"""Per-cell tracing for Jupyter/IPython.
+
+Usage::
+
+    %load_ext ommx.tracing
+
+    %%ommx_trace
+    instance = Instance.from_bytes(blob)
+    solution = instance.evaluate(state)
+
+Cell output shows a nested text tree of every span produced during the
+cell (Rust and Python alike), annotated with durations and attributes,
+plus a download link for the full trace in Chrome Trace Event Format.
+
+The public surface is intentionally tiny:
+
+* :func:`load_ipython_extension` — wired by ``%load_ext ommx.tracing``;
+  installs the ``%%ommx_trace`` cell magic and attaches a collector to
+  the active OpenTelemetry ``TracerProvider`` (creating one if none
+  exists).
+* :func:`unload_ipython_extension` — pair for ``%unload_ext``. Kept as a
+  no-op because IPython magics cannot be cleanly unregistered without
+  disturbing user state; leaving the collector installed costs nothing.
+
+Everything else (``_collector``, ``_render``, ``_setup``, ``_magic``) is
+internal and may change without notice. Reach for them only if you are
+building on top of this module and can tolerate breakage.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from IPython.core.interactiveshell import InteractiveShell
+
+
+__all__ = ["load_ipython_extension", "unload_ipython_extension"]
+
+
+def load_ipython_extension(ipython: "InteractiveShell") -> None:
+    """Register the ``%%ommx_trace`` cell magic on ``ipython``.
+
+    Invoked by IPython when the user runs ``%load_ext ommx.tracing``.
+    Safe to call more than once — later calls are no-ops since IPython
+    dedupes magics by name.
+    """
+    from ._magic import register_magic
+
+    register_magic(ipython)
+
+
+def unload_ipython_extension(ipython: "InteractiveShell") -> None:
+    """IPython extension hook, kept as a no-op.
+
+    Removing a previously-registered magic leaves the shell in an
+    awkward state (the name still resolves for tab completion), and
+    there is no user-observable state to tear down — the collector
+    sheds its entries on retrieval already.
+    """
+    del ipython

--- a/python/ommx/ommx/tracing/_collector.py
+++ b/python/ommx/ommx/tracing/_collector.py
@@ -1,0 +1,58 @@
+"""Collect finished OTel spans keyed by ``trace_id``.
+
+``%%ommx_trace`` creates a root span for each cell and asks this collector
+for every span that shares that cell's ``trace_id``. The cell magic is
+the only expected caller — this module does not define a public API.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Dict, List
+
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+
+
+class _CellSpanCollector(SpanProcessor):
+    """``SpanProcessor`` that stashes finished spans by ``trace_id``.
+
+    The collector is registered once per ``TracerProvider`` (see
+    :func:`._setup.ensure_collector_installed`) and lives for the duration
+    of the notebook session. The cell magic retrieves and then discards
+    the entries for its own ``trace_id`` to keep memory bounded.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._spans_by_trace: Dict[int, List[ReadableSpan]] = {}
+
+    # ---- SpanProcessor API -------------------------------------------------
+
+    def on_start(self, span, parent_context=None) -> None:  # type: ignore[override]
+        # Collection happens on end; nothing to do when a span starts.
+        pass
+
+    def on_end(self, span: ReadableSpan) -> None:  # type: ignore[override]
+        ctx = span.context
+        if ctx is None:
+            return
+        with self._lock:
+            self._spans_by_trace.setdefault(ctx.trace_id, []).append(span)
+
+    def shutdown(self) -> None:  # type: ignore[override]
+        with self._lock:
+            self._spans_by_trace.clear()
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:  # type: ignore[override]
+        return True
+
+    # ---- Cell-magic facing ------------------------------------------------
+
+    def pop_trace(self, trace_id: int) -> List[ReadableSpan]:
+        """Return (and remove) spans collected for ``trace_id``.
+
+        Entries are removed on retrieval so the collector does not
+        accumulate state across cells.
+        """
+        with self._lock:
+            return self._spans_by_trace.pop(trace_id, [])

--- a/python/ommx/ommx/tracing/_collector.py
+++ b/python/ommx/ommx/tracing/_collector.py
@@ -1,29 +1,26 @@
-"""Collect finished OTel spans keyed by ``trace_id``.
+"""Collect finished OTel spans for active cell traces.
 
-``%%ommx_trace`` creates a root span for each cell and asks this collector
-for every span that shares that cell's ``trace_id``. The cell magic is
-the only expected caller — this module does not define a public API.
+``%%ommx_trace`` brackets each cell with :meth:`begin_capture` and
+:meth:`end_capture` calls on the collector. Spans whose ``trace_id`` is
+not between a matching begin/end pair are dropped immediately — without
+this gate, a long-lived notebook with other instrumentation would leak
+memory as unrelated traces accumulated in :attr:`_spans_by_trace`.
 """
 
 from __future__ import annotations
 
 import threading
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 
 
 class _CellSpanCollector(SpanProcessor):
-    """``SpanProcessor`` that stashes finished spans by ``trace_id``.
-
-    The collector is registered once per ``TracerProvider`` (see
-    :func:`._setup.ensure_collector_installed`) and lives for the duration
-    of the notebook session. The cell magic retrieves and then discards
-    the entries for its own ``trace_id`` to keep memory bounded.
-    """
+    """``SpanProcessor`` that stashes spans for explicitly captured traces."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._active_traces: Set[int] = set()
         self._spans_by_trace: Dict[int, List[ReadableSpan]] = {}
 
     # ---- SpanProcessor API -------------------------------------------------
@@ -37,10 +34,15 @@ class _CellSpanCollector(SpanProcessor):
         if ctx is None:
             return
         with self._lock:
+            if ctx.trace_id not in self._active_traces:
+                # Span from unrelated instrumentation; dropping avoids
+                # unbounded memory growth in long-lived notebooks.
+                return
             self._spans_by_trace.setdefault(ctx.trace_id, []).append(span)
 
     def shutdown(self) -> None:  # type: ignore[override]
         with self._lock:
+            self._active_traces.clear()
             self._spans_by_trace.clear()
 
     def force_flush(self, timeout_millis: int = 30_000) -> bool:  # type: ignore[override]
@@ -48,11 +50,21 @@ class _CellSpanCollector(SpanProcessor):
 
     # ---- Cell-magic facing ------------------------------------------------
 
-    def pop_trace(self, trace_id: int) -> List[ReadableSpan]:
-        """Return (and remove) spans collected for ``trace_id``.
+    def begin_capture(self, trace_id: int) -> None:
+        """Start collecting spans tagged with ``trace_id``.
 
-        Entries are removed on retrieval so the collector does not
-        accumulate state across cells.
+        Must be paired with :meth:`end_capture`. Re-registering the same
+        ``trace_id`` while it is still active is a no-op.
         """
         with self._lock:
+            self._active_traces.add(trace_id)
+
+    def end_capture(self, trace_id: int) -> List[ReadableSpan]:
+        """Stop collecting ``trace_id`` and return the spans gathered so far.
+
+        Also drops the trace_id from the active set so any late-arriving
+        spans are discarded rather than retained.
+        """
+        with self._lock:
+            self._active_traces.discard(trace_id)
             return self._spans_by_trace.pop(trace_id, [])

--- a/python/ommx/ommx/tracing/_magic.py
+++ b/python/ommx/ommx/tracing/_magic.py
@@ -1,0 +1,71 @@
+"""``%%ommx_trace`` cell magic implementation.
+
+Registered via ``%load_ext ommx.tracing``. The magic wraps cell execution
+in a single OTel root span, collects every span emitted during the cell
+through :mod:`._collector`, and displays a text tree plus a Chrome Trace
+JSON download link as the cell output.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+from opentelemetry import trace
+
+from ._render import render_cell_output_html
+from ._setup import ensure_collector_installed
+
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from IPython.core.interactiveshell import InteractiveShell
+
+
+_CELL_TRACER_NAME = "ommx.tracing.cell"
+_CELL_ROOT_SPAN_NAME = "ommx_trace_cell"
+
+
+def run_cell_with_trace(
+    shell: "InteractiveShell",
+    cell: str,
+) -> Tuple[str, Optional[BaseException]]:
+    """Execute ``cell`` inside an ``ommx_trace_cell`` root span.
+
+    Returns ``(html_blob, exc)`` where ``html_blob`` is the rendered
+    trace output (always produced, even if the cell raised) and ``exc``
+    is the exception that escaped the cell, or ``None``. The caller is
+    responsible for displaying the HTML and re-raising the exception —
+    that split keeps this function testable without IPython's display
+    machinery in scope.
+    """
+    collector = ensure_collector_installed()
+    tracer = trace.get_tracer(_CELL_TRACER_NAME)
+
+    cell_exc: Optional[BaseException] = None
+    with tracer.start_as_current_span(_CELL_ROOT_SPAN_NAME) as root:
+        trace_id = root.get_span_context().trace_id
+        try:
+            shell.ex(cell)
+        except BaseException as exc:  # noqa: BLE001 - re-raised by caller
+            cell_exc = exc
+
+    spans = collector.pop_trace(trace_id)
+    return render_cell_output_html(spans), cell_exc
+
+
+def register_magic(shell: "InteractiveShell") -> None:
+    """Attach ``%%ommx_trace`` to ``shell``. Called from ``load_ipython_extension``."""
+    from IPython.core.magic import register_cell_magic
+    from IPython.display import HTML, display
+
+    @register_cell_magic("ommx_trace")  # type: ignore[misc]
+    def _ommx_trace(line: str, cell: str) -> None:
+        # ``line`` is unused in the MVP; reserved for future flags
+        # (e.g. a filename override for the download link).
+        del line
+        html_blob, cell_exc = run_cell_with_trace(shell, cell)
+        display(HTML(html_blob))
+        if cell_exc is not None:
+            raise cell_exc
+
+    # Reference for static analysers; decorator already installed the magic.
+    del _ommx_trace

--- a/python/ommx/ommx/tracing/_magic.py
+++ b/python/ommx/ommx/tracing/_magic.py
@@ -4,19 +4,26 @@ Registered via ``%load_ext ommx.tracing``. The magic wraps cell execution
 in a single OTel root span, asks :class:`._collector._CellSpanCollector`
 to stash only that trace's spans, and displays the result as HTML.
 
-Cell-body execution goes through :meth:`InteractiveShell.ex` rather
-than :meth:`InteractiveShell.run_cell`: we want the exception raised by
-the user's cell to propagate naturally so the outer (magic-invoking)
-``run_cell`` reports the failure to upstream automation
-(``nbconvert --execute``, papermill, pytest-nbval, …). ``run_cell``
-captures and displays the exception itself, which would either swallow
-it or double-display the traceback once we re-raise.
+Cell-body execution goes through :meth:`InteractiveShell.run_cell` so
+the full IPython pipeline — input transforms, top-level ``await``, line
+magics, cell-input cleanups — behaves the way it would in an untraced
+cell. The point is that ``%%ommx_trace`` should be observational: a
+user removes the magic, the cell body still does the same thing.
+
+Re-raising without a double traceback is slightly delicate. ``run_cell``
+catches exceptions internally and calls ``shell.showtraceback()`` before
+returning; if we then re-raise the captured exception, the *outer*
+``run_cell`` (the one that invoked our magic) prints it a second time.
+We work around that by temporarily pointing ``shell.showtraceback`` at
+a no-op during the inner call, so the traceback is shown exactly once —
+by the outer ``run_cell`` when our re-raise reaches it.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Tuple
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 
 from ._render import render_cell_output_html
@@ -35,18 +42,21 @@ def run_cell_with_trace(
     shell: "InteractiveShell",
     cell: str,
 ) -> Tuple[str, Optional[BaseException]]:
-    """Execute ``cell`` inside an ``ommx_trace_cell`` root span.
+    """Execute ``cell`` inside a fresh ``ommx_trace_cell`` root span.
 
     Returns ``(html_blob, error)`` where ``html_blob`` is the rendered
-    trace output (always produced, even if the cell raised) and ``error``
-    is the exception raised during execution or ``None``. Splitting
-    rendering from re-raise keeps the function testable without having
-    to drive IPython's display machinery; the cell magic entry point
+    trace output (always produced, even if the cell raised) and
+    ``error`` is the exception raised during execution or ``None``.
+    Splitting rendering from re-raise keeps the function testable
+    without driving IPython's display machinery; the magic entry point
     (:func:`register_magic`) is what actually re-raises.
 
-    ``end_capture`` sits in a ``finally`` so the collector's active-trace
-    set does not leak the trace_id on ``KeyboardInterrupt`` or
-    ``SystemExit``.
+    The root span is started with an explicit empty OTel ``Context`` so
+    the cell's ``trace_id`` is always fresh, detached from any ambient
+    span that might be in scope. Without that detach, an ambient span
+    installed by an unrelated extension would share a ``trace_id`` with
+    the cell, and the collector — which keys captures by ``trace_id`` —
+    would pull unrelated spans into the cell's output.
     """
     collector = ensure_collector_installed()
     tracer = trace.get_tracer(_CELL_TRACER_NAME)
@@ -54,23 +64,44 @@ def run_cell_with_trace(
     cell_exc: Optional[BaseException] = None
     trace_id: Optional[int] = None
     try:
-        with tracer.start_as_current_span(_CELL_ROOT_SPAN_NAME) as root:
+        with tracer.start_as_current_span(
+            _CELL_ROOT_SPAN_NAME,
+            # ``context=Context()`` detaches from whatever context is
+            # currently active, forcing a brand-new trace. Without this
+            # the cell would inherit an ambient span's trace_id and the
+            # collector's capture window would pull in unrelated spans.
+            context=otel_context.Context(),
+        ) as root:
             trace_id = root.get_span_context().trace_id
             collector.begin_capture(trace_id)
+
+            # Suppress the inner ``showtraceback``: ``run_cell`` calls
+            # it unconditionally on error, but the outer ``run_cell``
+            # will also call it once our re-raise reaches it, and we
+            # don't want the traceback printed twice.
+            original_showtraceback = shell.showtraceback
+            shell.showtraceback = lambda *args, **kwargs: None
             try:
-                # ``shell.ex`` exec's the string in the user namespace
-                # with minimal IPython machinery; exceptions propagate
-                # naturally and are caught one layer up.
-                shell.ex(cell)
-            except BaseException as exc:  # noqa: BLE001 - re-raised by caller
-                cell_exc = exc
+                result = shell.run_cell(cell, store_history=False)
+            finally:
+                shell.showtraceback = original_showtraceback
+            # Both parse-time and runtime errors are surfaced.
+            # ``error_before_exec`` is typed as ``BaseException | True |
+            # None`` in IPython's stubs (``True`` was a legacy sentinel)
+            # so narrow through ``isinstance`` before handing it back.
+            err_before = result.error_before_exec
+            cell_exc = (
+                err_before
+                if isinstance(err_before, BaseException)
+                else result.error_in_exec
+            )
     finally:
         # Call ``end_capture`` *after* the ``with`` block exits so the
         # root span's ``on_end`` fires first and lands in the collector.
         # Moving this into the inner ``finally`` (inside ``with``) would
-        # drop the root span itself from the rendered tree. Using an
-        # outer ``finally`` also makes sure the collector's active-trace
-        # set is cleared even on ``KeyboardInterrupt`` or ``SystemExit``.
+        # drop the root span itself from the rendered tree. The outer
+        # ``finally`` also makes sure the collector's active-trace set
+        # is cleared on ``KeyboardInterrupt`` / ``SystemExit``.
         spans = collector.end_capture(trace_id) if trace_id is not None else []
 
     return render_cell_output_html(spans), cell_exc

--- a/python/ommx/ommx/tracing/_magic.py
+++ b/python/ommx/ommx/tracing/_magic.py
@@ -1,9 +1,14 @@
 """``%%ommx_trace`` cell magic implementation.
 
 Registered via ``%load_ext ommx.tracing``. The magic wraps cell execution
-in a single OTel root span, collects every span emitted during the cell
-through :mod:`._collector`, and displays a text tree plus a Chrome Trace
-JSON download link as the cell output.
+in a single OTel root span, asks :class:`._collector._CellSpanCollector`
+to stash only that trace's spans, and displays the result as HTML.
+
+Execution goes through :meth:`InteractiveShell.run_cell` rather than
+``shell.ex`` so that input transforms, display hooks, and error
+formatting all behave the same way they would in a normal cell. The
+cell-magic call site has already stored the raw cell in history, so we
+pass ``store_history=False`` to avoid logging the body twice.
 """
 
 from __future__ import annotations
@@ -30,26 +35,33 @@ def run_cell_with_trace(
 ) -> Tuple[str, Optional[BaseException]]:
     """Execute ``cell`` inside an ``ommx_trace_cell`` root span.
 
-    Returns ``(html_blob, exc)`` where ``html_blob`` is the rendered
-    trace output (always produced, even if the cell raised) and ``exc``
-    is the exception that escaped the cell, or ``None``. The caller is
-    responsible for displaying the HTML and re-raising the exception —
-    that split keeps this function testable without IPython's display
-    machinery in scope.
+    Returns ``(html_blob, error)`` where ``html_blob`` is the rendered
+    trace output (always produced, even if the cell raised) and ``error``
+    is the exception raised during execution or ``None``. IPython's
+    ``run_cell`` has already displayed the traceback when ``error`` is
+    non-None; the caller uses it only for test assertions and does not
+    need to re-raise.
     """
     collector = ensure_collector_installed()
     tracer = trace.get_tracer(_CELL_TRACER_NAME)
 
-    cell_exc: Optional[BaseException] = None
     with tracer.start_as_current_span(_CELL_ROOT_SPAN_NAME) as root:
         trace_id = root.get_span_context().trace_id
+        collector.begin_capture(trace_id)
         try:
-            shell.ex(cell)
-        except BaseException as exc:  # noqa: BLE001 - re-raised by caller
-            cell_exc = exc
+            # ``store_history=False`` avoids duplicating the cell body in
+            # ``In[...]`` (the magic invocation itself is already stored).
+            result = shell.run_cell(cell, store_history=False)
+        finally:
+            # ``end_capture`` must run even on SystemExit/KeyboardInterrupt
+            # so the collector doesn't leak this trace's entries.
+            pass
 
-    spans = collector.pop_trace(trace_id)
-    return render_cell_output_html(spans), cell_exc
+    spans = collector.end_capture(trace_id)
+    # ``run_cell`` surfaces errors on the result object rather than
+    # raising; IPython has already printed the traceback via its normal
+    # display hooks by the time we get here.
+    return render_cell_output_html(spans), result.error_in_exec
 
 
 def register_magic(shell: "InteractiveShell") -> None:
@@ -62,10 +74,10 @@ def register_magic(shell: "InteractiveShell") -> None:
         # ``line`` is unused in the MVP; reserved for future flags
         # (e.g. a filename override for the download link).
         del line
-        html_blob, cell_exc = run_cell_with_trace(shell, cell)
+        html_blob, _exc = run_cell_with_trace(shell, cell)
+        # No re-raise: ``shell.run_cell`` already reported the error via
+        # IPython's normal traceback UI, preserving the user-cell frames.
         display(HTML(html_blob))
-        if cell_exc is not None:
-            raise cell_exc
 
     # Reference for static analysers; decorator already installed the magic.
     del _ommx_trace

--- a/python/ommx/ommx/tracing/_magic.py
+++ b/python/ommx/ommx/tracing/_magic.py
@@ -4,11 +4,13 @@ Registered via ``%load_ext ommx.tracing``. The magic wraps cell execution
 in a single OTel root span, asks :class:`._collector._CellSpanCollector`
 to stash only that trace's spans, and displays the result as HTML.
 
-Execution goes through :meth:`InteractiveShell.run_cell` rather than
-``shell.ex`` so that input transforms, display hooks, and error
-formatting all behave the same way they would in a normal cell. The
-cell-magic call site has already stored the raw cell in history, so we
-pass ``store_history=False`` to avoid logging the body twice.
+Cell-body execution goes through :meth:`InteractiveShell.ex` rather
+than :meth:`InteractiveShell.run_cell`: we want the exception raised by
+the user's cell to propagate naturally so the outer (magic-invoking)
+``run_cell`` reports the failure to upstream automation
+(``nbconvert --execute``, papermill, pytest-nbval, …). ``run_cell``
+captures and displays the exception itself, which would either swallow
+it or double-display the traceback once we re-raise.
 """
 
 from __future__ import annotations
@@ -37,31 +39,41 @@ def run_cell_with_trace(
 
     Returns ``(html_blob, error)`` where ``html_blob`` is the rendered
     trace output (always produced, even if the cell raised) and ``error``
-    is the exception raised during execution or ``None``. IPython's
-    ``run_cell`` has already displayed the traceback when ``error`` is
-    non-None; the caller uses it only for test assertions and does not
-    need to re-raise.
+    is the exception raised during execution or ``None``. Splitting
+    rendering from re-raise keeps the function testable without having
+    to drive IPython's display machinery; the cell magic entry point
+    (:func:`register_magic`) is what actually re-raises.
+
+    ``end_capture`` sits in a ``finally`` so the collector's active-trace
+    set does not leak the trace_id on ``KeyboardInterrupt`` or
+    ``SystemExit``.
     """
     collector = ensure_collector_installed()
     tracer = trace.get_tracer(_CELL_TRACER_NAME)
 
-    with tracer.start_as_current_span(_CELL_ROOT_SPAN_NAME) as root:
-        trace_id = root.get_span_context().trace_id
-        collector.begin_capture(trace_id)
-        try:
-            # ``store_history=False`` avoids duplicating the cell body in
-            # ``In[...]`` (the magic invocation itself is already stored).
-            result = shell.run_cell(cell, store_history=False)
-        finally:
-            # ``end_capture`` must run even on SystemExit/KeyboardInterrupt
-            # so the collector doesn't leak this trace's entries.
-            pass
+    cell_exc: Optional[BaseException] = None
+    trace_id: Optional[int] = None
+    try:
+        with tracer.start_as_current_span(_CELL_ROOT_SPAN_NAME) as root:
+            trace_id = root.get_span_context().trace_id
+            collector.begin_capture(trace_id)
+            try:
+                # ``shell.ex`` exec's the string in the user namespace
+                # with minimal IPython machinery; exceptions propagate
+                # naturally and are caught one layer up.
+                shell.ex(cell)
+            except BaseException as exc:  # noqa: BLE001 - re-raised by caller
+                cell_exc = exc
+    finally:
+        # Call ``end_capture`` *after* the ``with`` block exits so the
+        # root span's ``on_end`` fires first and lands in the collector.
+        # Moving this into the inner ``finally`` (inside ``with``) would
+        # drop the root span itself from the rendered tree. Using an
+        # outer ``finally`` also makes sure the collector's active-trace
+        # set is cleared even on ``KeyboardInterrupt`` or ``SystemExit``.
+        spans = collector.end_capture(trace_id) if trace_id is not None else []
 
-    spans = collector.end_capture(trace_id)
-    # ``run_cell`` surfaces errors on the result object rather than
-    # raising; IPython has already printed the traceback via its normal
-    # display hooks by the time we get here.
-    return render_cell_output_html(spans), result.error_in_exec
+    return render_cell_output_html(spans), cell_exc
 
 
 def register_magic(shell: "InteractiveShell") -> None:
@@ -74,10 +86,20 @@ def register_magic(shell: "InteractiveShell") -> None:
         # ``line`` is unused in the MVP; reserved for future flags
         # (e.g. a filename override for the download link).
         del line
-        html_blob, _exc = run_cell_with_trace(shell, cell)
-        # No re-raise: ``shell.run_cell`` already reported the error via
-        # IPython's normal traceback UI, preserving the user-cell frames.
+        html_blob, cell_exc = run_cell_with_trace(shell, cell)
+        # Display the trace first so the user sees it above any
+        # traceback that IPython will print when we re-raise.
         display(HTML(html_blob))
+        if cell_exc is not None:
+            # Propagate so the outer ``run_cell`` records the failure.
+            # Without this, notebook automation (``nbconvert --execute``,
+            # papermill, pytest-nbval) would silently treat traced cells
+            # as successful even when the user code raised.
+            #
+            # Python preserves the original traceback on ``cell_exc``
+            # via ``__traceback__``, so IPython's display will still
+            # show the frames inside the user's cell.
+            raise cell_exc
 
     # Reference for static analysers; decorator already installed the magic.
     del _ommx_trace

--- a/python/ommx/ommx/tracing/_render.py
+++ b/python/ommx/ommx/tracing/_render.py
@@ -1,0 +1,211 @@
+"""Render a collected trace as a text tree and a Chrome Trace JSON blob.
+
+Both renderers take a ``list[ReadableSpan]`` and are independent of the
+cell-magic plumbing — :func:`render_text_tree` is useful from a plain REPL
+as well, and the JSON writer is what backs the download link surfaced by
+the magic's HTML output.
+"""
+
+from __future__ import annotations
+
+import base64
+import html
+import json
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from opentelemetry.sdk.trace import ReadableSpan
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _duration_ms(span: ReadableSpan) -> float:
+    """Return the span's duration in milliseconds.
+
+    Open spans (which should not reach the renderer, but we still want
+    to survive them) have ``end_time is None`` — report ``0.0`` instead
+    of crashing.
+    """
+    if span.start_time is None or span.end_time is None:
+        return 0.0
+    return (span.end_time - span.start_time) / 1_000_000.0
+
+
+def _format_duration(ms: float) -> str:
+    if ms >= 1000:
+        return f"{ms / 1000:.2f} s"
+    if ms >= 1:
+        return f"{ms:.2f} ms"
+    return f"{ms * 1000:.1f} µs"
+
+
+def _interesting_attributes(span: ReadableSpan) -> str:
+    """Subset of attributes worth showing inline in the tree node.
+
+    Filters out the ``tracing`` crate's bookkeeping keys (``busy_ns``,
+    ``idle_ns``, ``thread.id``, ``code.*``) that are noise for human
+    consumers. Everything else is fair game.
+    """
+    if not span.attributes:
+        return ""
+    skip = {"busy_ns", "idle_ns", "thread.id"}
+    pairs = [
+        f"{k}={v!r}"
+        for k, v in span.attributes.items()
+        if k not in skip and not k.startswith("code.")
+    ]
+    if not pairs:
+        return ""
+    return " [" + ", ".join(pairs) + "]"
+
+
+# ---------------------------------------------------------------------------
+# Text tree
+# ---------------------------------------------------------------------------
+
+
+def render_text_tree(spans: Sequence[ReadableSpan]) -> str:
+    """Render ``spans`` as a nested ASCII tree, one root per top-level span.
+
+    The tree preserves parent→child relationships as recorded by OTel.
+    Siblings are sorted by start time so the output reflects execution
+    order.
+    """
+    if not spans:
+        return "(no spans)"
+
+    by_id: Dict[int, ReadableSpan] = {}
+    children: Dict[Optional[int], List[ReadableSpan]] = {}
+    for span in spans:
+        ctx = span.context
+        if ctx is None:
+            continue
+        by_id[ctx.span_id] = span
+        parent_id = span.parent.span_id if span.parent is not None else None
+        children.setdefault(parent_id, []).append(span)
+
+    # A span's parent may not be in `spans` (e.g. the cell root was created
+    # outside the collected set). Treat those as roots too so we never drop
+    # branches on the floor.
+    roots: List[ReadableSpan] = []
+    for parent_id, kids in children.items():
+        if parent_id is None or parent_id not in by_id:
+            roots.extend(kids)
+    roots.sort(key=lambda s: s.start_time or 0)
+
+    lines: List[str] = []
+
+    def walk(span: ReadableSpan, prefix: str, is_last: bool) -> None:
+        marker = "└── " if is_last else "├── "
+        lines.append(
+            f"{prefix}{marker}{span.name} "
+            f"({_format_duration(_duration_ms(span))})"
+            f"{_interesting_attributes(span)}"
+        )
+        next_prefix = prefix + ("    " if is_last else "│   ")
+        ctx = span.context
+        if ctx is None:
+            return
+        kids = children.get(ctx.span_id, [])
+        kids.sort(key=lambda s: s.start_time or 0)
+        for i, kid in enumerate(kids):
+            walk(kid, next_prefix, i == len(kids) - 1)
+
+    for i, root in enumerate(roots):
+        marker = "└── " if i == len(roots) - 1 else "├── "
+        lines.append(
+            f"{marker}{root.name} ({_format_duration(_duration_ms(root))})"
+            f"{_interesting_attributes(root)}"
+        )
+        next_prefix = "    " if i == len(roots) - 1 else "│   "
+        ctx = root.context
+        if ctx is None:
+            continue
+        kids = children.get(ctx.span_id, [])
+        kids.sort(key=lambda s: s.start_time or 0)
+        for j, kid in enumerate(kids):
+            walk(kid, next_prefix, j == len(kids) - 1)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Chrome Trace Event Format
+# ---------------------------------------------------------------------------
+
+
+def _attribute_to_json(value) -> object:
+    """Coerce an OTel attribute value into something ``json.dumps`` accepts."""
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_attribute_to_json(v) for v in value]
+    return str(value)
+
+
+def to_chrome_trace(spans: Iterable[ReadableSpan]) -> dict:
+    """Convert a list of OTel spans to the Chrome Trace Event Format.
+
+    Uses complete-duration events (``ph: "X"``) with ``ts``/``dur`` in
+    microseconds, which is what Perfetto, speedscope, and
+    ``chrome://tracing`` all consume. The per-span ``args`` dict carries
+    OTel attributes so they show up in tool tooltips.
+    """
+    events: List[dict] = []
+    for span in spans:
+        if span.start_time is None or span.end_time is None:
+            continue
+        ts_us = span.start_time // 1_000
+        dur_us = max((span.end_time - span.start_time) // 1_000, 1)
+        args = {k: _attribute_to_json(v) for k, v in (span.attributes or {}).items()}
+        events.append(
+            {
+                "name": span.name,
+                "cat": "ommx",
+                "ph": "X",
+                "ts": ts_us,
+                "dur": dur_us,
+                "pid": 1,
+                "tid": 1,
+                "args": args,
+            }
+        )
+    events.sort(key=lambda e: (e["ts"], -e["dur"]))
+    return {"traceEvents": events, "displayTimeUnit": "ms"}
+
+
+def chrome_trace_json(spans: Iterable[ReadableSpan]) -> str:
+    return json.dumps(to_chrome_trace(spans))
+
+
+# ---------------------------------------------------------------------------
+# HTML glue for the cell magic
+# ---------------------------------------------------------------------------
+
+
+def render_cell_output_html(
+    spans: Sequence[ReadableSpan],
+    *,
+    download_filename: str = "ommx_trace.json",
+) -> str:
+    """HTML blob for ``display(HTML(...))`` from :mod:`_magic`.
+
+    Renders the text tree inside a ``<pre>`` and attaches a download link
+    pointing at a base64 data URL of the Chrome Trace JSON. This keeps
+    the magic dependency-free — no ipywidgets, no assets.
+    """
+    tree = html.escape(render_text_tree(spans))
+    payload = chrome_trace_json(spans)
+    b64 = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+    data_url = f"data:application/json;base64,{b64}"
+    size_kb = len(payload) / 1024
+    return (
+        '<div class="ommx-trace">'
+        f"<pre>{tree}</pre>"
+        f'<p><a href="{data_url}" download="{html.escape(download_filename)}">'
+        f"Download Chrome Trace JSON ({size_kb:.1f} KB)"
+        "</a> — open in Perfetto, speedscope, or <code>chrome://tracing</code>.</p>"
+        "</div>"
+    )

--- a/python/ommx/ommx/tracing/_render.py
+++ b/python/ommx/ommx/tracing/_render.py
@@ -201,10 +201,16 @@ def render_cell_output_html(
     b64 = base64.b64encode(payload.encode("utf-8")).decode("ascii")
     data_url = f"data:application/json;base64,{b64}"
     size_kb = len(payload) / 1024
+    # ``quote=True`` escapes both ``"`` and ``'`` — essential when the
+    # value lands inside an HTML attribute where an un-escaped quote
+    # would terminate the attribute and allow injection. Cell magic
+    # callers currently pass a literal default, but the parameter is
+    # public, so harden it anyway.
+    safe_filename = html.escape(download_filename, quote=True)
     return (
         '<div class="ommx-trace">'
         f"<pre>{tree}</pre>"
-        f'<p><a href="{data_url}" download="{html.escape(download_filename)}">'
+        f'<p><a href="{data_url}" download="{safe_filename}">'
         f"Download Chrome Trace JSON ({size_kb:.1f} KB)"
         "</a> — open in Perfetto, speedscope, or <code>chrome://tracing</code>.</p>"
         "</div>"

--- a/python/ommx/ommx/tracing/_render.py
+++ b/python/ommx/ommx/tracing/_render.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import base64
 import html
 import json
-from typing import Dict, Iterable, List, Optional, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence, Set
 
 from opentelemetry.sdk.trace import ReadableSpan
 
@@ -76,13 +76,13 @@ def render_text_tree(spans: Sequence[ReadableSpan]) -> str:
     if not spans:
         return "(no spans)"
 
-    by_id: Dict[int, ReadableSpan] = {}
+    span_ids: Set[int] = set()
     children: Dict[Optional[int], List[ReadableSpan]] = {}
     for span in spans:
         ctx = span.context
         if ctx is None:
             continue
-        by_id[ctx.span_id] = span
+        span_ids.add(ctx.span_id)
         parent_id = span.parent.span_id if span.parent is not None else None
         children.setdefault(parent_id, []).append(span)
 
@@ -91,7 +91,7 @@ def render_text_tree(spans: Sequence[ReadableSpan]) -> str:
     # branches on the floor.
     roots: List[ReadableSpan] = []
     for parent_id, kids in children.items():
-        if parent_id is None or parent_id not in by_id:
+        if parent_id is None or parent_id not in span_ids:
             roots.extend(kids)
     roots.sort(key=lambda s: s.start_time or 0)
 
@@ -104,29 +104,17 @@ def render_text_tree(spans: Sequence[ReadableSpan]) -> str:
             f"({_format_duration(_duration_ms(span))})"
             f"{_interesting_attributes(span)}"
         )
-        next_prefix = prefix + ("    " if is_last else "│   ")
         ctx = span.context
         if ctx is None:
             return
         kids = children.get(ctx.span_id, [])
         kids.sort(key=lambda s: s.start_time or 0)
+        next_prefix = prefix + ("    " if is_last else "│   ")
         for i, kid in enumerate(kids):
             walk(kid, next_prefix, i == len(kids) - 1)
 
     for i, root in enumerate(roots):
-        marker = "└── " if i == len(roots) - 1 else "├── "
-        lines.append(
-            f"{marker}{root.name} ({_format_duration(_duration_ms(root))})"
-            f"{_interesting_attributes(root)}"
-        )
-        next_prefix = "    " if i == len(roots) - 1 else "│   "
-        ctx = root.context
-        if ctx is None:
-            continue
-        kids = children.get(ctx.span_id, [])
-        kids.sort(key=lambda s: s.start_time or 0)
-        for j, kid in enumerate(kids):
-            walk(kid, next_prefix, j == len(kids) - 1)
+        walk(root, "", i == len(roots) - 1)
 
     return "\n".join(lines)
 

--- a/python/ommx/ommx/tracing/_setup.py
+++ b/python/ommx/ommx/tracing/_setup.py
@@ -46,14 +46,14 @@ def ensure_collector_installed() -> _CellSpanCollector:
             return _COLLECTOR
 
         provider = trace.get_tracer_provider()
-        if not hasattr(provider, "add_span_processor"):
+        if not isinstance(provider, SdkTracerProvider):
             # Typically the default ``ProxyTracerProvider`` — we have a
             # licence to install a real one. If the user installed a
             # custom non-SDK provider, ``set_tracer_provider`` below is
             # silently ignored and we'll detect that on the re-read.
             trace.set_tracer_provider(SdkTracerProvider())
             provider = trace.get_tracer_provider()
-            if not hasattr(provider, "add_span_processor"):
+            if not isinstance(provider, SdkTracerProvider):
                 raise RuntimeError(
                     "ommx.tracing could not install an SDK TracerProvider: "
                     f"a {type(provider).__name__!s} is already active and "

--- a/python/ommx/ommx/tracing/_setup.py
+++ b/python/ommx/ommx/tracing/_setup.py
@@ -70,11 +70,6 @@ def ensure_collector_installed() -> _CellSpanCollector:
         return collector
 
 
-def get_collector() -> Optional[_CellSpanCollector]:
-    """Return the cached collector, or ``None`` if not yet installed."""
-    return _COLLECTOR
-
-
 def reset_for_testing() -> None:
     """Drop the cached collector. Only intended for unit tests."""
     global _COLLECTOR

--- a/python/ommx/ommx/tracing/_setup.py
+++ b/python/ommx/ommx/tracing/_setup.py
@@ -1,0 +1,69 @@
+"""Lazy setup of the OTel pipeline for the cell magic.
+
+The cell magic must work in notebooks that have *not* configured OTel at
+all, as well as in notebooks where the user has already set up a
+``TracerProvider``. This module hides that distinction behind
+:func:`ensure_collector_installed`.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+from ._collector import _CellSpanCollector
+
+_COLLECTOR: Optional[_CellSpanCollector] = None
+_LOCK = threading.Lock()
+
+
+def ensure_collector_installed() -> _CellSpanCollector:
+    """Install the cell-trace collector onto the active ``TracerProvider``.
+
+    Behavior:
+
+    * If the global provider is already an ``sdk.trace.TracerProvider``,
+      attach a collector to it (non-destructive — existing processors keep
+      receiving spans).
+    * Otherwise install a new SDK provider as the global and attach the
+      collector to it. This mirrors the escape hatch documented in
+      :mod:`ommx.tracing` for notebooks that have not configured OTel.
+
+    The collector instance is cached so repeated magic invocations in the
+    same session reuse a single collector.
+    """
+    global _COLLECTOR
+    with _LOCK:
+        if _COLLECTOR is not None:
+            return _COLLECTOR
+
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, SdkTracerProvider):
+            # The default ``ProxyTracerProvider`` from the OTel API package
+            # has no ``add_span_processor``. Install a bare SDK provider so
+            # Rust spans flowing through ``pyo3-tracing-opentelemetry`` have
+            # somewhere to land.
+            provider = SdkTracerProvider()
+            trace.set_tracer_provider(provider)
+
+        collector = _CellSpanCollector()
+        # ``add_span_processor`` wraps the processor directly; no exporter
+        # is required because we read finished spans out of the collector.
+        provider.add_span_processor(collector)
+        _COLLECTOR = collector
+        return collector
+
+
+def get_collector() -> Optional[_CellSpanCollector]:
+    """Return the cached collector, or ``None`` if not yet installed."""
+    return _COLLECTOR
+
+
+def reset_for_testing() -> None:
+    """Drop the cached collector. Only intended for unit tests."""
+    global _COLLECTOR
+    with _LOCK:
+        _COLLECTOR = None

--- a/python/ommx/ommx/tracing/_setup.py
+++ b/python/ommx/ommx/tracing/_setup.py
@@ -4,60 +4,103 @@ The cell magic must work in notebooks that have *not* configured OTel at
 all, as well as in notebooks where the user has already set up a
 ``TracerProvider``. This module hides that distinction behind
 :func:`ensure_collector_installed`.
+
+The OpenTelemetry SDK is an optional dependency (``ommx[tracing]``);
+we defer the import so that ``import ommx`` stays cheap for users who
+never touch the tracing magic, and so the failure message points at the
+right pip install.
 """
 
 from __future__ import annotations
 
 import threading
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 
-from ._collector import _CellSpanCollector
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from ._collector import _CellSpanCollector
 
-_COLLECTOR: Optional[_CellSpanCollector] = None
+
+_COLLECTOR: Optional["_CellSpanCollector"] = None
 _LOCK = threading.Lock()
 
 
-def ensure_collector_installed() -> _CellSpanCollector:
+_OTEL_SDK_MISSING_MESSAGE = (
+    "ommx.tracing requires opentelemetry-sdk. Install it with "
+    "`pip install ommx[tracing]` (or `pip install opentelemetry-sdk`) "
+    "and reload the extension."
+)
+
+
+def _import_sdk():
+    """Import the OTel SDK classes we need, with a friendly error.
+
+    Returning the module objects keeps :func:`ensure_collector_installed`
+    short — no need to thread ``try``/``except`` through it.
+    """
+    try:
+        from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+    except ImportError as exc:  # pragma: no cover - exercised manually
+        raise RuntimeError(_OTEL_SDK_MISSING_MESSAGE) from exc
+    from opentelemetry import trace
+
+    from ._collector import _CellSpanCollector
+
+    return trace, SdkTracerProvider, _CellSpanCollector
+
+
+def ensure_collector_installed() -> "_CellSpanCollector":
     """Install the cell-trace collector onto the active ``TracerProvider``.
 
     Behavior:
 
-    * If the global provider is already an ``sdk.trace.TracerProvider``,
-      attach a collector to it (non-destructive — existing processors keep
-      receiving spans).
-    * Otherwise install a new SDK provider as the global and attach the
-      collector to it. This mirrors the escape hatch documented in
-      :mod:`ommx.tracing` for notebooks that have not configured OTel.
+    * If the global provider already supports ``add_span_processor``
+      (i.e. it's an SDK provider, or something compatible), attach a
+      collector to it. Existing processors are undisturbed.
+    * If the global provider does not support ``add_span_processor``
+      (e.g. the default ``ProxyTracerProvider`` from a fresh notebook),
+      try to install an SDK provider. OpenTelemetry only honours the
+      *first* ``set_tracer_provider`` call, so after the attempt we
+      re-read the global and fail with a helpful message if we still
+      don't have something we can attach to.
 
     The collector instance is cached so repeated magic invocations in the
-    same session reuse a single collector.
+    same session reuse a single collector (no per-cell processor
+    accumulation on the provider).
     """
     global _COLLECTOR
     with _LOCK:
         if _COLLECTOR is not None:
             return _COLLECTOR
 
+        trace, SdkTracerProvider, _CellSpanCollector = _import_sdk()
+
         provider = trace.get_tracer_provider()
-        if not isinstance(provider, SdkTracerProvider):
-            # The default ``ProxyTracerProvider`` from the OTel API package
-            # has no ``add_span_processor``. Install a bare SDK provider so
-            # Rust spans flowing through ``pyo3-tracing-opentelemetry`` have
-            # somewhere to land.
-            provider = SdkTracerProvider()
-            trace.set_tracer_provider(provider)
+        if not hasattr(provider, "add_span_processor"):
+            # Typically the default ``ProxyTracerProvider`` — we have a
+            # licence to install a real one. If the user installed a
+            # custom non-SDK provider, ``set_tracer_provider`` below is
+            # silently ignored and we'll detect that on the re-read.
+            trace.set_tracer_provider(SdkTracerProvider())
+            provider = trace.get_tracer_provider()
+            if not hasattr(provider, "add_span_processor"):
+                raise RuntimeError(
+                    "ommx.tracing could not install an SDK TracerProvider: "
+                    f"a {type(provider).__name__!s} is already active and "
+                    "OpenTelemetry refuses to replace the global "
+                    "TracerProvider once set. Install "
+                    "``opentelemetry.sdk.trace.TracerProvider`` yourself "
+                    "before loading this extension, or clear the existing "
+                    "provider."
+                )
 
         collector = _CellSpanCollector()
-        # ``add_span_processor`` wraps the processor directly; no exporter
-        # is required because we read finished spans out of the collector.
         provider.add_span_processor(collector)
         _COLLECTOR = collector
         return collector
 
 
-def get_collector() -> Optional[_CellSpanCollector]:
+def get_collector() -> Optional["_CellSpanCollector"]:
     """Return the cached collector, or ``None`` if not yet installed."""
     return _COLLECTOR
 

--- a/python/ommx/ommx/tracing/_setup.py
+++ b/python/ommx/ommx/tracing/_setup.py
@@ -1,55 +1,27 @@
 """Lazy setup of the OTel pipeline for the cell magic.
 
-The cell magic must work in notebooks that have *not* configured OTel at
-all, as well as in notebooks where the user has already set up a
-``TracerProvider``. This module hides that distinction behind
-:func:`ensure_collector_installed`.
-
-The OpenTelemetry SDK is an optional dependency (``ommx[tracing]``);
-we defer the import so that ``import ommx`` stays cheap for users who
-never touch the tracing magic, and so the failure message points at the
-right pip install.
+``opentelemetry-sdk`` is a hard runtime dependency of ``ommx``, so we
+can import the SDK at the top level. The function below is still called
+"lazy" in the architectural sense: it only installs the collector on
+first use, not at ``import ommx.tracing`` time.
 """
 
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+from ._collector import _CellSpanCollector
 
 
-if TYPE_CHECKING:  # pragma: no cover - type hints only
-    from ._collector import _CellSpanCollector
-
-
-_COLLECTOR: Optional["_CellSpanCollector"] = None
+_COLLECTOR: Optional[_CellSpanCollector] = None
 _LOCK = threading.Lock()
 
 
-_OTEL_SDK_MISSING_MESSAGE = (
-    "ommx.tracing requires opentelemetry-sdk. Install it with "
-    "`pip install ommx[tracing]` (or `pip install opentelemetry-sdk`) "
-    "and reload the extension."
-)
-
-
-def _import_sdk():
-    """Import the OTel SDK classes we need, with a friendly error.
-
-    Returning the module objects keeps :func:`ensure_collector_installed`
-    short — no need to thread ``try``/``except`` through it.
-    """
-    try:
-        from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
-    except ImportError as exc:  # pragma: no cover - exercised manually
-        raise RuntimeError(_OTEL_SDK_MISSING_MESSAGE) from exc
-    from opentelemetry import trace
-
-    from ._collector import _CellSpanCollector
-
-    return trace, SdkTracerProvider, _CellSpanCollector
-
-
-def ensure_collector_installed() -> "_CellSpanCollector":
+def ensure_collector_installed() -> _CellSpanCollector:
     """Install the cell-trace collector onto the active ``TracerProvider``.
 
     Behavior:
@@ -59,10 +31,10 @@ def ensure_collector_installed() -> "_CellSpanCollector":
       collector to it. Existing processors are undisturbed.
     * If the global provider does not support ``add_span_processor``
       (e.g. the default ``ProxyTracerProvider`` from a fresh notebook),
-      try to install an SDK provider. OpenTelemetry only honours the
-      *first* ``set_tracer_provider`` call, so after the attempt we
-      re-read the global and fail with a helpful message if we still
-      don't have something we can attach to.
+      install an SDK provider. OpenTelemetry only honours the *first*
+      ``set_tracer_provider`` call, so after the attempt we re-read the
+      global and fail with a helpful message if we still don't have
+      something we can attach to.
 
     The collector instance is cached so repeated magic invocations in the
     same session reuse a single collector (no per-cell processor
@@ -72,8 +44,6 @@ def ensure_collector_installed() -> "_CellSpanCollector":
     with _LOCK:
         if _COLLECTOR is not None:
             return _COLLECTOR
-
-        trace, SdkTracerProvider, _CellSpanCollector = _import_sdk()
 
         provider = trace.get_tracer_provider()
         if not hasattr(provider, "add_span_processor"):
@@ -100,7 +70,7 @@ def ensure_collector_installed() -> "_CellSpanCollector":
         return collector
 
 
-def get_collector() -> Optional["_CellSpanCollector"]:
+def get_collector() -> Optional[_CellSpanCollector]:
     """Return the cached collector, or ``None`` if not yet installed."""
     return _COLLECTOR
 

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -33,6 +33,16 @@ dependencies = [
   "typing-extensions >= 4.12.2, < 5.0.0",
 ]
 
+[project.optional-dependencies]
+# ``%%ommx_trace`` and ``ommx.tracing`` require the OpenTelemetry Python SDK
+# (for the ``TracerProvider`` / ``SpanProcessor`` types). Users who do not
+# need tracing should not have to pay that cost, hence an optional extra:
+# ``pip install ommx[tracing]``.
+tracing = [
+  "opentelemetry-sdk>=1.20.0",
+  "ipython>=7.0.0",
+]
+
 [project.urls]
 Repository = "https://github.com/Jij-Inc/ommx"
 Issues = "https://github.com/Jij-Inc/ommx/issues"

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -26,22 +26,19 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
+  # ``ipython`` and ``opentelemetry-sdk`` back the ``ommx.tracing`` module
+  # (``%%ommx_trace`` cell magic). They are declared as hard runtime deps
+  # rather than an optional extra because the feature is part of the
+  # main user-facing surface and the ``pip install ommx[extra]`` dance is
+  # a known source of footguns for users who only ever see the feature
+  # error out at ``%load_ext`` time.
+  "ipython>=7.0.0",
   "numpy>=1.23.0, <3.0.0",
   "opentelemetry-sdk>=1.20.0",
   "pandas>=2.0.0, <3.0.0",
   "pyarrow>=16.0.0, <23.0.0",
   "python-dateutil>=2.9.0, <3.0.0",
   "typing-extensions >= 4.12.2, < 5.0.0",
-]
-
-[project.optional-dependencies]
-# ``%%ommx_trace`` and ``ommx.tracing`` require the OpenTelemetry Python SDK
-# (for the ``TracerProvider`` / ``SpanProcessor`` types). Users who do not
-# need tracing should not have to pay that cost, hence an optional extra:
-# ``pip install ommx[tracing]``.
-tracing = [
-  "opentelemetry-sdk>=1.20.0",
-  "ipython>=7.0.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2171,33 +2171,28 @@ name = "ommx"
 version = "3.0.0a3"
 source = { editable = "python/ommx" }
 dependencies = [
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-sdk" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
 
-[package.optional-dependencies]
-tracing = [
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-sdk" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "ipython", marker = "extra == 'tracing'", specifier = ">=7.0.0" },
+    { name = "ipython", specifier = ">=7.0.0" },
     { name = "numpy", specifier = ">=1.23.0,<3.0.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "pandas", specifier = ">=2.0.0,<3.0.0" },
     { name = "pyarrow", specifier = ">=16.0.0,<23.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0,<3.0.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
 ]
-provides-extras = ["tracing"]
 
 [[package]]
 name = "ommx-highs-adapter"

--- a/uv.lock
+++ b/uv.lock
@@ -2179,14 +2179,25 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 
+[package.optional-dependencies]
+tracing = [
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-sdk" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "ipython", marker = "extra == 'tracing'", specifier = ">=7.0.0" },
     { name = "numpy", specifier = ">=1.23.0,<3.0.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.20.0" },
     { name = "pandas", specifier = ">=2.0.0,<3.0.0" },
     { name = "pyarrow", specifier = ">=16.0.0,<23.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0,<3.0.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
 ]
+provides-extras = ["tracing"]
 
 [[package]]
 name = "ommx-highs-adapter"


### PR DESCRIPTION
Part of #817 (PR4).

Adds per-cell tracing for Jupyter/IPython. `%%ommx_trace` wraps a cell in an OpenTelemetry root span, collects every span emitted during the cell (including Rust spans forwarded by `pyo3-tracing-opentelemetry`), and displays a nested text tree plus a Chrome Trace Event Format JSON download link as the cell output.

## Usage

```python
%load_ext ommx.tracing

%%ommx_trace
from ommx.v1 import Instance, DecisionVariable
x = [DecisionVariable.binary(i) for i in range(5)]
instance = Instance.from_components(
    decision_variables=x,
    objective=sum(x),
    constraints={},
    sense=Instance.MINIMIZE,
)
solution = instance.evaluate({0: 1.0, 1: 0.0, 2: 1.0, 3: 0.0, 4: 1.0})
qubo, constant = instance.to_qubo()
```

Cell output (text tree, rendered live on real Rust spans):

```
└── ommx_trace_cell (11.52 ms)
    ├── evaluate (693.0 µs)
    ├── qubo_hubo_pipeline (1.0 µs)
    └── as_qubo_format (55.0 µs)
```

Plus an HTML `<a>` link with a base64-encoded `data:application/json` URL for the full Chrome Trace — opens directly in Perfetto, speedscope, or `chrome://tracing`.

## Architecture

Four small modules under `python/ommx/ommx/tracing/`:

| File | Responsibility |
| --- | --- |
| `__init__.py` | `load_ipython_extension` / `unload_ipython_extension` (public) |
| `_setup.py` | Install the `_CellSpanCollector` lazily onto the active `TracerProvider` on first traced cell. Creates an SDK provider when the default `ProxyTracerProvider` is in place; if some other non-SDK provider was already set, raises a descriptive `RuntimeError` rather than attaching to an unused local object. |
| `_collector.py` | `SpanProcessor` subclass with an active-trace gate (`begin_capture` / `end_capture`). Spans whose `trace_id` isn't currently captured are dropped immediately on `on_end`, keeping memory bounded in long-lived notebooks. |
| `_magic.py` | The `%%ommx_trace` cell magic. Starts a root span with an explicit empty OTel `Context` (fresh `trace_id`), runs the cell body through `shell.run_cell` so input transforms / top-level `await` / line magics work, re-raises on failure so automation (`nbconvert --execute`, papermill, pytest-nbval) sees traced cells fail. |
| `_render.py` | Text-tree renderer, Chrome-Trace JSON writer, and the `display(HTML(...))` glue. Filters noisy `tracing`-crate bookkeeping attributes (`busy_ns`, `idle_ns`, `code.*`), escapes the download filename for attribute context (`quote=True`), drops open spans. |

### Design notes

- **Observational, not behaviour-changing**: cell bodies run through `shell.run_cell(cell, store_history=False)` so everything that works in an untraced cell (top-level `await`, `%` line magics, input transforms) still works. Removing `%%ommx_trace` from a cell leaves its behaviour intact.
- **Fresh trace per cell**: `start_as_current_span(..., context=Context())` detaches from any ambient OTel context, so spans emitted by unrelated instrumentation never leak into the cell's rendered tree.
- **Single traceback on failure**: `run_cell` normally prints a traceback internally; if we re-raise after it, the outer `run_cell` prints it again. We temporarily point `shell.showtraceback` at a no-op during the inner call so only the outer printer fires, and IPython's traceback UI looks identical to an untraced cell's.
- **Re-raises for automation**: `result.error_before_exec or result.error_in_exec` is surfaced and re-raised after rendering, so notebook runners that rely on cell failures to stop execution behave correctly.
- **Non-destructive provider install**: the collector is `add_span_processor`'d onto the active provider. Pre-existing exporters keep receiving spans. This relies on the dynamic span-processor resolution landed in `pyo3-tracing-opentelemetry` 0.2.0.
- **Bounded state**: the collector only retains spans whose `trace_id` was opened with `begin_capture`; `end_capture` pops and clears the slot.
- **Dependencies**: `opentelemetry-sdk` and `ipython` are declared as regular (not optional) runtime deps, since the optional-extras pattern is a known footgun (users only learn they need `pip install ommx[extra]` at `%load_ext` time).

## Tests

`python/ommx-tests/tests/test_tracing_magic.py` covers:

- **Collector**: active-trace gate (outside-window spans dropped), single-use `end_capture`, thread safety under 4 concurrent workers × 20 spans.
- **Renderer**: tree-indent nesting, empty input, Chrome-Trace event shape (`ph: X`, microsecond durations, attribute roundtrip), open-span skip, XSS regression for crafted `download_filename`.
- **Setup**: `ensure_collector_installed` is idempotent; pre-existing processors continue receiving spans after the collector attaches.
- **End-to-end through an `IPython.testing.globalipapp` shell**: user code lands in the namespace, cell exceptions surface on the return tuple, the registered magic propagates the exception (`test_magic_reraises_cell_exception`), `%load_ext` actually registers the magic, ambient spans don't leak into cell traces, top-level `await` inside the cell body works.

17 new tests; full `task python:test` remains green.

## Test plan

- [x] `task python:test` green (211 core + 17 tracing)
- [x] `task format` applied; `ruff`/`pyright` clean
- [x] `book_en` and `book_ja:build` succeed (the `autoapi/ommx/tracing/index` document is referenced from `docs/api/index.rst` so Sphinx's toctree check passes)
- [x] Manual smoke test: `%%ommx_trace` on a realistic `Instance.from_components` → `evaluate` → `to_qubo` cell produces the tree above and a working download link

## Follow-up (PR5 under #817)

Documentation: OTel setup guide, `%%ommx_trace` usage walk-through, span-naming convention rule, and troubleshooting notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)