### PR TITLE
chore: bump astral-sh/setup-uv to v8

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -58,7 +58,7 @@ runs:
       uses: Swatinem/rust-cache@v2
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v8
       with:
         python-version: ${{ inputs.python-version }}
     

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -58,7 +58,7 @@ runs:
       uses: Swatinem/rust-cache@v2
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ inputs.python-version }}
     


### PR DESCRIPTION
## Summary
- Update `astral-sh/setup-uv` in `.github/actions/setup-test-environment` from v3 to v8.
- v3 runs on Node.js 20, which GitHub Actions is forcing off on 2026-06-02 and removing on 2026-09-16. v8 already runs on `node24`.
- v3 also does not declare a `python-version` input, so the value the composite action was passing in was silently ignored (the runner emits an "Unexpected input(s) 'python-version'" warning). v8 accepts `python-version` natively, so callers' Python version specifications now take effect.
- The other Node 20 actions called from the same composite (`arduino/setup-protoc@v3`, `arduino/setup-task@v2`, `bufbuild/buf-setup-action@v1`) do not yet have Node 24-based releases upstream, so they stay on their current pins until upstream publishes one.

## Test plan
- [ ] CI green on this branch.
- [ ] Workflow runner no longer reports the `Unexpected input(s) 'python-version'` warning, and `astral-sh/setup-uv` is no longer listed in the Node.js 20 deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)