### PR TITLE
Add format_version field and forward compatibility check (v3 port)

### DIFF
--- a/proto/ommx/v1/instance.proto
+++ b/proto/ommx/v1/instance.proto
@@ -71,7 +71,7 @@ message Instance {
   //
   // - 0 means the format as of OMMX Python SDK 2.5.1 and earlier.
   // - This is only bumped by semantic-breaking format changes (major-only; no minor/patch).
-  // - Each SDK declares an accepted maximum; reading data with a higher version fails with an "upgrade the SDK" error.
+  // - Each SDK declares a current version; it writes that value and accepts any `<= current`. Data with a higher version fails with an "upgrade the SDK" error.
   // - Non-semantic-breaking additions keep protobuf's standard forward compatibility (unknown fields ignored) and do not bump this.
   uint32 format_version = 100;
 }

--- a/proto/ommx/v1/instance.proto
+++ b/proto/ommx/v1/instance.proto
@@ -66,4 +66,12 @@ message Instance {
   map<uint64, Function> decision_variable_dependency = 9;
 
   repeated NamedFunction named_functions = 10;
+
+  // Format version of this message for forward compatibility checks.
+  //
+  // - 0 means the format as of OMMX Python SDK 2.5.1 and earlier.
+  // - This is only bumped by semantic-breaking format changes (major-only; no minor/patch).
+  // - Each SDK declares an accepted maximum; reading data with a higher version fails with an "upgrade the SDK" error.
+  // - Non-semantic-breaking additions keep protobuf's standard forward compatibility (unknown fields ignored) and do not bump this.
+  uint32 format_version = 100;
 }

--- a/proto/ommx/v1/parametric_instance.proto
+++ b/proto/ommx/v1/parametric_instance.proto
@@ -62,4 +62,8 @@ message ParametricInstance {
   map<uint64, Function> decision_variable_dependency = 9;
 
   repeated NamedFunction named_functions = 10;
+
+  // Format version of this message for forward compatibility checks.
+  // See `Instance.format_version` for semantics.
+  uint32 format_version = 100;
 }

--- a/proto/ommx/v1/sample_set.proto
+++ b/proto/ommx/v1/sample_set.proto
@@ -134,4 +134,8 @@ message SampleSet {
 
   // Minimize or Maximize
   Instance.Sense sense = 5;
+
+  // Format version of this message for forward compatibility checks.
+  // See `Instance.format_version` for semantics.
+  uint32 format_version = 100;
 }

--- a/proto/ommx/v1/solution.proto
+++ b/proto/ommx/v1/solution.proto
@@ -64,6 +64,10 @@ message Solution {
 
   // Whether the problem is a minimization or maximization problem.
   Instance.Sense sense = 10;
+
+  // Format version of this message for forward compatibility checks.
+  // See `Instance.format_version` for semantics.
+  uint32 format_version = 100;
 }
 
 // The solver proved that the problem is infeasible.

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -279,7 +279,7 @@ impl From<Instance> for v1::Instance {
             parameters: value.parameters,
             description: value.description,
             constraint_hints: None,
-            format_version: 0,
+            format_version: crate::CURRENT_FORMAT_VERSION,
         }
     }
 }
@@ -473,7 +473,7 @@ impl From<ParametricInstance> for v1::ParametricInstance {
                 .map(|(id, dep)| (id.into(), dep.into()))
                 .collect(),
             constraint_hints: None,
-            format_version: 0,
+            format_version: crate::CURRENT_FORMAT_VERSION,
         }
     }
 }

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -117,6 +117,7 @@ impl Parse for v1::Instance {
     type Context = ();
     fn parse(self, _context: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v1.Instance";
+        crate::parse::check_format_version(self.format_version, message)?;
         let sense = self.sense().parse_as(&(), message, "sense")?;
 
         let decision_variables =
@@ -278,6 +279,7 @@ impl From<Instance> for v1::Instance {
             parameters: value.parameters,
             description: value.description,
             constraint_hints: None,
+            format_version: 0,
         }
     }
 }
@@ -287,6 +289,7 @@ impl Parse for v1::ParametricInstance {
     type Context = ();
     fn parse(self, _context: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v1.ParametricInstance";
+        crate::parse::check_format_version(self.format_version, message)?;
         let sense = self.sense().parse_as(&(), message, "sense")?;
 
         let decision_variables =
@@ -470,6 +473,7 @@ impl From<ParametricInstance> for v1::ParametricInstance {
                 .map(|(id, dep)| (id.into(), dep.into()))
                 .collect(),
             constraint_hints: None,
+            format_version: 0,
         }
     }
 }
@@ -510,6 +514,7 @@ mod tests {
             decision_variable_dependency: HashMap::new(),
             constraint_hints: None,
             description: None,
+            ..Default::default()
         };
 
         // This should fail because variable ID 999 is used in objective but not defined
@@ -548,6 +553,7 @@ mod tests {
             decision_variable_dependency: HashMap::new(),
             constraint_hints: None,
             description: None,
+            ..Default::default()
         };
 
         // This should fail because variable ID 999 is used in constraint but not defined
@@ -576,6 +582,7 @@ mod tests {
             parameters: None,
             description: None,
             constraint_hints: None,
+            ..Default::default()
         };
 
         // This should fail because variable ID 999 is used in objective but not defined
@@ -610,6 +617,7 @@ mod tests {
             parameters: None,
             description: None,
             constraint_hints: None,
+            ..Default::default()
         };
 
         // This should fail because variable ID 999 is used in constraint but not defined
@@ -653,6 +661,7 @@ mod tests {
             decision_variable_dependency: HashMap::new(),
             constraint_hints: None,
             description: None,
+            ..Default::default()
         };
 
         // This should fail because constraint ID 1 appears in both constraints and removed_constraints
@@ -692,6 +701,7 @@ mod tests {
             parameters: None,
             description: None,
             constraint_hints: None,
+            ..Default::default()
         };
 
         // This should fail because constraint ID 1 appears in both constraints and removed_constraints
@@ -724,6 +734,7 @@ mod tests {
             decision_variable_dependency: HashMap::new(),
             constraint_hints: None,
             description: None,
+            ..Default::default()
         };
 
         // Invalid sense value should be converted to default (Minimize)
@@ -750,6 +761,7 @@ mod tests {
             parameters: None,
             description: None,
             constraint_hints: None,
+            ..Default::default()
         };
 
         // Invalid sense value should be converted to default (Minimize)
@@ -780,6 +792,7 @@ mod tests {
             decision_variable_dependency: HashMap::new(),
             constraint_hints: None,
             description: None,
+            ..Default::default()
         };
 
         // This should fail because objective is missing
@@ -807,6 +820,7 @@ mod tests {
             parameters: None,
             description: None,
             constraint_hints: None,
+            ..Default::default()
         };
 
         // This should fail because objective is missing
@@ -838,6 +852,7 @@ mod tests {
             decision_variable_dependency: HashMap::new(),
             constraint_hints: None,
             description: None,
+            ..Default::default()
         };
 
         // This should fail because ID 1 is used for both decision variable and parameter
@@ -876,6 +891,7 @@ mod tests {
             decision_variable_dependency: HashMap::new(),
             constraint_hints: None,
             description: None,
+            ..Default::default()
         };
 
         // This should fail because constraint ID 1 appears twice in constraints
@@ -910,6 +926,7 @@ mod tests {
             parameters: None,
             description: None,
             constraint_hints: None,
+            ..Default::default()
         };
 
         // This should fail because constraint ID 1 appears twice in constraints
@@ -918,6 +935,40 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.Instance[constraints]
         Duplicated constraint ID is found in definition: ConstraintID(1)
+        "###);
+    }
+
+    // Data produced by a future SDK whose format version exceeds what this SDK supports
+    // must be rejected with a clear upgrade-the-SDK error rather than silently misread.
+    #[test]
+    fn test_instance_parse_rejects_future_format_version() {
+        let v1_instance = v1::Instance {
+            sense: v1::instance::Sense::Minimize as i32,
+            objective: Some(Default::default()),
+            format_version: 1,
+            ..Default::default()
+        };
+        let result = v1_instance.parse(&());
+        insta::assert_snapshot!(result.unwrap_err(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.Instance[format_version]
+        Unsupported ommx format version: data has format_version=1, but this SDK supports up to 0. Please upgrade the OMMX SDK.
+        "###);
+    }
+
+    #[test]
+    fn test_parametric_instance_parse_rejects_future_format_version() {
+        let v1_parametric_instance = v1::ParametricInstance {
+            sense: v1::instance::Sense::Minimize as i32,
+            objective: Some(Default::default()),
+            format_version: 1,
+            ..Default::default()
+        };
+        let result = v1_parametric_instance.parse(&());
+        insta::assert_snapshot!(result.unwrap_err(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.ParametricInstance[format_version]
+        Unsupported ommx format version: data has format_version=1, but this SDK supports up to 0. Please upgrade the OMMX SDK.
         "###);
     }
 }

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -74,12 +74,14 @@ pub use solution::*;
 pub use sos1_constraint::*;
 pub use substitute::*;
 
-/// Maximum `format_version` this SDK accepts when parsing top-level messages.
+/// The `format_version` this SDK produces and the maximum it can read.
 ///
-/// Data whose `format_version` exceeds this value was produced by a newer SDK
-/// with semantic-breaking format changes and cannot be read correctly.
+/// This SDK writes `format_version = CURRENT_FORMAT_VERSION` on all top-level
+/// messages and accepts any value `<= CURRENT_FORMAT_VERSION` on parse. Data
+/// whose `format_version` exceeds this value was produced by a newer SDK with
+/// semantic-breaking format changes and cannot be read correctly.
 /// See `proto/ommx/v1/instance.proto` for the full policy.
-pub const ACCEPTED_FORMAT_VERSION: u32 = 0;
+pub const CURRENT_FORMAT_VERSION: u32 = 0;
 
 /// Module created from `ommx.v1` proto files
 #[allow(clippy::doc_overindented_list_items)] // prost breaks markdown indents

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -74,6 +74,13 @@ pub use solution::*;
 pub use sos1_constraint::*;
 pub use substitute::*;
 
+/// Maximum `format_version` this SDK accepts when parsing top-level messages.
+///
+/// Data whose `format_version` exceeds this value was produced by a newer SDK
+/// with semantic-breaking format changes and cannot be read correctly.
+/// See `proto/ommx/v1/instance.proto` for the full policy.
+pub const ACCEPTED_FORMAT_VERSION: u32 = 0;
+
 /// Module created from `ommx.v1` proto files
 #[allow(clippy::doc_overindented_list_items)] // prost breaks markdown indents
 pub mod v1 {

--- a/rust/ommx/src/ommx.v1.rs
+++ b/rust/ommx/src/ommx.v1.rs
@@ -496,7 +496,7 @@ pub struct Instance {
     ///
     /// - 0 means the format as of OMMX Python SDK 2.5.1 and earlier.
     /// - This is only bumped by semantic-breaking format changes (major-only; no minor/patch).
-    /// - Each SDK declares an accepted maximum; reading data with a higher version fails with an "upgrade the SDK" error.
+    /// - Each SDK declares a current version; it writes that value and accepts any `<= current`. Data with a higher version fails with an "upgrade the SDK" error.
     /// - Non-semantic-breaking additions keep protobuf's standard forward compatibility (unknown fields ignored) and do not bump this.
     #[prost(uint32, tag = "100")]
     pub format_version: u32,

--- a/rust/ommx/src/ommx.v1.rs
+++ b/rust/ommx/src/ommx.v1.rs
@@ -492,6 +492,14 @@ pub struct Instance {
     pub decision_variable_dependency: ::std::collections::HashMap<u64, Function>,
     #[prost(message, repeated, tag = "10")]
     pub named_functions: ::prost::alloc::vec::Vec<NamedFunction>,
+    /// Format version of this message for forward compatibility checks.
+    ///
+    /// - 0 means the format as of OMMX Python SDK 2.5.1 and earlier.
+    /// - This is only bumped by semantic-breaking format changes (major-only; no minor/patch).
+    /// - Each SDK declares an accepted maximum; reading data with a higher version fails with an "upgrade the SDK" error.
+    /// - Non-semantic-breaking additions keep protobuf's standard forward compatibility (unknown fields ignored) and do not bump this.
+    #[prost(uint32, tag = "100")]
+    pub format_version: u32,
 }
 /// Nested message and enum types in `Instance`.
 pub mod instance {
@@ -602,6 +610,10 @@ pub struct ParametricInstance {
     pub decision_variable_dependency: ::std::collections::HashMap<u64, Function>,
     #[prost(message, repeated, tag = "10")]
     pub named_functions: ::prost::alloc::vec::Vec<NamedFunction>,
+    /// Format version of this message for forward compatibility checks.
+    /// See `Instance.format_version` for semantics.
+    #[prost(uint32, tag = "100")]
+    pub format_version: u32,
 }
 /// A set of values of decision variables, without any evaluation, even the
 /// feasiblity of the solution.
@@ -655,6 +667,10 @@ pub struct Solution {
     /// Whether the problem is a minimization or maximization problem.
     #[prost(enumeration = "instance::Sense", tag = "10")]
     pub sense: i32,
+    /// Format version of this message for forward compatibility checks.
+    /// See `Instance.format_version` for semantics.
+    #[prost(uint32, tag = "100")]
+    pub format_version: u32,
 }
 /// The solver proved that the problem is infeasible.
 ///
@@ -933,4 +949,8 @@ pub struct SampleSet {
     /// Minimize or Maximize
     #[prost(enumeration = "instance::Sense", tag = "5")]
     pub sense: i32,
+    /// Format version of this message for forward compatibility checks.
+    /// See `Instance.format_version` for semantics.
+    #[prost(uint32, tag = "100")]
+    pub format_version: u32,
 }

--- a/rust/ommx/src/parse.rs
+++ b/rust/ommx/src/parse.rs
@@ -78,11 +78,11 @@ pub enum RawParseError {
     /// The message's `format_version` exceeds what this SDK supports.
     /// The data was produced by a newer SDK whose format is not backward compatible with this one.
     #[error(
-        "Unsupported ommx format version: data has format_version={data_version}, but this SDK supports up to {accepted_version}. Please upgrade the OMMX SDK."
+        "Unsupported ommx format version: data has format_version={data_version}, but this SDK supports up to {current_version}. Please upgrade the OMMX SDK."
     )]
     UnsupportedFormatVersion {
         data_version: u32,
-        accepted_version: u32,
+        current_version: u32,
     },
 
     /// In proto3, all fields of message types are implicitly optional even if explicit `optional` flag is absent.
@@ -148,10 +148,10 @@ pub(crate) fn check_format_version(
     format_version: u32,
     message: &'static str,
 ) -> Result<(), ParseError> {
-    if format_version > crate::ACCEPTED_FORMAT_VERSION {
+    if format_version > crate::CURRENT_FORMAT_VERSION {
         return Err(RawParseError::UnsupportedFormatVersion {
             data_version: format_version,
-            accepted_version: crate::ACCEPTED_FORMAT_VERSION,
+            current_version: crate::CURRENT_FORMAT_VERSION,
         }
         .context(message, "format_version"));
     }

--- a/rust/ommx/src/parse.rs
+++ b/rust/ommx/src/parse.rs
@@ -75,6 +75,16 @@ pub enum RawParseError {
     )]
     UnsupportedV1Function,
 
+    /// The message's `format_version` exceeds what this SDK supports.
+    /// The data was produced by a newer SDK whose format is not backward compatible with this one.
+    #[error(
+        "Unsupported ommx format version: data has format_version={data_version}, but this SDK supports up to {accepted_version}. Please upgrade the OMMX SDK."
+    )]
+    UnsupportedFormatVersion {
+        data_version: u32,
+        accepted_version: u32,
+    },
+
     /// In proto3, all fields of message types are implicitly optional even if explicit `optional` flag is absent.
     /// When the SDK requires a field to be present, it will return this error.
     #[error("Field {field} in {message} is missing.")]
@@ -131,6 +141,21 @@ impl RawParseError {
             error: self,
         }
     }
+}
+
+/// Validate that a message's `format_version` does not exceed what this SDK accepts.
+pub(crate) fn check_format_version(
+    format_version: u32,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    if format_version > crate::ACCEPTED_FORMAT_VERSION {
+        return Err(RawParseError::UnsupportedFormatVersion {
+            data_version: format_version,
+            accepted_version: crate::ACCEPTED_FORMAT_VERSION,
+        }
+        .context(message, "format_version"));
+    }
+    Ok(())
 }
 
 pub(crate) fn as_constraint_id(

--- a/rust/ommx/src/qplib/convert.rs
+++ b/rust/ommx/src/qplib/convert.rs
@@ -16,6 +16,7 @@ pub fn convert(mut qplib: QplibFile) -> v1::Instance {
         objective: Some(objective),
         constraints,
         sense: convert_sense(qplib.sense),
+        format_version: crate::CURRENT_FORMAT_VERSION,
         ..Default::default()
     }
 }

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -172,6 +172,7 @@ impl From<SampleSet> for crate::v1::SampleSet {
             feasible_relaxed,
             feasible,
             sense,
+            format_version: crate::CURRENT_FORMAT_VERSION,
             ..Default::default()
         }
     }

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -8,6 +8,7 @@ impl Parse for crate::v1::SampleSet {
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v1.SampleSet";
+        crate::parse::check_format_version(self.format_version, message)?;
 
         // Parse decision variables into BTreeMap
         let mut decision_variables = BTreeMap::new();
@@ -320,6 +321,22 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.SampleSet[feasible]
         Inconsistent feasibility for sample 0: provided=true, computed=false
+        "###);
+    }
+
+    // Data produced by a future SDK whose format version exceeds what this SDK supports
+    // must be rejected with a clear upgrade-the-SDK error rather than silently misread.
+    #[test]
+    fn test_sample_set_parse_rejects_future_format_version() {
+        let v1_sample_set = v1::SampleSet {
+            format_version: 1,
+            ..Default::default()
+        };
+        let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
+        insta::assert_snapshot!(result.unwrap_err().to_string(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.SampleSet[format_version]
+        Unsupported ommx format version: data has format_version=1, but this SDK supports up to 0. Please upgrade the OMMX SDK.
         "###);
     }
 }

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -7,6 +7,7 @@ impl Parse for crate::v1::Solution {
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v1.Solution";
+        crate::parse::check_format_version(self.format_version, message)?;
 
         let provided_feasible = match self.feasible_relaxed {
             Some(_) => self.feasible,
@@ -195,6 +196,7 @@ impl From<Solution> for crate::v1::Solution {
             relaxation,
             feasible_unrelaxed,
             sense,
+            format_version: 0,
         }
     }
 }
@@ -428,6 +430,22 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
         Missing value for variable 1: not found in state and no substituted_value
+        "###);
+    }
+
+    // Data produced by a future SDK whose format version exceeds what this SDK supports
+    // must be rejected with a clear upgrade-the-SDK error rather than silently misread.
+    #[test]
+    fn test_solution_parse_rejects_future_format_version() {
+        let v1_solution = v1::Solution {
+            format_version: 1,
+            ..Default::default()
+        };
+        let result: Result<Solution, ParseError> = v1_solution.parse(&());
+        insta::assert_snapshot!(result.unwrap_err().to_string(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.Solution[format_version]
+        Unsupported ommx format version: data has format_version=1, but this SDK supports up to 0. Please upgrade the OMMX SDK.
         "###);
     }
 }

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -196,7 +196,7 @@ impl From<Solution> for crate::v1::Solution {
             relaxation,
             feasible_unrelaxed,
             sense,
-            format_version: 0,
+            format_version: crate::CURRENT_FORMAT_VERSION,
         }
     }
 }


### PR DESCRIPTION
## Summary

Ports the `format_version` forward-compatibility check from the v2 maintenance release (#835, on `dev-2.x`) onto the v3 main branch, so v3 ships with the same infrastructure for rejecting data produced by future SDKs with semantic-breaking format changes.

## Forward compatibility policy

- `ommx.v1` backward compatibility is unchanged — old data remains readable by new SDKs.
- Non-semantic-breaking proto additions continue to rely on protobuf's standard forward compatibility (unknown fields are ignored).
- Semantic-breaking format changes bump `format_version` (major-only, single `uint32`; no minor/patch).
- A single `CURRENT_FORMAT_VERSION` constant serves both sides: the SDK writes that value on all outgoing messages and accepts any `<= CURRENT_FORMAT_VERSION` on parse. Data with a higher `format_version` produces `RawParseError::UnsupportedFormatVersion` with a clear upgrade message.

## Changes

- Proto: add `uint32 format_version = 100` to `Instance`, `Solution`, `SampleSet`, `ParametricInstance`.
- Rust: add `pub const CURRENT_FORMAT_VERSION: u32 = 0`, the `UnsupportedFormatVersion { data_version, current_version }` variant on `RawParseError`, and a `check_format_version` helper called at the start of each of the four `Parse` implementations. All three writer sites (`From<Instance>`, `From<ParametricInstance>`, `From<Solution>` for their v1 counterparts) stamp `format_version: crate::CURRENT_FORMAT_VERSION` rather than a literal so bumping the version is a one-line change.
- Tests: four new Rust tests verify that `format_version = 1` is rejected with the expected error message on each message type.

## Naming difference vs. #835

The v2 maintenance PR (#835) introduced this constant as `ACCEPTED_FORMAT_VERSION`. Review feedback on this PR pointed out that the written and accepted versions are equal by construction, so they were unified into one constant and renamed to `CURRENT_FORMAT_VERSION` here. The v2 side is left as-is (released API surface); only v3 uses the new name.

## v3-specific adjustments during cherry-pick

- `rust/ommx/src/instance/parse.rs`: conflicts resolved to keep v3's `constraint_hints: None` in `From<Instance>` / `From<ParametricInstance>` (v3 absorbs hints into first-class `OneHot`/`SOS1` collections and does not currently serialize them back to the v1 proto), while adding `format_version: crate::CURRENT_FORMAT_VERSION`.
- The v2 patch touched `rust/ommx/src/v1_ext/parametric_instance.rs` and the generated `python/ommx/ommx/v1/*_pb2.py*` stubs; neither exists in v3 (v1_ext removed; Python-side protobuf dependency removed), so those file changes were dropped.

## Note on the writer-side `format_version`

This PR keeps `CURRENT_FORMAT_VERSION = 0` — matching the v2 maintenance release exactly. Whether v3 should bump it to `1` depends on whether any of the v3 changes constitute a semantic-breaking format change (as opposed to purely in-memory API changes). That decision is intentionally deferred to a follow-up; when it is made, flipping the constant is a single-line change and all three writer sites update together.

## Test plan

- [x] `cargo test -p ommx --lib` passes (463 tests).
- [x] `task python:test` passes.
- [x] `task format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)