### PR TITLE
feat(pandas): unify per-kind constraints_df into kind=/include=/removed= dispatch

### DIFF
--- a/.claude/rules/pyo3-bindings.md
+++ b/.claude/rules/pyo3-bindings.md
@@ -73,3 +73,21 @@ impl From<TypeName> for ommx::TypeName { ... }
 ## Free-threaded Python support
 
 The module uses `#[pymodule(gil_used = false)]` for Python 3.13t compatibility. Avoid storing Python objects in global state.
+
+## Stub-side type customization: define a Rust type, not `override_type`
+
+`pyo3-stub-gen` exposes a per-argument `#[gen_stub(override_type(type_repr = "...", imports = (...)))]` attribute that lets you write a Python type expression directly into the generated stub. **Reserve this for one-shot cases only** — typically when a single argument needs a fully ad-hoc Python type that has no first-class meaning in the Rust codebase (e.g. a `**kwargs` HashMap rendered as `str`).
+
+For any type that appears at multiple call sites — `Literal[...]`, union of accepted Python types, etc. — define a Rust type instead and put the stub representation on the type itself:
+
+1. **`FromPyObject`** — runtime validation / conversion (`Borrowed<'_, 'py, PyAny>` → `Self`).
+2. **`IntoPyObject`** (when the value can appear as a default or be returned) — so `pyo3-stub-gen` can render defaults via `fmt_py_obj`.
+3. **`pyo3_stub_gen::PyStubType`** — owns the `type_input()` / `type_output()` `Literal[...]` / union representation and any required `imports`.
+
+Existing examples:
+
+- `ConstraintKind` in `python/ommx/src/pandas.rs` — string `Literal[...]` on the way in, normalised to a Rust `enum` before downstream `match` arms see it.
+- `Function` / `ToFunction` in `python/ommx/src/function.rs` — multi-type union (`int | float | DecisionVariable | … | Function`) with `pyo3_stub_gen::type_alias!` for the Python-side alias.
+- `Samples` / `ToSamples` in `python/ommx/src/samples.rs` — same pattern with extra `Mapping[int, ToState]` / `Iterable[ToState]` marker types.
+
+Why: `override_type` duplicates the same `type_repr` / `imports` literal at every call site, which breaks both DRY (changing the literal means hunting through N annotations) and exhaustiveness (a Rust `enum` gets compile-time `match` checks; a `&str` argument validated ad-hoc does not). One Rust type, one set of impls, one source of truth.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -2,9 +2,9 @@
 
 Status: **Rust SDK landed; Python wrappers landed (snapshot model);
 `include=` + long-format sidecar dfs landed (Wave 1.5); per-kind
-`*_df` consolidation landed (Wave 2, PR #847); Series accessors,
-two-mode Attached wrappers, and `Literal[...]` typing deferred to
-follow-up PRs**
+`*_df` consolidation + `kind: Literal[...]` typing landed (Wave 2,
+PR #847); Series accessors and two-mode Attached wrappers deferred
+to follow-up PRs**
 
 This proposal is a **prerequisite** for `SPECIAL_CONSTRAINTS_V3.md` (PR #841).
 The proto-schema redesign in #841 cannot be finalized without first deciding
@@ -54,13 +54,15 @@ here. The implementation shipped in three waves:
   Wide `*_df` index column renamed from unqualified `id` to
   `{kind}_constraint_id`, matching the Wave 1.5 sidecars; empty
   collections still produce a DataFrame whose `df.index.name` is
-  the kind-qualified label. `kind` stays `str` at runtime;
-  `Literal[...]` typing + `@overload` stubs are kept as a follow-up.
+  the kind-qualified label. `kind` is typed
+  `Literal["regular","indicator","one_hot","sos1"]` in the stubs so
+  type checkers catch typos at edit time; runtime continues to
+  validate against the same set and raise `ValueError` on unknown
+  values for callers without a type checker.
 - **Future (deferred):** `Series[ID -> Object]` collection
   accessors, the two-mode Standalone / Attached wrappers with
   `Py<Instance>` back-references and write-through metadata setters,
-  `Literal[...]` typing on `kind=`, and the `NamedFunction` SoA
-  migration.
+  and the `NamedFunction` SoA migration.
 
 Sections below mark each item with **(landed)** or **(deferred)** so it
 is clear which parts are live in v3 alpha and which are still proposal.
@@ -594,7 +596,7 @@ Series accessor and the `kind=Literal` consolidation of per-kind
    handles)      back-referenced       constraint_provenance_df(kind=...) /
                  to the store)         constraint_removed_reasons_df(kind=...)
                                        (bulk-built from the SoA via column-wise
-                                       builders; kind via Literal + @overload)
+                                       builders; kind typed Literal[...])
 ```
 
 Wrapper objects, Series, and DataFrames are three views over the same
@@ -1112,8 +1114,15 @@ shape is:
   `{kind}_constraint_id` (matching the Wave 1.5 sidecars). Empty
   collections still produce a DataFrame whose `df.index.name` is
   the kind-qualified label.
-- `kind` typing stays `str` at runtime; `Literal[...]` typing +
-  `@overload` stubs are deferred to a follow-up.
+- `kind` is typed
+  `Literal["regular","indicator","one_hot","sos1"]` in the
+  `pyo3-stub-gen`-emitted stubs (`__init__.pyi`) so type checkers
+  catch typos at edit time. Runtime continues to validate against
+  the same set and raise `ValueError` on unknown values for callers
+  without a type checker. Per-kind `@overload` stubs that vary the
+  *return type* by kind are intentionally not emitted: every
+  `*_df` accessor returns a uniform `pandas.DataFrame`, so
+  overload-style typing has no return-type variation to express.
 
 ### Deferred to follow-up wave
 
@@ -1123,11 +1132,6 @@ shape is:
   - `s.values()` (method call) → `s.tolist()` or `list(s)`.
   - List-positional reliance on the old `decision_variables: list[…]`
     ordering breaks; index by `VariableID` instead.
-- `Literal[...]` typing on `kind=` (both the wide
-  `constraints_df(kind=...)` and the sidecars) plus the
-  `@overload` stubs that surface per-kind column schemas. The
-  runtime semantics land in Wave 2; this follow-up tightens the
-  static typing.
 - Wrapper-object metadata setters become write-through to the SoA
   store via the Standalone / Attached two-mode design.
 - `NamedFunction` / `EvaluatedNamedFunction` /
@@ -1147,15 +1151,17 @@ Numbering preserved from the original Open Questions list for
 traceability with earlier review comments.
 
 1. **Kind dispatch in Python — single method with `kind=...`
-   parameter.** Both the wide `constraints_df(kind=...)` (Wave 2)
-   and the long-format sidecar accessors (Wave 1.5) take a
-   `kind: str` argument validated at runtime against
-   `{"regular", "indicator", "one_hot", "sos1"}` (default
-   `"regular"`). `Literal[...]` typing + `pyo3-stub-gen`
-   `@overload` stubs are deferred to a separate follow-up so the
-   runtime semantics could be settled first; once landed, the
-   `Literal` typing covers both the wide and the sidecar accessors
-   uniformly.
+   parameter, typed `Literal[...]`.** Both the wide
+   `constraints_df(kind=...)` (Wave 2) and the long-format sidecar
+   accessors (Wave 1.5) take `kind:
+   Literal["regular","indicator","one_hot","sos1"]` (default
+   `"regular"`) in the generated stubs, with the same set
+   validated at runtime so callers without a type checker still
+   get a clean `ValueError` on a typo. `pyo3-stub-gen` `@overload`
+   stubs are intentionally *not* used: every `*_df` accessor
+   returns a uniform `pandas.DataFrame`, so overloads would have
+   no return-type variation to express; the input `Literal`
+   annotation is the entire static-typing benefit on offer.
 2. **`removed_reason` — surfaced both via wide df and via long-
    format sidecar.** `RemovedReason` is collection-level metadata
    in Rust, not part of the constraint. Wave 1.5 shipped the
@@ -1273,19 +1279,6 @@ traceability with earlier review comments.
   `*_metadata_mut`). These three methods should be narrowed to
   `pub(crate)` (or smaller) in a follow-up so the only way to break
   the collection's invariants is from inside the crate.
-- **`kind=Literal[...]` + `@overload` typing.** Wave 2 lands the
-  runtime semantics — single `constraints_df(kind=...)` per host,
-  `kind` validated at runtime against the four kind strings, and a
-  `{kind}_constraint_id` qualified index name on the wide df. The
-  static typing — `Literal["regular","indicator","one_hot","sos1"]`
-  on `kind` plus optional `pyo3-stub-gen`-emitted `@overload`
-  stubs that surface per-kind column schemas — is held off until
-  the runtime API has soaked. The hook to emit these is already in
-  pyo3-stub-gen (the `python_overload` parameter on
-  `gen_stub_pyfunction` / the `submit!` + `gen_methods_from_python!`
-  pattern); whether the per-kind column-schema overloads are worth
-  the maintenance, or only the `Literal[...]` input typing is, is a
-  question for the follow-up.
 - **`NamedFunction` SoA migration.** Track the
   `NamedFunctionMetadataStore` work described under
   "NamedFunction (deferred — separate PR)" above.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -1,8 +1,10 @@
 # Metadata Storage in OMMX v3 — Design Proposal
 
 Status: **Rust SDK landed; Python wrappers landed (snapshot model);
-`include=` + long-format sidecar dfs landed; Series accessors and
-two-mode Attached wrappers deferred to follow-up PRs**
+`include=` + long-format sidecar dfs landed (Wave 1.5); per-kind
+`*_df` consolidation in progress (Wave 2); Series accessors,
+two-mode Attached wrappers, and `Literal[...]` typing deferred to
+follow-up PRs**
 
 This proposal is a **prerequisite** for `SPECIAL_CONSTRAINTS_V3.md` (PR #841).
 The proto-schema redesign in #841 cannot be finalized without first deciding
@@ -37,11 +39,24 @@ here. The implementation shipped in three waves:
   `variable_metadata_df()`, `variable_parameters_df()`. Mechanical
   v3-alpha breaking change: every `*_df` accessor is now a method
   (`instance.constraints_df` → `instance.constraints_df()`).
-- **Wave 2 (deferred):** `Series[ID -> Object]` collection accessors,
-  the two-mode Standalone / Attached wrappers with `Py<Instance>`
-  back-references and write-through metadata setters, and the
-  `kind=Literal[...]` consolidation that collapses today's per-kind
-  `*_constraints_df` family into one `constraints_df(kind=...)`.
+- **Wave 2 (proposed, this PR):** Per-kind `*_constraints_df`,
+  `removed_*_constraints_df`, and `*_removed_reasons_df` families
+  on every host collapse into a single `constraints_df(kind=...)`.
+  `Instance` / `ParametricInstance` gain a new `removed: bool = False`
+  parameter that expands rows to include the removed map and auto-
+  adds `removed_reason` / `removed_reason.{key}` columns (NA on
+  active rows). `Solution` / `SampleSet` always return all rows
+  (no active/removed distinction at the evaluated / sampled
+  stage); reason columns are gated by `"removed_reason"` in
+  `include=`. Wide `*_df` index column renamed from unqualified
+  `id` to `{kind}_constraint_id`, matching the Wave 1.5 sidecars.
+  `kind` stays `str` at runtime; `Literal[...]` typing + `@overload`
+  stubs are kept as a follow-up.
+- **Future (deferred):** `Series[ID -> Object]` collection
+  accessors, the two-mode Standalone / Attached wrappers with
+  `Py<Instance>` back-references and write-through metadata setters,
+  `Literal[...]` typing on `kind=`, and the `NamedFunction` SoA
+  migration.
 
 Sections below mark each item with **(landed)** or **(deferred)** so it
 is clear which parts are live in v3 alpha and which are still proposal.
@@ -128,12 +143,19 @@ SoA store; the behavior they implement is unchanged.
   `pandas.Series[ID -> Object]` shape is **deferred** to a follow-up PR.
 - `*_df` accessors are now methods (not `#[getter]` properties), each
   with an `include=` parameter that gates the metadata / parameters
-  column families. Default `include=("metadata", "parameters")`
-  preserves the v2 wide shape; `include=[]` drops both, single-element
-  forms keep the named family. **(landed in PR #846)** Internally the
-  rendering path uses a `WithMetadata<'a, T, M>` wrapper to pair items
-  with snapshots; a post-filter in `entries_to_dataframe` drops the
-  gated columns before the DataFrame is built.
+  / removed-reason column families. Default
+  `include=("metadata", "parameters")` preserves the v2 wide shape;
+  `include=[]` drops everything; single-element forms keep just the
+  named family. **(`include=` for metadata / parameters landed in
+  PR #846; `"removed_reason"` joins them in Wave 2.)** Internally
+  the rendering path uses a `WithMetadata<'a, T, M>` wrapper to pair
+  items with snapshots; a post-filter in `entries_to_dataframe`
+  drops the gated columns before the DataFrame is built.
+- Per-kind `*_constraints_df` / `removed_*_constraints_df` /
+  `*_removed_reasons_df` collapse into one `constraints_df(kind=...)`
+  per host. On `Instance` / `ParametricInstance` a new
+  `removed: bool = False` parameter expands rows to include the
+  removed map and auto-adds reason columns. **(Wave 2 — proposed.)**
 - Six long-format / id-indexed sidecar dataframes read directly from
   the SoA stores: `constraint_metadata_df(kind=...)`,
   `constraint_parameters_df(kind=...)`,
@@ -704,36 +726,78 @@ indexing, `.items()`, `.index`. Operations users lose vs. dict:
   The right answer is `instance.constraints_df()["equality"]`, which
   is bulk-built from the SoA. Document this; do not enforce.
 
-### `*_df` methods → derived views with `include` **(landed in PR #846; `kind=` consolidation deferred)**
+### `*_df` methods → derived views with `include` and `kind=` **(Wave 1.5 + Wave 2)**
 
 Each `*_df` is a derived view: type-specific core columns extracted
 from the SoA store, plus whichever sidecars the caller asks for via
 `include`. The default `include` matches v2's wide-DataFrame shape
-(`metadata` + `parameters`), so v2 user code keeps working unchanged
-on the per-kind methods that exist today.
+(`metadata` + `parameters`).
+
+The per-kind `constraints_df` / `indicator_constraints_df` /
+`one_hot_constraints_df` / `sos1_constraints_df` family — and the
+parallel `removed_*_constraints_df` (`Instance` / `ParametricInstance`)
+and `*_removed_reasons_df` (`Solution` / `SampleSet`) families —
+collapse into one method per host:
 
 ```python
-# === v2-equivalent wide DataFrame (default include) — landed ===
+# Wave 2 — unified API on every host
+instance.constraints_df(
+    kind: str = "regular",        # "regular" | "indicator" | "one_hot" | "sos1"
+    include: Sequence[str] | None = None,  # default ("metadata", "parameters")
+    removed: bool = False,        # Instance / ParametricInstance only
+)
+
+solution.constraints_df(
+    kind: str = "regular",
+    include: Sequence[str] | None = None,  # default ("metadata", "parameters")
+)
+# (Solution / SampleSet have no `removed=` parameter — at the
+# evaluated / sampled stage there is no active/removed distinction.)
+```
+
+`include` accepts a `Sequence[str]` containing `"metadata"` /
+`"parameters"` / `"removed_reason"` (singular). Unknown values
+raise `ValueError`. `"removed_reason"` is a unit flag — it gates
+both the reason-name column (`removed_reason`) and the reason-
+parameter columns (`removed_reason.{key}`) together, since the name
+without its parameters is rarely useful. `"parameters"` continues
+to gate only the constraint's own metadata parameters
+(`parameters.{key}`); the two `parameters` namespaces stay
+independent.
+
+On `Instance` / `ParametricInstance`, `removed=False` (default)
+returns active rows only; `removed=True` returns active + removed
+rows in the same DataFrame and **auto-sets `"removed_reason"`** so
+that removed rows are distinguishable (active rows have NA in the
+reason columns).
+
+```python
+# === v2-equivalent wide DataFrame (default include) ===
 df = instance.constraints_df()
-# ≡ instance.constraints_df(include=("metadata", "parameters"))
+# ≡ instance.constraints_df(kind="regular", include=("metadata", "parameters"))
 # columns: equality, function_type, used_ids,
 #          name, subscripts, description, parameters.{key}, ...
-# (Note: today's per-kind `constraints_df` / `indicator_constraints_df`
-# / `one_hot_constraints_df` / `sos1_constraints_df` family is kept
-# intact in PR #846; the `kind=Literal[...]` consolidation that
-# collapses these into one is deferred to a follow-up PR.)
+# index: regular_constraint_id
 
-df = instance.decision_variables_df()
-# ≡ instance.decision_variables_df(include=("metadata", "parameters"))
-# columns: kind, lower, upper, substituted_value,
-#          name, subscripts, description, parameters.{key}, ...
-
-# === Core only — pass include=[] (landed) ===
+# === Core only — pass include=[] ===
 df = instance.constraints_df(include=[])
 # columns: equality, function_type, used_ids
 
-df = instance.decision_variables_df(include=[])
-# columns: kind, lower, upper, substituted_value
+# === Active + removed in one table ===
+df = instance.constraints_df(removed=True)
+# rows: active + removed (in regular_constraint_id order)
+# columns: equality, function_type, used_ids,
+#          name, subscripts, description, parameters.{key},
+#          removed_reason, removed_reason.{key}
+# (active rows have NA in the removed_reason columns)
+
+# === Per-kind dispatch ===
+df = instance.constraints_df(kind="indicator")
+# index: indicator_constraint_id
+
+# === decision_variables_df takes include= (no kind= or removed=) ===
+df = instance.decision_variables_df()
+# ≡ instance.decision_variables_df(include=("metadata", "parameters"))
 
 # === Long-format sidecars (landed in PR #846) ===
 meta     = instance.constraint_metadata_df(kind="regular")
@@ -753,23 +817,18 @@ vmeta    = instance.variable_metadata_df()
 vparams  = instance.variable_parameters_df()
 ```
 
-The shipping `include=` accepts `Sequence[str]` containing
-`"metadata"` and/or `"parameters"`. Unknown values raise
-`ValueError`. The originally-proposed `"removed_reasons"` flag is
-**not** part of the landed shape — folding removed reasons into the
-active wide df would require unifying the active + removed iteration
-paths, which is deferred along with the `kind=` consolidation. Users
-who want removed-reason data go through the dedicated
-`constraint_removed_reasons_df(kind=...)` long-format sidecar.
+`provenance` is intentionally absent from `include` for the long-
+term shape: chains have variable length, so a wide pivot would
+either explode the column space (`provenance.0.*`,
+`provenance.1.*`, …) or produce an object-dtype list column. Users
+who want provenance pivot the long-format
+`constraint_provenance_df()` themselves.
 
-`provenance` is intentionally absent from `include` for the long-term
-shape too: chains have variable length, so a wide pivot would either
-explode the column space (`provenance.0.*`, `provenance.1.*`, …) or
-produce an object-dtype list column. Users who want provenance pivot
-the long-format `constraint_provenance_df()` themselves.
-
-`Solution` and `SampleSet` expose the same `*_df` family with stage-
-appropriate core-column schemas and the same `include` parameter:
+`Solution` and `SampleSet` expose the same `constraints_df` shape
+with stage-appropriate core-column schemas. They have no
+`removed=` parameter (no active/removed distinction at the
+evaluated / sampled stage); reason data is gated by
+`"removed_reason"` in `include=`:
 
 ```python
 # Solution — evaluated stage; v2-style default
@@ -777,6 +836,13 @@ df = solution.constraints_df(kind="regular")
                                             # core: equality, evaluated_value, feasible,
                                             # used_ids, dual_variable
                                             # + metadata, parameters columns by default
+                                            # index: regular_constraint_id
+
+df = solution.constraints_df(kind="regular",
+                             include=("metadata", "parameters",
+                                      "removed_reason"))
+                                            # + removed_reason / removed_reason.{key}
+                                            # columns (NA for non-removed rows)
 
 df = solution.decision_variables_df()       # core: kind, lower, upper, value
                                             # + metadata, parameters columns by default
@@ -794,6 +860,24 @@ are stage-independent — they describe the same constraint, so
 folded into `*_df` are identical across stages too). There's no per-
 stage divergence to manage.
 
+#### Why `removed=` lives on `Instance` but not on `Solution`
+
+At the `Instance` / `ParametricInstance` stage, active and removed
+constraints are the same data — the constraint definition (function,
+equality, metadata) is identical, only the lifecycle stage differs.
+Putting them in separate DataFrames (`constraints_df` vs.
+`removed_constraints_df`) duplicates the schema and forces users to
+`pd.concat` to see the whole picture. The `removed=True` flag puts
+both into one table with a `removed_reason` column to distinguish.
+
+At the `Solution` / `SampleSet` stage there's no such distinction:
+the evaluated / sampled value is what each row carries, and removal
+already happened upstream. Constraints that were removed before
+evaluation simply have no value to report; surfacing them as a
+separate row family doesn't add information. The reason data, if
+the user wants it, comes through `"removed_reason"` in `include=` —
+a column-level concern, not a row-level one.
+
 `*_df` (with `include=`) is what users call when they want a wide
 table for analysis; the long-format sidecars are what they call when
 they want tidy data for joins or aggregation; the Series is what they
@@ -801,7 +885,7 @@ call when they want individual wrapper objects; the wrapper getters
 are what they call when they already hold one wrapper. Four surfaces,
 one canonical store.
 
-### Avoiding cross-ID-space joins **(partially landed)**
+### Avoiding cross-ID-space joins
 
 Each constraint kind has its own ID space (regular ID 5 ≠ indicator ID 5),
 and decision variable IDs live in yet another space. With every df sharing
@@ -809,9 +893,8 @@ an `int64` index, `df.join()` between mismatched-kind dfs would silently
 produce an incorrect-but-shaped result. We ward off that mistake at the
 naming and helper layers:
 
-1. **Distinct index names per ID space (landed in PR #846 for sidecars).**
-   The new long-format / id-indexed sidecar dfs set their index column
-   to a kind-qualified label:
+1. **Distinct index names per ID space.** Every constraint / variable
+   df sets its index column to a kind-qualified label:
 
    ```
    variable_id                   # decision variables
@@ -821,11 +904,10 @@ naming and helper layers:
    sos1_constraint_id            # SOS1 constraints
    ```
 
-   The wide per-kind `*_df` accessors still index by the unqualified
-   `id` column (a v2 carry-over). Renaming those is bundled with the
-   `kind=Literal[...]` consolidation that turns
-   `indicator_constraints_df()` etc. into `constraints_df(kind=...)`,
-   and is therefore deferred along with that work.
+   The Wave 1.5 long-format sidecars used these names from the
+   start; the wide `constraints_df(kind=...)` adopts the same scheme
+   in Wave 2 (replacing the unqualified `id` column from the PR #846
+   era).
 
    pandas `df.join(other)` aligns by index but does *not* enforce that
    the index names match. The qualified names alone won't stop a wrong
@@ -833,21 +915,28 @@ naming and helper layers:
    inspection, and migration-guide examples, so users see the mismatch
    immediately rather than chasing a silent bug downstream.
 
-2. **`include=` covers the common "wide" case without manual join
-   (landed).** The wide `*_df` methods accept an `include` parameter
-   that gates the metadata / parameters column families, so most users
-   never write a `df.join(other_df)` at all:
+2. **`include=` covers the common "wide" case without manual join.**
+   The wide `*_df` methods accept an `include` parameter that gates
+   the metadata / parameters / removed-reason column families, so
+   most users never write a `df.join(other_df)` at all:
 
    ```python
    instance.constraints_df()
    # default include=("metadata","parameters") — v2-equivalent shape
+
+   instance.constraints_df(removed=True)
+   # active + removed in one DataFrame; reason columns auto-added
+
+   solution.constraints_df(include=("metadata","parameters",
+                                    "removed_reason"))
+   # same shape on Solution; reason columns gated by include= flag
    ```
 
-   `include` is a `Sequence[str]` containing `"metadata"` and/or
-   `"parameters"`. The originally-proposed `"removed_reasons"` flag is
-   not part of the landed shape — for removed-reason data, users go
-   through `constraint_removed_reasons_df(kind=...)` (long format),
-   where the qualified index name (point 1) makes the kind explicit.
+   `include` is a `Sequence[str]` containing `"metadata"` /
+   `"parameters"` / `"removed_reason"`. Long-format access for
+   merge / aggregate workflows continues through the dedicated
+   sidecars (where the qualified index name above makes the kind
+   explicit).
 
 3. **Wrapper-object access stays the safest path for single-id
    lookups.** `instance.constraints[id].name` reads metadata directly
@@ -972,6 +1061,37 @@ shape is:
   (default `"regular"`); unknown values raise `ValueError`. Index
   column names are kind-qualified.
 
+### Wave 2 (proposed)
+
+- Per-kind `*_constraints_df`, `removed_*_constraints_df`
+  (`Instance` / `ParametricInstance`), and `*_removed_reasons_df`
+  (`Solution` / `SampleSet`) families are removed; one
+  `constraints_df(kind=...)` per host replaces them. `kind` is
+  validated at runtime against
+  `{"regular", "indicator", "one_hot", "sos1"}` (default
+  `"regular"`).
+- `Instance.constraints_df` / `ParametricInstance.constraints_df`
+  accept a new `removed: bool = False` parameter. `removed=False`
+  returns active rows only (the today's-default behavior);
+  `removed=True` returns active + removed rows in the same
+  DataFrame and **auto-sets `"removed_reason"`** so the reason
+  columns (`removed_reason` and `removed_reason.{key}`) appear,
+  with NA on active rows.
+- `Solution.constraints_df` / `SampleSet.constraints_df` always
+  return all rows (no active/removed distinction at the evaluated
+  / sampled stage). `"removed_reason"` in `include=` adds reason
+  columns; otherwise reason data is omitted.
+- `include=` accepts `"metadata"` / `"parameters"` /
+  `"removed_reason"` (singular). `"removed_reason"` is a unit flag
+  — it gates both the reason name and the reason parameter columns
+  together. `"parameters"` continues to gate only the constraint's
+  own metadata parameters; the two `parameters` namespaces stay
+  independent.
+- Wide `*_df` index column renamed from unqualified `id` to
+  `{kind}_constraint_id` (matching the Wave 1.5 sidecars).
+- `kind` typing stays `str` at runtime; `Literal[...]` typing +
+  `@overload` stubs are deferred to a follow-up.
+
 ### Deferred to follow-up wave
 
 - `instance.constraints`, `decision_variables`, `*_constraints` change
@@ -980,11 +1100,11 @@ shape is:
   - `s.values()` (method call) → `s.tolist()` or `list(s)`.
   - List-positional reliance on the old `decision_variables: list[…]`
     ordering breaks; index by `VariableID` instead.
-- Per-kind `indicator_constraints_df()`,
-  `one_hot_constraints_df()`, `sos1_constraints_df()`, and
-  `removed_*_constraints_df()` collapse into the single
-  `constraints_df(kind=...)` overload set (with `kind=Literal[...]`
-  + `pyo3-stub-gen` `@overload` for per-kind column schemas).
+- `Literal[...]` typing on `kind=` (both the wide
+  `constraints_df(kind=...)` and the sidecars) plus the
+  `@overload` stubs that surface per-kind column schemas. The
+  runtime semantics land in Wave 2; this follow-up tightens the
+  static typing.
 - Wrapper-object metadata setters become write-through to the SoA
   store via the Standalone / Attached two-mode design.
 - `NamedFunction` / `EvaluatedNamedFunction` /
@@ -1004,23 +1124,29 @@ Numbering preserved from the original Open Questions list for
 traceability with earlier review comments.
 
 1. **Kind dispatch in Python — single method with `kind=...`
-   parameter.** The new sidecar accessors
-   (`constraint_metadata_df(kind="regular")` and siblings) take a
+   parameter.** Both the wide `constraints_df(kind=...)` (Wave 2)
+   and the long-format sidecar accessors (Wave 1.5) take a
    `kind: str` argument validated at runtime against
-   `{"regular", "indicator", "one_hot", "sos1"}`. The originally-
-   proposed `Literal[...]` typing + `pyo3-stub-gen` `@overload`
-   stubs are deferred along with the consolidation of today's
-   per-kind `constraints_df` / `indicator_constraints_df` /
-   `one_hot_constraints_df` / `sos1_constraints_df` family — when
-   that consolidation lands, the `Literal` typing covers both the
-   wide and the sidecar accessors uniformly.
-2. **`removed_reason` — separate long-format
-   `constraint_removed_reasons_df(kind=...)`.** `RemovedReason` is
-   collection-level metadata in Rust, not part of the constraint.
-   It is exposed only via the dedicated long-format sidecar; the
-   originally-proposed `include=("removed_reasons",)` pivot into
-   the wide `*_df` is deferred along with the active+removed
-   unification.
+   `{"regular", "indicator", "one_hot", "sos1"}` (default
+   `"regular"`). `Literal[...]` typing + `pyo3-stub-gen`
+   `@overload` stubs are deferred to a separate follow-up so the
+   runtime semantics could be settled first; once landed, the
+   `Literal` typing covers both the wide and the sidecar accessors
+   uniformly.
+2. **`removed_reason` — surfaced both via wide df and via long-
+   format sidecar.** `RemovedReason` is collection-level metadata
+   in Rust, not part of the constraint. Wave 1.5 shipped the
+   long-format `constraint_removed_reasons_df(kind=...)` sidecar.
+   Wave 2 also folds reason data into the wide `constraints_df`
+   via a `"removed_reason"` flag in `include=` (singular, unit
+   flag — turns on both `removed_reason` and
+   `removed_reason.{key}` columns together, since the reason name
+   without its parameters is rarely useful). On `Instance` /
+   `ParametricInstance`, `removed=True` auto-sets the
+   `"removed_reason"` flag because rows from the removed map need
+   a column that distinguishes them from active. On `Solution` /
+   `SampleSet`, the same flag is the only knob since there is no
+   active/removed distinction at those stages.
 3. **Atomic insert-with-metadata on the Rust side — `insert_with`
    takes the existing owned `ConstraintMetadata` struct.** The pre-
    v3 `ConstraintMetadata` (owned struct with `name`, `subscripts`,
@@ -1124,25 +1250,19 @@ traceability with earlier review comments.
   `*_metadata_mut`). These three methods should be narrowed to
   `pub(crate)` (or smaller) in a follow-up so the only way to break
   the collection's invariants is from inside the crate.
-- **`kind=Literal[...]` + `@overload` consolidation.** Today's
-  per-kind `*_constraints_df` family
-  (`indicator_constraints_df()` / `one_hot_constraints_df()` /
-  `sos1_constraints_df()` / `removed_*_constraints_df()`)
-  collapses into one `constraints_df(kind=...)` overload set,
-  with the `kind` parameter typed as `Literal[...]` and the
-  per-kind column schemas surfaced via
-  `pyo3-stub-gen`-emitted `@overload` stubs. The new sidecar
-  accessors landed in PR #846 already follow the `kind=...`
-  shape but still take `kind: str` validated at runtime; this
-  follow-up tightens the typing on both surfaces in one go and
-  adds a `_constraint_id` qualified index name on the wide
-  `*_df` accessors as part of the API rename.
-- **`include=("removed_reasons",)` on the wide `*_df`.**
-  Currently removed-reason data is only available via the
-  dedicated `constraint_removed_reasons_df(kind=...)` long-format
-  sidecar. Folding it into `constraints_df` requires unifying the
-  active + removed iteration paths and is bundled with the
-  consolidation above.
+- **`kind=Literal[...]` + `@overload` typing.** Wave 2 lands the
+  runtime semantics — single `constraints_df(kind=...)` per host,
+  `kind` validated at runtime against the four kind strings, and a
+  `{kind}_constraint_id` qualified index name on the wide df. The
+  static typing — `Literal["regular","indicator","one_hot","sos1"]`
+  on `kind` plus optional `pyo3-stub-gen`-emitted `@overload`
+  stubs that surface per-kind column schemas — is held off until
+  the runtime API has soaked. The hook to emit these is already in
+  pyo3-stub-gen (the `python_overload` parameter on
+  `gen_stub_pyfunction` / the `submit!` + `gen_methods_from_python!`
+  pattern); whether the per-kind column-schema overloads are worth
+  the maintenance, or only the `Literal[...]` input typing is, is a
+  question for the follow-up.
 - **`NamedFunction` SoA migration.** Track the
   `NamedFunctionMetadataStore` work described under
   "NamedFunction (deferred — separate PR)" above.

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -2,7 +2,7 @@
 
 Status: **Rust SDK landed; Python wrappers landed (snapshot model);
 `include=` + long-format sidecar dfs landed (Wave 1.5); per-kind
-`*_df` consolidation in progress (Wave 2); Series accessors,
+`*_df` consolidation landed (Wave 2, PR #847); Series accessors,
 two-mode Attached wrappers, and `Literal[...]` typing deferred to
 follow-up PRs**
 
@@ -39,19 +39,23 @@ here. The implementation shipped in three waves:
   `variable_metadata_df()`, `variable_parameters_df()`. Mechanical
   v3-alpha breaking change: every `*_df` accessor is now a method
   (`instance.constraints_df` → `instance.constraints_df()`).
-- **Wave 2 (proposed, this PR):** Per-kind `*_constraints_df`,
+- **Wave 2 (PR #847, landed):** Per-kind `*_constraints_df`,
   `removed_*_constraints_df`, and `*_removed_reasons_df` families
   on every host collapse into a single `constraints_df(kind=...)`.
   `Instance` / `ParametricInstance` gain a new `removed: bool = False`
-  parameter that expands rows to include the removed map and auto-
-  adds `removed_reason` / `removed_reason.{key}` columns (NA on
-  active rows). `Solution` / `SampleSet` always return all rows
-  (no active/removed distinction at the evaluated / sampled
-  stage); reason columns are gated by `"removed_reason"` in
-  `include=`. Wide `*_df` index column renamed from unqualified
-  `id` to `{kind}_constraint_id`, matching the Wave 1.5 sidecars.
-  `kind` stays `str` at runtime; `Literal[...]` typing + `@overload`
-  stubs are kept as a follow-up.
+  parameter that expands rows to include the removed map (active and
+  removed merged in **globally id-sorted** order) and auto-adds
+  `removed_reason` / `removed_reason.{key}` columns (NA on active
+  rows). `Solution` / `SampleSet` always return all rows (no
+  active/removed distinction at the evaluated / sampled stage);
+  reason columns are gated by `"removed_reason"` in `include=`,
+  and the `removed_reason` column always appears with NA values
+  when the flag is on but no row in the view carries a reason.
+  Wide `*_df` index column renamed from unqualified `id` to
+  `{kind}_constraint_id`, matching the Wave 1.5 sidecars; empty
+  collections still produce a DataFrame whose `df.index.name` is
+  the kind-qualified label. `kind` stays `str` at runtime;
+  `Literal[...]` typing + `@overload` stubs are kept as a follow-up.
 - **Future (deferred):** `Series[ID -> Object]` collection
   accessors, the two-mode Standalone / Attached wrappers with
   `Py<Instance>` back-references and write-through metadata setters,
@@ -785,11 +789,16 @@ df = instance.constraints_df(include=[])
 
 # === Active + removed in one table ===
 df = instance.constraints_df(removed=True)
-# rows: active + removed (in regular_constraint_id order)
+# rows: active + removed merged into a single globally id-sorted
+#       sequence (a removed id between two active ids interleaves
+#       in id order, not "active section then removed section").
 # columns: equality, function_type, used_ids,
 #          name, subscripts, description, parameters.{key},
 #          removed_reason, removed_reason.{key}
-# (active rows have NA in the removed_reason columns)
+# (active rows have NA in the removed_reason columns; the
+#  removed_reason column is guaranteed to appear whenever the
+#  "removed_reason" flag is active, even if every row happens to
+#  have NA — useful for downstream code that branches on schema.)
 
 # === Per-kind dispatch ===
 df = instance.constraints_df(kind="indicator")
@@ -842,7 +851,11 @@ df = solution.constraints_df(kind="regular",
                              include=("metadata", "parameters",
                                       "removed_reason"))
                                             # + removed_reason / removed_reason.{key}
-                                            # columns (NA for non-removed rows)
+                                            # columns (NA for non-removed rows; the
+                                            # `removed_reason` column appears even when
+                                            # no constraint was removed before evaluation,
+                                            # so the schema only depends on `include=`,
+                                            # not on the actual data.)
 
 df = solution.decision_variables_df()       # core: kind, lower, upper, value
                                             # + metadata, parameters columns by default
@@ -1061,7 +1074,7 @@ shape is:
   (default `"regular"`); unknown values raise `ValueError`. Index
   column names are kind-qualified.
 
-### Wave 2 (proposed)
+### Landed in Wave 2 (PR #847)
 
 - Per-kind `*_constraints_df`, `removed_*_constraints_df`
   (`Instance` / `ParametricInstance`), and `*_removed_reasons_df`
@@ -1069,14 +1082,15 @@ shape is:
   `constraints_df(kind=...)` per host replaces them. `kind` is
   validated at runtime against
   `{"regular", "indicator", "one_hot", "sos1"}` (default
-  `"regular"`).
+  `"regular"`); unknown values raise `ValueError`.
 - `Instance.constraints_df` / `ParametricInstance.constraints_df`
   accept a new `removed: bool = False` parameter. `removed=False`
   returns active rows only (the today's-default behavior);
-  `removed=True` returns active + removed rows in the same
-  DataFrame and **auto-sets `"removed_reason"`** so the reason
-  columns (`removed_reason` and `removed_reason.{key}`) appear,
-  with NA on active rows.
+  `removed=True` returns active + removed rows merged into a
+  **globally id-sorted** sequence in the same DataFrame and
+  **auto-sets `"removed_reason"`** so the reason columns
+  (`removed_reason` and `removed_reason.{key}`) appear, with NA
+  on active rows.
 - `Solution.constraints_df` / `SampleSet.constraints_df` always
   return all rows (no active/removed distinction at the evaluated
   / sampled stage). `"removed_reason"` in `include=` adds reason
@@ -1086,9 +1100,18 @@ shape is:
   — it gates both the reason name and the reason parameter columns
   together. `"parameters"` continues to gate only the constraint's
   own metadata parameters; the two `parameters` namespaces stay
-  independent.
+  independent. Unknown flags raise `ValueError`.
+- The `removed_reason` column is **schema-stable**: when the flag
+  is on, the column appears in the resulting DataFrame regardless
+  of whether any row carries a reason (NA-filled rows otherwise).
+  The `removed_reason.{key}` parameter columns remain
+  data-dependent — their key set is too. Keys within the
+  `removed_reason.{key}` family are emitted in lexicographic
+  order, matching the existing `*_parameters_df` sidecar shape.
 - Wide `*_df` index column renamed from unqualified `id` to
-  `{kind}_constraint_id` (matching the Wave 1.5 sidecars).
+  `{kind}_constraint_id` (matching the Wave 1.5 sidecars). Empty
+  collections still produce a DataFrame whose `df.index.name` is
+  the kind-qualified label.
 - `kind` typing stays `str` at runtime; `Literal[...]` typing +
   `@overload` stubs are deferred to a follow-up.
 

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -161,7 +161,8 @@ SoA store; the behavior they implement is unchanged.
   `*_removed_reasons_df` collapse into one `constraints_df(kind=...)`
   per host. On `Instance` / `ParametricInstance` a new
   `removed: bool = False` parameter expands rows to include the
-  removed map and auto-adds reason columns. **(Wave 2 — proposed.)**
+  removed map and auto-adds reason columns.
+  **(landed in Wave 2, PR #847.)**
 - Six long-format / id-indexed sidecar dataframes read directly from
   the SoA stores: `constraint_metadata_df(kind=...)`,
   `constraint_parameters_df(kind=...)`,

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -571,9 +571,10 @@ on every wrapper and is gated behind the deferred Series accessor work.
 
 ### Layered views over the Rust SoA store **(partially landed)**
 
-`include=` and the long-format sidecar dfs are landed (PR #846); the
-Series accessor and the `kind=Literal` consolidation of per-kind
-`*_constraints_df` remain deferred.
+`include=` and the long-format sidecar dfs landed in PR #846; the
+`kind=Literal[...]` consolidation of per-kind `*_constraints_df`
+landed in PR #847 (Wave 2). Only the Series accessor remains
+deferred.
 
 ```
                   Rust SoA store (canonical)
@@ -885,12 +886,15 @@ Putting them in separate DataFrames (`constraints_df` vs.
 `pd.concat` to see the whole picture. The `removed=True` flag puts
 both into one table with a `removed_reason` column to distinguish.
 
-At the `Solution` / `SampleSet` stage there's no such distinction:
-the evaluated / sampled value is what each row carries, and removal
-already happened upstream. Constraints that were removed before
-evaluation simply have no value to report; surfacing them as a
-separate row family doesn't add information. The reason data, if
-the user wants it, comes through `"removed_reason"` in `include=` —
+At the `Solution` / `SampleSet` stage there's no such row-level
+distinction: the underlying `EvaluatedCollection<T>` (and its
+sampled counterpart) keeps both active and previously-removed
+constraints in a single `constraints` map and tracks removal
+status alongside in `removed_reasons`. Both kinds of row carry an
+evaluated / sampled value, used_ids, etc., so `constraints_df`
+emits a single row per id without an active/removed split. The
+reason data, if the user wants to tell which rows came from a
+removed entry, comes through `"removed_reason"` in `include=` —
 a column-level concern, not a row-level one.
 
 `*_df` (with `include=`) is what users call when they want a wide

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -7123,7 +7123,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -7173,7 +7173,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -7223,7 +7223,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -7273,7 +7273,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -7323,7 +7323,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     },
                     {
@@ -12638,7 +12638,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -12688,7 +12688,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -12738,7 +12738,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -12788,7 +12788,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -12838,7 +12838,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     },
                     {
@@ -16868,7 +16868,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -16918,7 +16918,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -16968,7 +16968,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -17018,7 +17018,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -17068,7 +17068,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     },
                     {
@@ -19051,7 +19051,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -19101,7 +19101,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -19151,7 +19151,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -19201,7 +19201,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     }
                   ],
@@ -19251,7 +19251,7 @@
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "\"regular\""
+                        "value": "'regular'"
                       }
                     },
                     {

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -7205,10 +7205,22 @@
             },
             {
               "name": "constraints_df",
-              "doc": "DataFrame of constraints",
+              "doc": "DataFrame of constraints, dispatched on `kind=`.\n\n`kind` selects the constraint family — `\"regular\"`, `\"indicator\"`,\n`\"one_hot\"`, or `\"sos1\"`. The DataFrame is indexed by the kind-\nqualified id column (`{kind}_constraint_id`).\n\n`include` selects which optional column families to fold in. It\naccepts a sequence of `\"metadata\"` / `\"parameters\"` /\n`\"removed_reason\"`; passing `None` (the default) yields the\nv2-equivalent shape (`metadata` + `parameters`). `\"removed_reason\"`\nis a unit flag that gates both the `removed_reason` column and the\n`removed_reason.{key}` parameter columns together.\n\n`removed=False` (default) returns active constraints only.\n`removed=True` returns active + removed rows in the same DataFrame\nand auto-sets `\"removed_reason\"` so removed rows are\ndistinguishable (active rows have NA in the reason columns).",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "kind",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "'regular'"
+                      }
+                    },
                     {
                       "name": "include",
                       "type_": {
@@ -7231,6 +7243,18 @@
                       "default": {
                         "kind": "Simple",
                         "value": "None"
+                      }
+                    },
+                    {
+                      "name": "removed",
+                      "type_": {
+                        "display": "bool",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "False"
                       }
                     }
                   ],
@@ -8041,47 +8065,6 @@
               "deprecated": null
             },
             {
-              "name": "indicator_constraints_df",
-              "doc": "DataFrame of indicator constraints",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
               "name": "load_mps",
               "doc": "",
               "signatures": [
@@ -8187,47 +8170,6 @@
             {
               "name": "named_functions_df",
               "doc": "DataFrame of named functions",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "one_hot_constraints_df",
-              "doc": "DataFrame of one-hot constraints",
               "signatures": [
                 {
                   "parameters": [
@@ -8578,170 +8520,6 @@
               "deprecated": null
             },
             {
-              "name": "removed_constraints_df",
-              "doc": "DataFrame of removed constraints",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "removed_indicator_constraints_df",
-              "doc": "DataFrame of removed indicator constraints",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "removed_one_hot_constraints_df",
-              "doc": "DataFrame of removed one-hot constraints",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "removed_sos1_constraints_df",
-              "doc": "DataFrame of removed SOS1 constraints",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
               "name": "required_ids",
               "doc": "Get the set of decision variable IDs used in the objective and remaining constraints.\n\n# Examples\n\n```python\n>>> from ommx.v1 import Instance, DecisionVariable\n>>> x = [DecisionVariable.binary(i) for i in range(3)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints=[],\n...     sense=Instance.MAXIMIZE,\n... )\n>>> instance.required_ids()\n{0, 1, 2}\n```",
               "signatures": [
@@ -8845,47 +8623,6 @@
                   ],
                   "return_type": {
                     "display": "None",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "sos1_constraints_df",
-              "doc": "DataFrame of SOS1 constraints",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
                     "link_target": null,
                     "children": []
                   }
@@ -12878,10 +12615,22 @@
             },
             {
               "name": "constraints_df",
-              "doc": "DataFrame of constraints",
+              "doc": "DataFrame of constraints, dispatched on `kind=`. See\n{meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /\n`include=` / `removed=` semantics.",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "kind",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "'regular'"
+                      }
+                    },
                     {
                       "name": "include",
                       "type_": {
@@ -12904,6 +12653,18 @@
                       "default": {
                         "kind": "Simple",
                         "value": "None"
+                      }
+                    },
+                    {
+                      "name": "removed",
+                      "type_": {
+                        "display": "bool",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "False"
                       }
                     }
                   ],
@@ -13384,47 +13145,6 @@
             {
               "name": "parameters_df",
               "doc": "DataFrame of parameters",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "removed_constraints_df",
-              "doc": "DataFrame of removed constraints",
               "signatures": [
                 {
                   "parameters": [
@@ -17020,10 +16740,22 @@
             },
             {
               "name": "constraints_df",
-              "doc": "DataFrame of constraints with per-sample value and feasibility columns.\nStatic columns: id, equality, used_ids, name, subscripts, description.\nDynamic columns: value.{sample_id} and feasible.{sample_id} for each sample.",
+              "doc": "DataFrame of sampled constraints, dispatched on `kind=`. See\n{meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /\n`include=` semantics. Adds dynamic per-sample columns\n(`value.{sample_id}`, `feasible.{sample_id}`, etc.) on top of\nthe kind-specific core columns.\n\n`SampleSet` has no `removed=` parameter (no active/removed\ndistinction at the sampled stage); reason data is gated by\n`\"removed_reason\"` in `include=`.",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "kind",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "'regular'"
+                      }
+                    },
                     {
                       "name": "include",
                       "type_": {
@@ -17558,63 +17290,6 @@
               "deprecated": null
             },
             {
-              "name": "indicator_constraints_df",
-              "doc": "DataFrame of indicator constraints with per-sample value, feasibility, and indicator_active columns.\nStatic columns: id, indicator_variable_id, equality, used_ids, name, subscripts, description.\nDynamic columns: value.{sample_id}, feasible.{sample_id}, indicator_active.{sample_id} for each sample.",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "indicator_removed_reasons_df",
-              "doc": "DataFrame of removed indicator constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`indicator_constraints_df` using the `id` index.",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
               "name": "named_functions_df",
               "doc": "DataFrame of named functions with per-sample value columns.\nStatic columns: id, used_ids, name, subscripts, description, parameters.{key}.\nDynamic columns: one per sample_id (int) with the function's evaluated value.",
               "signatures": [
@@ -17672,79 +17347,6 @@
               "deprecated": null
             },
             {
-              "name": "one_hot_constraints_df",
-              "doc": "DataFrame of one-hot constraints with per-sample feasibility and active_variable columns.\nStatic columns: id, used_ids, name, subscripts, description.\nDynamic columns: feasible.{sample_id}, active_variable.{sample_id} for each sample.",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "one_hot_removed_reasons_df",
-              "doc": "DataFrame of removed one-hot constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`one_hot_constraints_df` using the `id` index.",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "removed_reasons_df",
-              "doc": "DataFrame of removed constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`constraints_df` using the `id` index.",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
               "name": "sample_ids",
               "doc": "",
               "signatures": [
@@ -17760,63 +17362,6 @@
                         "children": []
                       }
                     ]
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "sos1_constraints_df",
-              "doc": "DataFrame of SOS1 constraints with per-sample feasibility and active_variable columns.\nStatic columns: id, used_ids, name, subscripts, description.\nDynamic columns: feasible.{sample_id}, active_variable.{sample_id} for each sample.",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "sos1_removed_reasons_df",
-              "doc": "DataFrame of removed SOS1 constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`sos1_constraints_df` using the `id` index.",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
                   }
                 }
               ],
@@ -19273,10 +18818,22 @@
             },
             {
               "name": "constraints_df",
-              "doc": "DataFrame of evaluated constraints\n\nColumns: id (index), equality, value, used_ids, name, subscripts, description, dual_variable",
+              "doc": "DataFrame of evaluated constraints, dispatched on `kind=`. See\n{meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /\n`include=` semantics.\n\n`Solution` has no `removed=` parameter (no active/removed\ndistinction at the evaluated stage); reason data is gated by\n`\"removed_reason\"` in `include=`. When the flag is on, rows for\nconstraints removed before evaluation get `removed_reason` /\n`removed_reason.{key}` columns populated; other rows have NA.",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "kind",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "'regular'"
+                      }
+                    },
                     {
                       "name": "include",
                       "type_": {
@@ -19704,63 +19261,6 @@
               "deprecated": null
             },
             {
-              "name": "indicator_constraints_df",
-              "doc": "DataFrame of evaluated indicator constraints\n\nColumns: id (index), indicator_variable_id, equality, value, indicator_active, used_ids, name, subscripts, description",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "indicator_removed_reasons_df",
-              "doc": "DataFrame of removed indicator constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`indicator_constraints_df` using the `id` index.",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
               "name": "named_functions_df",
               "doc": "DataFrame of evaluated named functions\n\nColumns: id (index), value, used_ids, name, subscripts, description, parameters.{key}",
               "signatures": [
@@ -19791,79 +19291,6 @@
                       }
                     }
                   ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "one_hot_constraints_df",
-              "doc": "DataFrame of evaluated one-hot constraints\n\nColumns: id (index), feasible, active_variable, used_ids, name, subscripts, description",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "one_hot_removed_reasons_df",
-              "doc": "DataFrame of removed one-hot constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`one_hot_constraints_df` using the `id` index.",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "removed_reasons_df",
-              "doc": "DataFrame of removed constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`constraints_df` on the `id` index.\n\n# Examples\n\n```python\n>>> from ommx.v1 import Instance, DecisionVariable\n>>> x = [DecisionVariable.binary(i) for i in range(3)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints=[\n...         (x[0] + x[1] == 1).set_id(10),\n...         (x[1] + x[2] == 1).set_id(20),\n...     ],\n...     sense=Instance.MAXIMIZE,\n... )\n>>> instance.relax_constraint(10, \"test_reason\")\n>>> solution = instance.evaluate({0: 1, 1: 0, 2: 1})\n```\n\n`removed_reasons_df` contains only removed constraints:\n\n```python\n>>> solution.removed_reasons_df()\n    removed_reason\nid\n10    test_reason\n```\n\nJoin with `constraints_df` to get full information:\n\n```python\n>>> df = solution.constraints_df().join(solution.removed_reasons_df())\n>>> df[[\"value\", \"removed_reason\"]]\n    value removed_reason\nid\n10    0.0   test_reason\n20    0.0           NaN\n```",
-              "signatures": [
-                {
-                  "parameters": [],
                   "return_type": {
                     "display": "DataFrame",
                     "link_target": null,
@@ -19907,63 +19334,6 @@
                   ],
                   "return_type": {
                     "display": "None",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "sos1_constraints_df",
-              "doc": "DataFrame of evaluated SOS1 constraints\n\nColumns: id (index), feasible, active_variable, used_ids, name, subscripts, description",
-              "signatures": [
-                {
-                  "parameters": [
-                    {
-                      "name": "include",
-                      "type_": {
-                        "display": "Optional[Sequence[str]]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "Sequence[str]",
-                            "link_target": null,
-                            "children": [
-                              {
-                                "display": "str",
-                                "link_target": null,
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "default": {
-                        "kind": "Simple",
-                        "value": "None"
-                      }
-                    }
-                  ],
-                  "return_type": {
-                    "display": "DataFrame",
-                    "link_target": null,
-                    "children": []
-                  }
-                }
-              ],
-              "is_async": false,
-              "deprecated": null
-            },
-            {
-              "name": "sos1_removed_reasons_df",
-              "doc": "DataFrame of removed SOS1 constraint reasons.\n\nColumns: id (index), removed_reason, removed_reason.{key}\n\nCan be joined with {meth}`sos1_constraints_df` using the `id` index.",
-              "signatures": [
-                {
-                  "parameters": [],
-                  "return_type": {
-                    "display": "DataFrame",
                     "link_target": null,
                     "children": []
                   }

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -7096,13 +7096,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -7125,13 +7146,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -7154,13 +7196,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -7183,13 +7246,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -7212,13 +7296,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     },
                     {
@@ -12506,13 +12611,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -12535,13 +12661,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -12564,13 +12711,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -12593,13 +12761,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -12622,13 +12811,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     },
                     {
@@ -16631,13 +16841,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -16660,13 +16891,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -16689,13 +16941,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -16718,13 +16991,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -16747,13 +17041,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     },
                     {
@@ -18709,13 +19024,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -18738,13 +19074,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -18767,13 +19124,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -18796,13 +19174,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     }
                   ],
@@ -18825,13 +19224,34 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "str",
+                        "display": "Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
                         "link_target": null,
-                        "children": []
+                        "children": [
+                          {
+                            "display": "\"regular\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"indicator\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"one_hot\"",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "\"sos1\"",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": {
                         "kind": "Simple",
-                        "value": "'regular'"
+                        "value": "\"regular\""
                       }
                     },
                     {

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -137,7 +137,7 @@ For concrete usage, evaluation-result access, and the Indicator relax / restore 
 
 Accordingly, the legacy `ConstraintHints` / `OneHot` / `Sos1` classes, the `Instance.constraint_hints` property, and the PySCIPOpt Adapter's `use_sos1` flag are removed.
 
-### ⚠ `removed_reason` column gated by `include=` ([#796](https://github.com/Jij-Inc/ommx/pull/796))
+### ⚠ `removed_reason` column gated by `include=` ([#796](https://github.com/Jij-Inc/ommx/pull/796), [#847](https://github.com/Jij-Inc/ommx/pull/847))
 
 In v2.5.1 {meth}`Solution.constraints_df <ommx.v1.Solution.constraints_df>` carried a `removed_reason` column unconditionally. In v3.0.0a4 that column is gated by `"removed_reason"` in `include=` (a unit flag that controls both the reason name and `removed_reason.{key}` parameter columns). Rows whose constraint was not removed before evaluation get NA in those columns.
 

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -127,7 +127,7 @@ Global ID counters (`next_constraint_id` and friends) and per-constraint `to_byt
 
 ### 🆕 First-class special constraint types ([#789](https://github.com/Jij-Inc/ommx/pull/789), [#790](https://github.com/Jij-Inc/ommx/pull/790), [#795](https://github.com/Jij-Inc/ommx/pull/795), [#796](https://github.com/Jij-Inc/ommx/pull/796), [#798](https://github.com/Jij-Inc/ommx/pull/798))
 
-In addition to regular constraints, the following three special constraint types are now first-class citizens — they can be passed to `Instance.from_components` via `indicator_constraints=` / `one_hot_constraints=` / `sos1_constraints=`, and corresponding `*_constraints_df` DataFrames are available on {class}`~ommx.v1.Solution` / {class}`~ommx.v1.SampleSet`.
+In addition to regular constraints, the following three special constraint types are now first-class citizens — they can be passed to `Instance.from_components` via `indicator_constraints=` / `one_hot_constraints=` / `sos1_constraints=`, and read back through {meth}`~ommx.v1.Solution.constraints_df` / {meth}`~ommx.v1.SampleSet.constraints_df` with `kind=` selecting the family.
 
 - {class}`~ommx.v1.IndicatorConstraint` — conditional constraint on a binary variable (new)
 - {class}`~ommx.v1.OneHotConstraint` — replaces the previous `ConstraintHints.OneHot` metadata
@@ -137,19 +137,21 @@ For concrete usage, evaluation-result access, and the Indicator relax / restore 
 
 Accordingly, the legacy `ConstraintHints` / `OneHot` / `Sos1` classes, the `Instance.constraint_hints` property, and the PySCIPOpt Adapter's `use_sos1` flag are removed.
 
-### ⚠ `removed_reason` column split into a separate table ([#796](https://github.com/Jij-Inc/ommx/pull/796))
+### ⚠ `removed_reason` column gated by `include=` ([#796](https://github.com/Jij-Inc/ommx/pull/796))
 
-In v2.5.1 {meth}`Solution.constraints_df <ommx.v1.Solution.constraints_df>` carried a `removed_reason` column. In v3.0.0a2 that column is split out into a separate {meth}`Solution.removed_reasons_df <ommx.v1.Solution.removed_reasons_df>` table, which you can join on if you need the previous shape. The same change applies to {class}`~ommx.v1.SampleSet`.
+In v2.5.1 {meth}`Solution.constraints_df <ommx.v1.Solution.constraints_df>` carried a `removed_reason` column unconditionally. In v3.0.0a4 that column is gated by `"removed_reason"` in `include=` (a unit flag that controls both the reason name and `removed_reason.{key}` parameter columns). Rows whose constraint was not removed before evaluation get NA in those columns.
 
 ```python
 # Before (2.5.1)
 df = solution.constraints_df  # contains a 'removed_reason' column
 
-# After (3.0.0a3 — `*_df` are now methods)
-df = solution.constraints_df().join(solution.removed_reasons_df())
+# After (3.0.0a4 — `*_df` are now methods)
+df = solution.constraints_df()  # no removed_reason column
+df = solution.constraints_df(include=("metadata", "parameters", "removed_reason"))
+# ↳ adds removed_reason / removed_reason.{key} (NA for active rows)
 ```
 
-Corresponding `*_removed_reasons_df` accessors are also provided for Indicator, OneHot, and SOS1.
+The same `kind=` / `include=` shape applies on {class}`~ommx.v1.SampleSet`. On {class}`~ommx.v1.Instance` and {class}`~ommx.v1.ParametricInstance`, `removed=True` returns active + removed rows in one DataFrame and auto-sets `"removed_reason"` so removed rows are distinguishable.
 
 ### 🆕 Adapter Capability Model ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#805](https://github.com/Jij-Inc/ommx/pull/805), [#810](https://github.com/Jij-Inc/ommx/pull/810), [#811](https://github.com/Jij-Inc/ommx/pull/811), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 

--- a/docs/en/user_guide/capability_model.md
+++ b/docs/en/user_guide/capability_model.md
@@ -156,9 +156,11 @@ The original special constraints are not discarded; they are kept as "removed" e
 
 | Original type | Removed dict | DataFrame |
 |---|---|---|
-| OneHotConstraint | {attr}`~ommx.v1.Instance.removed_one_hot_constraints` | {meth}`~ommx.v1.Instance.removed_one_hot_constraints_df` |
-| Sos1Constraint | {attr}`~ommx.v1.Instance.removed_sos1_constraints` | {meth}`~ommx.v1.Instance.removed_sos1_constraints_df` |
-| IndicatorConstraint | {attr}`~ommx.v1.Instance.removed_indicator_constraints` | {meth}`~ommx.v1.Instance.removed_indicator_constraints_df` |
+| OneHotConstraint | {attr}`~ommx.v1.Instance.removed_one_hot_constraints` | `instance.constraints_df(kind="one_hot", removed=True)` |
+| Sos1Constraint | {attr}`~ommx.v1.Instance.removed_sos1_constraints` | `instance.constraints_df(kind="sos1", removed=True)` |
+| IndicatorConstraint | {attr}`~ommx.v1.Instance.removed_indicator_constraints` | `instance.constraints_df(kind="indicator", removed=True)` |
+
+`removed=True` returns active + removed rows in the same DataFrame and auto-adds the `removed_reason` / `removed_reason.{key}` columns so removed rows are distinguishable from active ones.
 
 Each entry ({class}`~ommx.v1.RemovedOneHotConstraint` / {class}`~ommx.v1.RemovedSos1Constraint` / {class}`~ommx.v1.RemovedIndicatorConstraint`) records a `removed_reason` string (for example, `"ommx.Instance.convert_one_hot_to_constraint"`) and stores the generated regular-constraint IDs in `removed_reason_parameters`. The key name and shape differ by constraint type:
 
@@ -191,4 +193,4 @@ for cid, c in instance2.constraints.items():
 | Declare supported capabilities on an adapter | The `ADDITIONAL_CAPABILITIES` class attribute |
 | Auto-convert every unsupported special constraint | {meth}`Instance.reduce_capabilities <ommx.v1.Instance.reduce_capabilities>` |
 | Convert individually to regular constraints | `convert_*_to_constraint(s)` / `convert_all_*_to_constraints` |
-| Audit conversion history | `Instance.removed_*_constraints(_df)` / `Solution.*_removed_reasons_df` |
+| Audit conversion history | `instance.constraints_df(kind=..., removed=True)` / `solution.constraints_df(kind=..., include=("...","removed_reason"))` |

--- a/docs/en/user_guide/special_constraints.md
+++ b/docs/en/user_guide/special_constraints.md
@@ -176,26 +176,36 @@ When a special constraint is converted to a regular constraint (see [Capability 
 
 ## Accessing evaluation results
 
-The {class}`~ommx.v1.Solution` or {class}`~ommx.v1.SampleSet` obtained after solving provides a DataFrame accessor for each special constraint type alongside the one for regular constraints.
+The {class}`~ommx.v1.Solution` or {class}`~ommx.v1.SampleSet` obtained after solving exposes a single {meth}`~ommx.v1.Solution.constraints_df` method that dispatches on `kind=`:
 
-| Constraint type | Accessor (on `Solution`) |
+| Constraint type | `kind=` value |
 |---|---|
-| Regular | {meth}`~ommx.v1.Solution.constraints_df` |
-| Indicator | {meth}`~ommx.v1.Solution.indicator_constraints_df` |
-| OneHot | {meth}`~ommx.v1.Solution.one_hot_constraints_df` |
-| SOS1 | {meth}`~ommx.v1.Solution.sos1_constraints_df` |
+| Regular | `"regular"` (default) |
+| Indicator | `"indicator"` |
+| OneHot | `"one_hot"` |
+| SOS1 | `"sos1"` |
+
+```python
+solution.constraints_df()                  # regular (default)
+solution.constraints_df(kind="indicator")  # indicator
+sample_set.constraints_df(kind="one_hot")  # one-hot
+```
+
+The DataFrame is indexed by the kind-qualified id column (`regular_constraint_id`, `indicator_constraint_id`, `one_hot_constraint_id`, `sos1_constraint_id`) — accidental cross-id-space `df.join()` mistakes surface in `df.head()` and friends.
 
 The Indicator DataFrame includes an `indicator_active` column that disambiguates "the indicator was OFF (constraint trivially satisfied)" from "the indicator was ON and the constraint was actually satisfied". Indicator constraints do not carry a dual variable — a dual value is not well-defined for a conditional constraint — so `dual_variable` is omitted.
 
-### removed_reasons_df separation
+### Removed reason columns via `include=`
 
-For regular constraints, `removed_reason` is no longer a column of {meth}`~ommx.v1.Solution.constraints_df`. It lives in {meth}`~ommx.v1.Solution.removed_reasons_df` as a separate table, which you can join as needed:
+`removed_reason` is no longer a default column of {meth}`~ommx.v1.Solution.constraints_df`. Pass `"removed_reason"` in `include=` to fold the reason name and the `removed_reason.{key}` parameter columns back in (rows whose constraint was not removed before evaluation get NA in those columns):
 
 ```python
-df = solution.constraints_df().join(solution.removed_reasons_df())
+df = solution.constraints_df(
+    include=("metadata", "parameters", "removed_reason"),
+)
 ```
 
-The same split applies to Indicator, OneHot, and SOS1: each has its own `indicator_removed_reasons_df` / `one_hot_removed_reasons_df` / `sos1_removed_reasons_df` on both {class}`~ommx.v1.Solution` and {class}`~ommx.v1.SampleSet`.
+The same applies to Indicator, OneHot, and SOS1: pass the corresponding `kind=` together with `"removed_reason"` in `include=`. The long-format {meth}`~ommx.v1.Solution.constraint_removed_reasons_df` sidecar (also `kind=`-dispatched) remains the right surface when you want one row per (constraint id, parameter key) pair for joins or aggregation.
 
 ## Relax / Restore
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -137,7 +137,7 @@ Instance.from_components(..., constraints={5: c}, ...)
 
 これに伴い旧 API である `ConstraintHints` / `OneHot` / `Sos1` クラス、`Instance.constraint_hints` プロパティ、PySCIPOpt Adapter の `use_sos1` フラグは削除されています。
 
-### ⚠ `removed_reason` カラムを `include=` でゲート ([#796](https://github.com/Jij-Inc/ommx/pull/796))
+### ⚠ `removed_reason` カラムを `include=` でゲート ([#796](https://github.com/Jij-Inc/ommx/pull/796), [#847](https://github.com/Jij-Inc/ommx/pull/847))
 
 v2.5.1 までは {meth}`Solution.constraints_df <ommx.v1.Solution.constraints_df>` に `removed_reason` カラムが常に含まれていましたが、v3.0.0a4 では `include=` の `"removed_reason"` フラグでゲートします（reason 名と `removed_reason.{key}` パラメータカラムをまとめて制御するユニットフラグ）。評価前に削除されていなかった行はそれらのカラムが NA になります。
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -127,7 +127,7 @@ Instance.from_components(..., constraints={5: c}, ...)
 
 ### 🆕 特殊制約型の整備 ([#789](https://github.com/Jij-Inc/ommx/pull/789), [#790](https://github.com/Jij-Inc/ommx/pull/790), [#795](https://github.com/Jij-Inc/ommx/pull/795), [#796](https://github.com/Jij-Inc/ommx/pull/796), [#798](https://github.com/Jij-Inc/ommx/pull/798))
 
-通常制約に加えて以下の3種類の特殊制約を、すべて第一級の制約型として `Instance.from_components` に `indicator_constraints=` / `one_hot_constraints=` / `sos1_constraints=` として渡せるようになりました。{class}`~ommx.v1.Solution` / {class}`~ommx.v1.SampleSet` にも対応する DataFrame (`*_constraints_df`) が提供されます。
+通常制約に加えて以下の3種類の特殊制約を、すべて第一級の制約型として `Instance.from_components` に `indicator_constraints=` / `one_hot_constraints=` / `sos1_constraints=` として渡せるようになりました。{class}`~ommx.v1.Solution` / {class}`~ommx.v1.SampleSet` でも、{meth}`~ommx.v1.Solution.constraints_df` を `kind=` で切り替えるだけで参照できます。
 
 - {class}`~ommx.v1.IndicatorConstraint` — バイナリ変数による条件付き制約 (新規追加)
 - {class}`~ommx.v1.OneHotConstraint` — 従来 `ConstraintHints.OneHot` として扱われていた one-hot 制約
@@ -137,19 +137,21 @@ Instance.from_components(..., constraints={5: c}, ...)
 
 これに伴い旧 API である `ConstraintHints` / `OneHot` / `Sos1` クラス、`Instance.constraint_hints` プロパティ、PySCIPOpt Adapter の `use_sos1` フラグは削除されています。
 
-### ⚠ `removed_reason` カラムを別テーブルに分離 ([#796](https://github.com/Jij-Inc/ommx/pull/796))
+### ⚠ `removed_reason` カラムを `include=` でゲート ([#796](https://github.com/Jij-Inc/ommx/pull/796))
 
-v2.5.1 までは {meth}`Solution.constraints_df <ommx.v1.Solution.constraints_df>` に `removed_reason` カラムが含まれていましたが、v3.0.0a2 ではこれを {meth}`Solution.removed_reasons_df <ommx.v1.Solution.removed_reasons_df>` という別テーブルに分離しました。従来の形が必要な場合は join してください。同じ変更が {class}`~ommx.v1.SampleSet` にも適用されています。
+v2.5.1 までは {meth}`Solution.constraints_df <ommx.v1.Solution.constraints_df>` に `removed_reason` カラムが常に含まれていましたが、v3.0.0a4 では `include=` の `"removed_reason"` フラグでゲートします（reason 名と `removed_reason.{key}` パラメータカラムをまとめて制御するユニットフラグ）。評価前に削除されていなかった行はそれらのカラムが NA になります。
 
 ```python
 # Before (2.5.1)
 df = solution.constraints_df  # 'removed_reason' カラムを含む
 
-# After (3.0.0a3 — `*_df` はメソッドになりました)
-df = solution.constraints_df().join(solution.removed_reasons_df())
+# After (3.0.0a4 — `*_df` はメソッドになりました)
+df = solution.constraints_df()  # removed_reason カラムなし
+df = solution.constraints_df(include=("metadata", "parameters", "removed_reason"))
+# ↳ removed_reason / removed_reason.{key} が追加（active 行は NA）
 ```
 
-Indicator / OneHot / SOS1 それぞれに対応する `*_removed_reasons_df` も提供されています。
+`kind=` / `include=` の形は {class}`~ommx.v1.SampleSet` でも同じです。{class}`~ommx.v1.Instance` / {class}`~ommx.v1.ParametricInstance` では、`removed=True` を渡すと active と removed の両方が同じ DataFrame に並び、`"removed_reason"` が自動的に有効化されるので、active 行と removed 行を見分けることができます。
 
 ### 🆕 Adapter Capability モデル ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#805](https://github.com/Jij-Inc/ommx/pull/805), [#810](https://github.com/Jij-Inc/ommx/pull/810), [#811](https://github.com/Jij-Inc/ommx/pull/811), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 

--- a/docs/ja/user_guide/capability_model.md
+++ b/docs/ja/user_guide/capability_model.md
@@ -156,9 +156,11 @@ $$
 
 | 元の制約型 | 除去先 | DataFrame |
 |---|---|---|
-| OneHotConstraint | {attr}`~ommx.v1.Instance.removed_one_hot_constraints` | {meth}`~ommx.v1.Instance.removed_one_hot_constraints_df` |
-| Sos1Constraint | {attr}`~ommx.v1.Instance.removed_sos1_constraints` | {meth}`~ommx.v1.Instance.removed_sos1_constraints_df` |
-| IndicatorConstraint | {attr}`~ommx.v1.Instance.removed_indicator_constraints` | {meth}`~ommx.v1.Instance.removed_indicator_constraints_df` |
+| OneHotConstraint | {attr}`~ommx.v1.Instance.removed_one_hot_constraints` | `instance.constraints_df(kind="one_hot", removed=True)` |
+| Sos1Constraint | {attr}`~ommx.v1.Instance.removed_sos1_constraints` | `instance.constraints_df(kind="sos1", removed=True)` |
+| IndicatorConstraint | {attr}`~ommx.v1.Instance.removed_indicator_constraints` | `instance.constraints_df(kind="indicator", removed=True)` |
+
+`removed=True` を付けると、active と removed が同じ DataFrame に並び、`removed_reason` / `removed_reason.{key}` カラムが自動的に追加されるので、active 行と removed 行を見分けることができます。
 
 それぞれのエントリ（{class}`~ommx.v1.RemovedOneHotConstraint` / {class}`~ommx.v1.RemovedSos1Constraint` / {class}`~ommx.v1.RemovedIndicatorConstraint`）には `removed_reason` 文字列（例: `"ommx.Instance.convert_one_hot_to_constraint"`）が記録され、`removed_reason_parameters` に変換で新しく生成された通常制約の ID が格納されます。ID のキー名と形式は制約型ごとに異なります:
 
@@ -191,4 +193,4 @@ for cid, c in instance2.constraints.items():
 | Adapter でサポート機能を宣言する | `ADDITIONAL_CAPABILITIES` クラス属性 |
 | 未サポートの特殊制約を一括で通常制約に変換する | {meth}`Instance.reduce_capabilities <ommx.v1.Instance.reduce_capabilities>` |
 | 個別に通常制約に変換する | `convert_*_to_constraint(s)` / `convert_all_*_to_constraints` |
-| 変換履歴を確認する | `Instance.removed_*_constraints(_df)` / `Solution.*_removed_reasons_df` |
+| 変換履歴を確認する | `instance.constraints_df(kind=..., removed=True)` / `solution.constraints_df(kind=..., include=("...","removed_reason"))` |

--- a/docs/ja/user_guide/special_constraints.md
+++ b/docs/ja/user_guide/special_constraints.md
@@ -176,26 +176,36 @@ assert set(instance_mix.sos1_constraints.keys()) == {1}
 
 ## 評価結果の参照
 
-インスタンスを解いて得られた {class}`~ommx.v1.Solution` や {class}`~ommx.v1.SampleSet` は、通常制約と同様に特殊制約それぞれに対する DataFrame アクセサを提供します。
+インスタンスを解いて得られた {class}`~ommx.v1.Solution` や {class}`~ommx.v1.SampleSet` は、共通の {meth}`~ommx.v1.Solution.constraints_df` を `kind=` で切り替えて使います。
 
-| 制約型 | アクセサ（Solution） |
+| 制約型 | `kind=` の値 |
 |---|---|
-| 通常制約 | {meth}`~ommx.v1.Solution.constraints_df` |
-| Indicator | {meth}`~ommx.v1.Solution.indicator_constraints_df` |
-| OneHot | {meth}`~ommx.v1.Solution.one_hot_constraints_df` |
-| SOS1 | {meth}`~ommx.v1.Solution.sos1_constraints_df` |
+| 通常制約 | `"regular"`（デフォルト） |
+| Indicator | `"indicator"` |
+| OneHot | `"one_hot"` |
+| SOS1 | `"sos1"` |
+
+```python
+solution.constraints_df()                  # regular（デフォルト）
+solution.constraints_df(kind="indicator")  # Indicator
+sample_set.constraints_df(kind="one_hot")  # OneHot
+```
+
+DataFrame の index 名は kind ごとに qualified（`regular_constraint_id` / `indicator_constraint_id` / `one_hot_constraint_id` / `sos1_constraint_id`）になっており、別 ID 空間どうしを誤って `df.join()` した場合に `df.head()` 等で気づきやすくなっています。
 
 Indicator 制約の DataFrame には、`indicator_active` というカラムが含まれます。これにより「インジケータが OFF だった（制約は自明に満たされた）」ケースと「インジケータが ON で制約が本当に満たされた」ケースを区別できます。なお、Indicator 制約には双対変数の値は定義されない（条件付き制約に対する双対値は一般に well-defined ではない）ため、`dual_variable` は含まれません。
 
-### removed_reasons_df の分離
+### `include=` で removed_reason カラムを追加する
 
-通常制約の `removed_reason` は {meth}`~ommx.v1.Solution.constraints_df` のカラムとしては持たず、{meth}`~ommx.v1.Solution.removed_reasons_df` という別テーブルとして提供されます。必要なら join して使います。
+`removed_reason` は {meth}`~ommx.v1.Solution.constraints_df` のデフォルトカラムには含まれません。`include=` に `"removed_reason"` を渡すと、reason 名と `removed_reason.{key}` パラメータカラムがまとめて追加されます（評価前に削除された制約の行のみ値が入り、それ以外の行は NA）。
 
 ```python
-df = solution.constraints_df().join(solution.removed_reasons_df())
+df = solution.constraints_df(
+    include=("metadata", "parameters", "removed_reason"),
+)
 ```
 
-Indicator・OneHot・SOS1 についても、それぞれ対応する `indicator_removed_reasons_df` / `one_hot_removed_reasons_df` / `sos1_removed_reasons_df` が {class}`~ommx.v1.Solution` および {class}`~ommx.v1.SampleSet` で利用できます。
+Indicator / OneHot / SOS1 でも同じく、対応する `kind=` と一緒に `"removed_reason"` を `include=` に渡せば取得できます。long-format で（id, parameter_key）の組合せごとに 1 行を得たい場合は、`kind=` で切り替えられる {meth}`~ommx.v1.Solution.constraint_removed_reasons_df` サイドカーを引き続き利用できます。
 
 ## Relax / Restore
 

--- a/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
@@ -1,0 +1,141 @@
+# serializer version: 1
+# name: test_instance_constraints_df_include_empty
+  '''
+                        equality    type   used_ids
+  regular_constraint_id                            
+  10                          =0  Linear  {0, 1, 2}
+  '''
+# ---
+# name: test_instance_constraints_df_include_metadata_only
+  '''
+                        equality    type   used_ids     name subscripts description
+  regular_constraint_id                                                            
+  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row
+  '''
+# ---
+# name: test_instance_constraints_df_include_parameters_only
+  '''
+                        equality    type   used_ids
+  regular_constraint_id                            
+  10                          =0  Linear  {0, 1, 2}
+  '''
+# ---
+# name: test_instance_constraints_df_kind[indicator]
+  '''
+                           indicator_variable_id equality    type   used_ids  name subscripts description
+  indicator_constraint_id                                                                                
+  20                                           0       =0  Linear  {0, 1, 2}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_instance_constraints_df_kind[one_hot]
+  '''
+                         variables  num_variables   used_ids  name subscripts description
+  one_hot_constraint_id                                                                  
+  30                     {0, 1, 2}              3  {0, 1, 2}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_instance_constraints_df_kind[regular]
+  '''
+                        equality    type   used_ids     name subscripts description
+  regular_constraint_id                                                            
+  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row
+  '''
+# ---
+# name: test_instance_constraints_df_kind[sos1]
+  '''
+                      variables  num_variables   used_ids  name subscripts description
+  sos1_constraint_id                                                                  
+  40                  {0, 1, 2}              3  {0, 1, 2}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_instance_constraints_df_removed_default_excludes_removed
+  '''
+  Empty DataFrame
+  Columns: []
+  Index: []
+  '''
+# ---
+# name: test_instance_constraints_df_removed_true_includes_both
+  '''
+                        equality    type   used_ids     name subscripts description removed_reason removed_reason.phase
+  regular_constraint_id                                                                                                
+  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row   manual_relax              warm-up
+  '''
+# ---
+# name: test_instance_constraints_df_removed_true_no_metadata
+  '''
+                        equality    type   used_ids removed_reason removed_reason.phase
+  regular_constraint_id                                                                
+  10                          =0  Linear  {0, 1, 2}   manual_relax              warm-up
+  '''
+# ---
+# name: test_parametric_instance_constraints_df_default
+  '''
+                        equality       type       used_ids  name subscripts description
+  regular_constraint_id                                                                
+  10                          =0  Quadratic  {0, 1, 2, 99}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_sample_set_constraints_df_kind[indicator]
+  '''
+                           indicator_variable_id equality   used_ids  name subscripts description  value.0  feasible.0  indicator_active.0  value.1  feasible.1  indicator_active.1
+  indicator_constraint_id                                                                                                                                                          
+  20                                           0       =0  {0, 1, 2}  <NA>         []        <NA>      0.0        True               False      0.0        True                True
+  '''
+# ---
+# name: test_sample_set_constraints_df_kind[one_hot]
+  '''
+                          used_ids  name subscripts description  feasible.0  active_variable.0  feasible.1 active_variable.1
+  one_hot_constraint_id                                                                                                     
+  30                     {0, 1, 2}  <NA>         []        <NA>        True                  1       False              <NA>
+  '''
+# ---
+# name: test_sample_set_constraints_df_kind[regular]
+  '''
+                        equality   used_ids     name subscripts description  value.0  feasible.0  value.1  feasible.1
+  regular_constraint_id                                                                                              
+  10                          =0  {0, 1, 2}  balance     [0, 1]  demand row      0.0        True      1.0       False
+  '''
+# ---
+# name: test_sample_set_constraints_df_kind[sos1]
+  '''
+                       used_ids  name subscripts description  feasible.0  active_variable.0  feasible.1 active_variable.1
+  sos1_constraint_id                                                                                                     
+  40                  {0, 1, 2}  <NA>         []        <NA>        True                  1       False              <NA>
+  '''
+# ---
+# name: test_solution_constraints_df_kind[indicator]
+  '''
+                           indicator_variable_id equality  value  indicator_active   used_ids  name subscripts description
+  indicator_constraint_id                                                                                                 
+  20                                           0       =0    0.0             False  {0, 1, 2}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_solution_constraints_df_kind[one_hot]
+  '''
+                         feasible  active_variable   used_ids  name subscripts description
+  one_hot_constraint_id                                                                   
+  30                         True                1  {0, 1, 2}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_solution_constraints_df_kind[regular]
+  '''
+                        equality  value   used_ids     name subscripts description dual_variable
+  regular_constraint_id                                                                         
+  10                          =0    0.0  {0, 1, 2}  balance     [0, 1]  demand row          <NA>
+  '''
+# ---
+# name: test_solution_constraints_df_kind[sos1]
+  '''
+                      feasible  active_variable   used_ids  name subscripts description
+  sos1_constraint_id                                                                   
+  40                      True                1  {0, 1, 2}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_solution_constraints_df_removed_reason_include
+  '''
+                        equality  value   used_ids     name subscripts description dual_variable removed_reason removed_reason.phase
+  regular_constraint_id                                                                                                             
+  10                          =0    0.0  {0, 1, 2}  balance     [0, 1]  demand row          <NA>   manual_relax              warm-up
+  '''
+# ---

--- a/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
@@ -15,9 +15,9 @@
 # ---
 # name: test_instance_constraints_df_include_parameters_only
   '''
-                        equality    type   used_ids
-  regular_constraint_id                            
-  10                          =0  Linear  {0, 1, 2}
+                        equality    type   used_ids parameters.region
+  regular_constraint_id                                              
+  10                          =0  Linear  {0, 1, 2}           us-east
   '''
 # ---
 # name: test_instance_constraints_df_kind[indicator]
@@ -36,9 +36,9 @@
 # ---
 # name: test_instance_constraints_df_kind[regular]
   '''
-                        equality    type   used_ids     name subscripts description
-  regular_constraint_id                                                            
-  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row
+                        equality    type   used_ids     name subscripts description parameters.region
+  regular_constraint_id                                                                              
+  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row           us-east
   '''
 # ---
 # name: test_instance_constraints_df_kind[sos1]
@@ -81,9 +81,9 @@
 # ---
 # name: test_instance_constraints_df_removed_true_includes_both
   '''
-                        equality    type   used_ids     name subscripts description removed_reason removed_reason.phase
-  regular_constraint_id                                                                                                
-  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row   manual_relax              warm-up
+                        equality    type   used_ids     name subscripts description parameters.region removed_reason removed_reason.phase
+  regular_constraint_id                                                                                                                  
+  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row           us-east   manual_relax              warm-up
   '''
 # ---
 # name: test_instance_constraints_df_removed_true_no_metadata
@@ -137,9 +137,9 @@
 # ---
 # name: test_sample_set_constraints_df_kind[regular]
   '''
-                        equality   used_ids     name subscripts description  value.0  feasible.0  value.1  feasible.1
-  regular_constraint_id                                                                                              
-  10                          =0  {0, 1, 2}  balance     [0, 1]  demand row      0.0        True      1.0       False
+                        equality   used_ids     name subscripts description parameters.region  value.0  feasible.0  value.1  feasible.1
+  regular_constraint_id                                                                                                                
+  10                          =0  {0, 1, 2}  balance     [0, 1]  demand row           us-east      0.0        True      1.0       False
   '''
 # ---
 # name: test_sample_set_constraints_df_kind[sos1]
@@ -165,9 +165,9 @@
 # ---
 # name: test_solution_constraints_df_kind[regular]
   '''
-                        equality  value   used_ids     name subscripts description dual_variable
-  regular_constraint_id                                                                         
-  10                          =0    0.0  {0, 1, 2}  balance     [0, 1]  demand row          <NA>
+                        equality  value   used_ids     name subscripts description parameters.region dual_variable
+  regular_constraint_id                                                                                           
+  10                          =0    0.0  {0, 1, 2}  balance     [0, 1]  demand row           us-east          <NA>
   '''
 # ---
 # name: test_solution_constraints_df_kind[sos1]

--- a/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
@@ -55,6 +55,22 @@
   Index: []
   '''
 # ---
+# name: test_instance_constraints_df_removed_reason_active_only_keeps_column
+  '''
+                        equality    type   used_ids     name subscripts description removed_reason
+  regular_constraint_id                                                                           
+  10                          =0  Linear  {0, 1, 2}  balance     [0, 1]  demand row           <NA>
+  '''
+# ---
+# name: test_instance_constraints_df_removed_true_id_sorted
+  '''
+                        equality    type used_ids  name subscripts description removed_reason
+  regular_constraint_id                                                                      
+  5                           =0  Linear   {0, 1}  <NA>         []        <NA>           <NA>
+  20                          =0  Linear   {0, 2}  <NA>         []        <NA>   relax_middle
+  30                          =0  Linear   {1, 2}  <NA>         []        <NA>           <NA>
+  '''
+# ---
 # name: test_instance_constraints_df_removed_true_includes_both
   '''
                         equality    type   used_ids     name subscripts description removed_reason removed_reason.phase
@@ -74,6 +90,27 @@
                         equality       type       used_ids  name subscripts description
   regular_constraint_id                                                                
   10                          =0  Quadratic  {0, 1, 2, 99}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_parametric_instance_constraints_df_special_kinds_empty[indicator]
+  '''
+  Empty DataFrame
+  Columns: []
+  Index: []
+  '''
+# ---
+# name: test_parametric_instance_constraints_df_special_kinds_empty[one_hot]
+  '''
+  Empty DataFrame
+  Columns: []
+  Index: []
+  '''
+# ---
+# name: test_parametric_instance_constraints_df_special_kinds_empty[sos1]
+  '''
+  Empty DataFrame
+  Columns: []
+  Index: []
   '''
 # ---
 # name: test_sample_set_constraints_df_kind[indicator]
@@ -137,5 +174,12 @@
                         equality  value   used_ids     name subscripts description dual_variable removed_reason removed_reason.phase
   regular_constraint_id                                                                                                             
   10                          =0    0.0  {0, 1, 2}  balance     [0, 1]  demand row          <NA>   manual_relax              warm-up
+  '''
+# ---
+# name: test_solution_constraints_df_removed_reason_no_removals_keeps_column
+  '''
+                        equality  value   used_ids     name subscripts description dual_variable removed_reason
+  regular_constraint_id                                                                                        
+  10                          =0    0.0  {0, 1, 2}  balance     [0, 1]  demand row          <NA>           <NA>
   '''
 # ---

--- a/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
@@ -48,6 +48,14 @@
   40                  {0, 1, 2}              3  {0, 1, 2}  <NA>         []        <NA>
   '''
 # ---
+# name: test_instance_constraints_df_one_hot_removed_true
+  '''
+                        variables  num_variables used_ids  name subscripts description                               removed_reason removed_reason.constraint_id
+  one_hot_constraint_id                                                                                                                                         
+  5                        {0, 1}              2   {0, 1}  <NA>         []        <NA>                                         <NA>                         <NA>
+  7                        {1, 2}              2   {1, 2}  <NA>         []        <NA>  ommx.Instance.convert_one_hot_to_constraint                            0
+  '''
+# ---
 # name: test_instance_constraints_df_removed_default_excludes_removed
   '''
   Empty DataFrame

--- a/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_constraints_df.ambr
@@ -92,21 +92,21 @@
   10                          =0  Quadratic  {0, 1, 2, 99}  <NA>         []        <NA>
   '''
 # ---
-# name: test_parametric_instance_constraints_df_special_kinds_empty[indicator]
+# name: test_parametric_instance_constraints_df_special_kinds_empty[indicator-indicator_constraint_id]
   '''
   Empty DataFrame
   Columns: []
   Index: []
   '''
 # ---
-# name: test_parametric_instance_constraints_df_special_kinds_empty[one_hot]
+# name: test_parametric_instance_constraints_df_special_kinds_empty[one_hot-one_hot_constraint_id]
   '''
   Empty DataFrame
   Columns: []
   Index: []
   '''
 # ---
-# name: test_parametric_instance_constraints_df_special_kinds_empty[sos1]
+# name: test_parametric_instance_constraints_df_special_kinds_empty[sos1-sos1_constraint_id]
   '''
   Empty DataFrame
   Columns: []

--- a/python/ommx-tests/tests/__snapshots__/test_dataframe_include.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_dataframe_include.ambr
@@ -1,16 +1,16 @@
 # serializer version: 1
 # name: test_constraints_df_default
   '''
-     equality    type   used_ids     name subscripts description
-  id                                                            
-  10       =0  Linear  {0, 1, 2}  balance         []        <NA>
+                        equality    type   used_ids     name subscripts description
+  regular_constraint_id                                                            
+  10                          =0  Linear  {0, 1, 2}  balance         []        <NA>
   '''
 # ---
 # name: test_constraints_df_include_empty
   '''
-     equality    type   used_ids
-  id                            
-  10       =0  Linear  {0, 1, 2}
+                        equality    type   used_ids
+  regular_constraint_id                            
+  10                          =0  Linear  {0, 1, 2}
   '''
 # ---
 # name: test_decision_variables_df_default

--- a/python/ommx-tests/tests/__snapshots__/test_dataframe_include.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_dataframe_include.ambr
@@ -15,11 +15,11 @@
 # ---
 # name: test_decision_variables_df_default
   '''
-        kind  lower  upper name subscripts description substituted_value parameters.role parameters.shard
+        kind  lower  upper name subscripts description parameters.role parameters.shard substituted_value
   id                                                                                                     
-  0   Binary    0.0    1.0   x0        [0]  variable 0              <NA>         primary                0
-  1   Binary    0.0    1.0   x1        [1]  variable 1              <NA>         primary                1
-  2   Binary    0.0    1.0   x2        [2]  variable 2              <NA>         primary                2
+  0   Binary    0.0    1.0   x0        [0]  variable 0         primary                0              <NA>
+  1   Binary    0.0    1.0   x1        [1]  variable 1         primary                1              <NA>
+  2   Binary    0.0    1.0   x2        [2]  variable 2         primary                2              <NA>
   '''
 # ---
 # name: test_decision_variables_df_include_empty
@@ -42,11 +42,11 @@
 # ---
 # name: test_decision_variables_df_include_parameters_only
   '''
-        kind  lower  upper substituted_value parameters.role parameters.shard
+        kind  lower  upper parameters.role parameters.shard substituted_value
   id                                                                         
-  0   Binary    0.0    1.0              <NA>         primary                0
-  1   Binary    0.0    1.0              <NA>         primary                1
-  2   Binary    0.0    1.0              <NA>         primary                2
+  0   Binary    0.0    1.0         primary                0              <NA>
+  1   Binary    0.0    1.0         primary                1              <NA>
+  2   Binary    0.0    1.0         primary                2              <NA>
   '''
 # ---
 # name: test_sample_set_decision_variables_df_include_empty

--- a/python/ommx-tests/tests/__snapshots__/test_indicator_constraint.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_indicator_constraint.ambr
@@ -1,0 +1,8 @@
+# serializer version: 1
+# name: test_removed_indicator_constraints_df_surfaces_reason_and_ids
+  '''
+                           indicator_variable_id equality    type used_ids  name subscripts description                                 removed_reason removed_reason.constraint_ids
+  indicator_constraint_id                                                                                                                                                           
+  7                                            1       =0  Linear   {0, 1}  <NA>         []        <NA>  ommx.Instance.convert_indicator_to_constraint                           0,1
+  '''
+# ---

--- a/python/ommx-tests/tests/__snapshots__/test_one_hot_sos1_constraints.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_one_hot_sos1_constraints.ambr
@@ -1,0 +1,71 @@
+# serializer version: 1
+# name: test_sample_set_one_hot_constraints_df_dynamic_columns
+  '''
+                          used_ids  name subscripts description  feasible.0  active_variable.0  feasible.1 active_variable.1
+  one_hot_constraint_id                                                                                                     
+  10                     {1, 2, 3}  <NA>         []        <NA>        True                  1       False              <NA>
+  '''
+# ---
+# name: test_sample_set_one_hot_removed_reasons_df_after_conversion
+  '''
+                          used_ids  name subscripts description  feasible.0  active_variable.0                               removed_reason removed_reason.constraint_id
+  one_hot_constraint_id                                                                                                                                                 
+  7                      {0, 1, 2}  <NA>         []        <NA>        True                  0  ommx.Instance.convert_one_hot_to_constraint                            0
+  '''
+# ---
+# name: test_sample_set_sos1_constraints_df_dynamic_columns
+  '''
+                       used_ids  name subscripts description  feasible.0  active_variable.0  feasible.1 active_variable.1  feasible.2 active_variable.2
+  sos1_constraint_id                                                                                                                                   
+  20                  {1, 2, 3}  <NA>         []        <NA>        True                  2        True              <NA>       False              <NA>
+  '''
+# ---
+# name: test_solution_one_hot_constraints_df_feasible
+  '''
+                         feasible  active_variable   used_ids  name subscripts description
+  one_hot_constraint_id                                                                   
+  10                         True                2  {1, 2, 3}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_solution_one_hot_constraints_df_infeasible
+  '''
+                         feasible active_variable   used_ids  name subscripts description
+  one_hot_constraint_id                                                                  
+  10                        False            <NA>  {1, 2, 3}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_solution_one_hot_removed_reasons_df_after_conversion
+  '''
+                         feasible  active_variable   used_ids  name subscripts description                               removed_reason removed_reason.constraint_id
+  one_hot_constraint_id                                                                                                                                             
+  7                          True                0  {0, 1, 2}  <NA>         []        <NA>  ommx.Instance.convert_one_hot_to_constraint                            0
+  '''
+# ---
+# name: test_solution_sos1_constraints_df_all_zero
+  '''
+                      feasible active_variable   used_ids  name subscripts description
+  sos1_constraint_id                                                                  
+  20                      True            <NA>  {1, 2, 3}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_solution_sos1_constraints_df_one_active
+  '''
+                      feasible  active_variable   used_ids  name subscripts description
+  sos1_constraint_id                                                                   
+  20                      True                2  {1, 2, 3}  <NA>         []        <NA>
+  '''
+# ---
+# name: test_solution_sos1_removed_reasons_df_after_conversion
+  '''
+                      feasible  active_variable   used_ids  name subscripts description                             removed_reason removed_reason.constraint_ids
+  sos1_constraint_id                                                                                                                                            
+  7                       True                0  {0, 1, 2}  <NA>         []        <NA>  ommx.Instance.convert_sos1_to_constraints                             0
+  '''
+# ---
+# name: test_sos1_constraints_df_roundtrips_removed_metadata
+  '''
+                      variables  num_variables   used_ids  name subscripts description                             removed_reason removed_reason.constraint_ids
+  sos1_constraint_id                                                                                                                                           
+  7                   {0, 1, 2}              3  {0, 1, 2}  <NA>         []        <NA>  ommx.Instance.convert_sos1_to_constraints                             0
+  '''
+# ---

--- a/python/ommx-tests/tests/test_constraints_df.py
+++ b/python/ommx-tests/tests/test_constraints_df.py
@@ -184,6 +184,45 @@ def test_instance_constraints_df_removed_true_no_metadata(snapshot):
     )
 
 
+def test_instance_constraints_df_removed_true_id_sorted(snapshot):
+    """`removed=True` returns a globally id-sorted union of active and
+    removed rows. With active ids {5, 30} and removed id 20 in the
+    middle, the output is [5, 20, 30] — not [5, 30, 20] (active first
+    then removed). Regression guard for the merge-sort path; the
+    naive `chain(active, removed)` would order rows by section
+    rather than by id."""
+    x = [DecisionVariable.binary(i) for i in range(3)]
+    inst = Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={
+            5: x[0] + x[1] == 1,
+            30: x[1] + x[2] == 1,
+            20: x[0] + x[2] == 1,
+        },
+        sense=Instance.MAXIMIZE,
+    )
+    inst.relax_constraint(20, "relax_middle")
+    df = inst.constraints_df(kind="regular", removed=True)
+    assert list(df.index) == [5, 20, 30]
+    assert _df_snap(df) == snapshot
+
+
+def test_instance_constraints_df_removed_reason_active_only_keeps_column(
+    snapshot,
+):
+    """Edge case: `include=("removed_reason",)` on an active-only view
+    (no `removed=True`, no actually-removed constraints) must still
+    surface the `removed_reason` column with NA values. Regression
+    guard against the column silently disappearing when no row in
+    the view carries a reason."""
+    df = _instance_all_kinds().constraints_df(
+        kind="regular", include=["metadata", "removed_reason"]
+    )
+    assert "removed_reason" in df.columns
+    assert _df_snap(df) == snapshot
+
+
 # ---------------------------------------------------------------------------
 # ParametricInstance.constraints_df
 # ---------------------------------------------------------------------------
@@ -192,6 +231,19 @@ def test_instance_constraints_df_removed_true_no_metadata(snapshot):
 def test_parametric_instance_constraints_df_default(snapshot):
     """`ParametricInstance.constraints_df()` uses the same wide shape as Instance."""
     assert _df_snap(_parametric_instance().constraints_df()) == snapshot
+
+
+@pytest.mark.parametrize("kind", ["indicator", "one_hot", "sos1"])
+def test_parametric_instance_constraints_df_special_kinds_empty(snapshot, kind):
+    """Python `ParametricInstance.from_components` only accepts regular
+    constraints, so the special-kind collections are always empty —
+    but the dispatch path must still return a DataFrame with the
+    correct kind-qualified index name.
+
+    Regression guard for the Wave 2 macro dispatch on the three
+    special-kind ParametricInstance accessors that the public Python
+    surface cannot populate."""
+    assert _df_snap(_parametric_instance().constraints_df(kind=kind)) == snapshot
 
 
 # ---------------------------------------------------------------------------
@@ -223,6 +275,19 @@ def test_solution_constraints_df_removed_reason_include(snapshot):
         )
         == snapshot
     )
+
+
+def test_solution_constraints_df_removed_reason_no_removals_keeps_column(snapshot):
+    """`include=("removed_reason",)` on a Solution where no constraint
+    was removed before evaluation must still surface the
+    `removed_reason` column with NA values. Regression guard for the
+    column silently disappearing when no row in the view carries a
+    reason."""
+    df = _solution_basic().constraints_df(
+        kind="regular", include=["metadata", "removed_reason"]
+    )
+    assert "removed_reason" in df.columns
+    assert _df_snap(df) == snapshot
 
 
 # ---------------------------------------------------------------------------

--- a/python/ommx-tests/tests/test_constraints_df.py
+++ b/python/ommx-tests/tests/test_constraints_df.py
@@ -124,9 +124,11 @@ def test_instance_constraints_df_kind(snapshot, kind):
 
 
 def test_instance_constraints_df_unknown_kind():
-    """Unknown `kind=` raises ValueError."""
+    """Unknown `kind=` raises ValueError. The `Literal` annotation
+    catches the typo statically; the runtime check is a defense-in-
+    depth fallback for callers without a type checker."""
     with pytest.raises(ValueError, match="unknown constraint kind"):
-        _instance_all_kinds().constraints_df(kind="bogus")
+        _instance_all_kinds().constraints_df(kind="bogus")  # type: ignore[arg-type]
 
 
 def test_instance_constraints_df_unknown_include_flag():

--- a/python/ommx-tests/tests/test_constraints_df.py
+++ b/python/ommx-tests/tests/test_constraints_df.py
@@ -1,0 +1,243 @@
+"""Snapshot tests for the unified `constraints_df(kind=, include=, removed=)`
+method on Instance / ParametricInstance / Solution / SampleSet.
+
+Wave 2 of the v3-alpha pandas surface collapses 26 per-kind methods into
+4 unified `constraints_df` accessors. The `.ambr` snapshots are the
+authoritative description of the column / index schema for each host ×
+kind × include / removed combination — update via
+`pytest --snapshot-update` after a deliberate API change.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from ommx.v1 import (
+    Constraint,
+    DecisionVariable,
+    Equality,
+    IndicatorConstraint,
+    Instance,
+    OneHotConstraint,
+    Parameter,
+    ParametricInstance,
+    Sos1Constraint,
+)
+
+
+def _df_snap(df: pd.DataFrame) -> str:
+    """Deterministic, snapshot-friendly rendering of a DataFrame."""
+    return df.to_string(na_rep="<NA>")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _instance_all_kinds() -> Instance:
+    """Instance with one constraint of each kind, all carrying metadata."""
+    x = [
+        DecisionVariable.binary(0, name="x0"),
+        DecisionVariable.binary(1, name="x1"),
+        DecisionVariable.binary(2, name="x2"),
+    ]
+    c = (
+        (x[0] + x[1] + x[2] == 1)
+        .set_name("balance")
+        .set_subscripts([0, 1])
+        .set_description("demand row")
+        .set_parameters({"region": "us-east"})
+    )
+    assert isinstance(c, Constraint)
+    return Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={10: c},
+        indicator_constraints={
+            20: IndicatorConstraint(
+                indicator_variable=x[0],
+                function=x[1] + x[2] - 1,
+                equality=Equality.EqualToZero,
+            )
+        },
+        one_hot_constraints={30: OneHotConstraint(variables=[0, 1, 2])},
+        sos1_constraints={40: Sos1Constraint(variables=[0, 1, 2])},
+        sense=Instance.MAXIMIZE,
+    )
+
+
+def _instance_with_removed() -> Instance:
+    """Instance whose regular constraint at id=10 has been relaxed."""
+    inst = _instance_all_kinds()
+    inst.relax_constraint(10, "manual_relax", phase="warm-up")
+    return inst
+
+
+def _parametric_instance() -> ParametricInstance:
+    """ParametricInstance with one regular constraint that uses a parameter."""
+    x = [DecisionVariable.binary(i) for i in range(3)]
+    p = Parameter(99, name="p")
+    c = x[0] + x[1] + p * x[2] == 1
+    assert isinstance(c, Constraint)
+    return ParametricInstance.from_components(
+        sense=Instance.MAXIMIZE,
+        objective=sum(x),
+        decision_variables=x,
+        constraints={10: c},
+        parameters=[p],
+    )
+
+
+def _solution_basic():
+    """Solution from `_instance_all_kinds()` evaluated at a feasible point."""
+    inst = _instance_all_kinds()
+    return inst.evaluate({0: 0.0, 1: 1.0, 2: 0.0})
+
+
+def _solution_with_removed():
+    """Solution where the regular constraint at id=10 was relaxed before evaluation."""
+    inst = _instance_with_removed()
+    return inst.evaluate({0: 0.0, 1: 1.0, 2: 0.0})
+
+
+def _sample_set_basic():
+    """SampleSet with two samples spanning feasible / infeasible."""
+    inst = _instance_all_kinds()
+    return inst.evaluate_samples(
+        {
+            0: {0: 0.0, 1: 1.0, 2: 0.0},
+            1: {0: 1.0, 1: 1.0, 2: 0.0},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instance.constraints_df — kind dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["regular", "indicator", "one_hot", "sos1"])
+def test_instance_constraints_df_kind(snapshot, kind):
+    """Default `include=` (metadata + parameters); index is `{kind}_constraint_id`."""
+    assert _df_snap(_instance_all_kinds().constraints_df(kind=kind)) == snapshot
+
+
+def test_instance_constraints_df_unknown_kind():
+    """Unknown `kind=` raises ValueError."""
+    with pytest.raises(ValueError, match="unknown constraint kind"):
+        _instance_all_kinds().constraints_df(kind="bogus")
+
+
+def test_instance_constraints_df_unknown_include_flag():
+    """Unknown `include=` flag raises ValueError."""
+    with pytest.raises(ValueError, match="unknown include flag"):
+        _instance_all_kinds().constraints_df(include=["bogus"])
+
+
+# ---------------------------------------------------------------------------
+# Instance.constraints_df — include= matrix
+# ---------------------------------------------------------------------------
+
+
+def test_instance_constraints_df_include_empty(snapshot):
+    """`include=[]` strips metadata + parameters columns; only core columns remain."""
+    assert _df_snap(_instance_all_kinds().constraints_df(include=[])) == snapshot
+
+
+def test_instance_constraints_df_include_metadata_only(snapshot):
+    """`include=("metadata",)` keeps name/subscripts/description, drops parameters."""
+    assert (
+        _df_snap(_instance_all_kinds().constraints_df(include=["metadata"])) == snapshot
+    )
+
+
+def test_instance_constraints_df_include_parameters_only(snapshot):
+    """`include=("parameters",)` keeps parameters.{key}, drops name/subscripts/description."""
+    assert (
+        _df_snap(_instance_all_kinds().constraints_df(include=["parameters"]))
+        == snapshot
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instance.constraints_df — removed=
+# ---------------------------------------------------------------------------
+
+
+def test_instance_constraints_df_removed_default_excludes_removed(snapshot):
+    """Default `removed=False` returns active rows only — relaxed id=10 omitted."""
+    assert _df_snap(_instance_with_removed().constraints_df()) == snapshot
+
+
+def test_instance_constraints_df_removed_true_includes_both(snapshot):
+    """`removed=True` returns active + removed; auto-sets `removed_reason` columns."""
+    assert _df_snap(_instance_with_removed().constraints_df(removed=True)) == snapshot
+
+
+def test_instance_constraints_df_removed_true_no_metadata(snapshot):
+    """`removed=True` together with `include=[]` keeps removed_reason columns
+    (the `removed=True` flag overrides include= for `removed_reason`)."""
+    assert (
+        _df_snap(_instance_with_removed().constraints_df(include=[], removed=True))
+        == snapshot
+    )
+
+
+# ---------------------------------------------------------------------------
+# ParametricInstance.constraints_df
+# ---------------------------------------------------------------------------
+
+
+def test_parametric_instance_constraints_df_default(snapshot):
+    """`ParametricInstance.constraints_df()` uses the same wide shape as Instance."""
+    assert _df_snap(_parametric_instance().constraints_df()) == snapshot
+
+
+# ---------------------------------------------------------------------------
+# Solution.constraints_df
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["regular", "indicator", "one_hot", "sos1"])
+def test_solution_constraints_df_kind(snapshot, kind):
+    """`Solution.constraints_df(kind=...)` — evaluated stage core columns +
+    metadata. No `removed=` parameter at this stage."""
+    assert _df_snap(_solution_basic().constraints_df(kind=kind)) == snapshot
+
+
+def test_solution_constraints_df_no_removed_parameter():
+    """`Solution.constraints_df` does not accept `removed=`."""
+    with pytest.raises(TypeError):
+        _solution_basic().constraints_df(removed=True)  # type: ignore[call-arg]
+
+
+def test_solution_constraints_df_removed_reason_include(snapshot):
+    """Constraints removed before evaluation get `removed_reason` /
+    `removed_reason.{key}` columns when the flag is in `include=`."""
+    assert (
+        _df_snap(
+            _solution_with_removed().constraints_df(
+                include=["metadata", "removed_reason"]
+            )
+        )
+        == snapshot
+    )
+
+
+# ---------------------------------------------------------------------------
+# SampleSet.constraints_df
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["regular", "indicator", "one_hot", "sos1"])
+def test_sample_set_constraints_df_kind(snapshot, kind):
+    """`SampleSet.constraints_df(kind=...)` adds per-sample dynamic columns
+    (`value.{sid}`, `feasible.{sid}`, ...) on top of the core schema."""
+    assert _df_snap(_sample_set_basic().constraints_df(kind=kind)) == snapshot
+
+
+def test_sample_set_constraints_df_no_removed_parameter():
+    """`SampleSet.constraints_df` does not accept `removed=`."""
+    with pytest.raises(TypeError):
+        _sample_set_basic().constraints_df(removed=True)  # type: ignore[call-arg]

--- a/python/ommx-tests/tests/test_constraints_df.py
+++ b/python/ommx-tests/tests/test_constraints_df.py
@@ -233,17 +233,29 @@ def test_parametric_instance_constraints_df_default(snapshot):
     assert _df_snap(_parametric_instance().constraints_df()) == snapshot
 
 
-@pytest.mark.parametrize("kind", ["indicator", "one_hot", "sos1"])
-def test_parametric_instance_constraints_df_special_kinds_empty(snapshot, kind):
+@pytest.mark.parametrize(
+    "kind, expected_name",
+    [
+        ("indicator", "indicator_constraint_id"),
+        ("one_hot", "one_hot_constraint_id"),
+        ("sos1", "sos1_constraint_id"),
+    ],
+)
+def test_parametric_instance_constraints_df_special_kinds_empty(
+    snapshot, kind, expected_name
+):
     """Python `ParametricInstance.from_components` only accepts regular
-    constraints, so the special-kind collections are always empty —
-    but the dispatch path must still return a DataFrame with the
-    correct kind-qualified index name.
+    constraints, so the special-kind collections are always empty.
 
-    Regression guard for the Wave 2 macro dispatch on the three
-    special-kind ParametricInstance accessors that the public Python
-    surface cannot populate."""
-    assert _df_snap(_parametric_instance().constraints_df(kind=kind)) == snapshot
+    Empty DataFrames must still carry the kind-qualified index name —
+    `df.to_string()` happens to render `Index: []` without the name,
+    so the assertion on `df.index.name` is the load-bearing check.
+    Regression guard for the Wave 2 macro dispatch and for empty-df
+    handling in `raw_entries_to_dataframe`."""
+    df = _parametric_instance().constraints_df(kind=kind)
+    assert df.empty
+    assert df.index.name == expected_name
+    assert _df_snap(df) == snapshot
 
 
 # ---------------------------------------------------------------------------

--- a/python/ommx-tests/tests/test_constraints_df.py
+++ b/python/ommx-tests/tests/test_constraints_df.py
@@ -225,6 +225,30 @@ def test_instance_constraints_df_removed_reason_active_only_keeps_column(
     assert _df_snap(df) == snapshot
 
 
+def test_instance_constraints_df_one_hot_removed_true(snapshot):
+    """`removed=True` on `kind="one_hot"` exercises the merge-sort and
+    reason-column path on a special-kind constraint. The capability-
+    model docs advertise this surface for auditing OneHot →
+    regular-constraint conversion (see capability_model.md), so it
+    deserves its own snapshot anchor."""
+    x = [DecisionVariable.binary(i) for i in range(3)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={},
+        one_hot_constraints={
+            5: OneHotConstraint(variables=[0, 1]),
+            7: OneHotConstraint(variables=[1, 2]),
+        },
+        sense=Instance.MAXIMIZE,
+    )
+    instance.convert_one_hot_to_constraint(7)
+    df = instance.constraints_df(kind="one_hot", removed=True)
+    # Globally id-sorted: active id 5, then removed id 7.
+    assert list(df.index) == [5, 7]
+    assert _df_snap(df) == snapshot
+
+
 # ---------------------------------------------------------------------------
 # ParametricInstance.constraints_df
 # ---------------------------------------------------------------------------

--- a/python/ommx-tests/tests/test_dataframe_sidecars.py
+++ b/python/ommx-tests/tests/test_dataframe_sidecars.py
@@ -93,7 +93,7 @@ def test_constraint_parameters_df(snapshot):
 def test_unknown_kind_raises_value_error():
     instance = _instance_with_metadata()
     with pytest.raises(ValueError):
-        instance.constraint_metadata_df(kind="bogus")
+        instance.constraint_metadata_df(kind="bogus")  # type: ignore[arg-type]
 
 
 def test_indicator_kind_metadata_df(snapshot):

--- a/python/ommx-tests/tests/test_indicator_constraint.py
+++ b/python/ommx-tests/tests/test_indicator_constraint.py
@@ -1,5 +1,6 @@
 """Tests for IndicatorConstraint Big-M conversion to regular constraints."""
 
+import pandas as pd
 import pytest
 from ommx.v1 import (
     Instance,
@@ -7,6 +8,11 @@ from ommx.v1 import (
     IndicatorConstraint,
     Equality,
 )
+
+
+def _df_snap(df: pd.DataFrame) -> str:
+    """Deterministic, snapshot-friendly rendering of a DataFrame."""
+    return df.to_string(na_rep="<NA>")
 
 
 def _instance(ic: IndicatorConstraint, x_lower: float = 0.0, x_upper: float = 5.0):
@@ -142,9 +148,9 @@ def test_convert_all_is_atomic_on_error():
     assert instance.removed_indicator_constraints == {}
 
 
-def test_removed_indicator_constraints_df_surfaces_reason_and_ids():
-    """`removed_indicator_constraints_df` exposes the reason and comma-joined
-    new-constraint IDs."""
+def test_removed_indicator_constraints_df_surfaces_reason_and_ids(snapshot):
+    """`constraints_df(kind="indicator", removed=True)` surfaces the
+    reason and comma-joined new-constraint IDs on removed rows."""
     y = DecisionVariable.binary(1)
     ic = IndicatorConstraint(
         indicator_variable=y,
@@ -152,14 +158,5 @@ def test_removed_indicator_constraints_df_surfaces_reason_and_ids():
         equality=Equality.EqualToZero,
     )
     instance = _instance(ic)
-
-    new_ids = instance.convert_indicator_to_constraint(7)
-
-    df = instance.removed_indicator_constraints_df()
-    assert list(df.index) == [7]
-    assert (
-        df.loc[7, "removed_reason"] == "ommx.Instance.convert_indicator_to_constraint"
-    )
-    assert df.loc[7, "removed_reason.constraint_ids"] == ",".join(
-        str(i) for i in new_ids
-    )
+    instance.convert_indicator_to_constraint(7)
+    assert _df_snap(instance.constraints_df(kind="indicator", removed=True)) == snapshot

--- a/python/ommx-tests/tests/test_one_hot_sos1_constraints.py
+++ b/python/ommx-tests/tests/test_one_hot_sos1_constraints.py
@@ -1,7 +1,13 @@
 """Tests for OneHotConstraint and Sos1Constraint as first-class constraint types."""
 
+import pandas as pd
 import pytest
 from ommx.v1 import Instance, DecisionVariable, OneHotConstraint, Sos1Constraint
+
+
+def _df_snap(df: pd.DataFrame) -> str:
+    """Deterministic, snapshot-friendly rendering of a DataFrame."""
+    return df.to_string(na_rep="<NA>")
 
 
 def test_one_hot_constraint_from_components():
@@ -261,8 +267,9 @@ def test_convert_sos1_rejects_domain_excluding_zero():
     assert 10 in instance.sos1_constraints
 
 
-def test_sos1_constraints_df_roundtrips_removed_metadata():
-    """removed_sos1_constraints_df surfaces reason + constraint_ids parameter as columns."""
+def test_sos1_constraints_df_roundtrips_removed_metadata(snapshot):
+    """`constraints_df(kind="sos1", removed=True)` surfaces reason + constraint_ids
+    parameter as columns on removed rows. Active is empty after conversion."""
     x = [DecisionVariable.binary(i) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -271,20 +278,10 @@ def test_sos1_constraints_df_roundtrips_removed_metadata():
         sos1_constraints={7: Sos1Constraint(variables=[0, 1, 2])},
         sense=Instance.MINIMIZE,
     )
-    new_ids = instance.convert_sos1_to_constraints(7)
+    instance.convert_sos1_to_constraints(7)
 
-    active_df = instance.sos1_constraints_df()
-    assert active_df.empty
-
-    removed_df = instance.removed_sos1_constraints_df()
-    assert list(removed_df.index) == [7]
-    assert (
-        removed_df.loc[7, "removed_reason"]
-        == "ommx.Instance.convert_sos1_to_constraints"
-    )
-    assert removed_df.loc[7, "removed_reason.constraint_ids"] == ",".join(
-        str(i) for i in new_ids
-    )
+    assert instance.constraints_df(kind="sos1").empty
+    assert _df_snap(instance.constraints_df(kind="sos1", removed=True)) == snapshot
 
 
 def test_evaluate_with_sos1_infeasible():
@@ -310,12 +307,9 @@ def test_evaluate_with_sos1_infeasible():
     assert not solution.feasible
 
 
-def test_solution_one_hot_constraints_df_surfaces_active_variable():
-    """`Solution.one_hot_constraints_df` exposes feasibility and the active variable
-    ID for each one-hot constraint. Feasible case: active_variable is set. Infeasible:
-    active_variable is NA."""
-    import pandas as pd
-
+@pytest.fixture
+def _solution_one_hot_feasible():
+    """One-hot constraint with a feasible solution (active_variable=2)."""
     x = [DecisionVariable.binary(i) for i in range(1, 4)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -324,25 +318,45 @@ def test_solution_one_hot_constraints_df_surfaces_active_variable():
         one_hot_constraints={10: OneHotConstraint(variables=[1, 2, 3])},
         sense=Instance.MAXIMIZE,
     )
-
-    sol_feas = instance.evaluate({1: 0.0, 2: 1.0, 3: 0.0})
-    df_feas = sol_feas.one_hot_constraints_df()
-    assert list(df_feas.index) == [10]
-    assert df_feas.loc[10, "feasible"]
-    assert df_feas.loc[10, "active_variable"] == 2
-    assert df_feas.loc[10, "used_ids"] == {1, 2, 3}
-
-    sol_infeas = instance.evaluate({1: 1.0, 2: 1.0, 3: 0.0})
-    df_infeas = sol_infeas.one_hot_constraints_df()
-    assert not df_infeas.loc[10, "feasible"]
-    assert pd.isna(df_infeas.loc[10, "active_variable"])
+    return instance.evaluate({1: 0.0, 2: 1.0, 3: 0.0})
 
 
-def test_solution_sos1_constraints_df_surfaces_active_variable():
-    """`Solution.sos1_constraints_df` exposes feasibility and the active variable
-    ID. All-zero is feasible for SOS1 and active_variable is NA."""
-    import pandas as pd
+@pytest.fixture
+def _solution_one_hot_infeasible():
+    """One-hot constraint with an infeasible solution (active_variable=NA)."""
+    x = [DecisionVariable.binary(i) for i in range(1, 4)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={},
+        one_hot_constraints={10: OneHotConstraint(variables=[1, 2, 3])},
+        sense=Instance.MAXIMIZE,
+    )
+    return instance.evaluate({1: 1.0, 2: 1.0, 3: 0.0})
 
+
+def test_solution_one_hot_constraints_df_feasible(snapshot, _solution_one_hot_feasible):
+    """`Solution.constraints_df(kind="one_hot")` for feasible: feasible=True,
+    active_variable=2."""
+    assert (
+        _df_snap(_solution_one_hot_feasible.constraints_df(kind="one_hot")) == snapshot
+    )
+
+
+def test_solution_one_hot_constraints_df_infeasible(
+    snapshot, _solution_one_hot_infeasible
+):
+    """`Solution.constraints_df(kind="one_hot")` for infeasible: feasible=False,
+    active_variable=NA."""
+    assert (
+        _df_snap(_solution_one_hot_infeasible.constraints_df(kind="one_hot"))
+        == snapshot
+    )
+
+
+@pytest.fixture
+def _solution_sos1_one_active():
+    """SOS1 with exactly one nonzero variable → feasible, active_variable=2."""
     x = [DecisionVariable.continuous(i, lower=0, upper=10) for i in range(1, 4)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -351,22 +365,38 @@ def test_solution_sos1_constraints_df_surfaces_active_variable():
         sos1_constraints={20: Sos1Constraint(variables=[1, 2, 3])},
         sense=Instance.MINIMIZE,
     )
-
-    sol_one_active = instance.evaluate({1: 0.0, 2: 5.0, 3: 0.0})
-    df = sol_one_active.sos1_constraints_df()
-    assert list(df.index) == [20]
-    assert df.loc[20, "feasible"]
-    assert df.loc[20, "active_variable"] == 2
-
-    sol_all_zero = instance.evaluate({1: 0.0, 2: 0.0, 3: 0.0})
-    df_zero = sol_all_zero.sos1_constraints_df()
-    assert df_zero.loc[20, "feasible"]
-    assert pd.isna(df_zero.loc[20, "active_variable"])
+    return instance.evaluate({1: 0.0, 2: 5.0, 3: 0.0})
 
 
-def test_solution_one_hot_removed_reasons_df_after_conversion():
-    """After `convert_one_hot_to_constraint`, the one-hot appears in
-    `Solution.one_hot_removed_reasons_df` with the conversion reason."""
+@pytest.fixture
+def _solution_sos1_all_zero():
+    """SOS1 with all zero → feasible (≤1 nonzero), active_variable=NA."""
+    x = [DecisionVariable.continuous(i, lower=0, upper=10) for i in range(1, 4)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={},
+        sos1_constraints={20: Sos1Constraint(variables=[1, 2, 3])},
+        sense=Instance.MINIMIZE,
+    )
+    return instance.evaluate({1: 0.0, 2: 0.0, 3: 0.0})
+
+
+def test_solution_sos1_constraints_df_one_active(snapshot, _solution_sos1_one_active):
+    """`Solution.constraints_df(kind="sos1")` with one nonzero: feasible=True,
+    active_variable=2."""
+    assert _df_snap(_solution_sos1_one_active.constraints_df(kind="sos1")) == snapshot
+
+
+def test_solution_sos1_constraints_df_all_zero(snapshot, _solution_sos1_all_zero):
+    """`Solution.constraints_df(kind="sos1")` with all-zero: feasible=True,
+    active_variable=NA."""
+    assert _df_snap(_solution_sos1_all_zero.constraints_df(kind="sos1")) == snapshot
+
+
+def test_solution_one_hot_removed_reasons_df_after_conversion(snapshot):
+    """`Solution.constraints_df(kind="one_hot", include=(..., "removed_reason"))`
+    after `convert_one_hot_to_constraint` carries the conversion reason."""
     x = [DecisionVariable.binary(i) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -376,23 +406,19 @@ def test_solution_one_hot_removed_reasons_df_after_conversion():
         sense=Instance.MINIMIZE,
     )
     instance.convert_one_hot_to_constraint(7)
-
     sol = instance.evaluate({0: 1.0, 1: 0.0, 2: 0.0})
-
-    active_df = sol.one_hot_constraints_df()
-    assert list(active_df.index) == [7]
-
-    removed_df = sol.one_hot_removed_reasons_df()
-    assert list(removed_df.index) == [7]
     assert (
-        removed_df.loc[7, "removed_reason"]
-        == "ommx.Instance.convert_one_hot_to_constraint"
+        _df_snap(
+            sol.constraints_df(kind="one_hot", include=["metadata", "removed_reason"])
+        )
+        == snapshot
     )
 
 
-def test_solution_sos1_removed_reasons_df_after_conversion():
-    """After `convert_sos1_to_constraints`, the SOS1 constraint appears in
-    `Solution.sos1_removed_reasons_df` with the conversion reason."""
+def test_solution_sos1_removed_reasons_df_after_conversion(snapshot):
+    """`Solution.constraints_df(kind="sos1", include=(..., "removed_reason"))`
+    after `convert_sos1_to_constraints` carries the conversion reason and
+    the comma-joined `constraint_ids` parameter."""
     x = [DecisionVariable.binary(i) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -401,26 +427,19 @@ def test_solution_sos1_removed_reasons_df_after_conversion():
         sos1_constraints={7: Sos1Constraint(variables=[0, 1, 2])},
         sense=Instance.MINIMIZE,
     )
-    new_ids = instance.convert_sos1_to_constraints(7)
-
+    instance.convert_sos1_to_constraints(7)
     sol = instance.evaluate({0: 1.0, 1: 0.0, 2: 0.0})
-
-    removed_df = sol.sos1_removed_reasons_df()
-    assert list(removed_df.index) == [7]
     assert (
-        removed_df.loc[7, "removed_reason"]
-        == "ommx.Instance.convert_sos1_to_constraints"
+        _df_snap(
+            sol.constraints_df(kind="sos1", include=["metadata", "removed_reason"])
+        )
+        == snapshot
     )
-    assert removed_df.loc[7, "removed_reason.constraint_ids"] == ",".join(
-        str(i) for i in new_ids
-    )
 
 
-def test_sample_set_one_hot_constraints_df_dynamic_columns():
-    """`SampleSet.one_hot_constraints_df` has static metadata columns plus per-sample
-    `feasible.{sample_id}` and `active_variable.{sample_id}` columns."""
-    import pandas as pd
-
+@pytest.fixture
+def _sample_set_one_hot():
+    """SampleSet with two samples: 0 feasible (active=1), 1 infeasible."""
     x = [DecisionVariable.binary(i) for i in range(1, 4)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -429,27 +448,25 @@ def test_sample_set_one_hot_constraints_df_dynamic_columns():
         one_hot_constraints={10: OneHotConstraint(variables=[1, 2, 3])},
         sense=Instance.MAXIMIZE,
     )
-    ss = instance.evaluate_samples(
+    return instance.evaluate_samples(
         {
-            0: {1: 1.0, 2: 0.0, 3: 0.0},  # feasible, active=1
-            1: {1: 1.0, 2: 1.0, 3: 0.0},  # infeasible
+            0: {1: 1.0, 2: 0.0, 3: 0.0},
+            1: {1: 1.0, 2: 1.0, 3: 0.0},
         }
     )
 
-    df = ss.one_hot_constraints_df()
-    assert list(df.index) == [10]
-    assert df.loc[10, "used_ids"] == {1, 2, 3}
-    assert df.loc[10, "feasible.0"]
-    assert df.loc[10, "active_variable.0"] == 1
-    assert not df.loc[10, "feasible.1"]
-    assert pd.isna(df.loc[10, "active_variable.1"])
+
+def test_sample_set_one_hot_constraints_df_dynamic_columns(
+    snapshot, _sample_set_one_hot
+):
+    """`SampleSet.constraints_df(kind="one_hot")` static columns + per-sample
+    `feasible.{sample_id}` / `active_variable.{sample_id}` columns."""
+    assert _df_snap(_sample_set_one_hot.constraints_df(kind="one_hot")) == snapshot
 
 
-def test_sample_set_sos1_constraints_df_dynamic_columns():
-    """`SampleSet.sos1_constraints_df` mirrors the one-hot shape with per-sample
-    feasibility and active_variable columns."""
-    import pandas as pd
-
+@pytest.fixture
+def _sample_set_sos1():
+    """SampleSet with three samples: 0 active=2, 1 all-zero (feasible, NA), 2 infeasible."""
     x = [DecisionVariable.continuous(i, lower=0, upper=10) for i in range(1, 4)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -458,26 +475,24 @@ def test_sample_set_sos1_constraints_df_dynamic_columns():
         sos1_constraints={20: Sos1Constraint(variables=[1, 2, 3])},
         sense=Instance.MINIMIZE,
     )
-    ss = instance.evaluate_samples(
+    return instance.evaluate_samples(
         {
-            0: {1: 0.0, 2: 3.0, 3: 0.0},  # feasible, active=2
-            1: {1: 0.0, 2: 0.0, 3: 0.0},  # feasible, no active (NA)
-            2: {1: 1.0, 2: 2.0, 3: 0.0},  # infeasible
+            0: {1: 0.0, 2: 3.0, 3: 0.0},
+            1: {1: 0.0, 2: 0.0, 3: 0.0},
+            2: {1: 1.0, 2: 2.0, 3: 0.0},
         }
     )
 
-    df = ss.sos1_constraints_df()
-    assert list(df.index) == [20]
-    assert df.loc[20, "feasible.0"]
-    assert df.loc[20, "active_variable.0"] == 2
-    assert df.loc[20, "feasible.1"]
-    assert pd.isna(df.loc[20, "active_variable.1"])
-    assert not df.loc[20, "feasible.2"]
+
+def test_sample_set_sos1_constraints_df_dynamic_columns(snapshot, _sample_set_sos1):
+    """`SampleSet.constraints_df(kind="sos1")` per-sample feasibility +
+    active_variable columns."""
+    assert _df_snap(_sample_set_sos1.constraints_df(kind="sos1")) == snapshot
 
 
-def test_sample_set_one_hot_removed_reasons_df_after_conversion():
-    """`SampleSet.one_hot_removed_reasons_df` surfaces conversion reasons the same
-    way the Solution variant does."""
+def test_sample_set_one_hot_removed_reasons_df_after_conversion(snapshot):
+    """`SampleSet.constraints_df(kind="one_hot", include=(..., "removed_reason"))`
+    after `convert_one_hot_to_constraint` surfaces conversion reasons."""
     x = [DecisionVariable.binary(i) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -487,12 +502,10 @@ def test_sample_set_one_hot_removed_reasons_df_after_conversion():
         sense=Instance.MINIMIZE,
     )
     instance.convert_one_hot_to_constraint(7)
-
     ss = instance.evaluate_samples({0: {0: 1.0, 1: 0.0, 2: 0.0}})
-
-    removed_df = ss.one_hot_removed_reasons_df()
-    assert list(removed_df.index) == [7]
     assert (
-        removed_df.loc[7, "removed_reason"]
-        == "ommx.Instance.convert_one_hot_to_constraint"
+        _df_snap(
+            ss.constraints_df(kind="one_hot", include=["metadata", "removed_reason"])
+        )
+        == snapshot
     )

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -2516,52 +2516,29 @@ class Instance:
         DataFrame of decision variables
         """
     def constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
+        self,
+        kind: builtins.str = "regular",
+        include: typing.Optional[typing.Sequence[builtins.str]] = None,
+        removed: builtins.bool = False,
     ) -> pandas.DataFrame:
         r"""
-        DataFrame of constraints
-        """
-    def indicator_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of indicator constraints
-        """
-    def removed_indicator_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed indicator constraints
-        """
-    def one_hot_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of one-hot constraints
-        """
-    def removed_one_hot_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed one-hot constraints
-        """
-    def sos1_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of SOS1 constraints
-        """
-    def removed_sos1_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed SOS1 constraints
-        """
-    def removed_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed constraints
+        DataFrame of constraints, dispatched on `kind=`.
+
+        `kind` selects the constraint family — `"regular"`, `"indicator"`,
+        `"one_hot"`, or `"sos1"`. The DataFrame is indexed by the kind-
+        qualified id column (`{kind}_constraint_id`).
+
+        `include` selects which optional column families to fold in. It
+        accepts a sequence of `"metadata"` / `"parameters"` /
+        `"removed_reason"`; passing `None` (the default) yields the
+        v2-equivalent shape (`metadata` + `parameters`). `"removed_reason"`
+        is a unit flag that gates both the `removed_reason` column and the
+        `removed_reason.{key}` parameter columns together.
+
+        `removed=False` (default) returns active constraints only.
+        `removed=True` returns active + removed rows in the same DataFrame
+        and auto-sets `"removed_reason"` so removed rows are
+        distinguishable (active rows have NA in the reason columns).
         """
     def named_functions_df(
         self, include: typing.Optional[typing.Sequence[builtins.str]] = None
@@ -3377,16 +3354,15 @@ class ParametricInstance:
         DataFrame of decision variables
         """
     def constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
+        self,
+        kind: builtins.str = "regular",
+        include: typing.Optional[typing.Sequence[builtins.str]] = None,
+        removed: builtins.bool = False,
     ) -> pandas.DataFrame:
         r"""
-        DataFrame of constraints
-        """
-    def removed_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed constraints
+        DataFrame of constraints, dispatched on `kind=`. See
+        {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
+        `include=` / `removed=` semantics.
         """
     def named_functions_df(
         self, include: typing.Optional[typing.Sequence[builtins.str]] = None
@@ -4160,68 +4136,20 @@ class SampleSet:
         Dynamic columns: one per sample_id (int) with the variable's value.
         """
     def constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
+        self,
+        kind: builtins.str = "regular",
+        include: typing.Optional[typing.Sequence[builtins.str]] = None,
     ) -> pandas.DataFrame:
         r"""
-        DataFrame of constraints with per-sample value and feasibility columns.
-        Static columns: id, equality, used_ids, name, subscripts, description.
-        Dynamic columns: value.{sample_id} and feasible.{sample_id} for each sample.
-        """
-    def removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed constraint reasons.
+        DataFrame of sampled constraints, dispatched on `kind=`. See
+        {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
+        `include=` semantics. Adds dynamic per-sample columns
+        (`value.{sample_id}`, `feasible.{sample_id}`, etc.) on top of
+        the kind-specific core columns.
 
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`constraints_df` using the `id` index.
-        """
-    def indicator_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of indicator constraints with per-sample value, feasibility, and indicator_active columns.
-        Static columns: id, indicator_variable_id, equality, used_ids, name, subscripts, description.
-        Dynamic columns: value.{sample_id}, feasible.{sample_id}, indicator_active.{sample_id} for each sample.
-        """
-    def indicator_removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed indicator constraint reasons.
-
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`indicator_constraints_df` using the `id` index.
-        """
-    def one_hot_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of one-hot constraints with per-sample feasibility and active_variable columns.
-        Static columns: id, used_ids, name, subscripts, description.
-        Dynamic columns: feasible.{sample_id}, active_variable.{sample_id} for each sample.
-        """
-    def one_hot_removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed one-hot constraint reasons.
-
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`one_hot_constraints_df` using the `id` index.
-        """
-    def sos1_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of SOS1 constraints with per-sample feasibility and active_variable columns.
-        Static columns: id, used_ids, name, subscripts, description.
-        Dynamic columns: feasible.{sample_id}, active_variable.{sample_id} for each sample.
-        """
-    def sos1_removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed SOS1 constraint reasons.
-
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`sos1_constraints_df` using the `id` index.
+        `SampleSet` has no `removed=` parameter (no active/removed
+        distinction at the sampled stage); reason data is gated by
+        `"removed_reason"` in `include=`.
         """
     def named_functions_df(
         self, include: typing.Optional[typing.Sequence[builtins.str]] = None
@@ -4742,106 +4670,20 @@ class Solution:
         Columns: id (index), kind, lower, upper, name, subscripts, description, substituted_value, value
         """
     def constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
+        self,
+        kind: builtins.str = "regular",
+        include: typing.Optional[typing.Sequence[builtins.str]] = None,
     ) -> pandas.DataFrame:
         r"""
-        DataFrame of evaluated constraints
+        DataFrame of evaluated constraints, dispatched on `kind=`. See
+        {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
+        `include=` semantics.
 
-        Columns: id (index), equality, value, used_ids, name, subscripts, description, dual_variable
-        """
-    def removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed constraint reasons.
-
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`constraints_df` on the `id` index.
-
-        # Examples
-
-        ```python
-        >>> from ommx.v1 import Instance, DecisionVariable
-        >>> x = [DecisionVariable.binary(i) for i in range(3)]
-        >>> instance = Instance.from_components(
-        ...     decision_variables=x,
-        ...     objective=sum(x),
-        ...     constraints=[
-        ...         (x[0] + x[1] == 1).set_id(10),
-        ...         (x[1] + x[2] == 1).set_id(20),
-        ...     ],
-        ...     sense=Instance.MAXIMIZE,
-        ... )
-        >>> instance.relax_constraint(10, "test_reason")
-        >>> solution = instance.evaluate({0: 1, 1: 0, 2: 1})
-        ```
-
-        `removed_reasons_df` contains only removed constraints:
-
-        ```python
-        >>> solution.removed_reasons_df()
-            removed_reason
-        id
-        10    test_reason
-        ```
-
-        Join with `constraints_df` to get full information:
-
-        ```python
-        >>> df = solution.constraints_df().join(solution.removed_reasons_df())
-        >>> df[["value", "removed_reason"]]
-            value removed_reason
-        id
-        10    0.0   test_reason
-        20    0.0           NaN
-        ```
-        """
-    def indicator_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of evaluated indicator constraints
-
-        Columns: id (index), indicator_variable_id, equality, value, indicator_active, used_ids, name, subscripts, description
-        """
-    def indicator_removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed indicator constraint reasons.
-
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`indicator_constraints_df` using the `id` index.
-        """
-    def one_hot_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of evaluated one-hot constraints
-
-        Columns: id (index), feasible, active_variable, used_ids, name, subscripts, description
-        """
-    def one_hot_removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed one-hot constraint reasons.
-
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`one_hot_constraints_df` using the `id` index.
-        """
-    def sos1_constraints_df(
-        self, include: typing.Optional[typing.Sequence[builtins.str]] = None
-    ) -> pandas.DataFrame:
-        r"""
-        DataFrame of evaluated SOS1 constraints
-
-        Columns: id (index), feasible, active_variable, used_ids, name, subscripts, description
-        """
-    def sos1_removed_reasons_df(self) -> pandas.DataFrame:
-        r"""
-        DataFrame of removed SOS1 constraint reasons.
-
-        Columns: id (index), removed_reason, removed_reason.{key}
-
-        Can be joined with {meth}`sos1_constraints_df` using the `id` index.
+        `Solution` has no `removed=` parameter (no active/removed
+        distinction at the evaluated stage); reason data is gated by
+        `"removed_reason"` in `include=`. When the flag is on, rows for
+        constraints removed before evaluation get `removed_reason` /
+        `removed_reason.{key}` columns populated; other rows have NA.
         """
     def named_functions_df(
         self, include: typing.Optional[typing.Sequence[builtins.str]] = None

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -2517,7 +2517,7 @@ class Instance:
         """
     def constraints_df(
         self,
-        kind: builtins.str = "regular",
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
         include: typing.Optional[typing.Sequence[builtins.str]] = None,
         removed: builtins.bool = False,
     ) -> pandas.DataFrame:
@@ -2547,7 +2547,8 @@ class Instance:
         DataFrame of named functions
         """
     def constraint_metadata_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint metadata DataFrame (id-indexed wide format).
@@ -2558,7 +2559,8 @@ class Instance:
         to read: `"regular"`, `"indicator"`, `"one_hot"`, or `"sos1"`.
         """
     def constraint_parameters_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint parameters DataFrame (long format).
@@ -2567,7 +2569,8 @@ class Instance:
         `{kind}_constraint_id`, `key`, `value`. Default RangeIndex.
         """
     def constraint_provenance_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint provenance DataFrame (long format).
@@ -2576,7 +2579,8 @@ class Instance:
         `{kind}_constraint_id`, `step`, `source_kind`, `source_id`.
         """
     def constraint_removed_reasons_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Removed-constraint reasons DataFrame (long format).
@@ -3355,7 +3359,7 @@ class ParametricInstance:
         """
     def constraints_df(
         self,
-        kind: builtins.str = "regular",
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
         include: typing.Optional[typing.Sequence[builtins.str]] = None,
         removed: builtins.bool = False,
     ) -> pandas.DataFrame:
@@ -3377,7 +3381,8 @@ class ParametricInstance:
         DataFrame of parameters
         """
     def constraint_metadata_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint metadata DataFrame (id-indexed). See
@@ -3385,19 +3390,22 @@ class ParametricInstance:
         semantics.
         """
     def constraint_parameters_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint parameters DataFrame (long format).
         """
     def constraint_provenance_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint provenance DataFrame (long format).
         """
     def constraint_removed_reasons_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Removed-constraint reasons DataFrame (long format).
@@ -4137,7 +4145,7 @@ class SampleSet:
         """
     def constraints_df(
         self,
-        kind: builtins.str = "regular",
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
         include: typing.Optional[typing.Sequence[builtins.str]] = None,
     ) -> pandas.DataFrame:
         r"""
@@ -4160,7 +4168,8 @@ class SampleSet:
         Dynamic columns: one per sample_id (int) with the function's evaluated value.
         """
     def constraint_metadata_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint metadata DataFrame (id-indexed). See
@@ -4168,19 +4177,22 @@ class SampleSet:
         semantics. Reads from the sampled collection's metadata store.
         """
     def constraint_parameters_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint parameters DataFrame (long format).
         """
     def constraint_provenance_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint provenance DataFrame (long format).
         """
     def constraint_removed_reasons_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Removed-constraint reasons DataFrame (long format).
@@ -4671,7 +4683,7 @@ class Solution:
         """
     def constraints_df(
         self,
-        kind: builtins.str = "regular",
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
         include: typing.Optional[typing.Sequence[builtins.str]] = None,
     ) -> pandas.DataFrame:
         r"""
@@ -4694,7 +4706,8 @@ class Solution:
         Columns: id (index), value, used_ids, name, subscripts, description, parameters.{key}
         """
     def constraint_metadata_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint metadata DataFrame (id-indexed). See
@@ -4702,19 +4715,22 @@ class Solution:
         semantics. Reads from the evaluated collection's metadata store.
         """
     def constraint_parameters_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint parameters DataFrame (long format).
         """
     def constraint_provenance_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Constraint provenance DataFrame (long format).
         """
     def constraint_removed_reasons_df(
-        self, kind: builtins.str = "regular"
+        self,
+        kind: typing.Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
     ) -> pandas.DataFrame:
         r"""
         Removed-constraint reasons DataFrame (long format).

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -1,7 +1,7 @@
 use crate::{
     pandas::{
         constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
-        PyDataFrame,
+        PyDataFrame, ToPandasEntry,
     },
     Constraint, DecisionVariable, Function, NamedFunction, ParametricInstance, RemovedConstraint,
     Rng, SampleSet, Samples, Sense, Solution, State, VariableBound,
@@ -1718,243 +1718,69 @@ impl Instance {
         )
     }
 
-    /// DataFrame of constraints
-    #[pyo3(signature = (include = None))]
+    /// DataFrame of constraints, dispatched on `kind=`.
+    ///
+    /// `kind` selects the constraint family — `"regular"`, `"indicator"`,
+    /// `"one_hot"`, or `"sos1"`. The DataFrame is indexed by the kind-
+    /// qualified id column (`{kind}_constraint_id`).
+    ///
+    /// `include` selects which optional column families to fold in. It
+    /// accepts a sequence of `"metadata"` / `"parameters"` /
+    /// `"removed_reason"`; passing `None` (the default) yields the
+    /// v2-equivalent shape (`metadata` + `parameters`). `"removed_reason"`
+    /// is a unit flag that gates both the `removed_reason` column and the
+    /// `removed_reason.{key}` parameter columns together.
+    ///
+    /// `removed=False` (default) returns active constraints only.
+    /// `removed=True` returns active + removed rows in the same DataFrame
+    /// and auto-sets `"removed_reason"` so removed rows are
+    /// distinguishable (active rows have NA in the reason columns).
+    #[pyo3(signature = (kind = String::from("regular"), include = None, removed = false))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
+        kind: String,
         include: Option<Vec<String>>,
+        removed: bool,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.constraint_collection().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::ConstraintID,
-            &ommx::Constraint,
-        )> = self
-            .inner
-            .constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of indicator constraints
-    #[pyo3(signature = (include = None))]
-    pub fn indicator_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self
-            .inner
-            .indicator_constraint_collection()
-            .metadata()
-            .clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::IndicatorConstraintID,
-            &ommx::IndicatorConstraint,
-        )> = self
-            .inner
-            .indicator_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed indicator constraints
-    #[pyo3(signature = (include = None))]
-    pub fn removed_indicator_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self
-            .inner
-            .indicator_constraint_collection()
-            .metadata()
-            .clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::IndicatorConstraintID,
-            &(ommx::IndicatorConstraint, ommx::RemovedReason),
-        )> = self
-            .inner
-            .removed_indicator_constraints()
-            .iter()
-            .map(|(id, pair)| (meta_store.collect_for(*id), *id, pair))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, pair)| crate::pandas::WithMetadata::new((*id, *pair), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of one-hot constraints
-    #[pyo3(signature = (include = None))]
-    pub fn one_hot_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self
-            .inner
-            .one_hot_constraint_collection()
-            .metadata()
-            .clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::OneHotConstraintID,
-            &ommx::OneHotConstraint,
-        )> = self
-            .inner
-            .one_hot_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed one-hot constraints
-    #[pyo3(signature = (include = None))]
-    pub fn removed_one_hot_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self
-            .inner
-            .one_hot_constraint_collection()
-            .metadata()
-            .clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::OneHotConstraintID,
-            &(ommx::OneHotConstraint, ommx::RemovedReason),
-        )> = self
-            .inner
-            .removed_one_hot_constraints()
-            .iter()
-            .map(|(id, pair)| (meta_store.collect_for(*id), *id, pair))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, pair)| crate::pandas::WithMetadata::new((*id, *pair), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of SOS1 constraints
-    #[pyo3(signature = (include = None))]
-    pub fn sos1_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.sos1_constraint_collection().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::Sos1ConstraintID,
-            &ommx::Sos1Constraint,
-        )> = self
-            .inner
-            .sos1_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed SOS1 constraints
-    #[pyo3(signature = (include = None))]
-    pub fn removed_sos1_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.sos1_constraint_collection().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::Sos1ConstraintID,
-            &(ommx::Sos1Constraint, ommx::RemovedReason),
-        )> = self
-            .inner
-            .removed_sos1_constraints()
-            .iter()
-            .map(|(id, pair)| (meta_store.collect_for(*id), *id, pair))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, pair)| crate::pandas::WithMetadata::new((*id, *pair), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed constraints
-    #[pyo3(signature = (include = None))]
-    pub fn removed_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.constraint_collection().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::ConstraintID,
-            &(ommx::Constraint, ommx::RemovedReason),
-        )> = self
-            .inner
-            .removed_constraints()
-            .iter()
-            .map(|(id, pair)| (meta_store.collect_for(*id), *id, pair))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, pair)| crate::pandas::WithMetadata::new((*id, *pair), m)),
-            "id",
-            flags,
+        let kind_enum = parse_constraint_kind(&kind)?;
+        let id_col = constraint_id_col(kind_enum);
+        let mut flags = crate::pandas::IncludeFlags::from_optional(include)?;
+        if removed {
+            flags.removed_reason = true;
+        }
+        constraint_kind_collection!(
+            self.inner,
+            kind_enum,
+            [
+                constraint_collection,
+                indicator_constraint_collection,
+                one_hot_constraint_collection,
+                sos1_constraint_collection
+            ],
+            |coll| {
+                let meta = coll.metadata().clone();
+                let mut entries: Vec<Bound<'py, pyo3::types::PyAny>> = Vec::new();
+                for (id, c) in coll.active().iter() {
+                    let m = meta.collect_for(*id);
+                    let dict =
+                        crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
+                    crate::pandas::apply_include_filter(&dict, flags)?;
+                    crate::pandas::rename_id_column(&dict, id_col)?;
+                    entries.push(dict.into_any());
+                }
+                if removed {
+                    for (id, pair) in coll.removed().iter() {
+                        let m = meta.collect_for(*id);
+                        let dict = crate::pandas::WithMetadata::new((*id, pair), &m)
+                            .to_pandas_entry(py)?;
+                        crate::pandas::apply_include_filter(&dict, flags)?;
+                        crate::pandas::rename_id_column(&dict, id_col)?;
+                        entries.push(dict.into_any());
+                    }
+                }
+                crate::pandas::raw_entries_to_dataframe(py, entries, id_col)
+            }
         )
     }
 

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -1760,20 +1760,54 @@ impl Instance {
             ],
             |coll| {
                 let meta = coll.metadata().clone();
+                let active = coll.active();
+                let removed_map = coll.removed();
                 let mut entries: Vec<Bound<'py, pyo3::types::PyAny>> = Vec::new();
-                for (id, c) in coll.active().iter() {
-                    let m = meta.collect_for(*id);
-                    let dict =
-                        crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
-                    crate::pandas::apply_include_filter(&dict, flags)?;
-                    crate::pandas::rename_id_column(&dict, id_col)?;
-                    entries.push(dict.into_any());
-                }
                 if removed {
-                    for (id, pair) in coll.removed().iter() {
+                    // Globally id-sorted merge of active and removed.
+                    // Both BTreeMaps are individually sorted; ids are
+                    // disjoint between the two maps.
+                    let mut ai = active.iter().peekable();
+                    let mut ri = removed_map.iter().peekable();
+                    loop {
+                        let pick_active = match (ai.peek(), ri.peek()) {
+                            (Some((aid, _)), Some((rid, _))) => aid <= rid,
+                            (Some(_), None) => true,
+                            (None, Some(_)) => false,
+                            (None, None) => break,
+                        };
+                        if pick_active {
+                            let (id, c) = ai.next().unwrap();
+                            let m = meta.collect_for(*id);
+                            let dict = crate::pandas::WithMetadata::new((*id, c), &m)
+                                .to_pandas_entry(py)?;
+                            // Active rows in a removed=True view get NA
+                            // in the (always-present) removed_reason column.
+                            crate::pandas::set_removed_reason_na(&dict)?;
+                            crate::pandas::apply_include_filter(&dict, flags)?;
+                            crate::pandas::rename_id_column(&dict, id_col)?;
+                            entries.push(dict.into_any());
+                        } else {
+                            let (id, pair) = ri.next().unwrap();
+                            let m = meta.collect_for(*id);
+                            let dict = crate::pandas::WithMetadata::new((*id, pair), &m)
+                                .to_pandas_entry(py)?;
+                            crate::pandas::apply_include_filter(&dict, flags)?;
+                            crate::pandas::rename_id_column(&dict, id_col)?;
+                            entries.push(dict.into_any());
+                        }
+                    }
+                } else {
+                    for (id, c) in active.iter() {
                         let m = meta.collect_for(*id);
-                        let dict = crate::pandas::WithMetadata::new((*id, pair), &m)
-                            .to_pandas_entry(py)?;
+                        let dict =
+                            crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
+                        // User-requested removed_reason on an active-only
+                        // view: ensure the column survives even when no
+                        // row carries a reason.
+                        if flags.removed_reason {
+                            crate::pandas::set_removed_reason_na(&dict)?;
+                        }
                         crate::pandas::apply_include_filter(&dict, flags)?;
                         crate::pandas::rename_id_column(&dict, id_col)?;
                         entries.push(dict.into_any());

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -1735,15 +1735,19 @@ impl Instance {
     /// `removed=True` returns active + removed rows in the same DataFrame
     /// and auto-sets `"removed_reason"` so removed rows are
     /// distinguishable (active rows have NA in the reason columns).
-    #[pyo3(signature = (kind = String::from("regular"), include = None, removed = false))]
+    #[pyo3(signature = (kind = "regular", include = None, removed = false))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
         include: Option<Vec<String>>,
         removed: bool,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(&kind)?;
+        let kind_enum = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind_enum);
         let mut flags = crate::pandas::IncludeFlags::from_optional(include)?;
         if removed {
@@ -1835,13 +1839,17 @@ impl Instance {
     /// `name`, `subscripts`, `description`. Index column is
     /// `{kind}_constraint_id`. `kind` selects which constraint family
     /// to read: `"regular"`, `"indicator"`, `"one_hot"`, or `"sos1"`.
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -1867,13 +1875,17 @@ impl Instance {
     ///
     /// One row per (constraint_id, parameter_key) pair. Columns:
     /// `{kind}_constraint_id`, `key`, `value`. Default RangeIndex.
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -1899,13 +1911,17 @@ impl Instance {
     ///
     /// One row per (constraint_id, step) pair. Columns:
     /// `{kind}_constraint_id`, `step`, `source_kind`, `source_id`.
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -1932,13 +1948,17 @@ impl Instance {
     /// One row per (constraint_id, parameter_key) pair, plus one row with
     /// `key`/`value` set to NA when the reason has no parameters. Columns:
     /// `{kind}_constraint_id`, `reason`, `key`, `value`.
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -1,6 +1,6 @@
 use crate::{
     pandas::{
-        constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
+        constraint_id_col, constraint_kind_collection, entries_to_dataframe, ConstraintKind,
         PyDataFrame, ToPandasEntry,
     },
     Constraint, DecisionVariable, Function, NamedFunction, ParametricInstance, RemovedConstraint,
@@ -1735,27 +1735,22 @@ impl Instance {
     /// `removed=True` returns active + removed rows in the same DataFrame
     /// and auto-sets `"removed_reason"` so removed rows are
     /// distinguishable (active rows have NA in the reason columns).
-    #[pyo3(signature = (kind = "regular", include = None, removed = false))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular, include = None, removed = false))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
         include: Option<Vec<String>>,
         removed: bool,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(kind)?;
-        let id_col = constraint_id_col(kind_enum);
+        let id_col = constraint_id_col(kind);
         let mut flags = crate::pandas::IncludeFlags::from_optional(include)?;
         if removed {
             flags.removed_reason = true;
         }
         constraint_kind_collection!(
             self.inner,
-            kind_enum,
+            kind,
             [
                 constraint_collection,
                 indicator_constraint_collection,
@@ -1839,17 +1834,12 @@ impl Instance {
     /// `name`, `subscripts`, `description`. Index column is
     /// `{kind}_constraint_id`. `kind` selects which constraint family
     /// to read: `"regular"`, `"indicator"`, `"one_hot"`, or `"sos1"`.
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -1875,17 +1865,12 @@ impl Instance {
     ///
     /// One row per (constraint_id, parameter_key) pair. Columns:
     /// `{kind}_constraint_id`, `key`, `value`. Default RangeIndex.
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -1911,17 +1896,12 @@ impl Instance {
     ///
     /// One row per (constraint_id, step) pair. Columns:
     /// `{kind}_constraint_id`, `step`, `source_kind`, `source_id`.
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -1948,17 +1928,12 @@ impl Instance {
     /// One row per (constraint_id, parameter_key) pair, plus one row with
     /// `key`/`value` set to NA when the reason has no parameters. Columns:
     /// `{kind}_constraint_id`, `reason`, `key`, `value`.
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/pandas.rs
+++ b/python/ommx/src/pandas.rs
@@ -77,20 +77,26 @@ impl pyo3_stub_gen::PyStubType for PyDataFrame {
 /// Which optional column families to fold into a wide `*_df` DataFrame.
 ///
 /// `metadata` toggles the `name` / `subscripts` / `description` columns.
-/// `parameters` toggles the `parameters.{key}` columns. The default
-/// (`Self::default_wide()`) preserves the v2-equivalent wide shape.
+/// `parameters` toggles the `parameters.{key}` columns. `removed_reason`
+/// is a unit flag that gates both the `removed_reason` (reason name)
+/// column and the `removed_reason.{key}` (reason parameters) columns
+/// together — the name without its parameters is rarely useful. The
+/// default (`Self::default_wide()`) preserves the v2-equivalent wide
+/// shape: metadata + parameters on, removed_reason off.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct IncludeFlags {
     pub metadata: bool,
     pub parameters: bool,
+    pub removed_reason: bool,
 }
 
 impl IncludeFlags {
-    /// Default for wide `*_df` — both metadata and parameters columns on.
+    /// Default for wide `*_df` — metadata and parameters on, removed_reason off.
     pub fn default_wide() -> Self {
         Self {
             metadata: true,
             parameters: true,
+            removed_reason: false,
         }
     }
 
@@ -104,9 +110,10 @@ impl IncludeFlags {
                     match v.as_str() {
                         "metadata" => flags.metadata = true,
                         "parameters" => flags.parameters = true,
+                        "removed_reason" => flags.removed_reason = true,
                         other => {
                             return Err(PyValueError::new_err(format!(
-                                "unknown include flag: {other:?} (expected one of \"metadata\", \"parameters\")"
+                                "unknown include flag: {other:?} (expected one of \"metadata\", \"parameters\", \"removed_reason\")"
                             )));
                         }
                     }
@@ -118,6 +125,8 @@ impl IncludeFlags {
 }
 
 const METADATA_KEYS: &[&str] = &["name", "subscripts", "description"];
+const REMOVED_REASON_KEY: &str = "removed_reason";
+const REMOVED_REASON_PREFIX: &str = "removed_reason.";
 
 // ---------------------------------------------------------------------------
 // kind= dispatch — shared by the 4 constraint sidecar accessors
@@ -476,10 +485,11 @@ fn long_format_dataframe<'py>(
 
 /// Drop columns from a per-row dict according to the include flags.
 ///
-/// `metadata` columns are dropped by name; `parameters.*` columns are
-/// dropped by prefix. Missing keys are silently skipped (some impls don't
-/// emit every key).
-fn apply_include_filter(dict: &Bound<PyDict>, include: IncludeFlags) -> PyResult<()> {
+/// `metadata` columns are dropped by name; `parameters.*` and
+/// `removed_reason` (name + `removed_reason.*` parameters) columns are
+/// dropped by prefix. Missing keys are silently skipped (some impls
+/// don't emit every key).
+pub(crate) fn apply_include_filter(dict: &Bound<PyDict>, include: IncludeFlags) -> PyResult<()> {
     if !include.metadata {
         for key in METADATA_KEYS {
             if dict.contains(key)? {
@@ -497,6 +507,61 @@ fn apply_include_filter(dict: &Bound<PyDict>, include: IncludeFlags) -> PyResult
         for key in to_drop {
             dict.del_item(key)?;
         }
+    }
+    if !include.removed_reason {
+        if dict.contains(REMOVED_REASON_KEY)? {
+            dict.del_item(REMOVED_REASON_KEY)?;
+        }
+        let to_drop: Vec<String> = dict
+            .keys()
+            .iter()
+            .filter_map(|k| k.extract::<String>().ok())
+            .filter(|k| k.starts_with(REMOVED_REASON_PREFIX))
+            .collect();
+        for key in to_drop {
+            dict.del_item(key)?;
+        }
+    }
+    Ok(())
+}
+
+/// Rename the per-row dict's `"id"` key to `id_col`.
+///
+/// All `ToPandasEntry` impls emit the constraint / variable id under
+/// the literal key `"id"`. Wave 2 surfaces the kind-qualified column
+/// name (`regular_constraint_id`, `indicator_constraint_id`, …) so
+/// cross-kind joins surface their mismatch on inspection — this helper
+/// rewrites the key in place at the call site. No-op when `id_col` is
+/// already `"id"`.
+pub(crate) fn rename_id_column(dict: &Bound<PyDict>, id_col: &str) -> PyResult<()> {
+    if id_col == "id" {
+        return Ok(());
+    }
+    let value = dict
+        .get_item("id")?
+        .ok_or_else(|| PyValueError::new_err("entry dict missing required \"id\" column"))?;
+    dict.del_item("id")?;
+    dict.set_item(id_col, value)?;
+    Ok(())
+}
+
+/// Set `removed_reason` and `removed_reason.{key}` columns on `dict`.
+///
+/// `removed_reason` carries the reason name; `removed_reason.{key}`
+/// columns carry the reason parameters. Keys are emitted in lexicographic
+/// order so column ordering is deterministic across runs (the underlying
+/// `HashMap` iteration order is not). Used by call sites that fold
+/// removed-reason columns into a wide constraints DataFrame.
+pub(crate) fn set_removed_reason_columns(
+    dict: &Bound<PyDict>,
+    reason: &RemovedReason,
+) -> PyResult<()> {
+    dict.set_item(REMOVED_REASON_KEY, &reason.reason)?;
+    let mut keys: Vec<&str> = reason.parameters.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    for key in keys {
+        let value = &reason.parameters[key];
+        dict.set_item(format!("{REMOVED_REASON_PREFIX}{key}"), value)?;
     }
     Ok(())
 }
@@ -872,10 +937,7 @@ impl<'m> ToPandasEntry
         let (id, inner) = self.item;
         let (ic, reason) = inner;
         let dict = WithMetadata::new((id, ic), self.metadata).to_pandas_entry(py)?;
-        dict.set_item("removed_reason", &reason.reason)?;
-        for (key, value) in &reason.parameters {
-            dict.set_item(format!("removed_reason.{key}"), value)?;
-        }
+        set_removed_reason_columns(&dict, reason)?;
         Ok(dict)
     }
 }
@@ -1040,10 +1102,7 @@ impl<'m> ToPandasEntry
         let (id, inner) = self.item;
         let (one_hot, reason) = inner;
         let dict = WithMetadata::new((id, one_hot), self.metadata).to_pandas_entry(py)?;
-        dict.set_item("removed_reason", &reason.reason)?;
-        for (key, value) in &reason.parameters {
-            dict.set_item(format!("removed_reason.{key}"), value)?;
-        }
+        set_removed_reason_columns(&dict, reason)?;
         Ok(dict)
     }
 }
@@ -1084,10 +1143,7 @@ impl<'m> ToPandasEntry
         let (id, inner) = self.item;
         let (sos1, reason) = inner;
         let dict = WithMetadata::new((id, sos1), self.metadata).to_pandas_entry(py)?;
-        dict.set_item("removed_reason", &reason.reason)?;
-        for (key, value) in &reason.parameters {
-            dict.set_item(format!("removed_reason.{key}"), value)?;
-        }
+        set_removed_reason_columns(&dict, reason)?;
         Ok(dict)
     }
 }
@@ -1102,22 +1158,8 @@ impl<'m> ToPandasEntry
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let (id, inner) = self.item;
         let (constraint, reason) = inner;
-        let m = self.metadata;
-        let dict = PyDict::new(py);
-        dict.set_item("id", id.into_inner())?;
-        set_equality(&dict, constraint.equality)?;
-        set_function_type(&dict, &constraint.stage.function)?;
-        set_used_ids(&dict, &constraint.stage.function.required_ids())?;
-        set_metadata(
-            &dict,
-            m.name.as_deref(),
-            &m.subscripts,
-            m.description.as_deref(),
-        )?;
-        dict.set_item("removed_reason", &reason.reason)?;
-        for (key, value) in &reason.parameters {
-            dict.set_item(format!("removed_reason.{key}"), value)?;
-        }
+        let dict = WithMetadata::new((id, constraint), self.metadata).to_pandas_entry(py)?;
+        set_removed_reason_columns(&dict, reason)?;
         Ok(dict)
     }
 }
@@ -1206,24 +1248,6 @@ impl<'m> ToPandasEntry
         match c.stage.dual_variable {
             Some(v) => dict.set_item("dual_variable", v)?,
             None => dict.set_item("dual_variable", &na)?,
-        }
-        Ok(dict)
-    }
-}
-
-/// Entry for removed_reasons_df: constraint_id → removed_reason, removed_reason.{key}
-pub struct RemovedReasonEntry<'a> {
-    pub id: u64,
-    pub reason: &'a ommx::RemovedReason,
-}
-
-impl ToPandasEntry for RemovedReasonEntry<'_> {
-    fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let dict = PyDict::new(py);
-        dict.set_item("id", self.id)?;
-        dict.set_item("removed_reason", &self.reason.reason)?;
-        for (key, value) in &self.reason.parameters {
-            dict.set_item(format!("removed_reason.{key}"), value)?;
         }
         Ok(dict)
     }

--- a/python/ommx/src/pandas.rs
+++ b/python/ommx/src/pandas.rs
@@ -654,6 +654,9 @@ pub fn entries_to_dataframe<'py, T: ToPandasEntry>(
 /// Build a `pandas.DataFrame` from pre-built entry dicts, indexed by `index_col`.
 ///
 /// Use this when entries need custom logic (e.g. SampleSet dynamic columns).
+/// Empty inputs still return a DataFrame whose index name is `index_col`,
+/// so downstream code can rely on the kind-qualified name (`df.index.name`)
+/// regardless of whether the underlying collection happened to be empty.
 pub fn raw_entries_to_dataframe<'py>(
     py: Python<'py>,
     entries: Vec<Bound<'py, PyAny>>,
@@ -662,7 +665,14 @@ pub fn raw_entries_to_dataframe<'py>(
     let pandas = py.import("pandas")?;
     let df = pandas.call_method1("DataFrame", (entries,))?;
     if df.getattr("empty")?.extract::<bool>()? {
-        return df.cast_into().map_err(Into::into);
+        // `set_index(index_col)` would fail because the column does not
+        // exist; `rename_axis` only sets the index name. Equivalent to
+        // `df.index.name = index_col` but returns a new DataFrame so the
+        // type / cast flow stays consistent with the non-empty branch.
+        return df
+            .call_method1("rename_axis", (index_col,))?
+            .cast_into()
+            .map_err(Into::into);
     }
     df.call_method1("set_index", (index_col,))?
         .cast_into()
@@ -671,7 +681,8 @@ pub fn raw_entries_to_dataframe<'py>(
 
 /// Build a sorted `pandas.DataFrame` from pre-built entry dicts.
 ///
-/// Sorts by `sort_by` columns before setting the index.
+/// Sorts by `sort_by` columns before setting the index. Empty inputs
+/// still get the index name set to `index_col`.
 pub fn sorted_entries_to_dataframe<'py>(
     py: Python<'py>,
     entries: Vec<Bound<'py, PyAny>>,
@@ -682,7 +693,10 @@ pub fn sorted_entries_to_dataframe<'py>(
     let pandas = py.import("pandas")?;
     let df = pandas.call_method1("DataFrame", (entries,))?;
     if df.getattr("empty")?.extract::<bool>()? {
-        return df.cast_into().map_err(Into::into);
+        return df
+            .call_method1("rename_axis", (index_col,))?
+            .cast_into()
+            .map_err(Into::into);
     }
     let sort_args = PyDict::new(py);
     sort_args.set_item("by", sort_by.to_vec())?;

--- a/python/ommx/src/pandas.rs
+++ b/python/ommx/src/pandas.rs
@@ -132,7 +132,17 @@ const REMOVED_REASON_PREFIX: &str = "removed_reason.";
 // kind= dispatch — shared by the 4 constraint sidecar accessors
 // ---------------------------------------------------------------------------
 
-/// Constraint family selector for `kind=` arguments on sidecar DataFrames.
+/// Constraint family selector for `kind=` arguments on the wide
+/// `constraints_df` and the four long-format sidecar accessors.
+///
+/// The Python surface is a string literal (`"regular"`, `"indicator"`,
+/// `"one_hot"`, `"sos1"`); on the Rust side we deal with this enum so
+/// downstream `match` arms get exhaustiveness checking. The
+/// [`FromPyObject`] / [`IntoPyObject`] / [`PyStubType`] impls bridge
+/// between the two: a Python `str` is validated and converted to the
+/// enum on the way in, the enum is rendered back as a Python `str` on
+/// the way out, and the stub surface is `typing.Literal[...]` so
+/// callers get static-typing assistance for typos at edit time.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ConstraintKind {
     Regular,
@@ -141,16 +151,65 @@ pub enum ConstraintKind {
     Sos1,
 }
 
-/// Parse the `kind=` string argument. Returns `ValueError` on unknown values.
-pub fn parse_constraint_kind(kind: &str) -> PyResult<ConstraintKind> {
-    match kind {
-        "regular" => Ok(ConstraintKind::Regular),
-        "indicator" => Ok(ConstraintKind::Indicator),
-        "one_hot" => Ok(ConstraintKind::OneHot),
-        "sos1" => Ok(ConstraintKind::Sos1),
-        other => Err(PyValueError::new_err(format!(
-            "unknown constraint kind: {other:?} (expected one of \"regular\", \"indicator\", \"one_hot\", \"sos1\")"
-        ))),
+impl ConstraintKind {
+    /// The Python string literal corresponding to this kind.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConstraintKind::Regular => "regular",
+            ConstraintKind::Indicator => "indicator",
+            ConstraintKind::OneHot => "one_hot",
+            ConstraintKind::Sos1 => "sos1",
+        }
+    }
+}
+
+/// Accept a Python `str` and validate it against the four known kinds.
+/// Unknown values yield `ValueError` for callers that bypass the
+/// `Literal[...]` stub typing (e.g. dynamically constructed strings).
+impl<'py> FromPyObject<'_, 'py> for ConstraintKind {
+    type Error = PyErr;
+    fn extract(ob: pyo3::Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        let s: &str = ob.extract()?;
+        match s {
+            "regular" => Ok(ConstraintKind::Regular),
+            "indicator" => Ok(ConstraintKind::Indicator),
+            "one_hot" => Ok(ConstraintKind::OneHot),
+            "sos1" => Ok(ConstraintKind::Sos1),
+            other => Err(PyValueError::new_err(format!(
+                "unknown constraint kind: {other:?} (expected one of \"regular\", \"indicator\", \"one_hot\", \"sos1\")"
+            ))),
+        }
+    }
+}
+
+/// Render back to a Python `str` so default values like
+/// `ConstraintKind::Regular` show up as `'regular'` in the generated
+/// stubs (via `pyo3_stub_gen::util::fmt_py_obj`).
+impl<'py> pyo3::IntoPyObject<'py> for ConstraintKind {
+    type Target = pyo3::types::PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = std::convert::Infallible;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(pyo3::types::PyString::new(py, self.as_str()))
+    }
+}
+
+/// Surface in `__init__.pyi` as a string `Literal`. Both input and
+/// output positions render identically — the wide `*_df` accessors
+/// take this enum but never return it, so `type_input` is the only
+/// position that matters in practice; `type_output` is provided for
+/// completeness.
+impl pyo3_stub_gen::PyStubType for ConstraintKind {
+    fn type_input() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: r#"typing.Literal["regular", "indicator", "one_hot", "sos1"]"#.to_string(),
+            source_module: None,
+            import: ["typing".into()].into(),
+            type_refs: Default::default(),
+        }
+    }
+    fn type_output() -> pyo3_stub_gen::TypeInfo {
+        Self::type_input()
     }
 }
 

--- a/python/ommx/src/pandas.rs
+++ b/python/ommx/src/pandas.rs
@@ -566,6 +566,20 @@ pub(crate) fn set_removed_reason_columns(
     Ok(())
 }
 
+/// Emit a placeholder NA `removed_reason` column on a row with no
+/// removed reason. Without this, a wide `*_df` requested with
+/// `include=("removed_reason",)` would silently drop the column when
+/// no row in the view actually carries a reason — pandas keys columns
+/// off whatever appears in any row dict. Calling this on the
+/// reason-less rows guarantees the column appears with `<NA>` values.
+/// `removed_reason.{key}` columns are intentionally not pre-emitted —
+/// their key set is data-dependent.
+pub(crate) fn set_removed_reason_na(dict: &Bound<PyDict>) -> PyResult<()> {
+    let na = get_na(dict.py())?;
+    dict.set_item(REMOVED_REASON_KEY, &na)?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // pandas.NA cache
 // ---------------------------------------------------------------------------

--- a/python/ommx/src/pandas.rs
+++ b/python/ommx/src/pandas.rs
@@ -879,6 +879,7 @@ impl<'m> ToPandasEntry for WithMetadata<'m, &ommx::DecisionVariable, DecisionVar
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         match dv.substituted_value() {
             Some(v) => dict.set_item("substituted_value", v)?,
             None => dict.set_item("substituted_value", &na)?,
@@ -905,6 +906,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         Ok(dict)
     }
 }
@@ -934,6 +936,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         Ok(dict)
     }
 }
@@ -964,6 +967,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         Ok(dict)
     }
 }
@@ -995,6 +999,7 @@ impl<'a, 'm> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         for &sample_id in self.item.sample_ids {
             let value = ic.stage.evaluated_values.get(sample_id).copied();
             dict.set_item(format!("value.{}", sample_id.into_inner()), value)?;
@@ -1054,6 +1059,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         Ok(dict)
     }
 }
@@ -1078,6 +1084,7 @@ impl<'a, 'm> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         for &sample_id in self.item.sample_ids {
             let feas = c.stage.feasible.get(&sample_id).copied();
             dict.set_item(format!("feasible.{}", sample_id.into_inner()), feas)?;
@@ -1116,6 +1123,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         Ok(dict)
     }
 }
@@ -1140,6 +1148,7 @@ impl<'a, 'm> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         for &sample_id in self.item.sample_ids {
             let feas = c.stage.feasible.get(&sample_id).copied();
             dict.set_item(format!("feasible.{}", sample_id.into_inner()), feas)?;
@@ -1171,6 +1180,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         Ok(dict)
     }
 }
@@ -1212,6 +1222,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         Ok(dict)
     }
 }
@@ -1306,6 +1317,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         // EvaluatedDecisionVariable has no substituted_value field
         dict.set_item("substituted_value", &na)?;
         dict.set_item("value", *dv.value())?;
@@ -1332,6 +1344,7 @@ impl<'m> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         match c.stage.dual_variable {
             Some(v) => dict.set_item("dual_variable", v)?,
             None => dict.set_item("dual_variable", &na)?,
@@ -1418,6 +1431,7 @@ impl<'a, 'm> ToPandasEntry
             &m.subscripts,
             m.description.as_deref(),
         )?;
+        set_parameter_columns(&dict, &m.parameters)?;
         for &sample_id in self.item.sample_ids {
             let value = sc.stage.evaluated_values.get(sample_id).copied();
             dict.set_item(format!("value.{}", sample_id.into_inner()), value)?;

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -1,7 +1,7 @@
 use crate::{
     pandas::{
         constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
-        PyDataFrame,
+        PyDataFrame, ToPandasEntry,
     },
     Constraint, DecisionVariable, Function, Instance, NamedFunction, Parameter, RemovedConstraint,
     Sense,
@@ -333,59 +333,55 @@ impl ParametricInstance {
         )
     }
 
-    /// DataFrame of constraints
-    #[pyo3(signature = (include = None))]
+    /// DataFrame of constraints, dispatched on `kind=`. See
+    /// {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
+    /// `include=` / `removed=` semantics.
+    #[pyo3(signature = (kind = String::from("regular"), include = None, removed = false))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
+        kind: String,
         include: Option<Vec<String>>,
+        removed: bool,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.constraint_collection().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::ConstraintID,
-            &ommx::Constraint,
-        )> = self
-            .inner
-            .constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed constraints
-    #[pyo3(signature = (include = None))]
-    pub fn removed_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.constraint_collection().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::ConstraintID,
-            &(ommx::Constraint, ommx::RemovedReason),
-        )> = self
-            .inner
-            .removed_constraints()
-            .iter()
-            .map(|(id, pair)| (meta_store.collect_for(*id), *id, pair))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, pair)| crate::pandas::WithMetadata::new((*id, *pair), m)),
-            "id",
-            flags,
+        let kind_enum = parse_constraint_kind(&kind)?;
+        let id_col = constraint_id_col(kind_enum);
+        let mut flags = crate::pandas::IncludeFlags::from_optional(include)?;
+        if removed {
+            flags.removed_reason = true;
+        }
+        constraint_kind_collection!(
+            self.inner,
+            kind_enum,
+            [
+                constraint_collection,
+                indicator_constraint_collection,
+                one_hot_constraint_collection,
+                sos1_constraint_collection
+            ],
+            |coll| {
+                let meta = coll.metadata().clone();
+                let mut entries: Vec<Bound<'py, pyo3::types::PyAny>> = Vec::new();
+                for (id, c) in coll.active().iter() {
+                    let m = meta.collect_for(*id);
+                    let dict =
+                        crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
+                    crate::pandas::apply_include_filter(&dict, flags)?;
+                    crate::pandas::rename_id_column(&dict, id_col)?;
+                    entries.push(dict.into_any());
+                }
+                if removed {
+                    for (id, pair) in coll.removed().iter() {
+                        let m = meta.collect_for(*id);
+                        let dict = crate::pandas::WithMetadata::new((*id, pair), &m)
+                            .to_pandas_entry(py)?;
+                        crate::pandas::apply_include_filter(&dict, flags)?;
+                        crate::pandas::rename_id_column(&dict, id_col)?;
+                        entries.push(dict.into_any());
+                    }
+                }
+                crate::pandas::raw_entries_to_dataframe(py, entries, id_col)
+            }
         )
     }
 

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -1,6 +1,6 @@
 use crate::{
     pandas::{
-        constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
+        constraint_id_col, constraint_kind_collection, entries_to_dataframe, ConstraintKind,
         PyDataFrame, ToPandasEntry,
     },
     Constraint, DecisionVariable, Function, Instance, NamedFunction, Parameter, RemovedConstraint,
@@ -336,27 +336,22 @@ impl ParametricInstance {
     /// DataFrame of constraints, dispatched on `kind=`. See
     /// {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
     /// `include=` / `removed=` semantics.
-    #[pyo3(signature = (kind = "regular", include = None, removed = false))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular, include = None, removed = false))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
         include: Option<Vec<String>>,
         removed: bool,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(kind)?;
-        let id_col = constraint_id_col(kind_enum);
+        let id_col = constraint_id_col(kind);
         let mut flags = crate::pandas::IncludeFlags::from_optional(include)?;
         if removed {
             flags.removed_reason = true;
         }
         constraint_kind_collection!(
             self.inner,
-            kind_enum,
+            kind,
             [
                 constraint_collection,
                 indicator_constraint_collection,
@@ -440,17 +435,12 @@ impl ParametricInstance {
     /// Constraint metadata DataFrame (id-indexed). See
     /// {meth}`ommx.v1.Instance.constraint_metadata_df` for column / `kind=`
     /// semantics.
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -473,17 +463,12 @@ impl ParametricInstance {
     }
 
     /// Constraint parameters DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -506,17 +491,12 @@ impl ParametricInstance {
     }
 
     /// Constraint provenance DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -539,17 +519,12 @@ impl ParametricInstance {
     }
 
     /// Removed-constraint reasons DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -336,15 +336,19 @@ impl ParametricInstance {
     /// DataFrame of constraints, dispatched on `kind=`. See
     /// {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
     /// `include=` / `removed=` semantics.
-    #[pyo3(signature = (kind = String::from("regular"), include = None, removed = false))]
+    #[pyo3(signature = (kind = "regular", include = None, removed = false))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
         include: Option<Vec<String>>,
         removed: bool,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(&kind)?;
+        let kind_enum = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind_enum);
         let mut flags = crate::pandas::IncludeFlags::from_optional(include)?;
         if removed {
@@ -436,13 +440,17 @@ impl ParametricInstance {
     /// Constraint metadata DataFrame (id-indexed). See
     /// {meth}`ommx.v1.Instance.constraint_metadata_df` for column / `kind=`
     /// semantics.
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -465,13 +473,17 @@ impl ParametricInstance {
     }
 
     /// Constraint parameters DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -494,13 +506,17 @@ impl ParametricInstance {
     }
 
     /// Constraint provenance DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -523,13 +539,17 @@ impl ParametricInstance {
     }
 
     /// Removed-constraint reasons DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -361,20 +361,46 @@ impl ParametricInstance {
             ],
             |coll| {
                 let meta = coll.metadata().clone();
+                let active = coll.active();
+                let removed_map = coll.removed();
                 let mut entries: Vec<Bound<'py, pyo3::types::PyAny>> = Vec::new();
-                for (id, c) in coll.active().iter() {
-                    let m = meta.collect_for(*id);
-                    let dict =
-                        crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
-                    crate::pandas::apply_include_filter(&dict, flags)?;
-                    crate::pandas::rename_id_column(&dict, id_col)?;
-                    entries.push(dict.into_any());
-                }
                 if removed {
-                    for (id, pair) in coll.removed().iter() {
+                    let mut ai = active.iter().peekable();
+                    let mut ri = removed_map.iter().peekable();
+                    loop {
+                        let pick_active = match (ai.peek(), ri.peek()) {
+                            (Some((aid, _)), Some((rid, _))) => aid <= rid,
+                            (Some(_), None) => true,
+                            (None, Some(_)) => false,
+                            (None, None) => break,
+                        };
+                        if pick_active {
+                            let (id, c) = ai.next().unwrap();
+                            let m = meta.collect_for(*id);
+                            let dict = crate::pandas::WithMetadata::new((*id, c), &m)
+                                .to_pandas_entry(py)?;
+                            crate::pandas::set_removed_reason_na(&dict)?;
+                            crate::pandas::apply_include_filter(&dict, flags)?;
+                            crate::pandas::rename_id_column(&dict, id_col)?;
+                            entries.push(dict.into_any());
+                        } else {
+                            let (id, pair) = ri.next().unwrap();
+                            let m = meta.collect_for(*id);
+                            let dict = crate::pandas::WithMetadata::new((*id, pair), &m)
+                                .to_pandas_entry(py)?;
+                            crate::pandas::apply_include_filter(&dict, flags)?;
+                            crate::pandas::rename_id_column(&dict, id_col)?;
+                            entries.push(dict.into_any());
+                        }
+                    }
+                } else {
+                    for (id, c) in active.iter() {
                         let m = meta.collect_for(*id);
-                        let dict = crate::pandas::WithMetadata::new((*id, pair), &m)
-                            .to_pandas_entry(py)?;
+                        let dict =
+                            crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
+                        if flags.removed_reason {
+                            crate::pandas::set_removed_reason_na(&dict)?;
+                        }
                         crate::pandas::apply_include_filter(&dict, flags)?;
                         crate::pandas::rename_id_column(&dict, id_col)?;
                         entries.push(dict.into_any());

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -672,10 +672,12 @@ impl SampleSet {
                         &m,
                     )
                     .to_pandas_entry(py)?;
-                    if let Some(reason) = removed_reasons.get(id) {
-                        crate::pandas::set_removed_reason_columns(&dict, reason)?;
-                    } else if flags.removed_reason {
-                        crate::pandas::set_removed_reason_na(&dict)?;
+                    if flags.removed_reason {
+                        if let Some(reason) = removed_reasons.get(id) {
+                            crate::pandas::set_removed_reason_columns(&dict, reason)?;
+                        } else {
+                            crate::pandas::set_removed_reason_na(&dict)?;
+                        }
                     }
                     crate::pandas::apply_include_filter(&dict, flags)?;
                     crate::pandas::rename_id_column(&dict, id_col)?;

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -674,6 +674,8 @@ impl SampleSet {
                     .to_pandas_entry(py)?;
                     if let Some(reason) = removed_reasons.get(id) {
                         crate::pandas::set_removed_reason_columns(&dict, reason)?;
+                    } else if flags.removed_reason {
+                        crate::pandas::set_removed_reason_na(&dict)?;
                     }
                     crate::pandas::apply_include_filter(&dict, flags)?;
                     crate::pandas::rename_id_column(&dict, id_col)?;

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -638,14 +638,18 @@ impl SampleSet {
     /// `SampleSet` has no `removed=` parameter (no active/removed
     /// distinction at the sampled stage); reason data is gated by
     /// `"removed_reason"` in `include=`.
-    #[pyo3(signature = (kind = String::from("regular"), include = None))]
+    #[pyo3(signature = (kind = "regular", include = None))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
         include: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(&kind)?;
+        let kind_enum = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind_enum);
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let sample_ids = sorted_sample_ids(&self.inner);
@@ -716,13 +720,17 @@ impl SampleSet {
     /// Constraint metadata DataFrame (id-indexed). See
     /// {meth}`ommx.v1.Instance.constraint_metadata_df` for column / `kind=`
     /// semantics. Reads from the sampled collection's metadata store.
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -745,13 +753,17 @@ impl SampleSet {
     }
 
     /// Constraint parameters DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -774,13 +786,17 @@ impl SampleSet {
     }
 
     /// Constraint provenance DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -803,13 +819,17 @@ impl SampleSet {
     }
 
     /// Removed-constraint reasons DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -1,7 +1,7 @@
 use crate::{
     pandas::{
         constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
-        sorted_entries_to_dataframe, PyDataFrame, WithSampleIds,
+        sorted_entries_to_dataframe, PyDataFrame, ToPandasEntry, WithSampleIds,
     },
     Solution,
 };
@@ -629,252 +629,58 @@ impl SampleSet {
         )
     }
 
-    /// DataFrame of constraints with per-sample value and feasibility columns.
-    /// Static columns: id, equality, used_ids, name, subscripts, description.
-    /// Dynamic columns: value.{sample_id} and feasible.{sample_id} for each sample.
-    #[pyo3(signature = (include = None))]
+    /// DataFrame of sampled constraints, dispatched on `kind=`. See
+    /// {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
+    /// `include=` semantics. Adds dynamic per-sample columns
+    /// (`value.{sample_id}`, `feasible.{sample_id}`, etc.) on top of
+    /// the kind-specific core columns.
+    ///
+    /// `SampleSet` has no `removed=` parameter (no active/removed
+    /// distinction at the sampled stage); reason data is gated by
+    /// `"removed_reason"` in `include=`.
+    #[pyo3(signature = (kind = String::from("regular"), include = None))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
+        kind: String,
         include: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
+        let kind_enum = parse_constraint_kind(&kind)?;
+        let id_col = constraint_id_col(kind_enum);
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let sample_ids = sorted_sample_ids(&self.inner);
-        let meta_store = self.inner.constraints().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::ConstraintID,
-            &ommx::SampledConstraint,
-        )> = self
-            .inner
-            .constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter().map(|(m, id, c)| {
-                crate::pandas::WithMetadata::new(
-                    WithSampleIds {
-                        item: (*id, *c),
-                        sample_ids: &sample_ids,
-                    },
-                    m,
-                )
-            }),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`constraints_df` using the `id` index.
-    pub fn removed_reasons_df<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
-        )
-    }
-
-    /// DataFrame of indicator constraints with per-sample value, feasibility, and indicator_active columns.
-    /// Static columns: id, indicator_variable_id, equality, used_ids, name, subscripts, description.
-    /// Dynamic columns: value.{sample_id}, feasible.{sample_id}, indicator_active.{sample_id} for each sample.
-    #[pyo3(signature = (include = None))]
-    pub fn indicator_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let sample_ids = sorted_sample_ids(&self.inner);
-        let meta_store = self.inner.indicator_constraints().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::IndicatorConstraintID,
-            &ommx::SampledIndicatorConstraint,
-        )> = self
-            .inner
-            .indicator_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter().map(|(m, id, c)| {
-                crate::pandas::WithMetadata::new(
-                    WithSampleIds {
-                        item: (*id, *c),
-                        sample_ids: &sample_ids,
-                    },
-                    m,
-                )
-            }),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed indicator constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`indicator_constraints_df` using the `id` index.
-    pub fn indicator_removed_reasons_df<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .indicator_constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
-        )
-    }
-
-    /// DataFrame of one-hot constraints with per-sample feasibility and active_variable columns.
-    /// Static columns: id, used_ids, name, subscripts, description.
-    /// Dynamic columns: feasible.{sample_id}, active_variable.{sample_id} for each sample.
-    #[pyo3(signature = (include = None))]
-    pub fn one_hot_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let sample_ids = sorted_sample_ids(&self.inner);
-        let meta_store = self.inner.one_hot_constraints().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::OneHotConstraintID,
-            &ommx::SampledOneHotConstraint,
-        )> = self
-            .inner
-            .one_hot_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter().map(|(m, id, c)| {
-                crate::pandas::WithMetadata::new(
-                    WithSampleIds {
-                        item: (*id, *c),
-                        sample_ids: &sample_ids,
-                    },
-                    m,
-                )
-            }),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed one-hot constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`one_hot_constraints_df` using the `id` index.
-    pub fn one_hot_removed_reasons_df<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .one_hot_constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
-        )
-    }
-
-    /// DataFrame of SOS1 constraints with per-sample feasibility and active_variable columns.
-    /// Static columns: id, used_ids, name, subscripts, description.
-    /// Dynamic columns: feasible.{sample_id}, active_variable.{sample_id} for each sample.
-    #[pyo3(signature = (include = None))]
-    pub fn sos1_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let sample_ids = sorted_sample_ids(&self.inner);
-        let meta_store = self.inner.sos1_constraints().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::Sos1ConstraintID,
-            &ommx::SampledSos1Constraint,
-        )> = self
-            .inner
-            .sos1_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter().map(|(m, id, c)| {
-                crate::pandas::WithMetadata::new(
-                    WithSampleIds {
-                        item: (*id, *c),
-                        sample_ids: &sample_ids,
-                    },
-                    m,
-                )
-            }),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed SOS1 constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`sos1_constraints_df` using the `id` index.
-    pub fn sos1_removed_reasons_df<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .sos1_constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
+        constraint_kind_collection!(
+            self.inner,
+            kind_enum,
+            [
+                constraints,
+                indicator_constraints,
+                one_hot_constraints,
+                sos1_constraints
+            ],
+            |coll| {
+                let meta = coll.metadata().clone();
+                let removed_reasons = coll.removed_reasons();
+                let mut entries: Vec<Bound<'py, pyo3::types::PyAny>> = Vec::new();
+                for (id, c) in coll.inner().iter() {
+                    let m = meta.collect_for(*id);
+                    let dict = crate::pandas::WithMetadata::new(
+                        WithSampleIds {
+                            item: (*id, c),
+                            sample_ids: &sample_ids,
+                        },
+                        &m,
+                    )
+                    .to_pandas_entry(py)?;
+                    if let Some(reason) = removed_reasons.get(id) {
+                        crate::pandas::set_removed_reason_columns(&dict, reason)?;
+                    }
+                    crate::pandas::apply_include_filter(&dict, flags)?;
+                    crate::pandas::rename_id_column(&dict, id_col)?;
+                    entries.push(dict.into_any());
+                }
+                crate::pandas::raw_entries_to_dataframe(py, entries, id_col)
+            }
         )
     }
 

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -1,7 +1,7 @@
 use crate::{
     pandas::{
-        constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
-        sorted_entries_to_dataframe, PyDataFrame, ToPandasEntry, WithSampleIds,
+        constraint_id_col, constraint_kind_collection, entries_to_dataframe,
+        sorted_entries_to_dataframe, ConstraintKind, PyDataFrame, ToPandasEntry, WithSampleIds,
     },
     Solution,
 };
@@ -638,24 +638,19 @@ impl SampleSet {
     /// `SampleSet` has no `removed=` parameter (no active/removed
     /// distinction at the sampled stage); reason data is gated by
     /// `"removed_reason"` in `include=`.
-    #[pyo3(signature = (kind = "regular", include = None))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular, include = None))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
         include: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(kind)?;
-        let id_col = constraint_id_col(kind_enum);
+        let id_col = constraint_id_col(kind);
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let sample_ids = sorted_sample_ids(&self.inner);
         constraint_kind_collection!(
             self.inner,
-            kind_enum,
+            kind,
             [
                 constraints,
                 indicator_constraints,
@@ -720,17 +715,12 @@ impl SampleSet {
     /// Constraint metadata DataFrame (id-indexed). See
     /// {meth}`ommx.v1.Instance.constraint_metadata_df` for column / `kind=`
     /// semantics. Reads from the sampled collection's metadata store.
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -753,17 +743,12 @@ impl SampleSet {
     }
 
     /// Constraint parameters DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -786,17 +771,12 @@ impl SampleSet {
     }
 
     /// Constraint provenance DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -819,17 +799,12 @@ impl SampleSet {
     }
 
     /// Removed-constraint reasons DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -1,5 +1,5 @@
 use crate::pandas::{
-    constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
+    constraint_id_col, constraint_kind_collection, entries_to_dataframe, ConstraintKind,
     PyDataFrame, ToPandasEntry,
 };
 use anyhow::Result;
@@ -509,23 +509,18 @@ impl Solution {
     /// `"removed_reason"` in `include=`. When the flag is on, rows for
     /// constraints removed before evaluation get `removed_reason` /
     /// `removed_reason.{key}` columns populated; other rows have NA.
-    #[pyo3(signature = (kind = "regular", include = None))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular, include = None))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
         include: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(kind)?;
-        let id_col = constraint_id_col(kind_enum);
+        let id_col = constraint_id_col(kind);
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         constraint_kind_collection!(
             self.inner,
-            kind_enum,
+            kind,
             [
                 evaluated_constraints,
                 evaluated_indicator_constraints,
@@ -581,17 +576,12 @@ impl Solution {
     /// Constraint metadata DataFrame (id-indexed). See
     /// {meth}`ommx.v1.Instance.constraint_metadata_df` for column / `kind=`
     /// semantics. Reads from the evaluated collection's metadata store.
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -614,17 +604,12 @@ impl Solution {
     }
 
     /// Constraint parameters DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -647,17 +632,12 @@ impl Solution {
     }
 
     /// Constraint provenance DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -680,17 +660,12 @@ impl Solution {
     }
 
     /// Removed-constraint reasons DataFrame (long format).
-    #[pyo3(signature = (kind = "regular"))]
+    #[pyo3(signature = (kind = ConstraintKind::Regular))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        #[gen_stub(override_type(
-            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
-            imports = ("typing")
-        ))]
-        kind: &str,
+        kind: ConstraintKind,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -1,6 +1,6 @@
 use crate::pandas::{
     constraint_id_col, constraint_kind_collection, entries_to_dataframe, parse_constraint_kind,
-    PyDataFrame,
+    PyDataFrame, ToPandasEntry,
 };
 use anyhow::Result;
 use pyo3::{
@@ -500,266 +500,51 @@ impl Solution {
         )
     }
 
-    /// DataFrame of evaluated constraints
+    /// DataFrame of evaluated constraints, dispatched on `kind=`. See
+    /// {meth}`ommx.v1.Instance.constraints_df` for column / `kind=` /
+    /// `include=` semantics.
     ///
-    /// Columns: id (index), equality, value, used_ids, name, subscripts, description, dual_variable
-    #[pyo3(signature = (include = None))]
+    /// `Solution` has no `removed=` parameter (no active/removed
+    /// distinction at the evaluated stage); reason data is gated by
+    /// `"removed_reason"` in `include=`. When the flag is on, rows for
+    /// constraints removed before evaluation get `removed_reason` /
+    /// `removed_reason.{key}` columns populated; other rows have NA.
+    #[pyo3(signature = (kind = String::from("regular"), include = None))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
+        kind: String,
         include: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
+        let kind_enum = parse_constraint_kind(&kind)?;
+        let id_col = constraint_id_col(kind_enum);
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.evaluated_constraints().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::ConstraintID,
-            &ommx::EvaluatedConstraint,
-        )> = self
-            .inner
-            .evaluated_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`constraints_df` on the `id` index.
-    ///
-    /// # Examples
-    ///
-    /// ```python
-    /// >>> from ommx.v1 import Instance, DecisionVariable
-    /// >>> x = [DecisionVariable.binary(i) for i in range(3)]
-    /// >>> instance = Instance.from_components(
-    /// ...     decision_variables=x,
-    /// ...     objective=sum(x),
-    /// ...     constraints=[
-    /// ...         (x[0] + x[1] == 1).set_id(10),
-    /// ...         (x[1] + x[2] == 1).set_id(20),
-    /// ...     ],
-    /// ...     sense=Instance.MAXIMIZE,
-    /// ... )
-    /// >>> instance.relax_constraint(10, "test_reason")
-    /// >>> solution = instance.evaluate({0: 1, 1: 0, 2: 1})
-    /// ```
-    ///
-    /// `removed_reasons_df` contains only removed constraints:
-    ///
-    /// ```python
-    /// >>> solution.removed_reasons_df()
-    ///     removed_reason
-    /// id
-    /// 10    test_reason
-    /// ```
-    ///
-    /// Join with `constraints_df` to get full information:
-    ///
-    /// ```python
-    /// >>> df = solution.constraints_df().join(solution.removed_reasons_df())
-    /// >>> df[["value", "removed_reason"]]
-    ///     value removed_reason
-    /// id
-    /// 10    0.0   test_reason
-    /// 20    0.0           NaN
-    /// ```
-    pub fn removed_reasons_df<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .evaluated_constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
-        )
-    }
-
-    /// DataFrame of evaluated indicator constraints
-    ///
-    /// Columns: id (index), indicator_variable_id, equality, value, indicator_active, used_ids, name, subscripts, description
-    #[pyo3(signature = (include = None))]
-    pub fn indicator_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self
-            .inner
-            .evaluated_indicator_constraints()
-            .metadata()
-            .clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::IndicatorConstraintID,
-            &ommx::EvaluatedIndicatorConstraint,
-        )> = self
-            .inner
-            .evaluated_indicator_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed indicator constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`indicator_constraints_df` using the `id` index.
-    pub fn indicator_removed_reasons_df<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .evaluated_indicator_constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
-        )
-    }
-
-    /// DataFrame of evaluated one-hot constraints
-    ///
-    /// Columns: id (index), feasible, active_variable, used_ids, name, subscripts, description
-    #[pyo3(signature = (include = None))]
-    pub fn one_hot_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self
-            .inner
-            .evaluated_one_hot_constraints()
-            .metadata()
-            .clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::OneHotConstraintID,
-            &ommx::EvaluatedOneHotConstraint,
-        )> = self
-            .inner
-            .evaluated_one_hot_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed one-hot constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`one_hot_constraints_df` using the `id` index.
-    pub fn one_hot_removed_reasons_df<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .evaluated_one_hot_constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
-        )
-    }
-
-    /// DataFrame of evaluated SOS1 constraints
-    ///
-    /// Columns: id (index), feasible, active_variable, used_ids, name, subscripts, description
-    #[pyo3(signature = (include = None))]
-    pub fn sos1_constraints_df<'py>(
-        &self,
-        py: Python<'py>,
-        include: Option<Vec<String>>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let flags = crate::pandas::IncludeFlags::from_optional(include)?;
-        let meta_store = self.inner.evaluated_sos1_constraints().metadata().clone();
-        let view: Vec<(
-            ommx::ConstraintMetadata,
-            ommx::Sos1ConstraintID,
-            &ommx::EvaluatedSos1Constraint,
-        )> = self
-            .inner
-            .evaluated_sos1_constraints()
-            .iter()
-            .map(|(id, c)| (meta_store.collect_for(*id), *id, c))
-            .collect();
-        entries_to_dataframe(
-            py,
-            view.iter()
-                .map(|(m, id, c)| crate::pandas::WithMetadata::new((*id, *c), m)),
-            "id",
-            flags,
-        )
-    }
-
-    /// DataFrame of removed SOS1 constraint reasons.
-    ///
-    /// Columns: id (index), removed_reason, removed_reason.{key}
-    ///
-    /// Can be joined with {meth}`sos1_constraints_df` using the `id` index.
-    pub fn sos1_removed_reasons_df<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Bound<'py, PyDataFrame>> {
-        use crate::pandas::{IncludeFlags, RemovedReasonEntry};
-        entries_to_dataframe(
-            py,
-            self.inner
-                .evaluated_sos1_constraints()
-                .removed_reasons()
-                .iter()
-                .map(|(id, reason)| RemovedReasonEntry {
-                    id: id.into_inner(),
-                    reason,
-                }),
-            "id",
-            IncludeFlags::default_wide(),
+        constraint_kind_collection!(
+            self.inner,
+            kind_enum,
+            [
+                evaluated_constraints,
+                evaluated_indicator_constraints,
+                evaluated_one_hot_constraints,
+                evaluated_sos1_constraints
+            ],
+            |coll| {
+                let meta = coll.metadata().clone();
+                let removed_reasons = coll.removed_reasons();
+                let mut entries: Vec<Bound<'py, pyo3::types::PyAny>> = Vec::new();
+                for (id, c) in coll.inner().iter() {
+                    let m = meta.collect_for(*id);
+                    let dict =
+                        crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
+                    if let Some(reason) = removed_reasons.get(id) {
+                        crate::pandas::set_removed_reason_columns(&dict, reason)?;
+                    }
+                    crate::pandas::apply_include_filter(&dict, flags)?;
+                    crate::pandas::rename_id_column(&dict, id_col)?;
+                    entries.push(dict.into_any());
+                }
+                crate::pandas::raw_entries_to_dataframe(py, entries, id_col)
+            }
         )
     }
 

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -509,14 +509,18 @@ impl Solution {
     /// `"removed_reason"` in `include=`. When the flag is on, rows for
     /// constraints removed before evaluation get `removed_reason` /
     /// `removed_reason.{key}` columns populated; other rows have NA.
-    #[pyo3(signature = (kind = String::from("regular"), include = None))]
+    #[pyo3(signature = (kind = "regular", include = None))]
     pub fn constraints_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
         include: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind_enum = parse_constraint_kind(&kind)?;
+        let kind_enum = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind_enum);
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         constraint_kind_collection!(
@@ -577,13 +581,17 @@ impl Solution {
     /// Constraint metadata DataFrame (id-indexed). See
     /// {meth}`ommx.v1.Instance.constraint_metadata_df` for column / `kind=`
     /// semantics. Reads from the evaluated collection's metadata store.
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_metadata_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -606,13 +614,17 @@ impl Solution {
     }
 
     /// Constraint parameters DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_parameters_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -635,13 +647,17 @@ impl Solution {
     }
 
     /// Constraint provenance DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_provenance_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,
@@ -664,13 +680,17 @@ impl Solution {
     }
 
     /// Removed-constraint reasons DataFrame (long format).
-    #[pyo3(signature = (kind = String::from("regular")))]
+    #[pyo3(signature = (kind = "regular"))]
     pub fn constraint_removed_reasons_df<'py>(
         &self,
         py: Python<'py>,
-        kind: String,
+        #[gen_stub(override_type(
+            type_repr = "typing.Literal[\"regular\", \"indicator\", \"one_hot\", \"sos1\"]",
+            imports = ("typing")
+        ))]
+        kind: &str,
     ) -> PyResult<Bound<'py, PyDataFrame>> {
-        let kind = parse_constraint_kind(&kind)?;
+        let kind = parse_constraint_kind(kind)?;
         let id_col = constraint_id_col(kind);
         constraint_kind_collection!(
             self.inner,

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -536,12 +536,16 @@ impl Solution {
                     let m = meta.collect_for(*id);
                     let dict =
                         crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
-                    if let Some(reason) = removed_reasons.get(id) {
-                        crate::pandas::set_removed_reason_columns(&dict, reason)?;
-                    } else if flags.removed_reason {
-                        // Ensure removed_reason column appears even
-                        // when no row in this view carries a reason.
-                        crate::pandas::set_removed_reason_na(&dict)?;
+                    if flags.removed_reason {
+                        // Always emit the `removed_reason` column when
+                        // requested so its existence in the resulting
+                        // DataFrame is a function of the flag, not of
+                        // whether any row happens to carry a reason.
+                        if let Some(reason) = removed_reasons.get(id) {
+                            crate::pandas::set_removed_reason_columns(&dict, reason)?;
+                        } else {
+                            crate::pandas::set_removed_reason_na(&dict)?;
+                        }
                     }
                     crate::pandas::apply_include_filter(&dict, flags)?;
                     crate::pandas::rename_id_column(&dict, id_col)?;

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -538,6 +538,10 @@ impl Solution {
                         crate::pandas::WithMetadata::new((*id, c), &m).to_pandas_entry(py)?;
                     if let Some(reason) = removed_reasons.get(id) {
                         crate::pandas::set_removed_reason_columns(&dict, reason)?;
+                    } else if flags.removed_reason {
+                        // Ensure removed_reason column appears even
+                        // when no row in this view carries a reason.
+                        crate::pandas::set_removed_reason_na(&dict)?;
                     }
                     crate::pandas::apply_include_filter(&dict, flags)?;
                     crate::pandas::rename_id_column(&dict, id_col)?;


### PR DESCRIPTION
## Summary

Wave 2 of the v3-alpha pandas surface. Collapses 26 per-kind methods (4 hosts × {regular, indicator, one_hot, sos1} × {active, removed}) into one `constraints_df` per host with `Literal`-typed `kind=` dispatch:

```python
# Instance / ParametricInstance
instance.constraints_df(
    kind: Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
    include: Sequence[str] | None = None,  # default ("metadata", "parameters")
    removed: bool = False,                 # active+removed in one DataFrame; auto-sets "removed_reason"
)

# Solution / SampleSet (no `removed=` — no active/removed distinction at the evaluated stage)
solution.constraints_df(
    kind: Literal["regular", "indicator", "one_hot", "sos1"] = "regular",
    include: Sequence[str] | None = None,
)
```

`include=` accepts `"metadata"` / `"parameters"` / `"removed_reason"`. `"removed_reason"` is a unit flag that gates both the reason name column and the `removed_reason.{key}` parameter columns; `"parameters"` continues to gate only the constraint's own metadata parameters.

Wide DataFrames now index by the kind-qualified id column (`regular_constraint_id`, `indicator_constraint_id`, `one_hot_constraint_id`, `sos1_constraint_id`) so accidental cross-id-space `df.join()` mistakes surface in `df.head()`. `removed_reason.{key}` columns are sorted lexicographically to match the existing `*_parameters_df` sidecar shape.

The same `Literal` typing applies to the four long-format sidecar accessors (`constraint_metadata_df` / `constraint_parameters_df` / `constraint_provenance_df` / `constraint_removed_reasons_df`) on every host.

Detailed design rationale lives in `METADATA_STORAGE_V3.md` (`### *_df methods → derived views with include and kind=`).

## Behavior guarantees

- **Globally id-sorted on `removed=True`.** Active and removed rows merge into a single id-sorted sequence, not section-by-section.
- **Schema-stable `removed_reason` column.** When `include=("removed_reason",)` is in effect, the column always appears in the resulting DataFrame, even when no row in the view actually carries a reason (NA-filled). The `removed_reason.{key}` columns remain data-dependent.
- **Kind-qualified `df.index.name` even on empty collections.** `*_df(kind="indicator")` on an instance with no indicator constraints still returns a DataFrame whose `df.index.name == "indicator_constraint_id"`.

## Type surface

`kind=` is typed `Literal["regular", "indicator", "one_hot", "sos1"]` in the generated stubs so type checkers catch typos (`kind="indicaator"`) at edit time. The runtime `FromPyObject` impl on `ConstraintKind` keeps validating against the same set and raising `ValueError` on unknown values for callers without a type checker.

This is implemented by giving `ConstraintKind` (an internal Rust enum) its own `PyStubType` / `FromPyObject` / `IntoPyObject` impls — mirroring the `ToFunction` / `ToState` / `ToSamples` pattern already used elsewhere in the crate. The 20× duplicated `#[gen_stub(override_type(...))]` attribute the first cut had is gone; the typing lives in one place. Recorded as a project rule in `.claude/rules/pyo3-bindings.md`: `override_type` is for one-shot cases only; recurring types own their own `PyStubType`.

`@overload` stubs that vary the *return type* by kind are intentionally not emitted: every `*_df` accessor returns a uniform `pandas.DataFrame`, so overloads have no return-type variation to express.

## Breaking changes

- `Instance.indicator_constraints_df()` → `instance.constraints_df(kind="indicator")` (and `"one_hot"` / `"sos1"` likewise).
- `Instance.removed_*_constraints_df()` → `instance.constraints_df(kind=..., removed=True)`.
- `Solution.*_removed_reasons_df()` / `SampleSet.*_removed_reasons_df()` → `solution.constraints_df(kind=..., include=("...","removed_reason"))`.
- Wide DataFrame index renamed from `id` to `{kind}_constraint_id`.

The long-format `constraint_removed_reasons_df(kind=...)` sidecar is unchanged — still the right surface when you want one row per (constraint id, parameter key) pair for joins or aggregation.

## Test plan

- [x] `task python:test` passes (290 unit + 37 bench + adapter suites)
- [x] `task rust:test` passes (44 doctests)
- [x] `task format` clean
- [x] `cargo clippy -p _ommx_rust` warning-free
- [x] `test_constraints_df.py` covers kind dispatch × include matrix × `removed=` × all 4 hosts × empty-collection edge cases (30 tests, ~26 snapshots)
- [x] Existing per-kind tests in `test_indicator_constraint.py` / `test_one_hot_sos1_constraints.py` migrated to snapshot form
- [x] Stubs regenerated via `task python:stubgen`; `Literal` types verified for every `kind=` site (5 methods × 4 hosts = 20 sites)
- [x] EN/JA docs updated (`special_constraints.md`, `capability_model.md`, `release_note/ommx-3.0.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)