### PR TITLE
refactor(rust): narrow ConstraintCollection mutation primitives to pub(crate)

### DIFF
--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -1470,7 +1470,9 @@ traceability with earlier review comments.
    ```rust
    impl<T: ConstraintType> ConstraintCollection<T> {
        pub fn unused_id(&self) -> T::ID;
-       pub fn insert_with(
+       // pub(crate) — external callers go through Instance::add_*
+       // (which validates required_ids and then delegates to insert_with).
+       pub(crate) fn insert_with(
            &mut self,
            id: T::ID,
            c: T::Created,
@@ -1478,6 +1480,8 @@ traceability with earlier review comments.
        );
    }
 
+   // Crate-internal usage (e.g. inside instance/setter.rs after
+   // validate_required_ids):
    let id = collection.unused_id();
    collection.insert_with(
        id,
@@ -1499,10 +1503,14 @@ traceability with earlier review comments.
      owned read, modeling-chain staging). Same shape as the pre-v3
      struct.
 
-   Pure Rust callers (algorithms, adapters, tests) constructing
-   constraints in loops use `insert_with` to avoid the silent-
-   metadata-loss footgun of the two-step form. Independent of the
-   Python staging bag, which serves the modeling chain.
+   Inside the `ommx` crate, algorithms / setters use `insert_with`
+   in tight loops to avoid the silent-metadata-loss footgun of the
+   two-step form (`active_mut().insert(id, c)` plus a separate
+   `metadata_mut().insert(id, m)`). External callers don't see this
+   primitive directly — they go through `Instance::add_*`, which
+   validates `required_ids()` first and then delegates to
+   `insert_with`. Independent of the Python staging bag, which
+   serves the modeling chain.
 4. **`parameters` Rust storage — nested
    `FnvHashMap<ID, FnvHashMap<String, String>>`.** Matches the
    existing per-object metadata shape, makes "all parameters of one

--- a/METADATA_STORAGE_V3.md
+++ b/METADATA_STORAGE_V3.md
@@ -1556,14 +1556,16 @@ traceability with earlier review comments.
 
 ## Follow-ups (post-#843, post-#846, post-#849, post-#850, post-#852)
 
-- **Tighten `ConstraintCollection<T>` mutation surface.**
-  `active_mut()` / `removed_mut()` / `insert_with()` are still `pub`
-  on `ConstraintCollection<T>` itself, even though no public caller
-  outside the crate needs them — `Instance` and `ParametricInstance`
-  now expose only invariant-safe operations (`add_*`, `relax`,
-  `restore`, `*_metadata_mut`). These three methods should be
-  narrowed to `pub(crate)` (or smaller) in a follow-up so the only
-  way to break the collection's invariants is from inside the crate.
+- **Tighten `ConstraintCollection<T>` mutation surface (landed).**
+  `active_mut()` / `removed_mut()` / `insert_with()` were still `pub`
+  on `ConstraintCollection<T>` even though no caller outside the crate
+  needed them — `Instance` and `ParametricInstance` already exposed
+  only invariant-safe operations (`add_*`, `relax_*`, `restore_*`,
+  `insert_constraint`, `*_metadata_mut`), and never handed out
+  `&mut ConstraintCollection<T>`. These three primitives are now
+  `pub(crate)`, so external callers can only mutate constraint
+  collections through the validating `Instance` API. The
+  `migration_guide` reference card was updated accordingly.
 - **Document the `AttachedX` family in
   `PYTHON_SDK_MIGRATION_GUIDE.md`.** The migration guide currently
   predates the write-through extension; a new section should cover

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -247,16 +247,14 @@ instance.removed_constraints()   // &BTreeMap<ConstraintID, (Constraint, Removed
 instance.constraint_collection() // &ConstraintCollection<Constraint>
 ```
 
-For internal/mutable access:
-```rust,ignore
-// ❌ Before
-self.constraints.values_mut()
-self.removed_constraints.entry(id)
-
-// ✅ After
-self.constraint_collection.active_mut().values_mut()
-self.constraint_collection.removed_mut().entry(id)
-```
+For mutable access, downstream code goes through invariant-safe
+`Instance` / `ParametricInstance` methods (`add_constraint`,
+`insert_constraint`, `relax_constraint`, `restore_constraint`, …) —
+these validate that every `id` referenced by the constraint exists in
+`decision_variables` and keep the active / removed maps disjoint. The
+raw `active_mut()` / `removed_mut()` mutators on
+`ConstraintCollection<T>` are `pub(crate)` and not callable from
+outside the crate.
 
 ### 6. getset Removal
 
@@ -387,12 +385,14 @@ pub struct ConstraintCollection<T: ConstraintType> {
     removed: BTreeMap<T::ID, (T::Created, RemovedReason)>,
 }
 
-// Methods
+// Methods (public)
 collection.active()                    // &BTreeMap<T::ID, T::Created>
 collection.removed()                   // &BTreeMap<T::ID, (T::Created, RemovedReason)>
-collection.active_mut()                // &mut BTreeMap
-collection.removed_mut()               // &mut BTreeMap
 collection.into_parts()                // (active, removed)
+// Mutation goes through Instance / ParametricInstance methods so
+// invariants (active/removed disjointness, variable-id validity)
+// are enforced; the raw `active_mut` / `removed_mut` / `insert_with`
+// primitives on this type are `pub(crate)`.
 
 // Evaluate trait impl
 collection.evaluate(state, atol)           // EvaluatedCollection<T>

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -388,7 +388,8 @@ pub struct ConstraintCollection<T: ConstraintType> {
 // Methods (public)
 collection.active()                    // &BTreeMap<T::ID, T::Created>
 collection.removed()                   // &BTreeMap<T::ID, (T::Created, RemovedReason)>
-collection.into_parts()                // (active, removed)
+collection.metadata()                  // &ConstraintMetadataStore<T::ID>
+collection.into_parts()                // (active, removed, metadata)
 // Mutation goes through Instance / ParametricInstance methods so
 // invariants (active/removed disjointness, variable-id validity)
 // are enforced; the raw `active_mut` / `removed_mut` / `insert_with`

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -250,12 +250,21 @@ impl<T: ConstraintType> ConstraintCollection<T> {
     }
 
     /// Mutable access to active constraints.
-    pub fn active_mut(&mut self) -> &mut BTreeMap<T::ID, T::Created> {
+    ///
+    /// Crate-internal: callers outside `ommx` go through invariant-safe
+    /// `Instance` / `ParametricInstance` methods (`add_*`, `relax_*`,
+    /// `restore_*`, `insert_constraint`, …). A raw `&mut` on the active
+    /// map can be used to insert a constraint whose `required_ids()` are
+    /// not in `decision_variables`, or to break the active/removed
+    /// disjointness — both of which the high-level API prevents.
+    pub(crate) fn active_mut(&mut self) -> &mut BTreeMap<T::ID, T::Created> {
         &mut self.active
     }
 
     /// Mutable access to removed constraints.
-    pub fn removed_mut(&mut self) -> &mut BTreeMap<T::ID, (T::Created, RemovedReason)> {
+    ///
+    /// Crate-internal: see [`Self::active_mut`].
+    pub(crate) fn removed_mut(&mut self) -> &mut BTreeMap<T::ID, (T::Created, RemovedReason)> {
         &mut self.removed
     }
 
@@ -264,7 +273,18 @@ impl<T: ConstraintType> ConstraintCollection<T> {
     /// `id` must not already be present in either the active or removed map.
     /// The metadata is written to the store; empty metadata fields are stored
     /// sparsely (i.e. omitted) by [`ConstraintMetadataStore::insert`].
-    pub fn insert_with(&mut self, id: T::ID, constraint: T::Created, metadata: ConstraintMetadata) {
+    ///
+    /// Crate-internal: external callers use the validating `Instance::add_*`
+    /// entry points. This primitive bypasses `validate_required_ids`, so the
+    /// caller is responsible for ensuring every `id` in
+    /// `constraint.required_ids()` exists in the parent instance's variable
+    /// store.
+    pub(crate) fn insert_with(
+        &mut self,
+        id: T::ID,
+        constraint: T::Created,
+        metadata: ConstraintMetadata,
+    ) {
         self.active.insert(id, constraint);
         self.metadata.insert(id, metadata);
     }


### PR DESCRIPTION
## Summary

- `ConstraintCollection<T>::active_mut` / `removed_mut` / `insert_with` go from `pub` to `pub(crate)`.
- All call sites are inside `rust/ommx/src/{instance/*,constraint_type.rs}` (algorithm passes, `Instance` setters, `evaluate.rs` propagation). External crates and the PyO3 bindings have no callers — `Instance` / `ParametricInstance` only ever hand out `&ConstraintCollection<T>`, never `&mut`.
- The validating `Instance` / `ParametricInstance` API (`add_*`, `relax_*`, `restore_*`, `insert_constraint`, `*_metadata_mut`) is now the only way external callers can mutate constraint collections, so the required-id and active/removed-disjointness invariants can no longer be broken from outside the crate.
- `rust/ommx/doc/migration_guide.md` reference card updated (raw mutators removed from the public listing). `METADATA_STORAGE_V3.md` Follow-up marked as landed.

## Test plan

- [x] `cargo check -p ommx` clean
- [x] `cargo test -p ommx --lib` — 485 / 485 pass
- [x] `cargo check -p _ommx_rust` clean (PyO3 bindings unaffected — they never reached for these methods)
- [x] `cargo doc -p ommx --no-deps` builds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)