### PR TITLE
Proposal: v3 metadata storage redesign

### DIFF
--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -11,31 +11,41 @@ makes sense once the runtime / Python-API direction is settled. So this
 discussion was split out of #841 and runs first.
 
 This is a single connected redesign covering Rust SDK runtime layout and
-Python SDK API surface. We don't break it into formal stages — every part
-needs to land within the v3 alpha window for the API to read coherently.
+Python SDK API surface. The document describes the target shape; phasing of
+the implementation across PRs is decided in the implementation issues, not
+here. (Recommended: split implementation into Rust-side SoA + parse boundary,
+Python-side Series + sidecar dfs + back-references, and the doc /
+migration-guide updates as separate PRs even though the design doc treats
+them as one piece.)
 
 ## Goal
 
-Today the same constraint / decision-variable fact lives in **three places**:
+Today the same fact lives in three places that have to stay in sync by
+hand:
 
 1. Rust — `BTreeMap<ID, T>`, with `metadata: TMetadata` inlined into each `T`.
-2. Python — `instance.constraints: dict[id, Constraint object]`, where
-   `Constraint.name`, `Constraint.subscripts`, … are getters that copy out
+2. Python — `instance.constraints: dict[id, Constraint object]`, with
+   getters `Constraint.name`, `Constraint.subscripts`, … that copy out
    what was inlined in (1).
 3. Python — `instance.constraints_df()`, a wide DataFrame with the same
    metadata replicated as columns next to the type-specific data.
 
-This metadata is rarely consulted by internal logic — `evaluate`, `parse`,
-`substitute`, etc. never read it — but it is copied around on every clone,
-serialized on every write, exposed via per-object getters, and duplicated
-into every wide `*_df` API. The duplication shows up in memory accounting
-(`logical_memory.rs` reports per-row `Option`/`Vec`/`FnvHashMap` headers
-under `Instance.constraint_collection;constraints;Constraint.metadata;…`)
-and in API surface drift (when a new metadata field is added it has to be
+We want one **canonical storage** in Rust and well-defined **derived views**
+on top of it. The user-visible surfaces (the PyO3 wrapper objects, the new
+`Series` collection accessors, the `*_df` methods) all stay — but they
+all read from the same SoA store rather than each carrying its own copy.
+
+The duplication shows up in memory accounting (`logical_memory.rs`
+reports per-row `Option`/`Vec`/`FnvHashMap` headers under
+`Instance.constraint_collection;constraints;Constraint.metadata;…`) and
+in API surface drift (when a new metadata field is added it has to be
 wired through the struct, the getter, and the DataFrame builder).
 
-We want a single source of truth on the Rust side and one well-defined
-"shape" for each kind of access on the Python side.
+Internal Rust logic is mostly metadata-blind, but not entirely: parsing
+and evaluation skip metadata, while `rust/ommx/src/sample_set/extract.rs`
+filters and dispatches on `metadata.name`, `metadata.subscripts`, and
+`metadata.parameters`. Those call sites move to reading the collection's
+SoA store; the behavior they implement is unchanged.
 
 ## Why now
 
@@ -43,9 +53,8 @@ We want a single source of truth on the Rust side and one well-defined
   extracts `ConstraintMetadata` as a shared sub-message but defers the
   inline-vs-top-level-columnar-map decision. That decision should follow,
   not lead, the runtime / Python-API direction set here.
-- The v3 alpha window is the right moment to break the wide-DataFrame
-  Python API and the per-object metadata getters. Doing it after v3 GA
-  would require another major.
+- The v3 alpha window is the right moment to break the Python `dict` /
+  wide-DataFrame API. Doing it after v3 GA would require another major.
 
 ## Target shape (one picture)
 
@@ -54,8 +63,8 @@ We want a single source of truth on the Rust side and one well-defined
 - Metadata moves into ID-keyed Struct-of-Arrays stores. The store sits at
   the collection layer:
   - `ConstraintCollection<T>` owns `ConstraintMetadataStore<T::ID>`.
-  - `Instance` and `ParametricInstance` own `VariableMetadataStore` directly
-    (no `DecisionVariableCollection` for symmetry's sake).
+  - `Instance` and `ParametricInstance` own `VariableMetadataStore`
+    directly (no `DecisionVariableCollection` for symmetry's sake).
   - `EvaluatedCollection<T>` and `SampledCollection<T>` carry the same
     `ConstraintMetadataStore<T::ID>` so Solution / SampleSet share one
     metadata source per collection.
@@ -68,19 +77,22 @@ We want a single source of truth on the Rust side and one well-defined
 ### Python
 
 - `instance.constraints`, `decision_variables`, `*_constraints` become
-  `pandas.Series[ID -> Object]` — index = ID, value = the (now slimmer)
-  PyO3 wrapper object. Series indexing (`s.loc[id]`, `s.iloc[i]`,
-  iteration, boolean indexing) replaces the current dict / list APIs.
-- `*_df` methods are explicitly **derived views**: each one is the
-  Series joined with the relevant metadata / parameters / removed-reason
-  sidecar dfs.
+  `pandas.Series[ID -> Object]` — index = ID, value = the PyO3 wrapper
+  object. Series indexing replaces dict / list APIs.
+- `*_df` methods are explicitly **derived views**: type-specific core
+  columns extracted from the SoA, joined with sidecar metadata /
+  parameters / provenance / removed-reason dfs.
 - Sidecar DataFrames (`*_metadata_df`, `*_parameters_df` long format,
   `*_provenance_df` long format, `*_removed_reasons_df` long format) are
   bulk-built from the Rust SoA store, one column allocation per field.
-- Wrapper objects (`Constraint`, `DecisionVariable`, …) carry only the
-  type's intrinsic data — `equality`, `function`, `kind`, `bound`, etc.
-  All `.name` / `.subscripts` / `.parameters` / `.description` getters
-  are removed; the only path to metadata is the metadata df.
+- **Wrapper objects keep their metadata getters** (`Constraint.name`,
+  `.subscripts`, `.parameters`, `.description`; same on the other
+  wrappers). For wrappers obtained from a collection ("attached"), the
+  getters read the collection's SoA store via a back-reference. For
+  wrappers built standalone in a modeling chain, the getters read a
+  staging bag that drains into the SoA store on insertion. The user
+  sees the same surface either way; the wrapper just doesn't own the
+  metadata bytes anymore.
 
 ### Proto
 
@@ -159,11 +171,11 @@ pub struct ParametricInstance {
 
 Why these levels:
 
-- For constraints, `ConstraintCollection<T>` already owns active/removed
-  split and is generic over constraint type — putting the store there keeps
-  the `relax` / `restore` pair touch-free (active ↔ removed transitions
-  don't move metadata at all). The same store rides through to
-  `EvaluatedCollection<T>` / `SampledCollection<T>` on the Solution /
+- For constraints, `ConstraintCollection<T>` already owns the active /
+  removed split and is generic over constraint type — putting the store
+  there keeps the `relax` / `restore` pair touch-free (active ↔ removed
+  transitions don't move metadata at all). The same store rides through
+  to `EvaluatedCollection<T>` / `SampledCollection<T>` on the Solution /
   SampleSet side.
 - For variables, there is no analogous `DecisionVariableCollection` and
   adding one only to host metadata would be over-engineering — `Instance`
@@ -191,19 +203,16 @@ pub struct Constraint<S: Stage<Self> = Created> {
 ```
 
 Standalone constraints (`Constraint::equal_to_zero(f)`,
-`OneHotConstraint::new(...)`, etc.) carry no metadata. Metadata is set
-after inserting into a collection:
+`OneHotConstraint::new(...)`, etc.) carry no metadata at the Rust
+level. Insertion drains a staging bag (Python wrappers) or accepts an
+explicit metadata argument:
 
 ```rust
 let id = collection.insert(Constraint::equal_to_zero(f));
 collection.metadata_mut().set_name(id, "demand_balance");
 collection.metadata_mut().push_subscripts(id, [i, j]);
-```
 
-A builder-style helper is provided for the common "insert with metadata"
-case:
-
-```rust
+// or via the convenience builder:
 collection.insert_with(
     Constraint::equal_to_zero(f),
     |m| m.name("demand_balance").subscripts([i, j]),
@@ -240,6 +249,12 @@ pub struct ConstraintMetadataView<'a> {
 keys (static const) so the `Option<FnvHashMap<…>>` storage doesn't leak
 through the public API.
 
+The internal call sites that used to read `c.metadata.*` directly (e.g.
+`rust/ommx/src/sample_set/extract.rs`'s `metadata.name`,
+`metadata.subscripts`, `metadata.parameters` filters) switch to
+`collection.metadata().name(id)` / `.subscripts(id)` / `.parameters(id)`
+accessors. Behavior unchanged.
+
 ### Parse / serialize boundaries
 
 The boundaries currently work per-element and need to move to per-collection:
@@ -259,27 +274,6 @@ The boundaries currently work per-element and need to move to per-collection:
   self.metadata.clone()` inside `SampledConstraintBehavior::get`) to a
   single store-level clone at the end.
 
-```rust
-impl<T: ConstraintType> EvaluatedCollection<T> {
-    pub fn into_v1(self) -> Vec<v1::EvaluatedConstraint> {
-        let (constraints, _removed) = self.into_parts();
-        constraints.into_iter().map(|(id, c)| {
-            let metadata = self.metadata.get(id);  // ConstraintMetadataView
-            v1::EvaluatedConstraint {
-                id: id.into_inner(),
-                equality: c.equality.into(),
-                evaluated_value: c.stage.evaluated_value,
-                name: metadata.name.map(str::to_owned),
-                subscripts: metadata.subscripts.to_vec(),
-                parameters: metadata.parameters.clone().into_iter().collect(),
-                description: metadata.description.map(str::to_owned),
-                // …
-            }
-        }).collect()
-    }
-}
-```
-
 ### Other types affected
 
 - **`#[derive(LogicalMemoryProfile)]`** is currently on `DecisionVariable`,
@@ -287,45 +281,118 @@ impl<T: ConstraintType> EvaluatedCollection<T> {
   structs. The new `*MetadataStore` types should derive
   `LogicalMemoryProfile` so memory accounting under
   `Instance.constraint_collection;metadata;…` keeps working.
-- **`pyo3-stub-gen`**: every renamed / removed / added Python method below
-  needs the `gen_stub_pymethods` decorator and the corresponding
+- **`pyo3-stub-gen`**: every renamed / removed / added Python method
+  below needs the `gen_stub_pymethods` decorator and the corresponding
   `ommx.v1.__init__.py` regen via `task python:stubgen`. The stores are
-  not exposed to Python directly (they surface only as Series and
-  DataFrames), so the stub surface change is limited to method
-  signatures.
+  not exposed to Python directly; they surface via wrapper getters,
+  Series accessors, and DataFrames.
 
 ## Python SDK design
 
-### Single source of truth
+### Layered views over the Rust SoA store
 
 ```
-            Rust SoA store (BTreeMap<ID, T> + ConstraintMetadataStore<ID>)
-                         │
-                         ▼
-        instance.constraints  ── pandas.Series[ID -> Constraint object]
-                         │
-                ┌────────┴────────────────────┐
-                │                             │
-       sidecar metadata df             core columns extracted
-       sidecar parameters df          from the Constraint object
-       sidecar removed_reasons df             │
-                └─────────────┬───────────────┘
-                              ▼
-                    instance.constraints_df()
-                    (joined view, never canonical)
+                  Rust SoA store (canonical)
+                  ┌────────────────────────────┐
+                  │ ConstraintCollection<T>    │
+                  │   active / removed         │
+                  │   metadata: SoA store      │
+                  └────────────────────────────┘
+                              │
+                              ▼ (PyO3 boundary)
+              ┌───────────────────────────────────┐
+              │ ConstraintCollection (Py wrapper) │
+              └─────┬─────────────────────────────┘
+                    │
+       ┌────────────┼─────────────────────┐
+       ▼            ▼                     ▼
+  Series         Constraint object     *_df / *_metadata_df / *_parameters_df
+  (per-id        (with .name / .       (bulk-built from the SoA store via
+   wrapper       subscripts / …        column-wise builders; not via
+   handles)      back-referenced       per-row dict construction)
+                 to the store)
 ```
 
-Wrapper objects carry only the type's intrinsic data. They have no
-`.name` / `.subscripts` / `.parameters` / `.description`. The sole path
-to metadata is the sidecar df keyed by id.
+Wrapper objects, Series, and DataFrames are three views over the same
+store. The wrapper getters and the DataFrame columns produce the same
+values for the same ID; the difference is bulk vs. per-id ergonomics.
 
-### Collection accessors → Series
+### Wrapper objects with back-reference
+
+PyO3 wrappers stay rich. The implementation is two-mode:
+
+```rust
+#[pyclass]
+pub struct Constraint {
+    inner: ConstraintInner,
+}
+
+enum ConstraintInner {
+    /// Standalone — built via Constraint::equal_to_zero(f) or operator
+    /// overloading. Holds owned core data and a metadata staging bag.
+    /// Setters write to the bag; getters read it.
+    Standalone {
+        constraint: ommx::Constraint,
+        staging:    ConstraintMetadataStaging,
+    },
+    /// Attached — obtained from a collection. Holds a back-reference to
+    /// the parent Instance plus the constraint's id. Getters look up
+    /// core data from the collection's BTreeMap and metadata from the
+    /// SoA store. Setters write through to the SoA store.
+    Attached {
+        instance: Py<Instance>,
+        kind:     ConstraintKind,
+        id:       ConstraintID,
+    },
+}
+```
+
+`Instance.add_constraint(c)` (and the special-constraint equivalents)
+takes a Standalone wrapper, drains its staging bag into the SoA store,
+and returns an Attached wrapper bound to that `id`. Series-derived
+wrappers (`s.loc[id]`) are also Attached.
+
+```python
+# Standalone modeling — staging bag in the wrapper
+c = (x[0] + x[1] == 1).add_name("balance").add_subscripts([0])
+print(c.name)        # "balance" — read from staging bag
+
+# Insertion — staging bag drains into the SoA store
+attached = instance.add_constraint(c)
+print(attached.name) # "balance" — read from SoA via back-reference
+
+# Series access — Attached wrappers
+s = instance.constraints
+print(s.loc[5].name) # back-reference lookup; same value as the metadata df
+
+# Mutation — write-through to SoA
+attached.name = "demand_balance"
+# or attached.add_name(...) keeping the chain shape
+```
+
+### Staleness / lifetime
+
+Attached wrappers hold `Py<Instance>` (a refcounted handle). The
+`Instance` stays alive as long as any wrapper points at it, so the back
+reference can't dangle. Open semantic question:
+
+- **`relax(id)`** moves the constraint to the removed map; the wrapper
+  remains valid (the SoA metadata store is keyed by id regardless of
+  active / removed).
+- **`drop_constraint(id)`** (does not exist today; would be added if
+  ever needed) would invalidate Attached wrappers for that id. Until
+  it exists, this question is moot.
+
+The simple rule: a wrapper's `id` stays in either the active or removed
+map for the lifetime of the parent `Instance`, so getters never panic.
+
+### Series-based collection accessors
 
 ```python
 s = instance.constraints                  # pandas.Series[ConstraintID -> Constraint]
-s.loc[5]                                  # individual Constraint object
-s.loc[5].equality                         # OK — type-intrinsic getter
-s.loc[5].name                             # AttributeError — removed
+s.loc[5]                                  # individual Constraint object (Attached)
+s.loc[5].equality                         # type-intrinsic getter
+s.loc[5].name                             # metadata getter via back-reference
 
 list(s.index)                             # all constraint IDs
 for cid, c in s.items(): ...              # iteration
@@ -340,18 +407,27 @@ solution.constraints                      # Series[ConstraintID -> EvaluatedCons
 sample_set.constraints                    # Series[ConstraintID -> SampledConstraint]
 ```
 
-The Series carries Python wrapper objects (object dtype). Per-element
-efficiency is the same as the old `dict[ID, Constraint]` — this is an
-API integration win, not a perf change. Modeling code that built
-constraints standalone and inserted them into a dict-like collection
-keeps working with the natural `instance.add_constraint(c)` /
-`s.add(c)` flow; index-based pandas operations (`.loc`, `.iloc`, boolean
-indexing, `.items()`) are now available out of the box.
+The Series carries Attached wrapper objects (object dtype). Per-element
+efficiency is the same as the old `dict[ID, Constraint]`. Indexing
+operations users get for free vs. dict: `.loc`, `.iloc`, boolean
+indexing, `.items()`, `.index`. Operations users lose vs. dict:
+
+- **`s.values()` is NOT a method**; pandas `Series.values` is a
+  property returning a numpy array. Existing `.values()` calls break
+  loudly. Migration: `s.tolist()`, `list(s)`, or `for c in s:`.
+- **`s[id]` works for an integer id** because Series allows index-by-
+  label lookup with `[]`, but `.loc[id]` is the explicit form.
+  Documentation should prefer `.loc[id]` to avoid the
+  position-vs-label ambiguity.
+- **`s.apply(lambda c: c.equality)` is an attractive nuisance**: it
+  iterates Python-side and rebuilds the equality column row-by-row.
+  The right answer is `instance.constraints_df()["equality"]`, which
+  is bulk-built from the SoA. Document this; do not enforce.
 
 ### `*_df` methods → derived views
 
-Each `*_df` is explicitly a derived view: type-specific core columns
-extracted from the Series, joined with the relevant sidecar dfs.
+Each `*_df` is a derived view. Implementation reads the SoA store
+directly via column-wise builders (no per-row dict construction).
 
 ```python
 # Decision variables
@@ -363,7 +439,7 @@ params   = instance.variable_parameters_df()      # columns: id, key, value (lon
 df       = instance.regular_constraints_df()      # index=id; equality, function_type, used_ids
 meta     = instance.regular_constraint_metadata_df()
                                                   # index=id; name, subscripts, description
-provs    = instance.regular_constraint_provenance_df()
+provenance_df = instance.regular_constraint_provenance_df()
                                                   # columns: id, step, source_kind, source_id (long)
 params   = instance.regular_constraint_parameters_df()
                                                   # columns: id, key, value (long format)
@@ -375,9 +451,9 @@ df.join(meta, how="left")
 ```
 
 `*_df` is what users call when they want a single rectangular table for
-analysis; the Series is what users call when they want individual wrapper
-objects. Both are derived from the same Rust SoA — neither is canonical
-relative to the other.
+analysis; the Series is what users call when they want individual
+wrapper objects; the wrapper getters are what users call when they
+already hold one wrapper. Three surfaces, one canonical store.
 
 ### `ToPandasEntry` restructuring
 
@@ -389,70 +465,44 @@ each producing a wide row dict.
   `set_metadata(...)` and `set_parameter_columns(...)` calls from each
   impl.
 - **Metadata dfs** are built column-wise from the SoA store, not via
-  `ToPandasEntry`. New helper `metadata_store_to_dataframe(store)` walks
-  the fields of the store and emits columns directly.
+  `ToPandasEntry`. New helper `metadata_store_to_dataframe(store)`
+  walks the fields of the store and emits columns directly.
 - **Long-format dfs** (`parameters`, `provenance`, `removed_reasons`)
   are built by flattening the SoA `FnvHashMap` into parallel vectors
   and constructing a DataFrame.
 - **Series accessors** wrap each Rust SoA's `BTreeMap<ID, T>` into a
-  `pandas.Series[ID -> Object]` — one Python list of wrappers + one
-  Index of IDs, no per-row dict allocation.
-
-Net result: roughly half the `ToPandasEntry` boilerplate disappears,
-metadata stops going through Python `dict` allocation per row, and the
-Series path is allocation-symmetric to today's `dict` path.
-
-### Standalone constraints and the modeling chain
-
-Today users write
-`(x[0] + x[1] == 1).add_name("c").add_subscripts([0])` and hand the
-result to `Instance.from_components`. With metadata removed from the
-Rust `Constraint<S>` and from the Python wrapper's getters, the chain
-needs an explicit landing place.
-
-**Working assumption**: keep `add_name` / `add_subscripts` /
-`add_description` on the Python `Constraint` wrapper, but make them
-populate a small inline staging bag rather than the (now-absent) Rust
-`metadata` field. `Instance.from_components` and the
-`add_constraint(...)` family drain the bag into the relevant
-`*MetadataStore` at insertion time.
-
-The alternative (drop the chain entirely; require keyword args at
-insertion or post-insertion mutation via the metadata accessor) is
-cleaner but breaks every modeling notebook. Confirm before
-implementation.
+  `pandas.Series[ID -> Object]` of Attached wrappers — one Python list
+  of wrappers + one Index of IDs, no per-row dict allocation.
 
 ### `subscripts` / `provenance` representation
 
-- `subscripts`: `List<Int64>` column on the metadata df (one row per id).
-  Part of the variable / constraint identity, consumed as a tuple, not
-  aggregated cross-row. List-of-int columns work in pandas (object
-  dtype) and are natively typed in polars.
+- `subscripts`: `List<Int64>` column on the metadata df (one row per
+  id). Part of the variable / constraint identity, consumed as a
+  tuple, not aggregated cross-row.
 - `provenance`: long format `(id, step, source_kind, source_id)` — one
-  row per `(id, step)` pair. Provenance chains are queries (e.g. "which
-  one-hot constraints became regular constraints?") and the long shape
-  is the natural one for that.
+  row per `(id, step)` pair.
 
 ## Breaking changes
 
 User-visible breakage relative to v3 alpha 2:
 
 - `instance.constraints`, `decision_variables`, `*_constraints` change
-  type from `dict` / `list` to `pandas.Series`. Most existing usage
-  (`s[id]`, iteration, `.items()`) keeps working because Series
-  reproduces those; positional reliance on `list[...]` ordering for
-  decision variables breaks.
-- `Constraint.name`, `.subscripts`, `.parameters`, `.description` (and
-  the same on `DecisionVariable` and the special-constraint wrappers)
-  are removed. Users must read from the metadata df.
+  type from `dict` / `list` to `pandas.Series`. Most usage (`s.loc[id]`,
+  iteration, `.items()`, `.index`) keeps working. Specific breakage:
+  - `s.values()` (method call) → `s.tolist()` or `list(s)`.
+  - List-positional reliance on the old `decision_variables: list[…]`
+    ordering breaks; index by `VariableID` instead.
 - `*_df` methods no longer carry `name`, `subscripts`, `description`,
-  or `parameters.{key}` columns. Users must `df.join(meta_df)` or pivot
-  the long parameters df.
+  or `parameters.{key}` columns. Users `df.join(meta_df)` or pivot the
+  long parameters df.
 - New `*_metadata_df`, `*_parameters_df`, `*_provenance_df`,
   `*_removed_reasons_df` methods are added per collection kind.
 - The Rust `metadata` field on `DecisionVariable` and `Constraint<S>`
-  is removed. Downstream Rust crates touching `c.metadata.*` directly
-  must switch to the collection's `metadata()` accessor.
+  is removed. Downstream Rust crates that touched `c.metadata.*`
+  directly switch to `collection.metadata()` accessors.
+- Wrapper-object metadata getters (`.name`, `.subscripts`, …) are
+  **preserved**; they switch from owned data to back-reference reads.
+  No user-visible change in the getter API.
 
 A new section in `PYTHON_SDK_MIGRATION_GUIDE.md` covers the Python side
 in detail.
@@ -478,9 +528,8 @@ before implementation.
 3. **Builder-style metadata setter**: flat
    (`metadata_mut().set_name(id, ...)`) only, vs. also
    `collection.insert_with(c, |m| m.name(...))` sugar.
-   - **Recommendation: add `insert_with`.** The flat form is too easy
-     to forget right after insertion, especially when authoring
-     constraints in a loop. Keep both.
+   - **Recommendation: add `insert_with`** on the Rust side. The
+     Python staging bag covers the equivalent Python ergonomics.
 4. **`parameters` storage on the Rust side**: `FnvHashMap<ID,
    FnvHashMap<String, String>>` vs. transposed `FnvHashMap<(ID,
    String), String>`.
@@ -498,14 +547,19 @@ before implementation.
    JOIN-based API is polars-friendly.
    - **Recommendation: pandas stays primary for v3.** `PyDataFrame`
      is pandas-backed; polars promotion is a separate v3.x discussion.
-7. **Modeling-chain choice**: staging wrapper (recommended) vs.
-   insertion-time-only API for Python `Constraint`.
-   - **Working assumption: staging wrapper.** Confirm before
-     implementation.
-8. **Series wrapper-object dtype**: object-dtype Series with PyO3
-   wrapper values is structurally fine but invites
-   `s.apply(lambda c: c.equality)` patterns that could be served more
-   efficiently by the corresponding df column.
-   - **Recommendation: document Series as the dict/list replacement
-     and `*_df` as the bulk-analysis surface.** No type-level
-     enforcement; trust users to pick the right tool.
+7. **`drop_constraint` / wrapper invalidation**: Attached wrappers
+   stay valid as long as the id is in either the active or removed
+   map. There's no `drop_constraint` API today, so the question is
+   moot — but if one is added later, it has to invalidate Attached
+   wrappers (panicking getters or `IsDroppedError`).
+   - **Recommendation: do not add `drop_constraint` in v3.** `relax`
+     is sufficient for the existing use cases. Defer wrapper
+     invalidation semantics to whenever `drop_constraint` actually
+     becomes necessary.
+8. **Attached wrapper `Py<Instance>` cycles**: the wrapper holds a
+   handle to the Instance; the Instance's collections own the SoA
+   store. There's no cycle (wrapper → Instance, Instance → store, no
+   back-pointer from store to wrapper), but heavy use of Series can
+   keep an Instance alive longer than expected.
+   - **Recommendation: documented behavior, no code-level mitigation.**
+     Users who care about lifetime drop the Series.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -431,20 +431,29 @@ directly via column-wise builders (no per-row dict construction).
 
 ```python
 # Decision variables
-df       = instance.decision_variables_df()       # index=id; kind, lower, upper, substituted_value
-meta     = instance.variable_metadata_df()        # index=id; name, subscripts, description
-params   = instance.variable_parameters_df()      # columns: id, key, value (long format)
+df       = instance.decision_variables_df()       # index name=variable_id;
+                                                  # kind, lower, upper, substituted_value
+meta     = instance.variable_metadata_df()        # index name=variable_id;
+                                                  # name, subscripts, description
+params   = instance.variable_parameters_df()      # columns: variable_id, key, value (long format)
 
-# Constraints (per kind)
-df       = instance.regular_constraints_df()      # index=id; equality, function_type, used_ids
-meta     = instance.regular_constraint_metadata_df()
-                                                  # index=id; name, subscripts, description
-provenance_df = instance.regular_constraint_provenance_df()
-                                                  # columns: id, step, source_kind, source_id (long)
-params   = instance.regular_constraint_parameters_df()
-                                                  # columns: id, key, value (long format)
-removed  = instance.regular_constraint_removed_reasons_df()
-                                                  # columns: id, reason, key, value (long format)
+# Constraints — kind dispatched via Literal + @overload so the IDE / type
+# checker still sees the kind-specific column schema for each call.
+df       = instance.constraints_df(kind="regular")
+                                                  # index name=regular_constraint_id;
+                                                  # equality, function_type, used_ids
+meta     = instance.constraint_metadata_df(kind="regular")
+                                                  # index name=regular_constraint_id;
+                                                  # name, subscripts, description
+provenance_df = instance.constraint_provenance_df(kind="regular")
+                                                  # columns: regular_constraint_id, step,
+                                                  # source_kind, source_id (long)
+params   = instance.constraint_parameters_df(kind="regular")
+                                                  # columns: regular_constraint_id, key,
+                                                  # value (long format)
+removed  = instance.constraint_removed_reasons_df(kind="regular")
+                                                  # columns: regular_constraint_id, reason,
+                                                  # key, value (long format)
 
 # Joining is explicit
 df.join(meta, how="left")
@@ -454,6 +463,59 @@ df.join(meta, how="left")
 analysis; the Series is what users call when they want individual
 wrapper objects; the wrapper getters are what users call when they
 already hold one wrapper. Three surfaces, one canonical store.
+
+### Avoiding cross-ID-space joins
+
+Each constraint kind has its own ID space (regular ID 5 ≠ indicator ID 5),
+and decision variable IDs live in yet another space. With every df sharing
+an `int64` index, `df.join()` between mismatched-kind dfs would silently
+produce an incorrect-but-shaped result. We ward off that mistake at the
+naming and helper layers:
+
+1. **Distinct index names per ID space.** All dfs returned by the API set
+   their index name to a kind-qualified label:
+
+   ```
+   variable_id                   # decision variables
+   regular_constraint_id         # regular constraints
+   indicator_constraint_id       # indicator constraints
+   one_hot_constraint_id         # one-hot constraints
+   sos1_constraint_id            # SOS1 constraints
+   ```
+
+   pandas `df.join(other)` aligns by index but does *not* enforce that
+   the index names match. The qualified names alone won't stop a wrong
+   join — but they're visible in `df.head()`, `df.info()`, IDE
+   inspection, and migration-guide examples, so users see the mismatch
+   immediately rather than chasing a silent bug downstream.
+
+2. **One-step joined helpers per kind.** For the common "I want core
+   columns plus name/subscripts/description in one frame" case, expose:
+
+   ```python
+   instance.constraints_full_df(kind="regular")
+   instance.decision_variables_full_df()
+   ```
+
+   These are convenience wrappers that perform the right join internally
+   (core ⨝ metadata, optionally also parameters / provenance via
+   keyword args). Users who only want a quick analysis frame call the
+   `*_full_df` form and never write a manual `.join()` at all. Users
+   who want the constituent dfs separately still get them via the
+   primary `*_df` family — the helper is purely additive.
+
+3. **Wrapper-object access stays the safest path for single-id
+   lookups.** `s.loc[id].name` reads metadata via the back-reference
+   without any join, so any code that operates a constraint at a time
+   sidesteps the issue entirely. `*_df` joins are reserved for bulk
+   analysis, where (1) and (2) cover the realistic mistake modes.
+
+A stronger guarantee — encoding kind in the index dtype itself
+(MultiIndex `(kind, id)`, or a custom ExtensionArray) — was considered
+and rejected. MultiIndex is intrusive on every analysis call; a custom
+ExtensionArray is a meaningful pandas integration and a maintenance
+burden disproportionate to the failure mode it prevents. The qualified
+index name + `*_full_df` helpers are sufficient.
 
 ### `ToPandasEntry` restructuring
 
@@ -513,12 +575,17 @@ Each item lists a working recommendation; flagged for explicit sign-off
 before implementation.
 
 1. **Constraint kind dispatch in Python**:
-   `constraint_metadata_df(kind="regular")` (one method, runtime kind)
-   vs. `regular_constraint_metadata_df()` (four methods).
-   - **Recommendation: four explicit methods.** `pyo3-stub-gen`
-     produces concrete pymethod stubs per method, so explicit names
-     give better IDE / type-checker discoverability than a runtime
-     `kind` arg.
+   `constraint_metadata_df(kind="regular")` (one method,
+   `Literal["regular","indicator","one_hot","sos1"]` overloads) vs.
+   `regular_constraint_metadata_df()` (four explicit methods).
+   - **Recommendation: single method with `Literal` + `@overload`.**
+     `pyo3-stub-gen` supports emitting `typing.overload` stubs keyed
+     on `Literal[…]` arguments, so a `kind` parameter gives the same
+     IDE / type-checker discoverability as four explicit methods
+     while keeping the API surface compact. Each kind's overload
+     advertises its specific column schema (e.g. only the regular and
+     indicator overloads include the `provenance` / `function_type`
+     columns where relevant).
 2. **`removed_reason` placement**: inline columns on the core df vs. a
    separate long-format `*_removed_reasons_df`.
    - **Recommendation: separate long-format df.** `Solution` already

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -219,50 +219,65 @@ let id = collection.insert(Constraint::equal_to_zero(f));
 collection.metadata_mut().set_name(id, "demand_balance");
 collection.metadata_mut().push_subscripts(id, [i, j]);
 
-// or via the convenience builder. Builder methods correspond to the
-// existing Python `set_*` semantics (replace, not extend) since the
-// builder always starts from an empty store:
+// or atomically with metadata via insert_with, taking the existing
+// owned ConstraintMetadata struct directly (the SoA store and the
+// owned struct are mutually convertible):
 collection.insert_with(
     Constraint::equal_to_zero(f),
-    |m| m.name("demand_balance").subscripts([i, j]),
+    ConstraintMetadata {
+        name: Some("demand_balance".into()),
+        subscripts: vec![i, j],
+        ..Default::default()
+    },
 );
 ```
 
 ### Access patterns
 
+`ConstraintMetadataStore<ID>` exposes per-field borrowing getters
+plus a one-shot owned reconstructor. There is no separate "view"
+type: callers either read one field at a time (cheap borrow) or
+collect the full set into the existing `ConstraintMetadata` struct
+(owned).
+
 ```rust
+impl<ID: Eq + Hash> ConstraintMetadataStore<ID> {
+    // Per-field borrows. Static EMPTY_* sentinels cover the absent
+    // case so the Option<FnvHashMap<…>> storage doesn't leak through
+    // the public API.
+    pub fn name(&self, id: ID)        -> Option<&str>;
+    pub fn subscripts(&self, id: ID)  -> &[i64];                          // empty slice if absent
+    pub fn parameters(&self, id: ID)  -> &FnvHashMap<String, String>;     // &EMPTY_MAP if absent
+    pub fn description(&self, id: ID) -> Option<&str>;
+    pub fn provenance(&self, id: ID)  -> &[Provenance];
+
+    // One-shot owned reconstruction.
+    pub fn collect_for(&self, id: ID) -> ConstraintMetadata;
+
+    // Setters (write-through to the SoA store).
+    pub fn set_name(&mut self, id: ID, name: impl Into<String>);
+    pub fn set_subscripts(&mut self, id: ID, s: impl Into<Vec<i64>>);
+    pub fn push_subscripts(&mut self, id: ID, s: impl IntoIterator<Item = i64>);
+    pub fn set_parameter(&mut self, id: ID, key: impl Into<String>, value: impl Into<String>);
+    pub fn set_description(&mut self, id: ID, desc: impl Into<String>);
+    pub fn push_provenance(&mut self, id: ID, p: Provenance);
+
+    // Bulk owned exchange with the I/O struct.
+    pub fn insert(&mut self, id: ID, metadata: ConstraintMetadata);
+    pub fn remove(&mut self, id: ID) -> ConstraintMetadata;  // for cleanup symmetry
+}
+
 impl<T: ConstraintType> ConstraintCollection<T> {
     pub fn metadata(&self) -> &ConstraintMetadataStore<T::ID> { ... }
     pub fn metadata_mut(&mut self) -> &mut ConstraintMetadataStore<T::ID> { ... }
-
-    /// Convenience view bundling constraint + metadata for a single ID.
-    pub fn view(&self, id: T::ID) -> Option<ConstraintView<'_, T>> { ... }
-}
-
-pub struct ConstraintView<'a, T: ConstraintType> {
-    pub id: T::ID,
-    pub constraint: &'a T::Created,
-    pub metadata: ConstraintMetadataView<'a>,
-}
-
-pub struct ConstraintMetadataView<'a> {
-    name:        Option<&'a str>,
-    subscripts:  &'a [i64],         // empty slice if absent
-    parameters:  &'a FnvHashMap<String, String>,   // &EMPTY if absent
-    description: Option<&'a str>,
-    provenance:  &'a [Provenance],
 }
 ```
 
-`ConstraintMetadataView::parameters()` returns `&EMPTY_MAP` for absent
-keys (static const) so the `Option<FnvHashMap<…>>` storage doesn't leak
-through the public API.
-
-The internal call sites that used to read `c.metadata.*` directly (e.g.
-`rust/ommx/src/sample_set/extract.rs`'s `metadata.name`,
+The internal call sites that used to read `c.metadata.*` directly
+(e.g. `rust/ommx/src/sample_set/extract.rs`'s `metadata.name`,
 `metadata.subscripts`, `metadata.parameters` filters) switch to
-`collection.metadata().name(id)` / `.subscripts(id)` / `.parameters(id)`
-accessors. Behavior unchanged.
+`collection.metadata().name(id)` / `.subscripts(id)` /
+`.parameters(id)` getters. Behavior unchanged.
 
 ### Parse / serialize boundaries
 
@@ -746,15 +761,51 @@ traceability with earlier review comments.
 
 Items still requiring sign-off before implementation.
 
-3. **Builder-style metadata setter on the Rust side**: flat
-   (`collection.insert(c)` followed by `metadata_mut().set_name(id,
-   ...)`) only, vs. also `collection.insert_with(c, |m|
-   m.name(...))` sugar.
-   - **Working recommendation: add `insert_with`.** Pure Rust
-     callers (algorithms, adapters, tests) construct constraints in
-     loops where the two-step form is easy to forget — the
-     constraint goes in but the metadata silently doesn't. The
-     closure-based form keeps insertion atomic at the call site.
-     This is independent of the Python staging bag, which serves the
-     modeling chain on the Python side; both surfaces exist for
-     their own ergonomics reasons.
+3. **Atomic insert-with-metadata on the Rust side**: provide
+   `collection.insert_with(c, metadata: ConstraintMetadata)`
+   alongside the flat
+   `collection.insert(c) + metadata_mut().set_name(id, ...)` form.
+   - **Working recommendation: add `insert_with` taking the existing
+     owned `ConstraintMetadata` struct.**
+
+     The pre-v3 `ConstraintMetadata` (owned struct with `name`,
+     `subscripts`, `parameters`, `description`, `provenance`) stays
+     as the I/O type even though it no longer lives inside
+     `Constraint<S>`. The SoA store and `ConstraintMetadata` are
+     mutually convertible: `store.collect_for(id) ->
+     ConstraintMetadata` for owned reads,
+     `store.insert(id, ConstraintMetadata)` for owned writes.
+
+     ```rust
+     impl<T: ConstraintType> ConstraintCollection<T> {
+         pub fn insert(&mut self, c: T::Created) -> T::ID;
+         pub fn insert_with(
+             &mut self,
+             c: T::Created,
+             metadata: ConstraintMetadata,
+         ) -> T::ID;
+     }
+
+     let id = collection.insert_with(
+         c,
+         ConstraintMetadata {
+             name: Some("demand_balance".into()),
+             subscripts: vec![i, j],
+             ..Default::default()
+         },
+     );
+     ```
+
+     Two types in the metadata layer cover all cases:
+     - `ConstraintMetadataStore<ID>` — internal SoA store, with
+       per-field borrowing getters (`name(id) -> Option<&str>`,
+       `subscripts(id) -> &[i64]`, …) and a `collect_for(id) ->
+       ConstraintMetadata` for one-shot owned reconstruction.
+     - `ConstraintMetadata` — owned struct used for I/O (insert,
+       owned read, modeling-chain staging). Same shape as the pre-v3
+       struct.
+
+     Pure Rust callers (algorithms, adapters, tests) constructing
+     constraints in loops use `insert_with` to avoid the silent-
+     metadata-loss footgun of the two-step form. Independent of the
+     Python staging bag, which serves the modeling chain.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -688,75 +688,74 @@ User-visible breakage relative to v3 alpha 2:
 A new section in `PYTHON_SDK_MIGRATION_GUIDE.md` covers the Python side
 in detail.
 
+## Resolved decisions
+
+Numbering preserved from the original Open Questions list for
+traceability with earlier review comments.
+
+1. **Kind dispatch in Python — single method with `Literal` +
+   `@overload`.** `constraint_metadata_df(kind="regular")` and the
+   sibling `*_df(kind=...)` family use a `kind:
+   Literal["regular","indicator","one_hot","sos1"]` parameter rather
+   than four separate methods. `pyo3-stub-gen` supports emitting
+   `typing.overload` stubs keyed on `Literal[…]` arguments, so each
+   kind's overload still advertises its specific column schema in
+   the IDE / type checker.
+2. **`removed_reason` — separate long-format
+   `constraint_removed_reasons_df(kind=...)`.** `RemovedReason` is
+   collection-level metadata in Rust, not part of the constraint.
+   Wide pivoting is available on opt-in via
+   `constraints_df(kind=..., include=("removed_reasons",))`.
+4. **`parameters` Rust storage — nested
+   `FnvHashMap<ID, FnvHashMap<String, String>>`.** Matches the
+   existing per-object metadata shape, makes "all parameters of one
+   id" a natural O(1) lookup, and the long-format Python export is a
+   one-pass flatten anyway.
+5. **`subscripts` long format — reject.** `subscripts` is part of the
+   variable / constraint identity (the "tuple index" in `x[i, j, k]`-
+   style expressions), not a collection that users meaningfully
+   iterate or aggregate over. Always served as a single
+   `List<Int64>` value per id, both on the metadata df and on the
+   wrapper getter.
+6. **Polars as primary in Python — no, pandas stays primary for v3.**
+   `PyDataFrame` is pandas-backed; polars promotion is a separate
+   v3.x discussion.
+8. **Attached wrapper `Py<Instance>` lifetime — documented behavior,
+   no code-level mitigation in this proposal.** The wrapper holds a
+   refcounted handle to the Instance; there's no cycle (wrapper →
+   Instance, Instance → store, no back-pointer from store to
+   wrapper), but heavy use of Series can keep an Instance alive
+   longer than expected. Users who care drop the Series. Whether the
+   pattern needs revisiting (e.g. weak-handle variant of the wrapper)
+   is a question to take up at implementation time, not before.
+
 ## Open questions
 
-Each item lists a working recommendation; flagged for explicit sign-off
-before implementation.
+Items still requiring sign-off before implementation.
 
-1. **Constraint kind dispatch in Python**:
-   `constraint_metadata_df(kind="regular")` (one method,
-   `Literal["regular","indicator","one_hot","sos1"]` overloads) vs.
-   `regular_constraint_metadata_df()` (four explicit methods).
-   - **Recommendation: single method with `Literal` + `@overload`.**
-     `pyo3-stub-gen` supports emitting `typing.overload` stubs keyed
-     on `Literal[…]` arguments, so a `kind` parameter gives the same
-     IDE / type-checker discoverability as four explicit methods
-     while keeping the API surface compact. Each kind's overload
-     advertises its specific column schema (e.g. only the regular and
-     indicator overloads include the `provenance` / `function_type`
-     columns where relevant).
-2. **`removed_reason` placement**: inline columns on the core df vs. a
-   separate long-format `*_removed_reasons_df`.
-   - **Recommendation: separate long-format df.** `Solution` already
-     exposes `removed_reasons_df` / `indicator_removed_reasons_df`
-     this way, and `RemovedReason` is collection-level metadata in
-     Rust, not part of the constraint.
 3. **Builder-style metadata setter on the Rust side**: flat
    (`collection.insert(c)` followed by `metadata_mut().set_name(id,
    ...)`) only, vs. also `collection.insert_with(c, |m|
    m.name(...))` sugar.
-   - **Recommendation: add `insert_with`.** Pure Rust callers
-     (algorithms, adapters, tests) construct constraints in loops
-     where the two-step form is easy to forget — the constraint goes
-     in but the metadata silently doesn't. The closure-based form
-     keeps insertion atomic at the call site. This is independent of
-     the Python staging bag, which serves the modeling chain on the
-     Python side; both surfaces exist for their own ergonomics
-     reasons.
-4. **`parameters` storage on the Rust side**: `FnvHashMap<ID,
-   FnvHashMap<String, String>>` vs. transposed `FnvHashMap<(ID,
-   String), String>`.
-   - **Recommendation: nested `FnvHashMap<ID, FnvHashMap<String,
-     String>>`.** Matches the existing per-object metadata shape,
-     makes "all parameters of one id" a natural lookup, and the
-     long-format Python export is a one-pass flatten anyway.
-5. **`subscripts` long format option**: in addition to the
-   `List<Int64>` column, offer a `subscripts_df` with `(id, position,
-   value)`.
-   - **Recommendation: reject.** `subscripts` is part of the
-     variable / constraint identity (the "tuple index" in expressions
-     like `x[i, j, k]`), not a collection that users meaningfully
-     iterate or aggregate over. Exposing it in long form would invite
-     treating positions as first-class entities, which is the wrong
-     mental model. Always serve `subscripts` as a single `List<Int64>`
-     value per id — both on the metadata df and on the wrapper getter.
-6. **Polars as primary in Python**: out of scope here, but the
-   JOIN-based API is polars-friendly.
-   - **Recommendation: pandas stays primary for v3.** `PyDataFrame`
-     is pandas-backed; polars promotion is a separate v3.x discussion.
+   - **Working recommendation: add `insert_with`.** Pure Rust
+     callers (algorithms, adapters, tests) construct constraints in
+     loops where the two-step form is easy to forget — the
+     constraint goes in but the metadata silently doesn't. The
+     closure-based form keeps insertion atomic at the call site.
+     This is independent of the Python staging bag, which serves the
+     modeling chain on the Python side; both surfaces exist for
+     their own ergonomics reasons.
 7. **`drop_constraint` / wrapper invalidation**: Attached wrappers
    stay valid as long as the id is in either the active or removed
    map. There's no `drop_constraint` API today, so the question is
    moot — but if one is added later, it has to invalidate Attached
    wrappers (panicking getters or `IsDroppedError`).
-   - **Recommendation: do not add `drop_constraint` in v3.** `relax`
-     is sufficient for the existing use cases. Defer wrapper
-     invalidation semantics to whenever `drop_constraint` actually
-     becomes necessary.
-8. **Attached wrapper `Py<Instance>` cycles**: the wrapper holds a
-   handle to the Instance; the Instance's collections own the SoA
-   store. There's no cycle (wrapper → Instance, Instance → store, no
-   back-pointer from store to wrapper), but heavy use of Series can
-   keep an Instance alive longer than expected.
-   - **Recommendation: documented behavior, no code-level mitigation.**
-     Users who care about lifetime drop the Series.
+   - **Working recommendation: do not add `drop_constraint` in
+     v3.** `relax` is sufficient for the existing use cases. Defer
+     wrapper invalidation semantics to whenever `drop_constraint`
+     actually becomes necessary. The risk to weigh: deferring means
+     that whoever adds `drop_constraint` later has to retrofit
+     invalidation onto Attached wrappers across every consumer (PR
+     scope balloons). Explicitly closing the door now ("v3 has no
+     drop") makes that future migration a separate feature, not a
+     compatibility break.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -1,0 +1,396 @@
+# Metadata Storage in OMMX v3 — Design Proposal
+
+Status: **Draft / WIP**
+
+Companion to `SPECIAL_CONSTRAINTS_V3.md`. That doc reshapes the proto schema for
+constraint types; this doc reshapes how *metadata* (`name`, `subscripts`,
+`parameters`, `description`, `provenance`) is stored at runtime and exposed to
+users.
+
+## Goal
+
+Today, `DecisionVariable` and every `Constraint<S>` (regular / indicator /
+one-hot / sos1, in all three lifecycle stages) carry an inline `metadata`
+field. This metadata is rarely consulted by internal logic — `evaluate`,
+`parse`, `substitute`, etc. never read it — but it is copied around on every
+clone, serialized on every write, and duplicated wholesale into every wide
+`*_df` API on the Python side.
+
+We want to:
+
+1. **Move metadata out of the per-object structs and into ID-keyed columnar
+   stores** owned by the enclosing collection (`ConstraintCollection<T>` for
+   constraints, `Instance` for decision variables). Internal types lose their
+   `metadata` field.
+2. **Replace the wide-DataFrame Python API with a JOIN-based one.** Each `*_df`
+   returns only the type-specific core columns (`id`, `kind`, `bound`,
+   `equality`, `evaluated_value`, …). Metadata, parameters, and provenance live
+   in their own thin DataFrames that the user joins on `id` when needed.
+
+These two changes reinforce each other: once the Python API stops embedding
+metadata in every wide DataFrame, the Rust-side stores can be exposed
+column-for-column without per-row repackaging.
+
+## Why now
+
+- Metadata is on the hot path for memory (`logical_memory.rs` reports the
+  per-row `Option`/`Vec`/`FnvHashMap` headers showing up under
+  `Instance.constraint_collection;constraints;Constraint.metadata;…` and the
+  same under `decision_variables`). Pulling it out lets the per-object struct
+  shrink.
+- The v3 alpha window is the right moment to break the wide-DataFrame Python
+  API. Doing it after v3 GA would require another major.
+- `SPECIAL_CONSTRAINTS_V3.md` already extracts `ConstraintMetadata` as a shared
+  proto sub-message, so the proto side is already lined up for the runtime
+  refactor.
+
+## SDK-level design split
+
+Rust SDK and Python SDK have different requirements; we keep the designs
+separate on purpose.
+
+### Rust SDK
+
+Internal users (algorithms, solver adapters, serialization) almost never
+look up metadata by ID. The dominant operations are bulk copy and bulk
+serialize. Partial updates (`add_decision_variable` one at a time) happen
+through normal modeling APIs.
+
+- Internal representation: **Struct-of-Arrays (SoA)**, `FnvHashMap<ID, T>` per
+  field. No `polars` dependency.
+- The 4 constraint types share the same metadata shape, so the store is one
+  generic type parameterized only by the ID type.
+- `DecisionVariable` and `Constraint<S>` lose their `metadata` field.
+
+### Python SDK
+
+End users analyze problems and solutions in DataFrames. They want to filter by
+`name`, group by `subscripts[0]`, and pivot on `parameters.{key}`.
+
+- Public API: pandas DataFrames with **JOIN-based composition**. Core df, metadata
+  df, parameters df, provenance df — separate, each thin, joined on `id`.
+- Implementation: bulk-construct each DataFrame from the Rust SoA store. The
+  `parameters.{key}` wide-column pattern goes away; `parameters` becomes a
+  long-format DataFrame.
+
+### Proto schema
+
+`SPECIAL_CONSTRAINTS_V3.md` already keeps `ConstraintMetadata` inline inside
+each constraint message. We retain that. Wire format is AoS; runtime
+representation is SoA; the conversion happens at parse / serialize time only.
+Hoisting metadata to a top-level `map<uint64, ConstraintMetadata>` would
+mirror the runtime layout but adds 4 additional top-level fields per stage and
+breaks the inline-readable shape — not worth it.
+
+## Rust SDK design
+
+### Metadata stores
+
+```rust
+// Generic over ID type so all 4 constraint types share one implementation.
+pub struct ConstraintMetadataStore<ID> {
+    name:        FnvHashMap<ID, String>,                         // missing = None
+    subscripts:  FnvHashMap<ID, Vec<i64>>,                       // missing = empty
+    parameters:  FnvHashMap<ID, FnvHashMap<String, String>>,     // missing = empty
+    description: FnvHashMap<ID, String>,                         // missing = None
+    provenance:  FnvHashMap<ID, Vec<Provenance>>,                // missing = empty
+}
+
+pub struct VariableMetadataStore {
+    name:        FnvHashMap<VariableID, String>,
+    subscripts:  FnvHashMap<VariableID, Vec<i64>>,
+    parameters:  FnvHashMap<VariableID, FnvHashMap<String, String>>,
+    description: FnvHashMap<VariableID, String>,
+    // no provenance for variables
+}
+```
+
+`provenance` lives only on constraints; the variable store omits it. Otherwise
+the two stores are structurally identical.
+
+### Where the stores live
+
+```rust
+pub struct ConstraintCollection<T: ConstraintType> {
+    active:   BTreeMap<T::ID, T::Created>,
+    removed:  BTreeMap<T::ID, (T::Created, RemovedReason)>,
+    metadata: ConstraintMetadataStore<T::ID>,   // new
+}
+
+pub struct EvaluatedCollection<T: ConstraintType> {
+    constraints:     BTreeMap<T::ID, T::Evaluated>,
+    removed_reasons: BTreeMap<T::ID, RemovedReason>,
+    metadata:        ConstraintMetadataStore<T::ID>,   // new — copied from parent collection
+}
+
+pub struct SampledCollection<T: ConstraintType> {
+    constraints:     BTreeMap<T::ID, T::Sampled>,
+    removed_reasons: BTreeMap<T::ID, RemovedReason>,
+    metadata:        ConstraintMetadataStore<T::ID>,   // new
+}
+
+pub struct Instance {
+    // existing fields …
+    decision_variables: BTreeMap<VariableID, DecisionVariable>,
+    constraint_collection:           ConstraintCollection<Constraint>,
+    indicator_constraint_collection: ConstraintCollection<IndicatorConstraint>,
+    one_hot_constraint_collection:   ConstraintCollection<OneHotConstraint>,
+    sos1_constraint_collection:      ConstraintCollection<Sos1Constraint>,
+
+    variable_metadata: VariableMetadataStore,   // new
+}
+```
+
+Why these levels:
+
+- For constraints, `ConstraintCollection<T>` already owns active/removed split
+  and is generic over constraint type — putting the store there keeps the
+  `relax` / `restore` pair touch-free (active ↔ removed transitions don't move
+  metadata at all). The same store rides through to `EvaluatedCollection<T>` /
+  `SampledCollection<T>` on the Solution / SampleSet side.
+- For variables, there is no analogous `DecisionVariableCollection` and adding
+  one only to host metadata would be over-engineering — `Instance` already
+  owns `BTreeMap<VariableID, DecisionVariable>` directly. We just add a
+  sibling field.
+
+### Per-object struct changes
+
+```rust
+pub struct DecisionVariable {
+    id:                VariableID,
+    kind:              Kind,
+    bound:             Bound,
+    substituted_value: Option<f64>,
+    // metadata field REMOVED
+}
+
+pub struct Constraint<S: Stage<Self> = Created> {
+    pub equality: Equality,
+    pub stage:    S::Data,
+    // metadata field REMOVED
+}
+
+// IndicatorConstraint, OneHotConstraint, Sos1Constraint — same: metadata removed.
+```
+
+Standalone constraints (created via `Constraint::equal_to_zero(f)`,
+`OneHotConstraint::new(...)`, etc.) carry no metadata. Metadata is set after
+inserting into a collection:
+
+```rust
+let id = collection.insert(Constraint::equal_to_zero(f));
+collection.metadata_mut().set_name(id, "demand_balance");
+collection.metadata_mut().push_subscripts(id, [i, j]);
+```
+
+A builder-style helper can sugar this when convenient:
+
+```rust
+collection.insert_with(
+    Constraint::equal_to_zero(f),
+    |m| m.name("demand_balance").subscripts([i, j]),
+);
+```
+
+### Access patterns
+
+```rust
+impl<T: ConstraintType> ConstraintCollection<T> {
+    pub fn metadata(&self) -> &ConstraintMetadataStore<T::ID> { ... }
+    pub fn metadata_mut(&mut self) -> &mut ConstraintMetadataStore<T::ID> { ... }
+
+    /// Convenience view bundling constraint + metadata for a single ID.
+    pub fn view(&self, id: T::ID) -> Option<ConstraintView<'_, T>> { ... }
+}
+
+pub struct ConstraintView<'a, T: ConstraintType> {
+    pub id: T::ID,
+    pub constraint: &'a T::Created,
+    pub metadata: ConstraintMetadataView<'a>,
+}
+
+pub struct ConstraintMetadataView<'a> {
+    name:        Option<&'a str>,
+    subscripts:  &'a [i64],         // empty slice if absent
+    parameters:  &'a FnvHashMap<String, String>,   // &EMPTY if absent
+    description: Option<&'a str>,
+    provenance:  &'a [Provenance],
+}
+```
+
+`ConstraintMetadataView::parameters()` returns `&EMPTY_MAP` for absent keys
+(static const) so the `Option<FnvHashMap<…>>` storage doesn't leak through the
+public API.
+
+### Conversion to / from `v1::*` proto types
+
+Currently `From<(ConstraintID, EvaluatedConstraint)> for v1::EvaluatedConstraint`
+reads `c.metadata.*` directly. After the refactor:
+
+```rust
+impl<T: ConstraintType> EvaluatedCollection<T> {
+    pub fn into_v1(self) -> Vec<v1::EvaluatedConstraint> {
+        let (constraints, removed) = self.into_parts();
+        constraints.into_iter().map(|(id, c)| {
+            let metadata = self.metadata.get(id);  // ConstraintMetadataView
+            v1::EvaluatedConstraint {
+                id: id.into_inner(),
+                equality: c.equality.into(),
+                evaluated_value: c.stage.evaluated_value,
+                name: metadata.name.map(str::to_owned),
+                subscripts: metadata.subscripts.to_vec(),
+                parameters: metadata.parameters.clone().into_iter().collect(),
+                description: metadata.description.map(str::to_owned),
+                // …
+            }
+        }).collect()
+    }
+}
+```
+
+Conversion happens at the *collection* level, not the per-element level.
+
+## Python SDK design
+
+### Current pain
+
+- `instance.decision_variables_df()` and the ~9 other `*_df` methods on
+  `Instance`, plus matching ones on `Solution` and `SampleSet`, return wide
+  DataFrames where every row carries `name`, `subscripts`, `description`,
+  `parameters.x`, `parameters.y`, …
+- Metadata columns are duplicated across every stage's df. A constraint with
+  rich metadata appears in `instance.regular_constraints_df()`,
+  `solution.constraints_df()`, and `sample_set.constraints_df()` with the same
+  metadata replicated each time.
+- `parameters.{key}` is a wide-column with **data-dependent column names**.
+  Aggregation, filtering, and union across instances are awkward.
+
+### Target API
+
+Three orthogonal axes:
+
+1. **Core df** — type-specific columns and `id` only.
+2. **Metadata df** — id-keyed sidecar with `name`, `subscripts`, `description`,
+   `provenance`. One per collection kind.
+3. **Long-format auxiliaries** — `parameters` (and `provenance`, optional)
+   exposed as `(id, key, value)` long-format DataFrames.
+
+```python
+# Decision variables
+df    = instance.decision_variables_df()       # id, kind, lower, upper, substituted_value
+meta  = instance.variable_metadata_df()        # id, name, subscripts, description
+prms  = instance.variable_parameters_df()      # id, key, value
+
+# Constraints (4 kinds, 3 stages each)
+df    = instance.regular_constraints_df()      # id, equality, function_type, used_ids
+meta  = instance.constraint_metadata_df(kind="regular")
+                                               # id, name, subscripts, description, provenance
+prms  = instance.constraint_parameters_df(kind="regular")
+                                               # id, key, value
+
+# User joins as needed
+df.merge(meta, on="id", how="left")
+```
+
+`removed_reason` stays on the core df as `removed_reason` (string) +
+`removed_reason.{param}` if we keep it wide, or moves to a long
+`removed_reasons_df(kind=...)` for consistency. Open question below.
+
+### Why JOIN-based is the right shape here
+
+- Metadata is **shared across stages** — the same metadata applies to a
+  Created constraint, its Evaluated form in a Solution, and its Sampled form
+  in a SampleSet. With wide dfs we copied it three times; with a sidecar
+  metadata df, the user fetches it once.
+- Metadata is **shared across active/removed** within a collection. Today
+  `removed_constraints_df` and `constraints_df` carry separate metadata
+  copies of the same id-keyed rows.
+- `parameters` long-format frees the column space from data dependence — same
+  schema regardless of which keys appear in which instance.
+- The Rust SoA store maps directly to a per-column pandas/polars DataFrame.
+  Bulk construction from `FnvHashMap<ID, …>` is one allocation per column.
+
+### `ToPandasEntry` impact
+
+`python/ommx/src/pandas.rs` currently has ~16 `ToPandasEntry` impls, each
+producing a wide row dict. Under JOIN-based:
+
+- **Core dfs** keep `ToPandasEntry`: row-based construction is fine for the
+  small set of type-specific columns. We strip the `set_metadata(...)` and
+  `set_parameter_columns(...)` calls from each impl.
+- **Metadata dfs** are built column-wise from the SoA store, not via
+  `ToPandasEntry`. New helper `metadata_store_to_dataframe(store)` walks the 4
+  fields of the store and emits columns directly.
+- **Parameters dfs** are built by flattening the SoA `FnvHashMap<ID,
+  FnvHashMap<String, String>>` into three parallel vectors (`id`, `key`,
+  `value`) and constructing a DataFrame.
+
+Net result: roughly half the `ToPandasEntry` boilerplate disappears, and the
+metadata path stops going through Python `dict` allocation per row.
+
+### `subscripts` / `provenance` representation
+
+- `subscripts`: kept as a List<Int64> column (one row per id). It is part of
+  the variable / constraint identity and is consumed as a tuple, not
+  aggregated cross-row. List-of-int columns are well-supported in pandas
+  (object) and natively typed in polars.
+- `provenance`: long format `(id, step, source_kind, source_id)` — one row per
+  `(id, step)` pair. Provenance chains are queries (e.g. "which one-hot
+  constraints became regular constraints?") and the long shape is the natural
+  one for that.
+
+## Migration strategy
+
+Two stages, executed in order. Doing them in the opposite order forces an
+ugly intermediate state where the Rust SoA store has to be re-marshalled into
+wide-DataFrame Python output.
+
+### Stage 1: Python API → JOIN-based (first)
+
+- Strip metadata columns from all `*_df` methods on `Instance`, `Solution`,
+  `SampleSet`.
+- Add new `*_metadata_df`, `*_parameters_df`, `*_provenance_df` methods
+  sourcing from the *current* AoS metadata field.
+- Migration note in `PYTHON_SDK_MIGRATION_GUIDE.md`: any user code that read
+  `df["name"]` or `df["parameters.{key}"]` must now `df.merge(metadata_df,
+  on="id")` or pivot the long parameters df.
+- Internal Rust types unchanged.
+
+### Stage 2: Rust SoA migration (second)
+
+- Add `ConstraintMetadataStore<T::ID>` and `VariableMetadataStore`.
+- Remove `metadata` field from `DecisionVariable`, `Constraint<S>`,
+  `IndicatorConstraint<S>`, `OneHotConstraint<S>`, `Sos1Constraint<S>`.
+- Wire `Evaluate` / `From<v1::*>` paths to read/write metadata at the
+  collection boundary.
+- Python `*_metadata_df` / `*_parameters_df` switch to direct SoA → DataFrame
+  bulk construction.
+
+Both stages are v3-alpha breaking changes. Combined with
+`SPECIAL_CONSTRAINTS_V3.md` they form the v3 metadata + special-constraints
+package.
+
+## Open questions
+
+1. **Constraint kind dispatch in Python**: `constraint_metadata_df(kind="regular")`
+   (one method, runtime kind) vs. `regular_constraint_metadata_df()` (four
+   methods)? Engine-side it's the same code; the question is stub clarity vs.
+   API surface size.
+2. **`removed_reason` placement**: keep inline on each core df (current shape,
+   wide `removed_reason.{key}`), or move to a separate
+   `removed_reasons_df(kind=...)` long DataFrame?
+3. **Builder-style metadata setter**: keep flat (`metadata_mut().set_name(id,
+   ...)`) only, or also add `collection.insert_with(c, |m| m.name(...))` sugar
+   for the common case?
+4. **`parameters` storage on the Rust side**: `FnvHashMap<ID,
+   FnvHashMap<String, String>>` (current shape) or transpose to
+   `FnvHashMap<(ID, String), String>` to match the long-format Python API
+   directly? The transposed form makes Python export trivial but penalizes
+   the (rare) "all parameters of a single id" lookup.
+5. **`subscripts` long format option**: in addition to the List<Int64> column,
+   offer a `subscripts_df` with `(id, position, value)`? Useful when
+   subscripts are heterogeneous lengths and the user wants to filter by
+   `subscripts[0] == "i"`. Could land later if demand emerges.
+6. **Polars as primary in Python**: out of scope here, but the JOIN-based API
+   is polars-friendly. If we want to make polars primary in v3.x, we should
+   ensure the Stage 1 API works equally well with `pl.DataFrame.join`.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -721,6 +721,48 @@ traceability with earlier review comments.
    collection-level metadata in Rust, not part of the constraint.
    Wide pivoting is available on opt-in via
    `constraints_df(kind=..., include=("removed_reasons",))`.
+3. **Atomic insert-with-metadata on the Rust side — `insert_with`
+   takes the existing owned `ConstraintMetadata` struct.** The pre-
+   v3 `ConstraintMetadata` (owned struct with `name`, `subscripts`,
+   `parameters`, `description`, `provenance`) stays as the I/O type
+   even though it no longer lives inside `Constraint<S>`. The SoA
+   store and `ConstraintMetadata` are mutually convertible:
+   `store.collect_for(id) -> ConstraintMetadata` for owned reads,
+   `store.insert(id, ConstraintMetadata)` for owned writes.
+
+   ```rust
+   impl<T: ConstraintType> ConstraintCollection<T> {
+       pub fn insert(&mut self, c: T::Created) -> T::ID;
+       pub fn insert_with(
+           &mut self,
+           c: T::Created,
+           metadata: ConstraintMetadata,
+       ) -> T::ID;
+   }
+
+   let id = collection.insert_with(
+       c,
+       ConstraintMetadata {
+           name: Some("demand_balance".into()),
+           subscripts: vec![i, j],
+           ..Default::default()
+       },
+   );
+   ```
+
+   Two types in the metadata layer cover all cases:
+   - `ConstraintMetadataStore<ID>` — internal SoA store, with
+     per-field borrowing getters (`name(id) -> Option<&str>`,
+     `subscripts(id) -> &[i64]`, …) and a `collect_for(id) ->
+     ConstraintMetadata` for one-shot owned reconstruction.
+   - `ConstraintMetadata` — owned struct used for I/O (insert,
+     owned read, modeling-chain staging). Same shape as the pre-v3
+     struct.
+
+   Pure Rust callers (algorithms, adapters, tests) constructing
+   constraints in loops use `insert_with` to avoid the silent-
+   metadata-loss footgun of the two-step form. Independent of the
+   Python staging bag, which serves the modeling chain.
 4. **`parameters` Rust storage — nested
    `FnvHashMap<ID, FnvHashMap<String, String>>`.** Matches the
    existing per-object metadata shape, makes "all parameters of one
@@ -759,53 +801,4 @@ traceability with earlier review comments.
 
 ## Open questions
 
-Items still requiring sign-off before implementation.
-
-3. **Atomic insert-with-metadata on the Rust side**: provide
-   `collection.insert_with(c, metadata: ConstraintMetadata)`
-   alongside the flat
-   `collection.insert(c) + metadata_mut().set_name(id, ...)` form.
-   - **Working recommendation: add `insert_with` taking the existing
-     owned `ConstraintMetadata` struct.**
-
-     The pre-v3 `ConstraintMetadata` (owned struct with `name`,
-     `subscripts`, `parameters`, `description`, `provenance`) stays
-     as the I/O type even though it no longer lives inside
-     `Constraint<S>`. The SoA store and `ConstraintMetadata` are
-     mutually convertible: `store.collect_for(id) ->
-     ConstraintMetadata` for owned reads,
-     `store.insert(id, ConstraintMetadata)` for owned writes.
-
-     ```rust
-     impl<T: ConstraintType> ConstraintCollection<T> {
-         pub fn insert(&mut self, c: T::Created) -> T::ID;
-         pub fn insert_with(
-             &mut self,
-             c: T::Created,
-             metadata: ConstraintMetadata,
-         ) -> T::ID;
-     }
-
-     let id = collection.insert_with(
-         c,
-         ConstraintMetadata {
-             name: Some("demand_balance".into()),
-             subscripts: vec![i, j],
-             ..Default::default()
-         },
-     );
-     ```
-
-     Two types in the metadata layer cover all cases:
-     - `ConstraintMetadataStore<ID>` — internal SoA store, with
-       per-field borrowing getters (`name(id) -> Option<&str>`,
-       `subscripts(id) -> &[i64]`, …) and a `collect_for(id) ->
-       ConstraintMetadata` for one-shot owned reconstruction.
-     - `ConstraintMetadata` — owned struct used for I/O (insert,
-       owned read, modeling-chain staging). Same shape as the pre-v3
-       struct.
-
-     Pure Rust callers (algorithms, adapters, tests) constructing
-     constraints in loops use `insert_with` to avoid the silent-
-     metadata-loss footgun of the two-step form. Independent of the
-     Python staging bag, which serves the modeling chain.
+None remaining. All eight items are resolved above.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -309,7 +309,19 @@ The boundaries currently work per-element and need to move to per-collection:
   below needs the `gen_stub_pymethods` decorator and the corresponding
   `ommx.v1.__init__.py` regen via `task python:stubgen`. The stores are
   not exposed to Python directly; they surface via wrapper getters,
-  Series accessors, and DataFrames.
+  Series accessors, and DataFrames. For the `Series[ID -> Object]`
+  return signatures, hand-written stub overrides cover whatever the
+  derive doesn't emit automatically.
+- **`Evaluate` / Sampled construction paths**:
+  `EvaluatedCollection<T>` and `SampledCollection<T>` currently
+  carry no metadata (`rust/ommx/src/constraint_type.rs`). To realize
+  the "Solution and SampleSet share the metadata store" guarantee,
+  every constructor of these collections — and every call site that
+  evaluates or samples constraints (the `Evaluate` impls in
+  `rust/ommx/src/constraint/evaluate.rs`, `instance/evaluate.rs`,
+  and the per-special-constraint evaluate modules) — has to thread
+  the source `ConstraintMetadataStore<T::ID>` through. This is a
+  required implementation task, not a separate optimization.
 
 ## Python SDK design
 
@@ -790,6 +802,18 @@ traceability with earlier review comments.
    a future version ever needs a `drop_constraint`, it lands as a
    separate feature with its own invalidation story; v3 does not
    need it.
+
+   **Parse-time normalization is the one explicit exception.**
+   `From<v1::Instance>` already absorbs constraint hints into the
+   first-class collections (`rust/ommx/src/instance/parse.rs`'s
+   hint-absorption path), which can drop "absorbed" regular
+   constraints during parsing. This is part of the parse step, not
+   a runtime mutation of an existing `ConstraintCollection`, so the
+   invariant above still holds at the runtime API. The practical
+   consequence is that a v2 proto round-tripped through v3 parse
+   may have fewer regular constraints than the input — an existing
+   v2 behavior, called out here so it isn't mistaken for a runtime
+   `drop` slipping in.
 8. **Attached wrapper `Py<Instance>` lifetime — documented behavior,
    no code-level mitigation in this proposal.** The wrapper holds a
    refcounted handle to the Instance; there's no cycle (wrapper →

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -79,12 +79,20 @@ SoA store; the behavior they implement is unchanged.
 - `instance.constraints`, `decision_variables`, `*_constraints` become
   `pandas.Series[ID -> Object]` — index = ID, value = the PyO3 wrapper
   object. Series indexing replaces dict / list APIs.
-- `*_df` methods are explicitly **derived views**: type-specific core
-  columns extracted from the SoA, joined with sidecar metadata /
-  parameters / provenance / removed-reason dfs.
-- Sidecar DataFrames (`*_metadata_df`, `*_parameters_df` long format,
-  `*_provenance_df` long format, `*_removed_reasons_df` long format) are
-  bulk-built from the Rust SoA store, one column allocation per field.
+- `*_df` methods are explicitly **derived views**: each one returns
+  type-specific core columns extracted from the SoA store, with no
+  metadata columns inlined. They do **not** join sidecars themselves;
+  callers either join the sidecar dfs explicitly or use the
+  `*_full_df` helper covered below.
+- Sidecar DataFrames are bulk-built from the Rust SoA store with one
+  column allocation per field. Constraint-side methods take a
+  `kind: Literal["regular","indicator","one_hot","sos1"]` argument
+  (`constraint_metadata_df(kind=...)`,
+  `constraint_parameters_df(kind=...)`,
+  `constraint_provenance_df(kind=...)`,
+  `constraint_removed_reasons_df(kind=...)`); decision-variable-side
+  methods need no kind (`variable_metadata_df`,
+  `variable_parameters_df`).
 - **Wrapper objects keep their metadata getters** (`Constraint.name`,
   `.subscripts`, `.parameters`, `.description`; same on the other
   wrappers). For wrappers obtained from a collection ("attached"), the
@@ -212,7 +220,9 @@ let id = collection.insert(Constraint::equal_to_zero(f));
 collection.metadata_mut().set_name(id, "demand_balance");
 collection.metadata_mut().push_subscripts(id, [i, j]);
 
-// or via the convenience builder:
+// or via the convenience builder. Builder methods correspond to the
+// existing Python `set_*` semantics (replace, not extend) since the
+// builder always starts from an empty store:
 collection.insert_with(
     Constraint::equal_to_zero(f),
     |m| m.name("demand_balance").subscripts([i, j]),
@@ -306,11 +316,11 @@ The boundaries currently work per-element and need to move to per-collection:
                     │
        ┌────────────┼─────────────────────┐
        ▼            ▼                     ▼
-  Series         Constraint object     *_df / *_metadata_df / *_parameters_df
-  (per-id        (with .name / .       (bulk-built from the SoA store via
-   wrapper       subscripts / …        column-wise builders; not via
-   handles)      back-referenced       per-row dict construction)
-                 to the store)
+  Series         Constraint object     constraints_df / constraint_metadata_df /
+  (per-id        (with .name /         constraint_parameters_df / etc.
+   wrapper       .subscripts / …       (bulk-built from the SoA store via
+   handles)      back-referenced       column-wise builders; kind dispatched
+                 to the store)         via Literal + @overload)
 ```
 
 Wrapper objects, Series, and DataFrames are three views over the same
@@ -349,8 +359,21 @@ enum ConstraintInner {
 
 `Instance.add_constraint(c)` (and the special-constraint equivalents)
 takes a Standalone wrapper, drains its staging bag into the SoA store,
-and returns an Attached wrapper bound to that `id`. Series-derived
-wrappers (`s.loc[id]`) are also Attached.
+and returns a fresh Attached wrapper bound to that `id`. The original
+Standalone wrapper is **transitioned in place**: its `inner` flips to
+`Attached { instance, kind, id }` so subsequent `c.name`,
+`c.add_name(...)`, etc. read / write the SoA store. Calling
+`add_constraint(c)` a second time on an already-Attached wrapper
+raises `ValueError("constraint already inserted")` rather than
+silently re-inserting. Series-derived wrappers (`s.loc[id]`) are
+also Attached, sharing the `Py<Instance>` of the parent.
+
+Two Attached wrappers that point at the same id observe the same
+state: a write through one (`a.name = "x"`) is visible through any
+other (`b.name == "x"`) and through the metadata df on the next
+call. Concurrency-wise this is the standard PyO3 borrow rule — the
+SoA store is mutated through `Bound<'py, Instance>` borrowing, which
+the runtime checks at `&mut` boundaries.
 
 ```python
 # Standalone modeling — staging bag in the wrapper
@@ -405,6 +428,14 @@ instance.sos1_constraints                 # Series[Sos1ConstraintID -> Sos1Const
 
 solution.constraints                      # Series[ConstraintID -> EvaluatedConstraint]
 sample_set.constraints                    # Series[ConstraintID -> SampledConstraint]
+
+# ParametricInstance follows the same surface as Instance: Series
+# accessors for variables / constraints / special constraints, the
+# corresponding *_df / *_metadata_df / *_full_df family, and back-
+# referenced wrappers for individual elements. The (unrelated)
+# parametric `parameters` field stays on its own dedicated accessor.
+parametric_instance.constraints           # Series[ConstraintID -> Constraint]
+parametric_instance.decision_variables    # Series[VariableID -> DecisionVariable]
 ```
 
 The Series carries Attached wrapper objects (object dtype). Per-element
@@ -459,10 +490,40 @@ removed  = instance.constraint_removed_reasons_df(kind="regular")
 df.join(meta, how="left")
 ```
 
-`*_df` is what users call when they want a single rectangular table for
-analysis; the Series is what users call when they want individual
-wrapper objects; the wrapper getters are what users call when they
-already hold one wrapper. Three surfaces, one canonical store.
+`Solution` and `SampleSet` expose the same `*_df` family with stage-
+appropriate column schemas. The method names match `Instance`:
+
+```python
+# Solution — evaluated stage
+df = solution.constraints_df(kind="regular")
+                                            # index name=regular_constraint_id;
+                                            # equality, evaluated_value, feasible,
+                                            # used_ids, dual_variable
+df = solution.decision_variables_df()       # index name=variable_id;
+                                            # kind, lower, upper, value
+solution.constraint_metadata_df(kind=...)   # same metadata schema as Instance
+solution.constraint_full_df(kind=...)       # core + metadata join
+# … same family for solution.variable_*_df / solution.constraint_*_df
+
+# SampleSet — sampled stage; columns are per-sample (value.{sid},
+# feasible.{sid}, …) where sid is each SampleID.
+df = sample_set.constraints_df(kind="regular")
+df = sample_set.decision_variables_df()
+sample_set.constraint_metadata_df(kind=...)
+sample_set.constraint_full_df(kind=...)
+```
+
+The metadata / parameters / provenance / removed-reasons sidecar dfs
+are stage-independent (they describe the same constraint), so on
+`Solution` and `SampleSet` they return the same data they would on
+the source `Instance` — there's no per-stage divergence to manage.
+
+`*_df` (core only) is what users call when they want a single
+rectangular table for analysis; `*_full_df` is the convenience
+join (see "Avoiding cross-ID-space joins"); the Series is what users
+call when they want individual wrapper objects; the wrapper getters
+are what users call when they already hold one wrapper. Four
+surfaces, one canonical store.
 
 ### Avoiding cross-ID-space joins
 
@@ -493,16 +554,33 @@ naming and helper layers:
    columns plus name/subscripts/description in one frame" case, expose:
 
    ```python
-   instance.constraints_full_df(kind="regular")
-   instance.decision_variables_full_df()
+   instance.constraints_full_df(
+       kind="regular",
+       include=("metadata",),     # default — name / subscripts / description
+                                  # joined as columns on the core df
+   )
+   instance.constraints_full_df(
+       kind="regular",
+       include=("metadata", "parameters", "provenance",
+                "removed_reasons"),
+   )
+   instance.decision_variables_full_df(
+       include=("metadata", "parameters"),
+   )
    ```
 
-   These are convenience wrappers that perform the right join internally
-   (core ⨝ metadata, optionally also parameters / provenance via
-   keyword args). Users who only want a quick analysis frame call the
-   `*_full_df` form and never write a manual `.join()` at all. Users
-   who want the constituent dfs separately still get them via the
-   primary `*_df` family — the helper is purely additive.
+   `include` is a tuple of literal strings (typed via `Literal[...]`)
+   selecting which sidecars to fold in. `"metadata"` is left-joined as
+   columns; `"parameters"` / `"provenance"` / `"removed_reasons"` are
+   left-joined after pivoting their long-format keys back to wide
+   columns under namespaced prefixes (`parameters.{key}`,
+   `provenance.{step}.source_id`, `removed_reasons.{key}`) — the
+   resulting df is heterogeneous-column-shaped, so this form is
+   strictly the convenience surface. Users who want clean long-form
+   data for analysis still go through the primary `*_df` family.
+
+   Users who only want a quick analysis frame call `*_full_df` and
+   never write a manual `.join()` at all.
 
 3. **Wrapper-object access stays the safest path for single-id
    lookups.** `s.loc[id].name` reads metadata via the back-reference
@@ -554,11 +632,25 @@ User-visible breakage relative to v3 alpha 2:
   - `s.values()` (method call) → `s.tolist()` or `list(s)`.
   - List-positional reliance on the old `decision_variables: list[…]`
     ordering breaks; index by `VariableID` instead.
-- `*_df` methods no longer carry `name`, `subscripts`, `description`,
-  or `parameters.{key}` columns. Users `df.join(meta_df)` or pivot the
-  long parameters df.
-- New `*_metadata_df`, `*_parameters_df`, `*_provenance_df`,
-  `*_removed_reasons_df` methods are added per collection kind.
+- `*_df` methods (`constraints_df(kind=...)`,
+  `decision_variables_df()`, and the Solution / SampleSet
+  counterparts) no longer carry `name`, `subscripts`, `description`,
+  or `parameters.{key}` columns. Users join the relevant metadata /
+  parameters df explicitly or call `*_full_df` for the joined form.
+- New methods on `Instance`, `Solution`, and `SampleSet`:
+  `constraint_metadata_df(kind=...)`,
+  `constraint_parameters_df(kind=...)`,
+  `constraint_provenance_df(kind=...)`,
+  `constraint_removed_reasons_df(kind=...)`,
+  `variable_metadata_df()`,
+  `variable_parameters_df()`,
+  plus `constraints_full_df(kind=...)` /
+  `decision_variables_full_df()` joined helpers.
+- Per-kind `indicator_constraints_df()`,
+  `one_hot_constraints_df()`, `sos1_constraints_df()`, and
+  `removed_*_constraints_df()` collapse into the single
+  `constraints_df(kind=...)` overload set; same for the corresponding
+  removed-reasons methods.
 - The Rust `metadata` field on `DecisionVariable` and `Constraint<S>`
   is removed. Downstream Rust crates that touched `c.metadata.*`
   directly switch to `collection.metadata()` accessors.
@@ -592,11 +684,18 @@ before implementation.
      exposes `removed_reasons_df` / `indicator_removed_reasons_df`
      this way, and `RemovedReason` is collection-level metadata in
      Rust, not part of the constraint.
-3. **Builder-style metadata setter**: flat
-   (`metadata_mut().set_name(id, ...)`) only, vs. also
-   `collection.insert_with(c, |m| m.name(...))` sugar.
-   - **Recommendation: add `insert_with`** on the Rust side. The
-     Python staging bag covers the equivalent Python ergonomics.
+3. **Builder-style metadata setter on the Rust side**: flat
+   (`collection.insert(c)` followed by `metadata_mut().set_name(id,
+   ...)`) only, vs. also `collection.insert_with(c, |m|
+   m.name(...))` sugar.
+   - **Recommendation: add `insert_with`.** Pure Rust callers
+     (algorithms, adapters, tests) construct constraints in loops
+     where the two-step form is easy to forget — the constraint goes
+     in but the metadata silently doesn't. The closure-based form
+     keeps insertion atomic at the call site. This is independent of
+     the Python staging bag, which serves the modeling chain on the
+     Python side; both surfaces exist for their own ergonomics
+     reasons.
 4. **`parameters` storage on the Rust side**: `FnvHashMap<ID,
    FnvHashMap<String, String>>` vs. transposed `FnvHashMap<(ID,
    String), String>`.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -631,11 +631,20 @@ each producing a wide row dict.
 
 ### `subscripts` / `provenance` representation
 
-- `subscripts`: `List<Int64>` column on the metadata df (one row per
-  id). Part of the variable / constraint identity, consumed as a
-  tuple, not aggregated cross-row.
+- `subscripts`: a single `List<Int64>` value per id — exposed as a
+  list column on `*_metadata_df` and as `wrapper.subscripts: list[int]`
+  via the back-reference. **Not** offered in long format. `subscripts`
+  is part of the variable / constraint identity (the "tuple index" in
+  `x[i, j, k]`-style expressions), and exploding it across rows would
+  invite treating positions as first-class entities — which is the
+  wrong mental model. Users who genuinely want to filter on
+  `subscripts[0]` do it in Python (`df[df.subscripts.str[0] == i]`)
+  rather than via a long-format API.
 - `provenance`: long format `(id, step, source_kind, source_id)` — one
-  row per `(id, step)` pair.
+  row per `(id, step)` pair. Unlike `subscripts`, provenance steps
+  *are* first-class entities (each step is one transformation event),
+  and chains have variable length, so the long shape is the natural
+  one.
 
 ## Breaking changes
 
@@ -724,9 +733,13 @@ before implementation.
 5. **`subscripts` long format option**: in addition to the
    `List<Int64>` column, offer a `subscripts_df` with `(id, position,
    value)`.
-   - **Recommendation: not in this proposal.** List column is enough
-     for identity-style use. Add later if demand for positional
-     filtering emerges.
+   - **Recommendation: reject.** `subscripts` is part of the
+     variable / constraint identity (the "tuple index" in expressions
+     like `x[i, j, k]`), not a collection that users meaningfully
+     iterate or aggregate over. Exposing it in long form would invite
+     treating positions as first-class entities, which is the wrong
+     mental model. Always serve `subscripts` as a single `List<Int64>`
+     value per id — both on the metadata df and on the wrapper getter.
 6. **Polars as primary in Python**: out of scope here, but the
    JOIN-based API is polars-friendly.
    - **Recommendation: pandas stays primary for v3.** `PyDataFrame`

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -720,6 +720,19 @@ traceability with earlier review comments.
 6. **Polars as primary in Python — no, pandas stays primary for v3.**
    `PyDataFrame` is pandas-backed; polars promotion is a separate
    v3.x discussion.
+7. **No API to remove constraints from a collection.** Once a
+   constraint has been added to a collection, it stays in either
+   the active or the removed map for the lifetime of the
+   `Instance`. `relax(id)` moves it from active to removed;
+   `restore(id)` moves it back. There is no operation that drops a
+   constraint from the collection entirely. Users whose workflow
+   needs to "forget" a constraint construct a fresh `Instance`
+   instead. This keeps Attached wrappers always valid (the id they
+   reference is guaranteed to be in one of the two maps), so
+   wrapper getters never panic or raise an invalidation error. If
+   a future version ever needs a `drop_constraint`, it lands as a
+   separate feature with its own invalidation story; v3 does not
+   need it.
 8. **Attached wrapper `Py<Instance>` lifetime — documented behavior,
    no code-level mitigation in this proposal.** The wrapper holds a
    refcounted handle to the Instance; there's no cycle (wrapper →
@@ -745,17 +758,3 @@ Items still requiring sign-off before implementation.
      This is independent of the Python staging bag, which serves the
      modeling chain on the Python side; both surfaces exist for
      their own ergonomics reasons.
-7. **`drop_constraint` / wrapper invalidation**: Attached wrappers
-   stay valid as long as the id is in either the active or removed
-   map. There's no `drop_constraint` API today, so the question is
-   moot — but if one is added later, it has to invalidate Attached
-   wrappers (panicking getters or `IsDroppedError`).
-   - **Working recommendation: do not add `drop_constraint` in
-     v3.** `relax` is sufficient for the existing use cases. Defer
-     wrapper invalidation semantics to whenever `drop_constraint`
-     actually becomes necessary. The risk to weigh: deferring means
-     that whoever adds `drop_constraint` later has to retrofit
-     invalidation onto Attached wrappers across every consumer (PR
-     scope balloons). Explicitly closing the door now ("v3 has no
-     drop") makes that future migration a separate feature, not a
-     compatibility break.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -79,20 +79,19 @@ SoA store; the behavior they implement is unchanged.
 - `instance.constraints`, `decision_variables`, `*_constraints` become
   `pandas.Series[ID -> Object]` — index = ID, value = the PyO3 wrapper
   object. Series indexing replaces dict / list APIs.
-- `*_df` methods are explicitly **derived views**: each one returns
-  type-specific core columns extracted from the SoA store, with no
-  metadata columns inlined. They do **not** join sidecars themselves;
-  callers either join the sidecar dfs explicitly or use the
-  `*_full_df` helper covered below.
+- `*_df` methods are explicitly **derived views** with an `include`
+  parameter that controls which sidecars are folded in. The default
+  `include` keeps the v2-style wide DataFrame shape, so existing user
+  code only needs to add the `kind=...` argument to keep working.
 - Sidecar DataFrames are bulk-built from the Rust SoA store with one
-  column allocation per field. Constraint-side methods take a
-  `kind: Literal["regular","indicator","one_hot","sos1"]` argument
+  column allocation per field. They are still exposed individually
   (`constraint_metadata_df(kind=...)`,
   `constraint_parameters_df(kind=...)`,
   `constraint_provenance_df(kind=...)`,
-  `constraint_removed_reasons_df(kind=...)`); decision-variable-side
-  methods need no kind (`variable_metadata_df`,
-  `variable_parameters_df`).
+  `constraint_removed_reasons_df(kind=...)`,
+  `variable_metadata_df`, `variable_parameters_df`) for users who
+  want long-format data, but the `*_df` family covers the common
+  "give me a wide table" case directly.
 - **Wrapper objects keep their metadata getters** (`Constraint.name`,
   `.subscripts`, `.parameters`, `.description`; same on the other
   wrappers). For wrappers obtained from a collection ("attached"), the
@@ -316,11 +315,13 @@ The boundaries currently work per-element and need to move to per-collection:
                     │
        ┌────────────┼─────────────────────┐
        ▼            ▼                     ▼
-  Series         Constraint object     constraints_df / constraint_metadata_df /
-  (per-id        (with .name /         constraint_parameters_df / etc.
-   wrapper       .subscripts / …       (bulk-built from the SoA store via
-   handles)      back-referenced       column-wise builders; kind dispatched
-                 to the store)         via Literal + @overload)
+  Series         Constraint object     constraints_df(kind=..., include=...) /
+  (per-id        (with .name /         constraint_metadata_df(kind=...) /
+   wrapper       .subscripts / …       constraint_parameters_df(kind=...) /
+   handles)      back-referenced       constraint_provenance_df(kind=...) /
+                 to the store)         constraint_removed_reasons_df(kind=...)
+                                       (bulk-built from the SoA via column-wise
+                                       builders; kind via Literal + @overload)
 ```
 
 Wrapper objects, Series, and DataFrames are three views over the same
@@ -431,9 +432,10 @@ sample_set.constraints                    # Series[ConstraintID -> SampledConstr
 
 # ParametricInstance follows the same surface as Instance: Series
 # accessors for variables / constraints / special constraints, the
-# corresponding *_df / *_metadata_df / *_full_df family, and back-
-# referenced wrappers for individual elements. The (unrelated)
-# parametric `parameters` field stays on its own dedicated accessor.
+# corresponding constraints_df / constraint_metadata_df / etc.
+# family with the same `include=` parameter, and back-referenced
+# wrappers for individual elements. The (unrelated) parametric
+# `parameters` field stays on its own dedicated accessor.
 parametric_instance.constraints           # Series[ConstraintID -> Constraint]
 parametric_instance.decision_variables    # Series[VariableID -> DecisionVariable]
 ```
@@ -455,75 +457,95 @@ indexing, `.items()`, `.index`. Operations users lose vs. dict:
   The right answer is `instance.constraints_df()["equality"]`, which
   is bulk-built from the SoA. Document this; do not enforce.
 
-### `*_df` methods → derived views
+### `*_df` methods → derived views with `include`
 
-Each `*_df` is a derived view. Implementation reads the SoA store
-directly via column-wise builders (no per-row dict construction).
+Each `*_df` is a derived view: type-specific core columns extracted
+from the SoA store, plus whichever sidecars the caller asks for via
+`include`. The default `include` matches v2's wide-DataFrame shape
+(`metadata` + `parameters`), so v2 user code keeps working with only
+a `kind=...` argument added.
 
 ```python
-# Decision variables
-df       = instance.decision_variables_df()       # index name=variable_id;
-                                                  # kind, lower, upper, substituted_value
-meta     = instance.variable_metadata_df()        # index name=variable_id;
-                                                  # name, subscripts, description
-params   = instance.variable_parameters_df()      # columns: variable_id, key, value (long format)
+# === v2-style wide DataFrame (default include) ===
+df = instance.constraints_df(kind="regular")
+# ≡ instance.constraints_df(kind="regular", include=("metadata", "parameters"))
+# index name = regular_constraint_id
+# columns: equality, function_type, used_ids,
+#          name, subscripts, description, parameters.{key}, ...
 
-# Constraints — kind dispatched via Literal + @overload so the IDE / type
-# checker still sees the kind-specific column schema for each call.
-df       = instance.constraints_df(kind="regular")
-                                                  # index name=regular_constraint_id;
-                                                  # equality, function_type, used_ids
+df = instance.decision_variables_df()
+# ≡ instance.decision_variables_df(include=("metadata", "parameters"))
+# index name = variable_id
+# columns: kind, lower, upper, substituted_value,
+#          name, subscripts, description, parameters.{key}, ...
+
+# === Core only — pass include=() ===
+df = instance.constraints_df(kind="regular", include=())
+# columns: equality, function_type, used_ids
+
+df = instance.decision_variables_df(include=())
+# columns: kind, lower, upper, substituted_value
+
+# === Add removed_reasons (not in v2 default) ===
+df = instance.constraints_df(
+    kind="regular",
+    include=("metadata", "parameters", "removed_reasons"),
+)
+# … plus removed_reasons.reason, removed_reasons.{key}
+
+# === Long-format sidecars when wide pivoting isn't what you want ===
 meta     = instance.constraint_metadata_df(kind="regular")
-                                                  # index name=regular_constraint_id;
-                                                  # name, subscripts, description
-provenance_df = instance.constraint_provenance_df(kind="regular")
-                                                  # columns: regular_constraint_id, step,
-                                                  # source_kind, source_id (long)
+                                            # index name=regular_constraint_id;
+                                            # name, subscripts, description
+provs    = instance.constraint_provenance_df(kind="regular")
+                                            # columns: regular_constraint_id, step,
+                                            # source_kind, source_id (long format)
 params   = instance.constraint_parameters_df(kind="regular")
-                                                  # columns: regular_constraint_id, key,
-                                                  # value (long format)
+                                            # columns: regular_constraint_id, key, value
 removed  = instance.constraint_removed_reasons_df(kind="regular")
-                                                  # columns: regular_constraint_id, reason,
-                                                  # key, value (long format)
-
-# Joining is explicit
-df.join(meta, how="left")
+                                            # columns: regular_constraint_id, reason,
+                                            # key, value
 ```
 
+`include` accepts a tuple of `Literal["metadata","parameters","removed_reasons"]`
+values. `provenance` is intentionally absent from `include`: chains
+have variable length, so a wide pivot would either explode the column
+space (`provenance.0.*`, `provenance.1.*`, …) or produce an
+object-dtype list column. Users who want provenance pivot the long-
+format `constraint_provenance_df()` themselves.
+
 `Solution` and `SampleSet` expose the same `*_df` family with stage-
-appropriate column schemas. The method names match `Instance`:
+appropriate core-column schemas and the same `include` parameter:
 
 ```python
-# Solution — evaluated stage
+# Solution — evaluated stage; v2-style default
 df = solution.constraints_df(kind="regular")
-                                            # index name=regular_constraint_id;
-                                            # equality, evaluated_value, feasible,
+                                            # core: equality, evaluated_value, feasible,
                                             # used_ids, dual_variable
-df = solution.decision_variables_df()       # index name=variable_id;
-                                            # kind, lower, upper, value
-solution.constraint_metadata_df(kind=...)   # same metadata schema as Instance
-solution.constraint_full_df(kind=...)       # core + metadata join
-# … same family for solution.variable_*_df / solution.constraint_*_df
+                                            # + metadata, parameters columns by default
 
-# SampleSet — sampled stage; columns are per-sample (value.{sid},
-# feasible.{sid}, …) where sid is each SampleID.
+df = solution.decision_variables_df()       # core: kind, lower, upper, value
+                                            # + metadata, parameters columns by default
+
+# SampleSet — sampled stage; per-sample core columns (value.{sid},
+# feasible.{sid}, …); same include defaults
 df = sample_set.constraints_df(kind="regular")
 df = sample_set.decision_variables_df()
-sample_set.constraint_metadata_df(kind=...)
-sample_set.constraint_full_df(kind=...)
 ```
 
 The metadata / parameters / provenance / removed-reasons sidecar dfs
-are stage-independent (they describe the same constraint), so on
-`Solution` and `SampleSet` they return the same data they would on
-the source `Instance` — there's no per-stage divergence to manage.
+are stage-independent — they describe the same constraint, so
+`solution.constraint_metadata_df(kind=...)` returns the same data as
+`instance.constraint_metadata_df(kind=...)` (and the `include=` columns
+folded into `*_df` are identical across stages too). There's no per-
+stage divergence to manage.
 
-`*_df` (core only) is what users call when they want a single
-rectangular table for analysis; `*_full_df` is the convenience
-join (see "Avoiding cross-ID-space joins"); the Series is what users
+`*_df` (with `include=`) is what users call when they want a wide
+table for analysis; the long-format sidecars are what they call when
+they want tidy data for joins or aggregation; the Series is what they
 call when they want individual wrapper objects; the wrapper getters
-are what users call when they already hold one wrapper. Four
-surfaces, one canonical store.
+are what they call when they already hold one wrapper. Four surfaces,
+one canonical store.
 
 ### Avoiding cross-ID-space joins
 
@@ -550,37 +572,30 @@ naming and helper layers:
    inspection, and migration-guide examples, so users see the mismatch
    immediately rather than chasing a silent bug downstream.
 
-2. **One-step joined helpers per kind.** For the common "I want core
-   columns plus name/subscripts/description in one frame" case, expose:
+2. **`include=` covers the common "wide" case without manual join.**
+   The `*_df` methods themselves accept an `include` parameter that
+   folds sidecars into the result, so most users never write a
+   `df.join(other_df)` at all:
 
    ```python
-   instance.constraints_full_df(
-       kind="regular",
-       include=("metadata",),     # default — name / subscripts / description
-                                  # joined as columns on the core df
-   )
-   instance.constraints_full_df(
-       kind="regular",
-       include=("metadata", "parameters", "provenance",
-                "removed_reasons"),
-   )
-   instance.decision_variables_full_df(
-       include=("metadata", "parameters"),
-   )
+   instance.constraints_df(kind="regular")
+   # default include=("metadata","parameters") — v2-equivalent shape
+
+   instance.constraints_df(kind="regular",
+                           include=("metadata","parameters","removed_reasons"))
+   # core + metadata + pivoted parameters + pivoted removed_reasons
    ```
 
-   `include` is a tuple of literal strings (typed via `Literal[...]`)
-   selecting which sidecars to fold in. `"metadata"` is left-joined as
-   columns; `"parameters"` / `"provenance"` / `"removed_reasons"` are
-   left-joined after pivoting their long-format keys back to wide
-   columns under namespaced prefixes (`parameters.{key}`,
-   `provenance.{step}.source_id`, `removed_reasons.{key}`) — the
-   resulting df is heterogeneous-column-shaped, so this form is
-   strictly the convenience surface. Users who want clean long-form
-   data for analysis still go through the primary `*_df` family.
-
-   Users who only want a quick analysis frame call `*_full_df` and
-   never write a manual `.join()` at all.
+   `include` is a tuple of literal strings (typed via `Literal[...]`).
+   `"metadata"` is left-joined as columns; `"parameters"` and
+   `"removed_reasons"` are left-joined after pivoting their long-
+   format keys back to wide columns under namespaced prefixes
+   (`parameters.{key}`, `removed_reasons.{key}`). Cross-ID-space
+   mistakes are impossible inside `include=` because the helper
+   knows the right kind to look up internally. Users who need a
+   manual cross-df `join` go through the long-format sidecars,
+   where the qualified index names (point 1) make the mistake
+   visible.
 
 3. **Wrapper-object access stays the safest path for single-id
    lookups.** `s.loc[id].name` reads metadata via the back-reference
@@ -593,7 +608,7 @@ A stronger guarantee — encoding kind in the index dtype itself
 and rejected. MultiIndex is intrusive on every analysis call; a custom
 ExtensionArray is a meaningful pandas integration and a maintenance
 burden disproportionate to the failure mode it prevents. The qualified
-index name + `*_full_df` helpers are sufficient.
+index name + `include=` covering the common wide case are sufficient.
 
 ### `ToPandasEntry` restructuring
 
@@ -634,23 +649,26 @@ User-visible breakage relative to v3 alpha 2:
     ordering breaks; index by `VariableID` instead.
 - `*_df` methods (`constraints_df(kind=...)`,
   `decision_variables_df()`, and the Solution / SampleSet
-  counterparts) no longer carry `name`, `subscripts`, `description`,
-  or `parameters.{key}` columns. Users join the relevant metadata /
-  parameters df explicitly or call `*_full_df` for the joined form.
-- New methods on `Instance`, `Solution`, and `SampleSet`:
-  `constraint_metadata_df(kind=...)`,
+  counterparts) gain an `include=` parameter selecting which
+  sidecars to fold in. The default
+  (`include=("metadata","parameters")`) reproduces the v2 wide-
+  DataFrame shape, so v2 user code keeps working with only a
+  `kind=...` argument added — `df["name"]`,
+  `df["parameters.{key}"]`, etc. continue to resolve. Users who
+  want only the core columns pass `include=()`.
+- New long-format sidecar methods on `Instance`, `Solution`, and
+  `SampleSet`: `constraint_metadata_df(kind=...)`,
   `constraint_parameters_df(kind=...)`,
   `constraint_provenance_df(kind=...)`,
   `constraint_removed_reasons_df(kind=...)`,
-  `variable_metadata_df()`,
-  `variable_parameters_df()`,
-  plus `constraints_full_df(kind=...)` /
-  `decision_variables_full_df()` joined helpers.
+  `variable_metadata_df()`, `variable_parameters_df()`. These
+  expose the SoA store as tidy long-format DataFrames for users
+  who want pivot / aggregation / cross-instance union beyond what
+  `include=` covers.
 - Per-kind `indicator_constraints_df()`,
   `one_hot_constraints_df()`, `sos1_constraints_df()`, and
   `removed_*_constraints_df()` collapse into the single
-  `constraints_df(kind=...)` overload set; same for the corresponding
-  removed-reasons methods.
+  `constraints_df(kind=...)` overload set.
 - The Rust `metadata` field on `DecisionVariable` and `Constraint<S>`
   is removed. Downstream Rust crates that touched `c.metadata.*`
   directly switch to `collection.metadata()` accessors.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -2,10 +2,13 @@
 
 Status: **Draft / WIP**
 
-Companion to `SPECIAL_CONSTRAINTS_V3.md`. That doc reshapes the proto schema for
-constraint types; this doc reshapes how *metadata* (`name`, `subscripts`,
-`parameters`, `description`, `provenance`) is stored at runtime and exposed to
-users.
+This proposal is a **prerequisite** for `SPECIAL_CONSTRAINTS_V3.md` (PR #841).
+The proto-schema redesign in #841 cannot be finalized without first deciding
+how metadata (`name`, `subscripts`, `parameters`, `description`, `provenance`)
+is stored at runtime and surfaced to users — the wire shape of
+`ConstraintMetadata` (inline per message vs. top-level columnar map) only
+makes sense once the runtime / Python-API direction is settled. So this
+discussion was split out of #841 and runs first.
 
 ## Goal
 
@@ -33,6 +36,10 @@ column-for-column without per-row repackaging.
 
 ## Why now
 
+- **Blocks #841.** The proto v3 design in `SPECIAL_CONSTRAINTS_V3.md` extracts
+  `ConstraintMetadata` as a shared sub-message but defers the inline-vs-
+  top-level-columnar-map decision. That decision should follow, not lead,
+  the runtime / Python-API direction set here.
 - Metadata is on the hot path for memory (`logical_memory.rs` reports the
   per-row `Option`/`Vec`/`FnvHashMap` headers showing up under
   `Instance.constraint_collection;constraints;Constraint.metadata;…` and the
@@ -40,9 +47,6 @@ column-for-column without per-row repackaging.
   shrink.
 - The v3 alpha window is the right moment to break the wide-DataFrame Python
   API. Doing it after v3 GA would require another major.
-- `SPECIAL_CONSTRAINTS_V3.md` already extracts `ConstraintMetadata` as a shared
-  proto sub-message, so the proto side is already lined up for the runtime
-  refactor.
 
 ## SDK-level design split
 
@@ -75,12 +79,21 @@ End users analyze problems and solutions in DataFrames. They want to filter by
 
 ### Proto schema
 
-`SPECIAL_CONSTRAINTS_V3.md` already keeps `ConstraintMetadata` inline inside
-each constraint message. We retain that. Wire format is AoS; runtime
-representation is SoA; the conversion happens at parse / serialize time only.
-Hoisting metadata to a top-level `map<uint64, ConstraintMetadata>` would
-mirror the runtime layout but adds 4 additional top-level fields per stage and
-breaks the inline-readable shape — not worth it.
+Out of scope for this proposal. Once the runtime / Python-API direction here
+is agreed, `SPECIAL_CONSTRAINTS_V3.md` (#841) finalizes the wire shape of
+`ConstraintMetadata`. Two candidates:
+
+- **Inline per constraint message** (currently sketched in #841). Wire format
+  is AoS; the parse / serialize boundary translates to / from the SoA stores
+  defined here.
+- **Top-level `map<uint64, ConstraintMetadata>`** per collection. Wire format
+  matches the runtime SoA store directly, eliminating the boundary translation
+  but adding 4 extra top-level fields per stage on `Instance` / `Solution` /
+  `SampleSet`.
+
+Either is workable on top of the runtime design here. The decision belongs in
+#841 and should be informed by what the parse / serialize boundary actually
+looks like once this proposal is implemented (Stage 2 below).
 
 ## Rust SDK design
 
@@ -138,6 +151,15 @@ pub struct Instance {
     sos1_constraint_collection:      ConstraintCollection<Sos1Constraint>,
 
     variable_metadata: VariableMetadataStore,   // new
+}
+
+pub struct ParametricInstance {
+    // same treatment as Instance — also owns
+    //   decision_variables: BTreeMap<VariableID, DecisionVariable>
+    // directly, so it gets its own variable_metadata field.
+    variable_metadata: VariableMetadataStore,   // new
+    // (`parameters: BTreeMap<VariableID, v1::Parameter>` is unrelated metadata
+    // and stays as-is.)
 }
 ```
 
@@ -250,6 +272,38 @@ impl<T: ConstraintType> EvaluatedCollection<T> {
 
 Conversion happens at the *collection* level, not the per-element level.
 
+### Boundary changes
+
+The SoA migration shifts several boundaries that are currently per-element:
+
+- **Parsing** (`From<v1::Instance> for Instance`, etc., in
+  `rust/ommx/src/instance/parse.rs` and `rust/ommx/src/constraint/parse.rs`).
+  Today each element is parsed with its metadata; in Stage 2, parsing emits
+  bare elements + a populated `*MetadataStore`. The natural locus is
+  `From<v1::Instance>` and `From<Vec<v1::Constraint>> for ConstraintCollection<...>`.
+- **Serialization** (`From<&Instance> for v1::Instance`,
+  `From<(ID, EvaluatedConstraint)> for v1::EvaluatedConstraint`, etc.).
+  Symmetric: serializers join element + metadata at the collection level.
+- **`Evaluate` for `ConstraintCollection<T>`** already iterates the collection
+  and constructs an `EvaluatedCollection<T>`; the metadata clone moves from
+  per-constraint (currently `metadata: self.metadata.clone()` inside
+  `SampledConstraintBehavior::get`) to a single store-level clone at the
+  end.
+
+### Other types affected
+
+- **`#[derive(LogicalMemoryProfile)]`** is used on `DecisionVariable`,
+  `ConstraintMetadata`, `DecisionVariableMetadata`, and the constraint
+  structs. The new `*MetadataStore` types should also derive
+  `LogicalMemoryProfile` so memory accounting under
+  `Instance.constraint_collection;metadata;…` keeps working.
+- **`pyo3-stub-gen`**: every new `*_df` method in Stage 1 and every renamed /
+  removed method in Stages 1–2 needs the `gen_stub_pymethods` decorator and
+  the corresponding `ommx.v1.__init__.py` regen via `task python:stubgen`.
+  No new types are exposed to Python directly (the stores stay Rust-internal
+  and surface only as DataFrames), so the stub surface change is limited to
+  method signatures.
+
 ## Python SDK design
 
 ### Current pain
@@ -277,24 +331,33 @@ Three orthogonal axes:
 
 ```python
 # Decision variables
-df    = instance.decision_variables_df()       # id, kind, lower, upper, substituted_value
-meta  = instance.variable_metadata_df()        # id, name, subscripts, description
-prms  = instance.variable_parameters_df()      # id, key, value
+df       = instance.decision_variables_df()       # index=id; kind, lower, upper, substituted_value
+meta     = instance.variable_metadata_df()        # index=id; name, subscripts, description
+params   = instance.variable_parameters_df()      # columns: id, key, value (long format)
 
 # Constraints (4 kinds, 3 stages each)
-df    = instance.regular_constraints_df()      # id, equality, function_type, used_ids
-meta  = instance.constraint_metadata_df(kind="regular")
-                                               # id, name, subscripts, description, provenance
-prms  = instance.constraint_parameters_df(kind="regular")
-                                               # id, key, value
+df       = instance.regular_constraints_df()      # index=id; equality, function_type, used_ids
+meta     = instance.regular_constraint_metadata_df()
+                                                  # index=id; name, subscripts, description, provenance
+params   = instance.regular_constraint_parameters_df()
+                                                  # columns: id, key, value (long format)
 
-# User joins as needed
-df.merge(meta, on="id", how="left")
+# User joins as needed (existing helpers like entries_to_dataframe set id as the
+# index, so .join() composes naturally; .merge(on="id") works equally if the
+# user resets the index first).
+df.join(meta, how="left")
 ```
 
-`removed_reason` stays on the core df as `removed_reason` (string) +
-`removed_reason.{param}` if we keep it wide, or moves to a long
-`removed_reasons_df(kind=...)` for consistency. Open question below.
+Removed reasons move to a separate long-format DataFrame for consistency:
+
+```python
+removed = instance.regular_constraint_removed_reasons_df()
+                                                  # columns: id, reason, key, value
+```
+
+This matches what `Solution` already does today (`removed_reasons_df`,
+`indicator_removed_reasons_df`) and aligns with `RemovedReason` being
+collection-level metadata in Rust, not part of the constraint itself.
 
 ### Why JOIN-based is the right shape here
 
@@ -341,56 +404,136 @@ metadata path stops going through Python `dict` allocation per row.
 
 ## Migration strategy
 
-Two stages, executed in order. Doing them in the opposite order forces an
-ugly intermediate state where the Rust SoA store has to be re-marshalled into
-wide-DataFrame Python output.
+Three stages overall. This proposal covers Stage 1 and Stage 2; Stage 3
+(proto) lives in #841 and is informed by the parse / serialize boundary that
+emerges from Stage 2.
 
-### Stage 1: Python API → JOIN-based (first)
+```
+Stage 1 (this PR)        Stage 2 (this PR)         Stage 3 (#841)
+┌──────────────────┐    ┌─────────────────────┐    ┌────────────────────┐
+│ Python *_df API  │ →  │ Rust SoA metadata   │ →  │ proto wire shape   │
+│ split into       │    │ stores;             │    │ for ConstraintMeta │
+│ JOIN-based dfs.  │    │ remove metadata     │    │ decided based on   │
+│ Internal Rust    │    │ from Constraint<S>  │    │ Stage 2 boundary.  │
+│ AoS unchanged.   │    │ and DecisionVar.    │    │                    │
+└──────────────────┘    └─────────────────────┘    └────────────────────┘
+```
 
-- Strip metadata columns from all `*_df` methods on `Instance`, `Solution`,
-  `SampleSet`.
-- Add new `*_metadata_df`, `*_parameters_df`, `*_provenance_df` methods
-  sourcing from the *current* AoS metadata field.
+### Stage 1: Python API → JOIN-based
+
+- Strip metadata columns from all `*_df` methods on `Instance`,
+  `ParametricInstance`, `Solution`, `SampleSet`.
+- Add new `*_metadata_df`, `*_parameters_df`, `*_provenance_df`,
+  `*_removed_reasons_df` methods sourcing from the *current* AoS metadata
+  field.
 - Migration note in `PYTHON_SDK_MIGRATION_GUIDE.md`: any user code that read
-  `df["name"]` or `df["parameters.{key}"]` must now `df.merge(metadata_df,
-  on="id")` or pivot the long parameters df.
-- Internal Rust types unchanged.
+  `df["name"]` or `df["parameters.{key}"]` must now `df.join(metadata_df)` or
+  pivot the long parameters df.
+- Internal Rust types unchanged. `ToPandasEntry` impls keep reading
+  `c.metadata.*` directly — but the metadata-extracting helpers
+  (`set_metadata`, `set_parameter_columns`) move out of the per-row impls and
+  into bulk column builders that walk the AoS metadata field once per
+  collection.
 
-### Stage 2: Rust SoA migration (second)
+### Stage 2: Rust SoA migration
 
-- Add `ConstraintMetadataStore<T::ID>` and `VariableMetadataStore`.
+- Add `ConstraintMetadataStore<T::ID>` and `VariableMetadataStore` (see "Rust
+  SDK design").
 - Remove `metadata` field from `DecisionVariable`, `Constraint<S>`,
   `IndicatorConstraint<S>`, `OneHotConstraint<S>`, `Sos1Constraint<S>`.
-- Wire `Evaluate` / `From<v1::*>` paths to read/write metadata at the
-  collection boundary.
-- Python `*_metadata_df` / `*_parameters_df` switch to direct SoA → DataFrame
-  bulk construction.
+- Move `From<v1::*>` parse / serialize boundaries from per-element to
+  per-collection (see "Boundary changes" below).
+- Stage 1's bulk column builders switch from "walk AoS field per element"
+  to "read SoA store directly" — same DataFrame columns, no API churn.
 
-Both stages are v3-alpha breaking changes. Combined with
-`SPECIAL_CONSTRAINTS_V3.md` they form the v3 metadata + special-constraints
-package.
+### Stage 3: proto wire shape (deferred to #841)
+
+Once Stage 2 lands, the parse / serialize boundary is concretely defined and
+#841 can choose between the inline (per-message `ConstraintMetadata`) and
+the top-level (`map<uint64, ConstraintMetadata>` per collection) wire shapes
+based on what actually maps cleanly to the SoA stores.
+
+### Why not Rust-first
+
+A defensible alternative is to land Stage 2 first and let the SoA store come
+out of `From<v1::*>` parse boundaries naturally — the per-collection
+conversion shape Codex flagged is a clean cut. We don't, because:
+
+- Stage 1 alone is a useful and shippable improvement (de-duplication,
+  long-format parameters, no `parameters.{key}` data-dependent columns) even
+  if Stage 2 slips.
+- Stage 1 forces clarity on the `*_df` schema, which in turn determines what
+  the SoA stores actually need to expose. Doing it second risks designing the
+  Rust store and then realizing the Python API needs one more axis.
+- Stage 1 surfaces the modeling-API question (next subsection) without
+  dragging proto changes along.
+
+### Standalone-constraint impact on Python modeling
+
+Today users build constraints with chains like
+`(x[0] + x[1] == 1).add_name("c").add_subscripts([0])` and then hand them to
+`Instance.from_components`. Once Stage 2 strips metadata from
+`Constraint<S>`, the Python wrapper for a standalone constraint can no
+longer carry `name`/`subscripts` either.
+
+Two options for the Python side:
+
+1. **Staging wrapper.** The Python `Constraint` wrapper keeps a small inline
+   metadata bag while it's standalone. `Instance.from_components` (and the
+   constraint-collection `add_*` methods) drains the bag into the
+   `*MetadataStore` at insertion time.
+2. **Insertion-time API only.** Drop `add_name` / `add_subscripts` from
+   standalone constraints entirely; require users to pass metadata as
+   keyword args at insertion (`instance.add_constraint(c, name="c",
+   subscripts=[0])`) or set it post-insertion via the metadata accessor.
+
+(1) preserves the current chain ergonomics and is recommended unless we have
+appetite for the breaking change to the modeling chain. (2) is cleaner but
+breaks every notebook.
+
+Stage 1 doesn't trigger this question (Rust still owns the metadata
+inline); Stage 2 does. The Python wrapper change should land in the same PR
+as Stage 2.
 
 ## Open questions
 
+Each item lists a working recommendation; flagged for explicit sign-off
+before implementation.
+
 1. **Constraint kind dispatch in Python**: `constraint_metadata_df(kind="regular")`
    (one method, runtime kind) vs. `regular_constraint_metadata_df()` (four
-   methods)? Engine-side it's the same code; the question is stub clarity vs.
-   API surface size.
-2. **`removed_reason` placement**: keep inline on each core df (current shape,
-   wide `removed_reason.{key}`), or move to a separate
-   `removed_reasons_df(kind=...)` long DataFrame?
-3. **Builder-style metadata setter**: keep flat (`metadata_mut().set_name(id,
-   ...)`) only, or also add `collection.insert_with(c, |m| m.name(...))` sugar
-   for the common case?
-4. **`parameters` storage on the Rust side**: `FnvHashMap<ID,
-   FnvHashMap<String, String>>` (current shape) or transpose to
-   `FnvHashMap<(ID, String), String>` to match the long-format Python API
-   directly? The transposed form makes Python export trivial but penalizes
-   the (rare) "all parameters of a single id" lookup.
-5. **`subscripts` long format option**: in addition to the List<Int64> column,
-   offer a `subscripts_df` with `(id, position, value)`? Useful when
-   subscripts are heterogeneous lengths and the user wants to filter by
-   `subscripts[0] == "i"`. Could land later if demand emerges.
-6. **Polars as primary in Python**: out of scope here, but the JOIN-based API
-   is polars-friendly. If we want to make polars primary in v3.x, we should
-   ensure the Stage 1 API works equally well with `pl.DataFrame.join`.
+   methods).
+   - **Recommendation: four explicit methods.** `pyo3-stub-gen` produces
+     concrete pymethod stubs per method, so explicit names give better
+     IDE / type-checker discoverability than a runtime `kind` arg.
+2. **`removed_reason` placement**: inline columns on the core df vs. a
+   separate long-format `*_removed_reasons_df`.
+   - **Recommendation: separate long-format df.** `Solution` already exposes
+     `removed_reasons_df` / `indicator_removed_reasons_df` this way, and
+     `RemovedReason` is collection-level metadata in Rust, not part of the
+     constraint. Reflected in the "Target API" code block above.
+3. **Builder-style metadata setter**: flat (`metadata_mut().set_name(id,
+   ...)`) only, vs. also `collection.insert_with(c, |m| m.name(...))` sugar.
+   - **Recommendation: add `insert_with`.** The flat form is too easy to
+     forget right after insertion, especially when authoring constraints in
+     a loop. Keep both.
+4. **`parameters` storage on the Rust side**: `FnvHashMap<ID, FnvHashMap<String,
+   String>>` vs. transposed `FnvHashMap<(ID, String), String>`.
+   - **Recommendation: nested `FnvHashMap<ID, FnvHashMap<String, String>>`.**
+     Matches the existing per-object metadata shape, makes "all parameters
+     of one id" a natural lookup, and the long-format Python export is a
+     one-pass flatten anyway.
+5. **`subscripts` long format option**: in addition to the `List<Int64>`
+   column, offer a `subscripts_df` with `(id, position, value)`.
+   - **Recommendation: not in this proposal.** List column is enough for
+     identity-style use. Add later if demand for positional filtering
+     emerges.
+6. **Polars as primary in Python**: out of scope here, but the JOIN-based
+   API is polars-friendly. If we want to make polars primary in v3.x, we
+   should ensure the Stage 1 API works equally well with `pl.DataFrame.join`.
+   - **Recommendation: pandas stays primary for v3.** `PyDataFrame` is
+     pandas-backed; polars promotion is a separate v3.x discussion.
+7. **Stage 2 modeling-chain choice**: staging wrapper vs. insertion-time-only
+   API for Python `Constraint`.
+   - **Working assumption: staging wrapper** (option 1 above). Confirm before
+     Stage 2 implementation lands.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -10,90 +10,84 @@ is stored at runtime and surfaced to users — the wire shape of
 makes sense once the runtime / Python-API direction is settled. So this
 discussion was split out of #841 and runs first.
 
+This is a single connected redesign covering Rust SDK runtime layout and
+Python SDK API surface. We don't break it into formal stages — every part
+needs to land within the v3 alpha window for the API to read coherently.
+
 ## Goal
 
-Today, `DecisionVariable` and every `Constraint<S>` (regular / indicator /
-one-hot / sos1, in all three lifecycle stages) carry an inline `metadata`
-field. This metadata is rarely consulted by internal logic — `evaluate`,
-`parse`, `substitute`, etc. never read it — but it is copied around on every
-clone, serialized on every write, and duplicated wholesale into every wide
-`*_df` API on the Python side.
+Today the same constraint / decision-variable fact lives in **three places**:
 
-We want to:
+1. Rust — `BTreeMap<ID, T>`, with `metadata: TMetadata` inlined into each `T`.
+2. Python — `instance.constraints: dict[id, Constraint object]`, where
+   `Constraint.name`, `Constraint.subscripts`, … are getters that copy out
+   what was inlined in (1).
+3. Python — `instance.constraints_df()`, a wide DataFrame with the same
+   metadata replicated as columns next to the type-specific data.
 
-1. **Move metadata out of the per-object structs and into ID-keyed columnar
-   stores** owned by the enclosing collection (`ConstraintCollection<T>` for
-   constraints, `Instance` for decision variables). Internal types lose their
-   `metadata` field.
-2. **Replace the wide-DataFrame Python API with a JOIN-based one.** Each `*_df`
-   returns only the type-specific core columns (`id`, `kind`, `bound`,
-   `equality`, `evaluated_value`, …). Metadata, parameters, and provenance live
-   in their own thin DataFrames that the user joins on `id` when needed.
+This metadata is rarely consulted by internal logic — `evaluate`, `parse`,
+`substitute`, etc. never read it — but it is copied around on every clone,
+serialized on every write, exposed via per-object getters, and duplicated
+into every wide `*_df` API. The duplication shows up in memory accounting
+(`logical_memory.rs` reports per-row `Option`/`Vec`/`FnvHashMap` headers
+under `Instance.constraint_collection;constraints;Constraint.metadata;…`)
+and in API surface drift (when a new metadata field is added it has to be
+wired through the struct, the getter, and the DataFrame builder).
 
-These two changes reinforce each other: once the Python API stops embedding
-metadata in every wide DataFrame, the Rust-side stores can be exposed
-column-for-column without per-row repackaging.
+We want a single source of truth on the Rust side and one well-defined
+"shape" for each kind of access on the Python side.
 
 ## Why now
 
-- **Blocks #841.** The proto v3 design in `SPECIAL_CONSTRAINTS_V3.md` extracts
-  `ConstraintMetadata` as a shared sub-message but defers the inline-vs-
-  top-level-columnar-map decision. That decision should follow, not lead,
-  the runtime / Python-API direction set here.
-- Metadata is on the hot path for memory (`logical_memory.rs` reports the
-  per-row `Option`/`Vec`/`FnvHashMap` headers showing up under
-  `Instance.constraint_collection;constraints;Constraint.metadata;…` and the
-  same under `decision_variables`). Pulling it out lets the per-object struct
-  shrink.
-- The v3 alpha window is the right moment to break the wide-DataFrame Python
-  API. Doing it after v3 GA would require another major.
+- **Blocks #841.** The proto v3 design in `SPECIAL_CONSTRAINTS_V3.md`
+  extracts `ConstraintMetadata` as a shared sub-message but defers the
+  inline-vs-top-level-columnar-map decision. That decision should follow,
+  not lead, the runtime / Python-API direction set here.
+- The v3 alpha window is the right moment to break the wide-DataFrame
+  Python API and the per-object metadata getters. Doing it after v3 GA
+  would require another major.
 
-## SDK-level design split
+## Target shape (one picture)
 
-Rust SDK and Python SDK have different requirements; we keep the designs
-separate on purpose.
+### Rust
 
-### Rust SDK
+- Metadata moves into ID-keyed Struct-of-Arrays stores. The store sits at
+  the collection layer:
+  - `ConstraintCollection<T>` owns `ConstraintMetadataStore<T::ID>`.
+  - `Instance` and `ParametricInstance` own `VariableMetadataStore` directly
+    (no `DecisionVariableCollection` for symmetry's sake).
+  - `EvaluatedCollection<T>` and `SampledCollection<T>` carry the same
+    `ConstraintMetadataStore<T::ID>` so Solution / SampleSet share one
+    metadata source per collection.
+- `DecisionVariable`, `Constraint<S>`, `IndicatorConstraint<S>`,
+  `OneHotConstraint<S>`, `Sos1Constraint<S>` lose their `metadata` field.
+  Per-object structs shrink to the type's intrinsic data only.
+- Parse / serialize boundaries move from per-element to per-collection so
+  metadata can be read / written column-by-column.
 
-Internal users (algorithms, solver adapters, serialization) almost never
-look up metadata by ID. The dominant operations are bulk copy and bulk
-serialize. Partial updates (`add_decision_variable` one at a time) happen
-through normal modeling APIs.
+### Python
 
-- Internal representation: **Struct-of-Arrays (SoA)**, `FnvHashMap<ID, T>` per
-  field. No `polars` dependency.
-- The 4 constraint types share the same metadata shape, so the store is one
-  generic type parameterized only by the ID type.
-- `DecisionVariable` and `Constraint<S>` lose their `metadata` field.
+- `instance.constraints`, `decision_variables`, `*_constraints` become
+  `pandas.Series[ID -> Object]` — index = ID, value = the (now slimmer)
+  PyO3 wrapper object. Series indexing (`s.loc[id]`, `s.iloc[i]`,
+  iteration, boolean indexing) replaces the current dict / list APIs.
+- `*_df` methods are explicitly **derived views**: each one is the
+  Series joined with the relevant metadata / parameters / removed-reason
+  sidecar dfs.
+- Sidecar DataFrames (`*_metadata_df`, `*_parameters_df` long format,
+  `*_provenance_df` long format, `*_removed_reasons_df` long format) are
+  bulk-built from the Rust SoA store, one column allocation per field.
+- Wrapper objects (`Constraint`, `DecisionVariable`, …) carry only the
+  type's intrinsic data — `equality`, `function`, `kind`, `bound`, etc.
+  All `.name` / `.subscripts` / `.parameters` / `.description` getters
+  are removed; the only path to metadata is the metadata df.
 
-### Python SDK
+### Proto
 
-End users analyze problems and solutions in DataFrames. They want to filter by
-`name`, group by `subscripts[0]`, and pivot on `parameters.{key}`.
-
-- Public API: pandas DataFrames with **JOIN-based composition**. Core df, metadata
-  df, parameters df, provenance df — separate, each thin, joined on `id`.
-- Implementation: bulk-construct each DataFrame from the Rust SoA store. The
-  `parameters.{key}` wide-column pattern goes away; `parameters` becomes a
-  long-format DataFrame.
-
-### Proto schema
-
-Out of scope for this proposal. Once the runtime / Python-API direction here
-is agreed, `SPECIAL_CONSTRAINTS_V3.md` (#841) finalizes the wire shape of
-`ConstraintMetadata`. Two candidates:
-
-- **Inline per constraint message** (currently sketched in #841). Wire format
-  is AoS; the parse / serialize boundary translates to / from the SoA stores
-  defined here.
-- **Top-level `map<uint64, ConstraintMetadata>`** per collection. Wire format
-  matches the runtime SoA store directly, eliminating the boundary translation
-  but adding 4 extra top-level fields per stage on `Instance` / `Solution` /
-  `SampleSet`.
-
-Either is workable on top of the runtime design here. The decision belongs in
-#841 and should be informed by what the parse / serialize boundary actually
-looks like once this proposal is implemented (Stage 2 below).
+Out of scope here. Once this lands and the parse / serialize boundary is
+concrete, #841 picks the wire shape (`ConstraintMetadata` inline per
+message vs. top-level `map<uint64, ConstraintMetadata>` per collection).
+Either is workable on top of the Rust SoA stores.
 
 ## Rust SDK design
 
@@ -118,8 +112,8 @@ pub struct VariableMetadataStore {
 }
 ```
 
-`provenance` lives only on constraints; the variable store omits it. Otherwise
-the two stores are structurally identical.
+`provenance` lives only on constraints; the variable store omits it.
+Otherwise the two stores are structurally identical.
 
 ### Where the stores live
 
@@ -143,20 +137,20 @@ pub struct SampledCollection<T: ConstraintType> {
 }
 
 pub struct Instance {
-    // existing fields …
-    decision_variables: BTreeMap<VariableID, DecisionVariable>,
+    decision_variables:              BTreeMap<VariableID, DecisionVariable>,
     constraint_collection:           ConstraintCollection<Constraint>,
     indicator_constraint_collection: ConstraintCollection<IndicatorConstraint>,
     one_hot_constraint_collection:   ConstraintCollection<OneHotConstraint>,
     sos1_constraint_collection:      ConstraintCollection<Sos1Constraint>,
 
     variable_metadata: VariableMetadataStore,   // new
+    // existing fields …
 }
 
 pub struct ParametricInstance {
-    // same treatment as Instance — also owns
+    // same treatment — ParametricInstance also owns
     //   decision_variables: BTreeMap<VariableID, DecisionVariable>
-    // directly, so it gets its own variable_metadata field.
+    // directly.
     variable_metadata: VariableMetadataStore,   // new
     // (`parameters: BTreeMap<VariableID, v1::Parameter>` is unrelated metadata
     // and stays as-is.)
@@ -165,15 +159,16 @@ pub struct ParametricInstance {
 
 Why these levels:
 
-- For constraints, `ConstraintCollection<T>` already owns active/removed split
-  and is generic over constraint type — putting the store there keeps the
-  `relax` / `restore` pair touch-free (active ↔ removed transitions don't move
-  metadata at all). The same store rides through to `EvaluatedCollection<T>` /
-  `SampledCollection<T>` on the Solution / SampleSet side.
-- For variables, there is no analogous `DecisionVariableCollection` and adding
-  one only to host metadata would be over-engineering — `Instance` already
-  owns `BTreeMap<VariableID, DecisionVariable>` directly. We just add a
-  sibling field.
+- For constraints, `ConstraintCollection<T>` already owns active/removed
+  split and is generic over constraint type — putting the store there keeps
+  the `relax` / `restore` pair touch-free (active ↔ removed transitions
+  don't move metadata at all). The same store rides through to
+  `EvaluatedCollection<T>` / `SampledCollection<T>` on the Solution /
+  SampleSet side.
+- For variables, there is no analogous `DecisionVariableCollection` and
+  adding one only to host metadata would be over-engineering — `Instance`
+  and `ParametricInstance` already own `BTreeMap<VariableID,
+  DecisionVariable>` directly. We just add a sibling field.
 
 ### Per-object struct changes
 
@@ -195,9 +190,9 @@ pub struct Constraint<S: Stage<Self> = Created> {
 // IndicatorConstraint, OneHotConstraint, Sos1Constraint — same: metadata removed.
 ```
 
-Standalone constraints (created via `Constraint::equal_to_zero(f)`,
-`OneHotConstraint::new(...)`, etc.) carry no metadata. Metadata is set after
-inserting into a collection:
+Standalone constraints (`Constraint::equal_to_zero(f)`,
+`OneHotConstraint::new(...)`, etc.) carry no metadata. Metadata is set
+after inserting into a collection:
 
 ```rust
 let id = collection.insert(Constraint::equal_to_zero(f));
@@ -205,7 +200,8 @@ collection.metadata_mut().set_name(id, "demand_balance");
 collection.metadata_mut().push_subscripts(id, [i, j]);
 ```
 
-A builder-style helper can sugar this when convenient:
+A builder-style helper is provided for the common "insert with metadata"
+case:
 
 ```rust
 collection.insert_with(
@@ -240,19 +236,33 @@ pub struct ConstraintMetadataView<'a> {
 }
 ```
 
-`ConstraintMetadataView::parameters()` returns `&EMPTY_MAP` for absent keys
-(static const) so the `Option<FnvHashMap<…>>` storage doesn't leak through the
-public API.
+`ConstraintMetadataView::parameters()` returns `&EMPTY_MAP` for absent
+keys (static const) so the `Option<FnvHashMap<…>>` storage doesn't leak
+through the public API.
 
-### Conversion to / from `v1::*` proto types
+### Parse / serialize boundaries
 
-Currently `From<(ConstraintID, EvaluatedConstraint)> for v1::EvaluatedConstraint`
-reads `c.metadata.*` directly. After the refactor:
+The boundaries currently work per-element and need to move to per-collection:
+
+- **Parsing** (`From<v1::Instance> for Instance`, etc., in
+  `rust/ommx/src/instance/parse.rs` and
+  `rust/ommx/src/constraint/parse.rs`). Today each element is parsed with
+  its metadata; after the refactor, parsing emits bare elements and a
+  populated `*MetadataStore`. The natural locus is `From<v1::Instance>`
+  and `From<Vec<v1::Constraint>> for ConstraintCollection<...>`.
+- **Serialization** (`From<&Instance> for v1::Instance`,
+  `From<(ID, EvaluatedConstraint)> for v1::EvaluatedConstraint`, etc.).
+  Symmetric: serializers join element + metadata at the collection level.
+- **`Evaluate` for `ConstraintCollection<T>`** already iterates the
+  collection and constructs an `EvaluatedCollection<T>`. The metadata
+  clone moves from per-constraint (currently `metadata:
+  self.metadata.clone()` inside `SampledConstraintBehavior::get`) to a
+  single store-level clone at the end.
 
 ```rust
 impl<T: ConstraintType> EvaluatedCollection<T> {
     pub fn into_v1(self) -> Vec<v1::EvaluatedConstraint> {
-        let (constraints, removed) = self.into_parts();
+        let (constraints, _removed) = self.into_parts();
         constraints.into_iter().map(|(id, c)| {
             let metadata = self.metadata.get(id);  // ConstraintMetadataView
             v1::EvaluatedConstraint {
@@ -270,64 +280,78 @@ impl<T: ConstraintType> EvaluatedCollection<T> {
 }
 ```
 
-Conversion happens at the *collection* level, not the per-element level.
-
-### Boundary changes
-
-The SoA migration shifts several boundaries that are currently per-element:
-
-- **Parsing** (`From<v1::Instance> for Instance`, etc., in
-  `rust/ommx/src/instance/parse.rs` and `rust/ommx/src/constraint/parse.rs`).
-  Today each element is parsed with its metadata; in Stage 2, parsing emits
-  bare elements + a populated `*MetadataStore`. The natural locus is
-  `From<v1::Instance>` and `From<Vec<v1::Constraint>> for ConstraintCollection<...>`.
-- **Serialization** (`From<&Instance> for v1::Instance`,
-  `From<(ID, EvaluatedConstraint)> for v1::EvaluatedConstraint`, etc.).
-  Symmetric: serializers join element + metadata at the collection level.
-- **`Evaluate` for `ConstraintCollection<T>`** already iterates the collection
-  and constructs an `EvaluatedCollection<T>`; the metadata clone moves from
-  per-constraint (currently `metadata: self.metadata.clone()` inside
-  `SampledConstraintBehavior::get`) to a single store-level clone at the
-  end.
-
 ### Other types affected
 
-- **`#[derive(LogicalMemoryProfile)]`** is used on `DecisionVariable`,
+- **`#[derive(LogicalMemoryProfile)]`** is currently on `DecisionVariable`,
   `ConstraintMetadata`, `DecisionVariableMetadata`, and the constraint
-  structs. The new `*MetadataStore` types should also derive
+  structs. The new `*MetadataStore` types should derive
   `LogicalMemoryProfile` so memory accounting under
   `Instance.constraint_collection;metadata;…` keeps working.
-- **`pyo3-stub-gen`**: every new `*_df` method in Stage 1 and every renamed /
-  removed method in Stages 1–2 needs the `gen_stub_pymethods` decorator and
-  the corresponding `ommx.v1.__init__.py` regen via `task python:stubgen`.
-  No new types are exposed to Python directly (the stores stay Rust-internal
-  and surface only as DataFrames), so the stub surface change is limited to
-  method signatures.
+- **`pyo3-stub-gen`**: every renamed / removed / added Python method below
+  needs the `gen_stub_pymethods` decorator and the corresponding
+  `ommx.v1.__init__.py` regen via `task python:stubgen`. The stores are
+  not exposed to Python directly (they surface only as Series and
+  DataFrames), so the stub surface change is limited to method
+  signatures.
 
 ## Python SDK design
 
-### Current pain
+### Single source of truth
 
-- `instance.decision_variables_df()` and the ~9 other `*_df` methods on
-  `Instance`, plus matching ones on `Solution` and `SampleSet`, return wide
-  DataFrames where every row carries `name`, `subscripts`, `description`,
-  `parameters.x`, `parameters.y`, …
-- Metadata columns are duplicated across every stage's df. A constraint with
-  rich metadata appears in `instance.regular_constraints_df()`,
-  `solution.constraints_df()`, and `sample_set.constraints_df()` with the same
-  metadata replicated each time.
-- `parameters.{key}` is a wide-column with **data-dependent column names**.
-  Aggregation, filtering, and union across instances are awkward.
+```
+            Rust SoA store (BTreeMap<ID, T> + ConstraintMetadataStore<ID>)
+                         │
+                         ▼
+        instance.constraints  ── pandas.Series[ID -> Constraint object]
+                         │
+                ┌────────┴────────────────────┐
+                │                             │
+       sidecar metadata df             core columns extracted
+       sidecar parameters df          from the Constraint object
+       sidecar removed_reasons df             │
+                └─────────────┬───────────────┘
+                              ▼
+                    instance.constraints_df()
+                    (joined view, never canonical)
+```
 
-### Target API
+Wrapper objects carry only the type's intrinsic data. They have no
+`.name` / `.subscripts` / `.parameters` / `.description`. The sole path
+to metadata is the sidecar df keyed by id.
 
-Three orthogonal axes:
+### Collection accessors → Series
 
-1. **Core df** — type-specific columns and `id` only.
-2. **Metadata df** — id-keyed sidecar with `name`, `subscripts`, `description`,
-   `provenance`. One per collection kind.
-3. **Long-format auxiliaries** — `parameters` (and `provenance`, optional)
-   exposed as `(id, key, value)` long-format DataFrames.
+```python
+s = instance.constraints                  # pandas.Series[ConstraintID -> Constraint]
+s.loc[5]                                  # individual Constraint object
+s.loc[5].equality                         # OK — type-intrinsic getter
+s.loc[5].name                             # AttributeError — removed
+
+list(s.index)                             # all constraint IDs
+for cid, c in s.items(): ...              # iteration
+
+# decision variables and the other constraint kinds get the same treatment
+instance.decision_variables               # Series[VariableID -> DecisionVariable]
+instance.indicator_constraints            # Series[IndicatorConstraintID -> IndicatorConstraint]
+instance.one_hot_constraints              # Series[OneHotConstraintID -> OneHotConstraint]
+instance.sos1_constraints                 # Series[Sos1ConstraintID -> Sos1Constraint]
+
+solution.constraints                      # Series[ConstraintID -> EvaluatedConstraint]
+sample_set.constraints                    # Series[ConstraintID -> SampledConstraint]
+```
+
+The Series carries Python wrapper objects (object dtype). Per-element
+efficiency is the same as the old `dict[ID, Constraint]` — this is an
+API integration win, not a perf change. Modeling code that built
+constraints standalone and inserted them into a dict-like collection
+keeps working with the natural `instance.add_constraint(c)` /
+`s.add(c)` flow; index-based pandas operations (`.loc`, `.iloc`, boolean
+indexing, `.items()`) are now available out of the box.
+
+### `*_df` methods → derived views
+
+Each `*_df` is explicitly a derived view: type-specific core columns
+extracted from the Series, joined with the relevant sidecar dfs.
 
 ```python
 # Decision variables
@@ -335,205 +359,153 @@ df       = instance.decision_variables_df()       # index=id; kind, lower, upper
 meta     = instance.variable_metadata_df()        # index=id; name, subscripts, description
 params   = instance.variable_parameters_df()      # columns: id, key, value (long format)
 
-# Constraints (4 kinds, 3 stages each)
+# Constraints (per kind)
 df       = instance.regular_constraints_df()      # index=id; equality, function_type, used_ids
 meta     = instance.regular_constraint_metadata_df()
-                                                  # index=id; name, subscripts, description, provenance
+                                                  # index=id; name, subscripts, description
+provs    = instance.regular_constraint_provenance_df()
+                                                  # columns: id, step, source_kind, source_id (long)
 params   = instance.regular_constraint_parameters_df()
                                                   # columns: id, key, value (long format)
+removed  = instance.regular_constraint_removed_reasons_df()
+                                                  # columns: id, reason, key, value (long format)
 
-# User joins as needed (existing helpers like entries_to_dataframe set id as the
-# index, so .join() composes naturally; .merge(on="id") works equally if the
-# user resets the index first).
+# Joining is explicit
 df.join(meta, how="left")
 ```
 
-Removed reasons move to a separate long-format DataFrame for consistency:
+`*_df` is what users call when they want a single rectangular table for
+analysis; the Series is what users call when they want individual wrapper
+objects. Both are derived from the same Rust SoA — neither is canonical
+relative to the other.
 
-```python
-removed = instance.regular_constraint_removed_reasons_df()
-                                                  # columns: id, reason, key, value
-```
+### `ToPandasEntry` restructuring
 
-This matches what `Solution` already does today (`removed_reasons_df`,
-`indicator_removed_reasons_df`) and aligns with `RemovedReason` being
-collection-level metadata in Rust, not part of the constraint itself.
+`python/ommx/src/pandas.rs` currently has ~16 `ToPandasEntry` impls,
+each producing a wide row dict.
 
-### Why JOIN-based is the right shape here
-
-- Metadata is **shared across stages** — the same metadata applies to a
-  Created constraint, its Evaluated form in a Solution, and its Sampled form
-  in a SampleSet. With wide dfs we copied it three times; with a sidecar
-  metadata df, the user fetches it once.
-- Metadata is **shared across active/removed** within a collection. Today
-  `removed_constraints_df` and `constraints_df` carry separate metadata
-  copies of the same id-keyed rows.
-- `parameters` long-format frees the column space from data dependence — same
-  schema regardless of which keys appear in which instance.
-- The Rust SoA store maps directly to a per-column pandas/polars DataFrame.
-  Bulk construction from `FnvHashMap<ID, …>` is one allocation per column.
-
-### `ToPandasEntry` impact
-
-`python/ommx/src/pandas.rs` currently has ~16 `ToPandasEntry` impls, each
-producing a wide row dict. Under JOIN-based:
-
-- **Core dfs** keep `ToPandasEntry`: row-based construction is fine for the
-  small set of type-specific columns. We strip the `set_metadata(...)` and
-  `set_parameter_columns(...)` calls from each impl.
+- **Core dfs** keep `ToPandasEntry`: row-based construction is fine for
+  the small set of type-specific columns. We strip the
+  `set_metadata(...)` and `set_parameter_columns(...)` calls from each
+  impl.
 - **Metadata dfs** are built column-wise from the SoA store, not via
-  `ToPandasEntry`. New helper `metadata_store_to_dataframe(store)` walks the 4
-  fields of the store and emits columns directly.
-- **Parameters dfs** are built by flattening the SoA `FnvHashMap<ID,
-  FnvHashMap<String, String>>` into three parallel vectors (`id`, `key`,
-  `value`) and constructing a DataFrame.
+  `ToPandasEntry`. New helper `metadata_store_to_dataframe(store)` walks
+  the fields of the store and emits columns directly.
+- **Long-format dfs** (`parameters`, `provenance`, `removed_reasons`)
+  are built by flattening the SoA `FnvHashMap` into parallel vectors
+  and constructing a DataFrame.
+- **Series accessors** wrap each Rust SoA's `BTreeMap<ID, T>` into a
+  `pandas.Series[ID -> Object]` — one Python list of wrappers + one
+  Index of IDs, no per-row dict allocation.
 
-Net result: roughly half the `ToPandasEntry` boilerplate disappears, and the
-metadata path stops going through Python `dict` allocation per row.
+Net result: roughly half the `ToPandasEntry` boilerplate disappears,
+metadata stops going through Python `dict` allocation per row, and the
+Series path is allocation-symmetric to today's `dict` path.
+
+### Standalone constraints and the modeling chain
+
+Today users write
+`(x[0] + x[1] == 1).add_name("c").add_subscripts([0])` and hand the
+result to `Instance.from_components`. With metadata removed from the
+Rust `Constraint<S>` and from the Python wrapper's getters, the chain
+needs an explicit landing place.
+
+**Working assumption**: keep `add_name` / `add_subscripts` /
+`add_description` on the Python `Constraint` wrapper, but make them
+populate a small inline staging bag rather than the (now-absent) Rust
+`metadata` field. `Instance.from_components` and the
+`add_constraint(...)` family drain the bag into the relevant
+`*MetadataStore` at insertion time.
+
+The alternative (drop the chain entirely; require keyword args at
+insertion or post-insertion mutation via the metadata accessor) is
+cleaner but breaks every modeling notebook. Confirm before
+implementation.
 
 ### `subscripts` / `provenance` representation
 
-- `subscripts`: kept as a List<Int64> column (one row per id). It is part of
-  the variable / constraint identity and is consumed as a tuple, not
-  aggregated cross-row. List-of-int columns are well-supported in pandas
-  (object) and natively typed in polars.
-- `provenance`: long format `(id, step, source_kind, source_id)` — one row per
-  `(id, step)` pair. Provenance chains are queries (e.g. "which one-hot
-  constraints became regular constraints?") and the long shape is the natural
-  one for that.
+- `subscripts`: `List<Int64>` column on the metadata df (one row per id).
+  Part of the variable / constraint identity, consumed as a tuple, not
+  aggregated cross-row. List-of-int columns work in pandas (object
+  dtype) and are natively typed in polars.
+- `provenance`: long format `(id, step, source_kind, source_id)` — one
+  row per `(id, step)` pair. Provenance chains are queries (e.g. "which
+  one-hot constraints became regular constraints?") and the long shape
+  is the natural one for that.
 
-## Migration strategy
+## Breaking changes
 
-Three stages overall. This proposal covers Stage 1 and Stage 2; Stage 3
-(proto) lives in #841 and is informed by the parse / serialize boundary that
-emerges from Stage 2.
+User-visible breakage relative to v3 alpha 2:
 
-```
-Stage 1 (this PR)        Stage 2 (this PR)         Stage 3 (#841)
-┌──────────────────┐    ┌─────────────────────┐    ┌────────────────────┐
-│ Python *_df API  │ →  │ Rust SoA metadata   │ →  │ proto wire shape   │
-│ split into       │    │ stores;             │    │ for ConstraintMeta │
-│ JOIN-based dfs.  │    │ remove metadata     │    │ decided based on   │
-│ Internal Rust    │    │ from Constraint<S>  │    │ Stage 2 boundary.  │
-│ AoS unchanged.   │    │ and DecisionVar.    │    │                    │
-└──────────────────┘    └─────────────────────┘    └────────────────────┘
-```
+- `instance.constraints`, `decision_variables`, `*_constraints` change
+  type from `dict` / `list` to `pandas.Series`. Most existing usage
+  (`s[id]`, iteration, `.items()`) keeps working because Series
+  reproduces those; positional reliance on `list[...]` ordering for
+  decision variables breaks.
+- `Constraint.name`, `.subscripts`, `.parameters`, `.description` (and
+  the same on `DecisionVariable` and the special-constraint wrappers)
+  are removed. Users must read from the metadata df.
+- `*_df` methods no longer carry `name`, `subscripts`, `description`,
+  or `parameters.{key}` columns. Users must `df.join(meta_df)` or pivot
+  the long parameters df.
+- New `*_metadata_df`, `*_parameters_df`, `*_provenance_df`,
+  `*_removed_reasons_df` methods are added per collection kind.
+- The Rust `metadata` field on `DecisionVariable` and `Constraint<S>`
+  is removed. Downstream Rust crates touching `c.metadata.*` directly
+  must switch to the collection's `metadata()` accessor.
 
-### Stage 1: Python API → JOIN-based
-
-- Strip metadata columns from all `*_df` methods on `Instance`,
-  `ParametricInstance`, `Solution`, `SampleSet`.
-- Add new `*_metadata_df`, `*_parameters_df`, `*_provenance_df`,
-  `*_removed_reasons_df` methods sourcing from the *current* AoS metadata
-  field.
-- Migration note in `PYTHON_SDK_MIGRATION_GUIDE.md`: any user code that read
-  `df["name"]` or `df["parameters.{key}"]` must now `df.join(metadata_df)` or
-  pivot the long parameters df.
-- Internal Rust types unchanged. `ToPandasEntry` impls keep reading
-  `c.metadata.*` directly — but the metadata-extracting helpers
-  (`set_metadata`, `set_parameter_columns`) move out of the per-row impls and
-  into bulk column builders that walk the AoS metadata field once per
-  collection.
-
-### Stage 2: Rust SoA migration
-
-- Add `ConstraintMetadataStore<T::ID>` and `VariableMetadataStore` (see "Rust
-  SDK design").
-- Remove `metadata` field from `DecisionVariable`, `Constraint<S>`,
-  `IndicatorConstraint<S>`, `OneHotConstraint<S>`, `Sos1Constraint<S>`.
-- Move `From<v1::*>` parse / serialize boundaries from per-element to
-  per-collection (see "Boundary changes" below).
-- Stage 1's bulk column builders switch from "walk AoS field per element"
-  to "read SoA store directly" — same DataFrame columns, no API churn.
-
-### Stage 3: proto wire shape (deferred to #841)
-
-Once Stage 2 lands, the parse / serialize boundary is concretely defined and
-#841 can choose between the inline (per-message `ConstraintMetadata`) and
-the top-level (`map<uint64, ConstraintMetadata>` per collection) wire shapes
-based on what actually maps cleanly to the SoA stores.
-
-### Why not Rust-first
-
-A defensible alternative is to land Stage 2 first and let the SoA store come
-out of `From<v1::*>` parse boundaries naturally — the per-collection
-conversion shape Codex flagged is a clean cut. We don't, because:
-
-- Stage 1 alone is a useful and shippable improvement (de-duplication,
-  long-format parameters, no `parameters.{key}` data-dependent columns) even
-  if Stage 2 slips.
-- Stage 1 forces clarity on the `*_df` schema, which in turn determines what
-  the SoA stores actually need to expose. Doing it second risks designing the
-  Rust store and then realizing the Python API needs one more axis.
-- Stage 1 surfaces the modeling-API question (next subsection) without
-  dragging proto changes along.
-
-### Standalone-constraint impact on Python modeling
-
-Today users build constraints with chains like
-`(x[0] + x[1] == 1).add_name("c").add_subscripts([0])` and then hand them to
-`Instance.from_components`. Once Stage 2 strips metadata from
-`Constraint<S>`, the Python wrapper for a standalone constraint can no
-longer carry `name`/`subscripts` either.
-
-Two options for the Python side:
-
-1. **Staging wrapper.** The Python `Constraint` wrapper keeps a small inline
-   metadata bag while it's standalone. `Instance.from_components` (and the
-   constraint-collection `add_*` methods) drains the bag into the
-   `*MetadataStore` at insertion time.
-2. **Insertion-time API only.** Drop `add_name` / `add_subscripts` from
-   standalone constraints entirely; require users to pass metadata as
-   keyword args at insertion (`instance.add_constraint(c, name="c",
-   subscripts=[0])`) or set it post-insertion via the metadata accessor.
-
-(1) preserves the current chain ergonomics and is recommended unless we have
-appetite for the breaking change to the modeling chain. (2) is cleaner but
-breaks every notebook.
-
-Stage 1 doesn't trigger this question (Rust still owns the metadata
-inline); Stage 2 does. The Python wrapper change should land in the same PR
-as Stage 2.
+A new section in `PYTHON_SDK_MIGRATION_GUIDE.md` covers the Python side
+in detail.
 
 ## Open questions
 
 Each item lists a working recommendation; flagged for explicit sign-off
 before implementation.
 
-1. **Constraint kind dispatch in Python**: `constraint_metadata_df(kind="regular")`
-   (one method, runtime kind) vs. `regular_constraint_metadata_df()` (four
-   methods).
-   - **Recommendation: four explicit methods.** `pyo3-stub-gen` produces
-     concrete pymethod stubs per method, so explicit names give better
-     IDE / type-checker discoverability than a runtime `kind` arg.
+1. **Constraint kind dispatch in Python**:
+   `constraint_metadata_df(kind="regular")` (one method, runtime kind)
+   vs. `regular_constraint_metadata_df()` (four methods).
+   - **Recommendation: four explicit methods.** `pyo3-stub-gen`
+     produces concrete pymethod stubs per method, so explicit names
+     give better IDE / type-checker discoverability than a runtime
+     `kind` arg.
 2. **`removed_reason` placement**: inline columns on the core df vs. a
    separate long-format `*_removed_reasons_df`.
-   - **Recommendation: separate long-format df.** `Solution` already exposes
-     `removed_reasons_df` / `indicator_removed_reasons_df` this way, and
-     `RemovedReason` is collection-level metadata in Rust, not part of the
-     constraint. Reflected in the "Target API" code block above.
-3. **Builder-style metadata setter**: flat (`metadata_mut().set_name(id,
-   ...)`) only, vs. also `collection.insert_with(c, |m| m.name(...))` sugar.
-   - **Recommendation: add `insert_with`.** The flat form is too easy to
-     forget right after insertion, especially when authoring constraints in
-     a loop. Keep both.
-4. **`parameters` storage on the Rust side**: `FnvHashMap<ID, FnvHashMap<String,
-   String>>` vs. transposed `FnvHashMap<(ID, String), String>`.
-   - **Recommendation: nested `FnvHashMap<ID, FnvHashMap<String, String>>`.**
-     Matches the existing per-object metadata shape, makes "all parameters
-     of one id" a natural lookup, and the long-format Python export is a
-     one-pass flatten anyway.
-5. **`subscripts` long format option**: in addition to the `List<Int64>`
-   column, offer a `subscripts_df` with `(id, position, value)`.
-   - **Recommendation: not in this proposal.** List column is enough for
-     identity-style use. Add later if demand for positional filtering
-     emerges.
-6. **Polars as primary in Python**: out of scope here, but the JOIN-based
-   API is polars-friendly. If we want to make polars primary in v3.x, we
-   should ensure the Stage 1 API works equally well with `pl.DataFrame.join`.
-   - **Recommendation: pandas stays primary for v3.** `PyDataFrame` is
-     pandas-backed; polars promotion is a separate v3.x discussion.
-7. **Stage 2 modeling-chain choice**: staging wrapper vs. insertion-time-only
-   API for Python `Constraint`.
-   - **Working assumption: staging wrapper** (option 1 above). Confirm before
-     Stage 2 implementation lands.
+   - **Recommendation: separate long-format df.** `Solution` already
+     exposes `removed_reasons_df` / `indicator_removed_reasons_df`
+     this way, and `RemovedReason` is collection-level metadata in
+     Rust, not part of the constraint.
+3. **Builder-style metadata setter**: flat
+   (`metadata_mut().set_name(id, ...)`) only, vs. also
+   `collection.insert_with(c, |m| m.name(...))` sugar.
+   - **Recommendation: add `insert_with`.** The flat form is too easy
+     to forget right after insertion, especially when authoring
+     constraints in a loop. Keep both.
+4. **`parameters` storage on the Rust side**: `FnvHashMap<ID,
+   FnvHashMap<String, String>>` vs. transposed `FnvHashMap<(ID,
+   String), String>`.
+   - **Recommendation: nested `FnvHashMap<ID, FnvHashMap<String,
+     String>>`.** Matches the existing per-object metadata shape,
+     makes "all parameters of one id" a natural lookup, and the
+     long-format Python export is a one-pass flatten anyway.
+5. **`subscripts` long format option**: in addition to the
+   `List<Int64>` column, offer a `subscripts_df` with `(id, position,
+   value)`.
+   - **Recommendation: not in this proposal.** List column is enough
+     for identity-style use. Add later if demand for positional
+     filtering emerges.
+6. **Polars as primary in Python**: out of scope here, but the
+   JOIN-based API is polars-friendly.
+   - **Recommendation: pandas stays primary for v3.** `PyDataFrame`
+     is pandas-backed; polars promotion is a separate v3.x discussion.
+7. **Modeling-chain choice**: staging wrapper (recommended) vs.
+   insertion-time-only API for Python `Constraint`.
+   - **Working assumption: staging wrapper.** Confirm before
+     implementation.
+8. **Series wrapper-object dtype**: object-dtype Series with PyO3
+   wrapper values is structurally fine but invites
+   `s.apply(lambda c: c.equality)` patterns that could be served more
+   efficiently by the corresponding df column.
+   - **Recommendation: document Series as the dict/list replacement
+     and `*_df` as the bulk-analysis surface.** No type-level
+     enforcement; trust users to pick the right tool.


### PR DESCRIPTION
## Summary

- Drafts the runtime / Python-API design for v3 metadata storage. **Prerequisite for #841**: the proto wire shape of `ConstraintMetadata` (inline per message vs. top-level columnar map) cannot be finalized until the runtime / Python-API direction here is settled.
- A single connected redesign — the document describes the target shape; phasing of the implementation across PRs is decided in the implementation issues, not here.

## Target shape

- **Rust SDK**: metadata moves into ID-keyed Struct-of-Arrays stores. `ConstraintCollection<T>` owns `ConstraintMetadataStore<T::ID>`; `Instance` and `ParametricInstance` own `VariableMetadataStore` directly. `DecisionVariable` and `Constraint<S>` (and the special-constraint variants) lose their `metadata` field. Parse / serialize boundaries move from per-element to per-collection. Internal call sites that read `c.metadata.*` (e.g. `sample_set/extract.rs`) switch to `collection.metadata()` accessors.
- **Python SDK**:
  - `instance.constraints`, `decision_variables`, and the special-constraint accessors become `pandas.Series[ID -> Object]` instead of `dict` / `list`.
  - `*_df` methods (`constraints_df(kind=..., include=...)`, `decision_variables_df(include=...)`, and Solution / SampleSet counterparts) take an `include=` parameter selecting which sidecars (`"metadata"`, `"parameters"`, `"removed_reasons"`) to fold in. **Default `include=("metadata","parameters")` reproduces v2's wide-DataFrame shape** — v2 user code keeps working with just a `kind=...` argument added.
  - Long-format sidecar dfs (`constraint_metadata_df`, `constraint_parameters_df`, `constraint_provenance_df`, `constraint_removed_reasons_df`, `variable_metadata_df`, `variable_parameters_df`) are bulk-built from the SoA store. `provenance` is intentionally not included via `include=` (variable-length chains pivot poorly) and is only available as the long-format df.
  - Per-kind `indicator_constraints_df` / `one_hot_constraints_df` / `sos1_constraints_df` collapse into the single `constraints_df(kind=...)` overload set, dispatched via `Literal` + `@overload` so the IDE / type checker still sees kind-specific column schemas.
- **Wrapper objects with back-reference**: PyO3 wrappers stay rich. They run in two modes — Standalone (modeling chain, owns a staging bag) or Attached (collection-derived, holds `Py<Instance>` + id and reads / writes the SoA store via back-reference). Getters `.name`, `.subscripts`, `.parameters`, `.description` are preserved; they switch from owning data to reading the store. The modeling chain `(x[0] + x[1] == 1).add_name("c")` keeps working through the staging bag, which drains into the SoA store on insertion.
- **Cross-ID-space JOIN safety**: each constraint kind plus decision variables uses a kind-qualified index name (`variable_id`, `regular_constraint_id`, `indicator_constraint_id`, `one_hot_constraint_id`, `sos1_constraint_id`). The default `include=` covers most "I want a wide table" cases without manual join, removing the most common opportunity for a wrong-kind merge.
- **Proto**: deferred to #841, picked once the parse / serialize boundary here is concrete.

## Relationship to #841

#842 first, #841 second. The proto-schema work in #841 currently sketches `ConstraintMetadata` inline per constraint message but defers the wire-shape decision (inline AoS vs. top-level `map<uint64, ConstraintMetadata>` per collection). That choice becomes concrete only after this proposal lands and the parse / serialize boundary has a clean shape.

## Open questions (with recommendations)

See the bottom of the doc for full reasoning.

1. Constraint kind dispatch in Python — **rec: single method with `Literal` + `@overload`**.
2. `removed_reason` placement — **rec: separate long-format df** (and `"removed_reasons"` opt-in via `include=` for the wide form).
3. Builder-style metadata setter — **rec: add `insert_with` on the Rust side** (independent of the Python staging bag).
4. `parameters` Rust-side storage — **rec: nested `FnvHashMap<ID, FnvHashMap<…>>`**.
5. Optional `subscripts_df` long format — **rec: defer**.
6. Polars as primary in Python — **rec: pandas stays primary for v3**.
7. `drop_constraint` / wrapper invalidation — **rec: do not add `drop_constraint` in v3**; defer the invalidation semantics until it's actually needed.
8. Attached wrapper `Py<Instance>` cycles — **rec: documented behavior, no code-level mitigation**.

## Test plan

- [ ] Design review on the doc — approve the SoA-on-collection placement, the Standalone/Attached wrapper architecture with back-reference, the Series + `*_df(include=...)` Python API, and the v2-compatible default.
- [ ] Sign off on each of the 8 open-question recommendations (or push back).
- [ ] Sign off on the v3-alpha breaking-change window for the Python `dict` → `Series` migration and the `*_df` `include=` reshape.
- [ ] Coordinate with #841 on the proto wire shape once the parse / serialize boundary is concrete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)