### PR TITLE
Add capture_trace + traced decorator for script-side tracing

### DIFF
--- a/python/ommx-tests/tests/test_tracing_capture.py
+++ b/python/ommx-tests/tests/test_tracing_capture.py
@@ -45,19 +45,30 @@ _SESSION_COLLECTOR: _CellSpanCollector | None = None
 @pytest.fixture
 def capture_collector():
     """Attach a single collector to the session provider and clear its
-    state between tests. Mirrors the pattern used by
-    ``test_tracing_magic.cell_collector``; the two test files can
-    reuse the same underlying collector via the module-global since
-    each test does its own state reset."""
+    state between tests.
+
+    Points ``_setup._COLLECTOR`` at the shared instance so
+    ``ensure_collector_installed()`` returns it unchanged rather than
+    creating a fresh ``_CellSpanCollector`` + attaching a new
+    ``SpanProcessor`` to the provider each test. Without that,
+    processors would pile up across the suite.
+    """
     global _SESSION_COLLECTOR
-    _setup.reset_for_testing()
     if _SESSION_COLLECTOR is None:
         _SESSION_COLLECTOR = _CellSpanCollector()
         get_test_provider().add_span_processor(_SESSION_COLLECTOR)
-    _SESSION_COLLECTOR.shutdown()
-    yield _SESSION_COLLECTOR
-    _setup.reset_for_testing()
-    _SESSION_COLLECTOR.shutdown()
+    # Reuse the shared collector for any ``capture_trace`` /
+    # ``run_cell_with_trace`` call made during the test.
+    _setup._COLLECTOR = _SESSION_COLLECTOR
+    _SESSION_COLLECTOR.shutdown()  # drop state from previous test
+    try:
+        yield _SESSION_COLLECTOR
+    finally:
+        _SESSION_COLLECTOR.shutdown()
+        # Hand the cache back to ``None`` so tests that explicitly
+        # exercise ``ensure_collector_installed`` start from a clean
+        # slate.
+        _setup._COLLECTOR = None
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +281,75 @@ def test_traced_decorator_uses_function_qualname_by_default(
     assert any("build_qubo" in n for n in names), (
         f"Span name should derive from the function. Got: {names}"
     )
+
+
+def test_traced_decorator_supports_async_functions(capture_collector, tmp_path):
+    """``async def`` must be traced end-to-end, not just coroutine creation.
+
+    A plain sync wrapper would run the decorated call, return the
+    coroutine object, close the capture window, and then the user
+    would ``await`` the coroutine *outside* the capture — every span
+    emitted by the awaited work would be dropped.
+    """
+    import asyncio
+
+    out = tmp_path / "async.json"
+
+    @traced(name="async_op", output=out)
+    async def async_process():
+        await asyncio.sleep(0)
+        return 11
+
+    result = asyncio.run(async_process())
+    assert result == 11
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    names = {e["name"] for e in payload["traceEvents"]}
+    # The root span from the ``capture_trace`` block is present —
+    # this asserts the capture actually wrapped the awaited body, not
+    # just the coroutine-creation moment.
+    assert "async_op" in names
+
+
+def test_traced_decorator_save_failure_does_not_mask_user_exception(
+    capture_collector, tmp_path
+):
+    """If the wrapped function raised and ``save_chrome_trace`` also
+    fails (e.g. disk full, read-only target, bad path), the user's
+    original exception must win — that's the signal they care about.
+    The save failure is swallowed in the exception path.
+    """
+    bad_path = tmp_path / "nonexistent-directory-that-will-be-a-file"
+    bad_path.write_text("not a directory")
+    # Path whose *parent* exists but is a file, so ``mkdir(parents=True)``
+    # fails → ``save_chrome_trace`` raises.
+    unusable_output = bad_path / "child.json"
+
+    @traced(name="failing_with_bad_output", output=unusable_output)
+    def process():
+        raise ValueError("original user failure")
+
+    with pytest.raises(ValueError, match="original user failure"):
+        process()
+
+
+def test_traced_decorator_save_failure_surfaces_on_success_path(
+    capture_collector, tmp_path
+):
+    """On the success path, a broken ``output`` configuration should
+    still be noticed — otherwise users never learn their trace writer
+    was misconfigured until they go looking for the file.
+    """
+    bad_path = tmp_path / "file_not_dir"
+    bad_path.write_text("not a directory")
+    unusable_output = bad_path / "child.json"
+
+    @traced(name="ok_but_bad_output", output=unusable_output)
+    def process():
+        return 1
+
+    with pytest.raises((OSError, NotADirectoryError, FileNotFoundError)):
+        process()
 
 
 def test_traced_decorator_preserves_metadata(capture_collector):

--- a/python/ommx-tests/tests/test_tracing_capture.py
+++ b/python/ommx-tests/tests/test_tracing_capture.py
@@ -13,10 +13,13 @@ IPython cell magic. Both APIs share the underlying ``_collector`` and
   the root span, the renderer flags it, and the traced exception
   still propagates to the caller.
 
-The session-scoped ``TracerProvider`` from :mod:`conftest` is reused;
-``_setup.reset_for_testing`` + a fresh ``_CellSpanCollector`` attached
-to the provider give each test isolation without touching the global
-OTel state.
+The session-scoped ``TracerProvider`` from :mod:`conftest` is reused,
+and a single module-level ``_CellSpanCollector`` is attached to it
+once and re-used across every test. The :func:`capture_collector`
+fixture swaps ``_setup._COLLECTOR`` to that shared instance for the
+duration of each test (so ``ensure_collector_installed`` returns it
+rather than piling up new processors on the provider) and clears the
+collector's internal state between tests via ``.shutdown()``.
 """
 
 from __future__ import annotations

--- a/python/ommx-tests/tests/test_tracing_capture.py
+++ b/python/ommx-tests/tests/test_tracing_capture.py
@@ -1,0 +1,334 @@
+"""Tests for the script-side tracing API (``capture_trace`` + ``@traced``).
+
+Complementary to :mod:`test_tracing_magic`, which exercises the
+IPython cell magic. Both APIs share the underlying ``_collector`` and
+``_render`` modules, so these tests focus on:
+
+* The context manager populates :class:`TraceResult.spans` and doesn't
+  swallow exceptions.
+* ``save_chrome_trace`` writes valid JSON, with parent dirs created.
+* ``@traced`` writes the trace on both the success and the exception
+  paths so users who rely on the file never see it silently missing.
+* Failure information survives: OTel records an ``ERROR`` status on
+  the root span, the renderer flags it, and the traced exception
+  still propagates to the caller.
+
+The session-scoped ``TracerProvider`` from :mod:`conftest` is reused;
+``_setup.reset_for_testing`` + a fresh ``_CellSpanCollector`` attached
+to the provider give each test isolation without touching the global
+OTel state.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace.status import StatusCode
+
+from ommx.tracing import TraceResult, capture_trace, traced
+from ommx.tracing import _setup
+from ommx.tracing._collector import _CellSpanCollector
+
+from conftest import get_test_provider
+
+
+# ---------------------------------------------------------------------------
+# Shared collector fixture
+# ---------------------------------------------------------------------------
+
+
+_SESSION_COLLECTOR: _CellSpanCollector | None = None
+
+
+@pytest.fixture
+def capture_collector():
+    """Attach a single collector to the session provider and clear its
+    state between tests. Mirrors the pattern used by
+    ``test_tracing_magic.cell_collector``; the two test files can
+    reuse the same underlying collector via the module-global since
+    each test does its own state reset."""
+    global _SESSION_COLLECTOR
+    _setup.reset_for_testing()
+    if _SESSION_COLLECTOR is None:
+        _SESSION_COLLECTOR = _CellSpanCollector()
+        get_test_provider().add_span_processor(_SESSION_COLLECTOR)
+    _SESSION_COLLECTOR.shutdown()
+    yield _SESSION_COLLECTOR
+    _setup.reset_for_testing()
+    _SESSION_COLLECTOR.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# capture_trace: happy path
+# ---------------------------------------------------------------------------
+
+
+def test_capture_trace_populates_result_on_success(capture_collector):
+    """``__exit__`` must fill in ``TraceResult.spans`` before returning."""
+    from opentelemetry import trace
+
+    with capture_trace("example_op") as result:
+        tracer = trace.get_tracer("ommx-capture-test")
+        with tracer.start_as_current_span("inner"):
+            pass
+
+    # Root + inner span land in the collected list.
+    names = sorted(s.name for s in result.spans)
+    assert names == ["example_op", "inner"]
+    # Text tree is useful to print from scripts.
+    tree = result.text_tree()
+    assert "example_op" in tree and "inner" in tree
+
+
+def test_capture_trace_custom_span_name(capture_collector):
+    """The caller can pick a descriptive root span name."""
+    with capture_trace("build_qubo") as result:
+        pass
+    assert [s.name for s in result.spans] == ["build_qubo"]
+
+
+# ---------------------------------------------------------------------------
+# capture_trace: exception path — must preserve info
+# ---------------------------------------------------------------------------
+
+
+def test_capture_trace_propagates_exception(capture_collector):
+    """The managed block must not swallow exceptions — the caller
+    relies on the failure to stop further work."""
+    with pytest.raises(ValueError, match="boom"):
+        with capture_trace() as _result:
+            raise ValueError("boom")
+
+
+def test_capture_trace_populates_result_on_exception(capture_collector):
+    """Even when the block raised, ``result.spans`` must be usable
+    from an outer ``try``/``except`` so the caller can still inspect
+    or save the trace — information is never dropped."""
+    result: TraceResult | None = None
+    try:
+        with capture_trace("failing_op") as r:
+            result = r
+            raise ValueError("boom")
+    except ValueError:
+        pass
+
+    assert result is not None
+    assert result.spans, "TraceResult.spans must be populated on the exception path"
+    # The root span sees the exception via OTel's default
+    # record_exception + set_status(ERROR).
+    root = next(s for s in result.spans if s.name == "failing_op")
+    assert root.status is not None
+    assert root.status.status_code == StatusCode.ERROR
+    # And the renderer surfaces the error status so the user can find
+    # the failing span at a glance.
+    tree = result.text_tree()
+    assert "[ERROR]" in tree
+    assert "failing_op" in tree
+
+
+def test_capture_trace_uses_fresh_trace_id(capture_collector):
+    """``start_as_current_span`` is handed an explicit empty Context
+    so each block is its own root, not a child of any ambient span.
+    Without the detach, spans from unrelated instrumentation could
+    land in the captured list."""
+    from opentelemetry import trace
+
+    tracer = trace.get_tracer("ommx-capture-test.ambient")
+    with tracer.start_as_current_span("ambient_parent") as ambient:
+        with tracer.start_as_current_span("ambient_sibling"):
+            pass
+        with capture_trace("isolated") as result:
+            pass
+        ambient_trace_id = ambient.get_span_context().trace_id
+
+    # Captured spans only contain the isolated root.
+    assert [s.name for s in result.spans] == ["isolated"]
+    # Their trace_ids differ. ``context`` is Optional[SpanContext];
+    # for a finished ``ReadableSpan`` it's always populated, but
+    # assert it for the type checker.
+    isolated_ctx = result.spans[0].context
+    assert isolated_ctx is not None
+    assert isolated_ctx.trace_id != ambient_trace_id
+
+
+# ---------------------------------------------------------------------------
+# Chrome Trace output + save_chrome_trace
+# ---------------------------------------------------------------------------
+
+
+def test_save_chrome_trace_writes_valid_json(capture_collector, tmp_path):
+    """``save_chrome_trace`` writes the JSON the other tools consume."""
+    with capture_trace() as result:
+        pass
+
+    out = tmp_path / "nested" / "trace.json"
+    result.save_chrome_trace(out)
+
+    assert out.exists(), "save_chrome_trace should create parent dirs"
+    parsed = json.loads(out.read_text(encoding="utf-8"))
+    assert parsed["displayTimeUnit"] == "ms"
+    assert parsed["traceEvents"], "Trace must include at least the root span event"
+
+
+def test_trace_result_chrome_trace_json_string(capture_collector):
+    """``chrome_trace_json`` is the same JSON that ``save_chrome_trace``
+    would write — handy for tests and for piping into another tool
+    without touching the filesystem."""
+    with capture_trace() as result:
+        pass
+    payload = result.chrome_trace_json()
+    parsed = json.loads(payload)
+    assert parsed["traceEvents"]
+
+
+# ---------------------------------------------------------------------------
+# @traced decorator
+# ---------------------------------------------------------------------------
+
+
+def test_traced_decorator_no_args_runs_and_returns(capture_collector):
+    """``@traced`` without arguments traces the call and returns the
+    wrapped function's result unchanged."""
+
+    @traced
+    def process(x, y):
+        return x + y
+
+    assert process(2, 3) == 5
+
+
+def test_traced_decorator_with_args(capture_collector):
+    """``@traced()`` with keyword args behaves identically to the
+    no-arg form for the caller."""
+
+    @traced(name="custom_name")
+    def process():
+        return 42
+
+    assert process() == 42
+
+
+def test_traced_decorator_writes_output_on_success(capture_collector, tmp_path):
+    """``output=...`` writes the Chrome Trace JSON on the success path."""
+    out = tmp_path / "success.json"
+
+    @traced(name="success_op", output=out)
+    def process():
+        return 7
+
+    assert process() == 7
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    names = {e["name"] for e in payload["traceEvents"]}
+    assert "success_op" in names
+
+
+def test_traced_decorator_writes_output_on_exception(capture_collector, tmp_path):
+    """The exception path must still write the trace to disk —
+    otherwise users who rely on the file for post-mortem analysis
+    would find it missing exactly when they need it most."""
+    out = tmp_path / "failure.json"
+
+    @traced(name="failing_op", output=out)
+    def process():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        process()
+
+    assert out.exists(), (
+        "Trace must be written even when the decorated function raised — "
+        "losing the trace on failure defeats the purpose of tracing."
+    )
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    names = {e["name"] for e in payload["traceEvents"]}
+    assert "failing_op" in names
+
+
+def test_traced_decorator_uses_function_qualname_by_default(
+    capture_collector, tmp_path
+):
+    """If ``name`` is omitted the span is named after the function so
+    traces from multiple decorated functions are easy to tell apart.
+
+    Uses ``__qualname__`` rather than ``__name__`` so methods inside a
+    class show up as ``ClassName.method_name`` (for a local function
+    in a test, the qualname includes the enclosing-test prefix — we
+    just check the function's base name appears in the event name).
+    """
+    out = tmp_path / "named.json"
+
+    @traced(output=out)
+    def build_qubo():
+        return 1
+
+    build_qubo()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    names = [e["name"] for e in payload["traceEvents"]]
+    assert any("build_qubo" in n for n in names), (
+        f"Span name should derive from the function. Got: {names}"
+    )
+
+
+def test_traced_decorator_preserves_metadata(capture_collector):
+    """``functools.wraps`` preserves ``__name__`` / ``__doc__`` —
+    important for introspection tools and help()."""
+
+    @traced(name="something_else")
+    def process():
+        """Do a thing."""
+        return 0
+
+    assert process.__name__ == "process"
+    assert process.__doc__ == "Do a thing."
+
+
+# ---------------------------------------------------------------------------
+# Renderer: the new [ERROR] marker
+# ---------------------------------------------------------------------------
+
+
+def test_text_tree_marks_error_spans(capture_collector):
+    """Spans with ``Status(ERROR)`` must be flagged in the tree output
+    so the failing leaf is obvious when reading a trace post-mortem."""
+    from opentelemetry import trace
+
+    result: TraceResult | None = None
+    try:
+        with capture_trace("outer") as r:
+            result = r
+            tracer = trace.get_tracer("ommx-capture-test")
+            with tracer.start_as_current_span("inner"):
+                raise RuntimeError("kaboom")
+    except RuntimeError:
+        pass
+
+    assert result is not None
+    tree = result.text_tree()
+    # Both the inner span (active when the exception fired) and the
+    # root block inherit the ERROR status.
+    outer_line = next(line for line in tree.splitlines() if "outer" in line)
+    inner_line = next(line for line in tree.splitlines() if "inner" in line)
+    assert "[ERROR]" in outer_line
+    assert "[ERROR]" in inner_line
+
+
+def test_text_tree_does_not_mark_successful_spans(capture_collector):
+    """Spans that completed without an exception must stay unmarked."""
+    with capture_trace("clean") as result:
+        pass
+    tree = result.text_tree()
+    assert "[ERROR]" not in tree
+
+
+# ---------------------------------------------------------------------------
+# Sanity check: ReadableSpan type is the real one (regression for Any stubs)
+# ---------------------------------------------------------------------------
+
+
+def test_trace_result_spans_are_readable_spans(capture_collector):
+    with capture_trace() as result:
+        pass
+    assert all(isinstance(s, ReadableSpan) for s in result.spans)

--- a/python/ommx-tests/tests/test_tracing_magic.py
+++ b/python/ommx-tests/tests/test_tracing_magic.py
@@ -332,6 +332,31 @@ def test_run_cell_with_trace_exec_user_code(ipython_shell):
         _setup.reset_for_testing()
 
 
+def test_run_cell_with_trace_marks_root_span_error_on_cell_failure(ipython_shell):
+    """When the cell raised, the ``ommx_trace_cell`` root span must
+    carry ``Status(ERROR)`` so the text tree shows ``[ERROR]`` on
+    the root line — otherwise ``shell.run_cell`` would swallow the
+    exception internally, the ``capture_trace`` block would exit
+    normally, and the span would close with the default OK status."""
+    _setup.reset_for_testing()
+    try:
+        html, exc = run_cell_with_trace(
+            ipython_shell,
+            "raise ValueError('root should be marked ERROR')",
+        )
+        assert isinstance(exc, ValueError)
+        # The HTML's text tree must contain [ERROR] next to the
+        # ``ommx_trace_cell`` line, not only on leaf spans.
+        root_line = next(
+            line for line in html.splitlines() if "ommx_trace_cell" in line
+        )
+        assert "[ERROR]" in root_line, (
+            f"Cell magic root span missing ERROR marker. Line was: {root_line}"
+        )
+    finally:
+        _setup.reset_for_testing()
+
+
 def test_run_cell_with_trace_reports_cell_exceptions(ipython_shell):
     """A cell that raises still produces HTML output. The caller
     (``register_magic``) is responsible for re-raising so failure

--- a/python/ommx-tests/tests/test_tracing_magic.py
+++ b/python/ommx-tests/tests/test_tracing_magic.py
@@ -57,21 +57,24 @@ _SESSION_COLLECTOR: _CellSpanCollector | None = None
 def cell_collector():
     """Return a session-wide collector with per-test state cleared.
 
-    Rebuilding the collector every test attaches a new ``SpanProcessor``
-    to the SDK provider — OTel does not expose a clean removal API, so
-    those processors would accumulate. Reuse is both cheaper and
-    exercises the real long-lived notebook behaviour.
+    Points ``_setup._COLLECTOR`` at the shared instance so
+    ``ensure_collector_installed()`` (called indirectly by
+    ``capture_trace`` / ``run_cell_with_trace``) returns it unchanged
+    rather than creating a fresh ``_CellSpanCollector`` + attaching a
+    new ``SpanProcessor`` every test. Without that, processors would
+    pile up across the suite.
     """
     global _SESSION_COLLECTOR
-    _setup.reset_for_testing()
     if _SESSION_COLLECTOR is None:
         _SESSION_COLLECTOR = _CellSpanCollector()
         get_test_provider().add_span_processor(_SESSION_COLLECTOR)
-    # Drop any leftover state from a previous test.
-    _SESSION_COLLECTOR.shutdown()
-    yield _SESSION_COLLECTOR
-    _setup.reset_for_testing()
-    _SESSION_COLLECTOR.shutdown()
+    _setup._COLLECTOR = _SESSION_COLLECTOR
+    _SESSION_COLLECTOR.shutdown()  # drop state from previous test
+    try:
+        yield _SESSION_COLLECTOR
+    finally:
+        _SESSION_COLLECTOR.shutdown()
+        _setup._COLLECTOR = None
 
 
 def _run_and_collect(collector: _CellSpanCollector, cell_fn):

--- a/python/ommx/ommx/tracing/__init__.py
+++ b/python/ommx/ommx/tracing/__init__.py
@@ -1,6 +1,8 @@
-"""Per-cell tracing for Jupyter/IPython.
+"""Per-cell / per-block tracing for OMMX.
 
-Usage::
+Two user-facing APIs, sharing the same OTel collector + renderers:
+
+**Jupyter cell magic** (best for notebooks)::
 
     %load_ext ommx.tracing
 
@@ -12,33 +14,63 @@ Cell output shows a nested text tree of every span produced during the
 cell (Rust and Python alike), annotated with durations and attributes,
 plus a download link for the full trace in Chrome Trace Event Format.
 
-The public surface is intentionally tiny:
+**Context manager / decorator** (best for scripts, tests, CI)::
 
+    from ommx.tracing import capture_trace, traced
+
+    with capture_trace() as trace:
+        solution = instance.evaluate(state)
+    print(trace.text_tree())
+    trace.save_chrome_trace("trace.json")
+
+    @traced(output="process.json")
+    def process():
+        ...
+
+The public surface is intentionally small:
+
+* :class:`capture_trace` — context manager; ``__enter__`` returns a
+  :class:`TraceResult` placeholder that ``__exit__`` fills in (for
+  success *and* for exceptions — information is never dropped).
+* :class:`TraceResult` — ``spans``, ``text_tree()``,
+  ``chrome_trace_json()``, ``save_chrome_trace(path)``.
+* :func:`traced` — decorator sugar on top of :class:`capture_trace`,
+  optionally writing the Chrome Trace JSON to disk.
 * :func:`load_ipython_extension` — wired by ``%load_ext ommx.tracing``;
   registers the ``%%ommx_trace`` cell magic. The collector itself is
   attached to the active OpenTelemetry ``TracerProvider`` lazily, on
   the first traced cell, so ``%load_ext`` stays cheap and cannot fail
   due to provider state that is still being configured further up the
   notebook.
-* :func:`unload_ipython_extension` — pair for ``%unload_ext``. Kept as a
-  no-op because IPython magics cannot be cleanly unregistered without
-  disturbing user state; leaving the collector installed costs nothing.
+* :func:`unload_ipython_extension` — pair for ``%unload_ext``. Kept as
+  a no-op because IPython magics cannot be cleanly unregistered
+  without disturbing user state; leaving the collector installed costs
+  nothing.
 
-Everything else (``_collector``, ``_render``, ``_setup``, ``_magic``) is
-internal and may change without notice. Reach for them only if you are
-building on top of this module and can tolerate breakage.
+Everything else (``_collector``, ``_render``, ``_setup``, ``_magic``,
+``_capture``) is internal and may change without notice. Reach for
+them only if you are building on top of this module and can tolerate
+breakage.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ._capture import TraceResult, capture_trace, traced
+
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from IPython.core.interactiveshell import InteractiveShell
 
 
-__all__ = ["load_ipython_extension", "unload_ipython_extension"]
+__all__ = [
+    "TraceResult",
+    "capture_trace",
+    "load_ipython_extension",
+    "traced",
+    "unload_ipython_extension",
+]
 
 
 def load_ipython_extension(ipython: "InteractiveShell") -> None:

--- a/python/ommx/ommx/tracing/_capture.py
+++ b/python/ommx/ommx/tracing/_capture.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Union, overload
@@ -51,7 +52,9 @@ from typing import Any, Callable, List, Optional, Union, overload
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import Span
 
+from ._collector import _CellSpanCollector
 from ._render import chrome_trace_json, render_text_tree
 from ._setup import ensure_collector_installed
 
@@ -110,8 +113,8 @@ class capture_trace:  # noqa: N801 - context-manager factory, lowercase on purpo
         self._name = name
         self._result = TraceResult()
         self._trace_id: Optional[int] = None
-        self._collector = None  # type: Any
-        self._span_cm = None  # type: Any
+        self._collector: Optional[_CellSpanCollector] = None
+        self._span_cm: Optional[AbstractContextManager[Span]] = None
 
     def __enter__(self) -> TraceResult:
         self._collector = ensure_collector_installed()

--- a/python/ommx/ommx/tracing/_capture.py
+++ b/python/ommx/ommx/tracing/_capture.py
@@ -43,6 +43,7 @@ raises normally — we never swallow. Before the exception propagates:
 from __future__ import annotations
 
 import functools
+import inspect
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Union, overload
@@ -194,26 +195,80 @@ def traced(
     are easy to tell apart in the rendered tree.
     """
 
+    def _save_if_configured(result: Optional[TraceResult]) -> None:
+        if output is not None and result is not None:
+            result.save_chrome_trace(output)
+
+    def _save_best_effort(result: Optional[TraceResult]) -> None:
+        """Like ``_save_if_configured`` but swallows any I/O failure.
+
+        Used on the exception path: a save failure here would *replace*
+        the user's original exception, which is the signal they care
+        about most. Silently dropping the save is the lesser evil.
+        """
+        if output is None or result is None:
+            return
+        try:
+            result.save_chrome_trace(output)
+        except Exception:  # noqa: BLE001 - intentional swallow
+            pass
+
     def _decorator(fn: _F) -> _F:
         span_name = name if name is not None else fn.__qualname__
+
+        if inspect.iscoroutinefunction(fn):
+            # ``async def`` needs its own wrapper: a plain sync wrapper
+            # would trace only the coroutine-object creation, finish
+            # the ``capture_trace`` block, and return the still-
+            # unawaited coroutine — by the time it runs, the capture
+            # window is closed and every span is silently dropped.
+            @functools.wraps(fn)
+            async def _async_wrapper(*args, **kwargs):
+                capture = capture_trace(span_name)
+                result: Optional[TraceResult] = None
+                # Pre-initialise so pyright can see ``retval`` is
+                # bound in the ``else`` branch even though the
+                # assignment below lives inside a ``with`` whose
+                # ``__exit__`` could theoretically raise.
+                retval: Any = None
+                try:
+                    with capture as r:
+                        result = r
+                        retval = await fn(*args, **kwargs)
+                except BaseException:
+                    # User exception: save best-effort, then propagate
+                    # it unchanged so the signal isn't lost to an I/O
+                    # hiccup from the trace writer.
+                    _save_best_effort(result)
+                    raise
+                else:
+                    # Success: let save errors surface so a broken
+                    # path configuration is noticed.
+                    _save_if_configured(result)
+                    return retval
+
+            return _async_wrapper  # type: ignore[return-value]
 
         @functools.wraps(fn)
         def _wrapper(*args, **kwargs):
             capture = capture_trace(span_name)
             result: Optional[TraceResult] = None
+            retval: Any = None
             try:
                 with capture as r:
                     result = r
-                    return fn(*args, **kwargs)
-            finally:
-                # ``capture.__exit__`` has populated ``result.spans``
-                # by the time this ``finally`` fires (the ``with`` exit
-                # runs before the enclosing try/finally's ``finally``).
-                # Writing the trace here covers both the success and
-                # the exception path, so the file is never missing
-                # when the user expected one.
-                if output is not None and result is not None:
-                    result.save_chrome_trace(output)
+                    retval = fn(*args, **kwargs)
+            except BaseException:
+                # User exception: save best-effort, then propagate
+                # it unchanged so the signal isn't lost to an I/O
+                # hiccup from the trace writer.
+                _save_best_effort(result)
+                raise
+            else:
+                # Success: let save errors surface so a broken path
+                # configuration is noticed.
+                _save_if_configured(result)
+                return retval
 
         return _wrapper
 

--- a/python/ommx/ommx/tracing/_capture.py
+++ b/python/ommx/ommx/tracing/_capture.py
@@ -55,7 +55,12 @@ from ._render import chrome_trace_json, render_text_tree
 from ._setup import ensure_collector_installed
 
 
-_TRACER_NAME = "ommx.tracing.script"
+# One tracer name for every entry point in ``ommx.tracing`` (the cell
+# magic, the context manager, and the decorator). The name is a
+# coarse instrumentation-scope label — the actual span *name* passed
+# to ``tracer.start_as_current_span`` is what appears in the tree, so
+# we don't need a per-entry-point tracer.
+_TRACER_NAME = "ommx.tracing"
 _DEFAULT_ROOT_SPAN_NAME = "ommx_trace_block"
 
 

--- a/python/ommx/ommx/tracing/_capture.py
+++ b/python/ommx/ommx/tracing/_capture.py
@@ -1,0 +1,218 @@
+"""Script-side tracing API: ``capture_trace`` and ``@traced``.
+
+The Jupyter cell magic (``%%ommx_trace``) is great inside a notebook
+but useless from a plain Python script. This module exposes the same
+``_collector`` / ``_render`` machinery through a context manager and a
+decorator so callers outside IPython get the same tree + JSON output.
+
+Usage::
+
+    from ommx.tracing import capture_trace
+
+    with capture_trace() as trace:
+        instance = Instance.from_bytes(blob)
+        solution = instance.evaluate(state)
+
+    print(trace.text_tree())
+    trace.save_chrome_trace("out.json")
+
+Or as a decorator::
+
+    from ommx.tracing import traced
+
+    @traced(output="process.json")
+    def process():
+        ...
+
+    process()  # writes process.json on return *and* on exception
+
+**Exception handling.** Everything inside the managed block still
+raises normally — we never swallow. Before the exception propagates:
+
+1. OTel's ``start_as_current_span`` records the exception on the root
+   span (``record_exception=True`` + ``set_status(ERROR)``), so any
+   exporter downstream (Chrome Trace consumers, OTLP backends) sees
+   the failure.
+2. ``TraceResult.spans`` is populated from the collector, so the
+   caller can still inspect or save the trace from an outer ``try``
+   block's ``except`` / ``finally`` arm.
+3. :func:`._render.render_text_tree` flags spans with ``[ERROR]`` so
+   the failure location is obvious in the rendered tree.
+"""
+
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Union, overload
+
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan
+
+from ._render import chrome_trace_json, render_text_tree
+from ._setup import ensure_collector_installed
+
+
+_TRACER_NAME = "ommx.tracing.script"
+_DEFAULT_ROOT_SPAN_NAME = "ommx_trace_block"
+
+
+@dataclass
+class TraceResult:
+    """Populated result of a ``capture_trace`` block.
+
+    Filled in by :class:`capture_trace` on ``__exit__`` (including the
+    exception path, so the caller can always inspect the trace even
+    when the block raised).
+    """
+
+    spans: List[ReadableSpan] = field(default_factory=list)
+
+    def text_tree(self) -> str:
+        """Return the nested text tree — same renderer the cell magic uses."""
+        return render_text_tree(self.spans)
+
+    def chrome_trace_json(self) -> str:
+        """Return a Chrome Trace Event Format JSON string."""
+        return chrome_trace_json(self.spans)
+
+    def save_chrome_trace(self, path: Union[str, Path]) -> None:
+        """Write the Chrome Trace JSON to ``path`` (creating parents as needed).
+
+        Overwrites any existing file. The UTF-8 encoding matches the
+        JSON spec and is what Perfetto / speedscope /
+        ``chrome://tracing`` all accept.
+        """
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(self.chrome_trace_json(), encoding="utf-8")
+
+
+class capture_trace:  # noqa: N801 - context-manager factory, lowercase on purpose
+    """Context manager that captures every OTel span inside the block.
+
+    The root span is started with an explicit empty OTel ``Context`` so
+    each block gets its own fresh ``trace_id`` regardless of any
+    ambient spans — the collector keys captures by ``trace_id``, so
+    without this guard sibling spans from unrelated instrumentation
+    would bleed into the result.
+    """
+
+    def __init__(self, name: str = _DEFAULT_ROOT_SPAN_NAME) -> None:
+        self._name = name
+        self._result = TraceResult()
+        self._trace_id: Optional[int] = None
+        self._collector = None  # type: Any
+        self._span_cm = None  # type: Any
+
+    def __enter__(self) -> TraceResult:
+        self._collector = ensure_collector_installed()
+        tracer = trace.get_tracer(_TRACER_NAME)
+        # ``context=Context()`` detaches from the ambient context so
+        # the block's trace_id is always fresh — keeps the capture
+        # window from pulling in unrelated sibling spans.
+        self._span_cm = tracer.start_as_current_span(
+            self._name,
+            context=otel_context.Context(),
+        )
+        root = self._span_cm.__enter__()
+        self._trace_id = root.get_span_context().trace_id
+        self._collector.begin_capture(self._trace_id)
+        return self._result
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        try:
+            # Delegate to the span context manager so OTel records the
+            # exception on the span (status=ERROR, exception event) —
+            # ``record_exception=True`` is the default on
+            # ``start_as_current_span``.
+            if self._span_cm is not None:
+                self._span_cm.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            # Populate the TraceResult whether or not the block raised,
+            # so callers can inspect/save the trace from an outer
+            # ``except`` or ``finally``.
+            if self._collector is not None and self._trace_id is not None:
+                self._result.spans = self._collector.end_capture(self._trace_id)
+        # Never swallow the exception.
+        return False
+
+
+# ---------------------------------------------------------------------------
+# @traced decorator
+# ---------------------------------------------------------------------------
+
+
+_F = Callable[..., Any]
+
+
+@overload
+def traced(func: _F) -> _F: ...
+
+
+@overload
+def traced(
+    *,
+    name: Optional[str] = ...,
+    output: Optional[Union[str, Path]] = ...,
+) -> Callable[[_F], _F]: ...
+
+
+def traced(
+    func: Optional[_F] = None,
+    *,
+    name: Optional[str] = None,
+    output: Optional[Union[str, Path]] = None,
+) -> Any:
+    """Decorator that runs the wrapped function under :class:`capture_trace`.
+
+    Supports all three call shapes::
+
+        @traced
+        def process(): ...
+
+        @traced()
+        def process(): ...
+
+        @traced(name="build_qubo", output="qubo.json")
+        def process(): ...
+
+    If ``output`` is given, the Chrome Trace JSON is written to that
+    path when the function returns **or raises** — information is
+    never dropped. The exception, if any, is re-raised unchanged after
+    the file is written.
+
+    If ``name`` is omitted, the span is named after the function
+    (``fn.__qualname__``) so traces from multiple decorated functions
+    are easy to tell apart in the rendered tree.
+    """
+
+    def _decorator(fn: _F) -> _F:
+        span_name = name if name is not None else fn.__qualname__
+
+        @functools.wraps(fn)
+        def _wrapper(*args, **kwargs):
+            capture = capture_trace(span_name)
+            result: Optional[TraceResult] = None
+            try:
+                with capture as r:
+                    result = r
+                    return fn(*args, **kwargs)
+            finally:
+                # ``capture.__exit__`` has populated ``result.spans``
+                # by the time this ``finally`` fires (the ``with`` exit
+                # runs before the enclosing try/finally's ``finally``).
+                # Writing the trace here covers both the success and
+                # the exception path, so the file is never missing
+                # when the user expected one.
+                if output is not None and result is not None:
+                    result.save_chrome_trace(output)
+
+        return _wrapper
+
+    if func is not None:
+        # ``@traced`` without parens.
+        return _decorator(func)
+    return _decorator

--- a/python/ommx/ommx/tracing/_collector.py
+++ b/python/ommx/ommx/tracing/_collector.py
@@ -1,10 +1,16 @@
-"""Collect finished OTel spans for active cell traces.
+"""Collect finished OTel spans for explicitly captured traces.
 
-``%%ommx_trace`` brackets each cell with :meth:`begin_capture` and
-:meth:`end_capture` calls on the collector. Spans whose ``trace_id`` is
-not between a matching begin/end pair are dropped immediately — without
-this gate, a long-lived notebook with other instrumentation would leak
+Both the ``%%ommx_trace`` cell magic and the ``capture_trace`` /
+``@traced`` script API bracket their tracked work with
+:meth:`_CellSpanCollector.begin_capture` / :meth:`end_capture` on this
+collector. Spans whose ``trace_id`` falls outside any active
+begin/end pair are dropped immediately — without that gate, a
+long-lived notebook or daemon with other instrumentation would leak
 memory as unrelated traces accumulated in :attr:`_spans_by_trace`.
+
+The ``_Cell`` prefix is a historical holdover from when the collector
+only backed the cell magic; it is shared by every entry point in
+``ommx.tracing`` now.
 """
 
 from __future__ import annotations

--- a/python/ommx/ommx/tracing/_magic.py
+++ b/python/ommx/ommx/tracing/_magic.py
@@ -73,6 +73,21 @@ def run_cell_with_trace(
             else result.error_in_exec
         )
 
+        if cell_exc is not None:
+            # ``shell.run_cell`` caught the exception internally rather
+            # than letting it propagate, so the ``capture_trace`` block
+            # is about to exit *normally* and the root span would
+            # close with an OK status — losing the ``[ERROR]`` marker
+            # in the rendered tree even though the cell did fail.
+            # Explicitly mark the root as failed and record the
+            # exception as a span event.
+            from opentelemetry import trace as otel_trace
+            from opentelemetry.trace.status import Status, StatusCode
+
+            root = otel_trace.get_current_span()
+            root.set_status(Status(StatusCode.ERROR, str(cell_exc)))
+            root.record_exception(cell_exc)
+
     return render_cell_output_html(trace_result.spans), cell_exc
 
 

--- a/python/ommx/ommx/tracing/_magic.py
+++ b/python/ommx/ommx/tracing/_magic.py
@@ -1,40 +1,38 @@
 """``%%ommx_trace`` cell magic implementation.
 
-Registered via ``%load_ext ommx.tracing``. The magic wraps cell execution
-in a single OTel root span, asks :class:`._collector._CellSpanCollector`
-to stash only that trace's spans, and displays the result as HTML.
+Registered via ``%load_ext ommx.tracing``. The magic is a thin wrapper
+around :class:`._capture.capture_trace`: it opens a ``capture_trace``
+block named ``ommx_trace_cell``, executes the cell body through
+``InteractiveShell.run_cell`` so the full IPython pipeline (input
+transforms, top-level ``await``, line magics) applies, and renders
+the collected trace as HTML.
 
-Cell-body execution goes through :meth:`InteractiveShell.run_cell` so
-the full IPython pipeline — input transforms, top-level ``await``, line
-magics, cell-input cleanups — behaves the way it would in an untraced
-cell. The point is that ``%%ommx_trace`` should be observational: a
-user removes the magic, the cell body still does the same thing.
+The only cell-magic-specific extras are:
 
-Re-raising without a double traceback is slightly delicate. ``run_cell``
-catches exceptions internally and calls ``shell.showtraceback()`` before
-returning; if we then re-raise the captured exception, the *outer*
-``run_cell`` (the one that invoked our magic) prints it a second time.
-We work around that by temporarily pointing ``shell.showtraceback`` at
-a no-op during the inner call, so the traceback is shown exactly once —
-by the outer ``run_cell`` when our re-raise reaches it.
+* We suppress ``run_cell``'s inbuilt ``showtraceback`` for the inner
+  call so the *outer* ``run_cell`` (which invoked the magic) prints
+  the traceback exactly once after our re-raise.
+* We re-raise the cell's exception so notebook automation
+  (``nbconvert --execute``, papermill, pytest-nbval, …) still sees
+  traced cells fail when the user code raised.
+
+Everything else (fresh trace context, active-trace collector gating,
+HTML rendering with the ``[ERROR]`` marker) comes from
+``capture_trace`` / ``_render``.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from opentelemetry import context as otel_context
-from opentelemetry import trace
-
+from ._capture import capture_trace
 from ._render import render_cell_output_html
-from ._setup import ensure_collector_installed
 
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from IPython.core.interactiveshell import InteractiveShell
 
 
-_CELL_TRACER_NAME = "ommx.tracing.cell"
 _CELL_ROOT_SPAN_NAME = "ommx_trace_cell"
 
 
@@ -42,69 +40,40 @@ def run_cell_with_trace(
     shell: "InteractiveShell",
     cell: str,
 ) -> Tuple[str, Optional[BaseException]]:
-    """Execute ``cell`` inside a fresh ``ommx_trace_cell`` root span.
+    """Execute ``cell`` inside an ``ommx_trace_cell`` root span.
 
     Returns ``(html_blob, error)`` where ``html_blob`` is the rendered
-    trace output (always produced, even if the cell raised) and
+    trace HTML (always produced, even if the cell raised) and
     ``error`` is the exception raised during execution or ``None``.
     Splitting rendering from re-raise keeps the function testable
-    without driving IPython's display machinery; the magic entry point
-    (:func:`register_magic`) is what actually re-raises.
-
-    The root span is started with an explicit empty OTel ``Context`` so
-    the cell's ``trace_id`` is always fresh, detached from any ambient
-    span that might be in scope. Without that detach, an ambient span
-    installed by an unrelated extension would share a ``trace_id`` with
-    the cell, and the collector — which keys captures by ``trace_id`` —
-    would pull unrelated spans into the cell's output.
+    without driving IPython's display machinery; the magic entry
+    point (:func:`register_magic`) is what actually re-raises.
     """
-    collector = ensure_collector_installed()
-    tracer = trace.get_tracer(_CELL_TRACER_NAME)
-
     cell_exc: Optional[BaseException] = None
-    trace_id: Optional[int] = None
-    try:
-        with tracer.start_as_current_span(
-            _CELL_ROOT_SPAN_NAME,
-            # ``context=Context()`` detaches from whatever context is
-            # currently active, forcing a brand-new trace. Without this
-            # the cell would inherit an ambient span's trace_id and the
-            # collector's capture window would pull in unrelated spans.
-            context=otel_context.Context(),
-        ) as root:
-            trace_id = root.get_span_context().trace_id
-            collector.begin_capture(trace_id)
+    with capture_trace(_CELL_ROOT_SPAN_NAME) as trace_result:
+        # Suppress the inner ``showtraceback``: ``run_cell`` calls it
+        # unconditionally on error, but the outer ``run_cell`` will
+        # also call it once our re-raise reaches it, and we don't
+        # want the traceback printed twice.
+        original_showtraceback = shell.showtraceback
+        shell.showtraceback = lambda *args, **kwargs: None
+        try:
+            result = shell.run_cell(cell, store_history=False)
+        finally:
+            shell.showtraceback = original_showtraceback
 
-            # Suppress the inner ``showtraceback``: ``run_cell`` calls
-            # it unconditionally on error, but the outer ``run_cell``
-            # will also call it once our re-raise reaches it, and we
-            # don't want the traceback printed twice.
-            original_showtraceback = shell.showtraceback
-            shell.showtraceback = lambda *args, **kwargs: None
-            try:
-                result = shell.run_cell(cell, store_history=False)
-            finally:
-                shell.showtraceback = original_showtraceback
-            # Both parse-time and runtime errors are surfaced.
-            # ``error_before_exec`` is typed as ``BaseException | True |
-            # None`` in IPython's stubs (``True`` was a legacy sentinel)
-            # so narrow through ``isinstance`` before handing it back.
-            err_before = result.error_before_exec
-            cell_exc = (
-                err_before
-                if isinstance(err_before, BaseException)
-                else result.error_in_exec
-            )
-    finally:
-        # Call ``end_capture`` *after* the ``with`` block exits so the
-        # root span's ``on_end`` fires first and lands in the collector.
-        # Moving this into the inner ``finally`` (inside ``with``) would
-        # drop the root span itself from the rendered tree. The outer
-        # ``finally`` also makes sure the collector's active-trace set
-        # is cleared on ``KeyboardInterrupt`` / ``SystemExit``.
-        spans = collector.end_capture(trace_id) if trace_id is not None else []
+        # Surface both parse-time and runtime errors.
+        # ``error_before_exec`` is typed as ``BaseException | True |
+        # None`` in IPython's stubs (``True`` was a legacy sentinel),
+        # so narrow through ``isinstance`` first.
+        err_before = result.error_before_exec
+        cell_exc = (
+            err_before
+            if isinstance(err_before, BaseException)
+            else result.error_in_exec
+        )
 
-    return render_cell_output_html(spans), cell_exc
+    return render_cell_output_html(trace_result.spans), cell_exc
 
 
 def register_magic(shell: "InteractiveShell") -> None:

--- a/python/ommx/ommx/tracing/_magic.py
+++ b/python/ommx/ommx/tracing/_magic.py
@@ -86,7 +86,12 @@ def run_cell_with_trace(
 
             root = otel_trace.get_current_span()
             root.set_status(Status(StatusCode.ERROR, str(cell_exc)))
-            root.record_exception(cell_exc)
+            # ``escaped=True`` because :func:`register_magic` below
+            # re-raises ``cell_exc`` so it escapes the root span. Letting
+            # downstream OTel consumers (OTLP, Jaeger, …) see that
+            # distinction — swallowed vs. propagated — matches the
+            # spec's intent for this flag.
+            root.record_exception(cell_exc, escaped=True)
 
     return render_cell_output_html(trace_result.spans), cell_exc
 

--- a/python/ommx/ommx/tracing/_render.py
+++ b/python/ommx/ommx/tracing/_render.py
@@ -164,7 +164,13 @@ def to_chrome_trace(spans: Iterable[ReadableSpan]) -> dict:
             continue
         ts_us = span.start_time // 1_000
         dur_us = max((span.end_time - span.start_time) // 1_000, 1)
-        args = {k: _attribute_to_json(v) for k, v in (span.attributes or {}).items()}
+        attrs = span.attributes or {}
+        args = {k: _attribute_to_json(v) for k, v in attrs.items()}
+        # All events are placed on a single logical thread for the MVP
+        # renderer. ``tracing``-crate spans carry a ``thread.id``
+        # attribute; surfacing it as ``tid`` would let Perfetto /
+        # speedscope lay out concurrent work on parallel tracks. Kept
+        # out of scope until there's a workload that actually benefits.
         events.append(
             {
                 "name": span.name,

--- a/python/ommx/ommx/tracing/_render.py
+++ b/python/ommx/ommx/tracing/_render.py
@@ -14,6 +14,7 @@ import json
 from typing import Dict, Iterable, List, Optional, Sequence, Set
 
 from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace.status import StatusCode
 
 
 # ---------------------------------------------------------------------------
@@ -39,6 +40,21 @@ def _format_duration(ms: float) -> str:
     if ms >= 1:
         return f"{ms:.2f} ms"
     return f"{ms * 1000:.1f} µs"
+
+
+def _status_marker(span: ReadableSpan) -> str:
+    """Return ``" [ERROR]"`` when the span recorded a failure, else ``""``.
+
+    OTel sets ``Status(ERROR)`` on spans whose context manager saw an
+    exception (``start_as_current_span`` defaults to
+    ``record_exception=True``). Surfacing that in the tree makes it
+    obvious which leaf failed when the user re-reads a trace for a
+    crashed block.
+    """
+    status = getattr(span, "status", None)
+    if status is not None and status.status_code == StatusCode.ERROR:
+        return " [ERROR]"
+    return ""
 
 
 def _interesting_attributes(span: ReadableSpan) -> str:
@@ -102,6 +118,7 @@ def render_text_tree(spans: Sequence[ReadableSpan]) -> str:
         lines.append(
             f"{prefix}{marker}{span.name} "
             f"({_format_duration(_duration_ms(span))})"
+            f"{_status_marker(span)}"
             f"{_interesting_attributes(span)}"
         )
         ctx = span.context


### PR DESCRIPTION
Part of #817 (PR5).

Adds the plain-Python counterpart to the `%%ommx_trace` cell magic that shipped in #828. Scripts, tests, and CI pipelines can now capture the same text tree and Chrome Trace JSON without dragging in IPython, and the cell magic itself is now implemented on top of this new core.

## Usage

**Context manager:**

```python
from ommx.tracing import capture_trace

with capture_trace() as trace:
    instance = Instance.from_bytes(blob)
    solution = instance.evaluate(state)

print(trace.text_tree())
trace.save_chrome_trace("trace.json")
```

Sample tree from a real OMMX pipeline:

```
└── ommx_trace_block (5.33 ms)
    ├── evaluate (53.0 µs)
    ├── qubo_hubo_pipeline (1.0 µs)
    └── as_qubo_format (8.0 µs)
```

**Decorator (sugar on top):**

```python
from ommx.tracing import traced

@traced(output=\"process.json\")
def process():
    instance = Instance.from_bytes(blob)
    return instance.evaluate(state)

process()
```

All three call shapes are supported: `@traced`, `@traced()`, `@traced(name=..., output=...)`. Async is auto-detected (``inspect.iscoroutinefunction``) and wrapped with ``await``-aware machinery — a plain sync wrapper would trace only coroutine creation and close the capture window before the awaited work ran.

## Public surface

| Name | Purpose |
| --- | --- |
| `capture_trace(name=\"ommx_trace_block\")` | Context manager; `__enter__` returns a `TraceResult` placeholder that `__exit__` populates. |
| `TraceResult` | `.spans: list[ReadableSpan]`, `.text_tree()`, `.chrome_trace_json()`, `.save_chrome_trace(path)`. |
| `traced(func=None, *, name=None, output=None)` | Decorator; optionally writes Chrome Trace JSON to `output` on return *and* on exception. Supports sync and `async def`. |

## Exception handling

Per #817 design: **information is never dropped**.

1. Exceptions inside the block propagate unchanged — no swallowing.
2. OTel's default `record_exception=True` + `set_status(ERROR)` on the root span decorates it with the failure info before it closes.
3. `TraceResult.spans` is populated on the exception path too, so the caller can still inspect / save the trace from an outer `try`/`except`.
4. `_render.render_text_tree` annotates failing spans with `[ERROR]` so the user can find the failing leaf at a glance:

```
└── outer (12.1 ms) [ERROR]
    └── inner (8.4 ms) [ERROR]
```

5. `@traced(output=...)` writes the trace on **both** the success path (save errors surface, so broken configuration is caught on first use) **and** the exception path (save errors are swallowed so they do not mask the user's original exception — the signal they care about most).

## Architecture

Single new module `python/ommx/ommx/tracing/_capture.py` holding `TraceResult` + `capture_trace` + `traced`, plus a small touch to `_render.py` for the `[ERROR]` marker.

**The cell magic is now implemented on top of ``capture_trace``.** ``_magic.run_cell_with_trace`` opens a ``capture_trace(\"ommx_trace_cell\")`` block and keeps only the two pieces of behaviour unique to the notebook case:

- Temporarily point ``shell.showtraceback`` at a no-op during the inner ``shell.run_cell`` so the outer ``run_cell`` prints the traceback exactly once on re-raise.
- Explicitly ``span.set_status(Status(ERROR))`` + ``record_exception`` on the root span when ``shell.run_cell`` caught the cell's exception internally — otherwise OTel would close the root with an OK status and the rendered tree would miss its ``[ERROR]`` marker even though the cell failed.

The refactor dropped ``_magic.py`` from 105 to ~120 lines (the extra lines are the ERROR-marking + docstring for why the manual set_status is needed; the fresh-context detach, ``begin_capture`` / ``end_capture``, and trace_id bookkeeping are gone).

Tracer name is unified to ``\"ommx.tracing\"`` across cell magic, context manager, and decorator — the per-entry-point distinction (``cell`` vs ``script``) was never surfaced to users anyway.

## Tests

`python/ommx-tests/tests/test_tracing_capture.py` — 19 tests:

- **Context manager**: populates result on success + on exception, exception propagates, fresh ``trace_id`` detaches from ambient spans, ``save_chrome_trace`` creates parent dirs, ``chrome_trace_json`` roundtrips.
- **Decorator**: all three call shapes, writes on success path, writes on exception path without masking the user's exception, **async function support**, save failure surfaces on success path, ``__qualname__`` default span name, ``functools.wraps`` metadata preserved.
- **Renderer**: ``[ERROR]`` marker fires for failing spans and is absent for successful ones.

`python/ommx-tests/tests/test_tracing_magic.py` picked up one extra test after the refactor:

- **Cell magic root span ERROR**: ``test_run_cell_with_trace_marks_root_span_error_on_cell_failure`` asserts the rendered tree's root line carries ``[ERROR]`` when the cell raised — the regression guard for the manual ``set_status`` path.

All 42 tracing tests (19 capture + 18 magic + 5 bridge) pass; full ``task python:test`` green; ``pyright`` clean; smoke test on a real ``Instance.from_components`` → ``evaluate`` → ``to_qubo`` pipeline produces the tree above.

## Test plan

- [x] ``task python:test`` green (230 core + 42 tracing)
- [x] ``task format`` applied; ruff + pyright clean
- [x] Manual smoke test: ``capture_trace`` and ``@traced`` (incl. async) on real OMMX workloads produce valid trees + JSON
- [x] Cell magic continues to work end-to-end after being refactored on top of ``capture_trace``

## Follow-up (PR6 under #817)

Documentation (en/ja): OTel setup guide, ``%%ommx_trace`` walk-through, ``capture_trace`` / ``@traced`` walk-through, span-naming rule, troubleshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)