### PR TITLE
Migrate dataset packaging to v3 Artifact Manifest under ommx/v3/* namespace

### DIFF
--- a/ARTIFACT_V3.md
+++ b/ARTIFACT_V3.md
@@ -672,5 +672,23 @@ v3 PR #864 で landing する範囲。
 | OTel trace layer 埋め込み | 8.4, 8.5 | Phase 1 は OTLP JSON のみ。global `TracerProvider` は設定しない (`trace="auto"`/`"required"` mode) |
 | Trace renderer | 8.6 | Phase 1 は post-hoc renderer、Phase 2 で scoped streaming |
 | `ommx artifact gc` と reachability analysis hook | 10 | Local Registry / 旧 archive / OCI directory layout を対象。remote registry は capability 検出できる場合のみ実削除 |
-| `rust/dataset/{miplib2017,qplib}` packaging path の v3 化 | 6.6 | 現状は legacy `OciDirBuilder` 使用。v3 Artifact Manifest pipeline に揃える |
+| `rust/dataset/{miplib2017,qplib}` packaging path の v3 化 | 6.6 | 新 namespace `ghcr.io/jij-inc/ommx/v3/{miplib2017,qplib}:*` を Artifact Manifest で publish する。既存 `ghcr.io/jij-inc/ommx/{miplib2017,qplib}:*` (Image Manifest) は freeze し、format flip しない (両 namespace は SQLite registry に identity-preserving に共存可能)。code 切替と publish の ordering は §12.3 step A / step B 後の re-publish に対応 |
 | DataStore / Experiment / Run / EnvironmentInfo の OMMX core 取り込み | 7 | minto-equivalent functionality を OMMX-owned で再設計。API compat は破棄 (4.3) |
+
+### 12.3 次の実装 milestone (A → B → C)
+
+§12.2 のうち、新機能ではなく構造を片付ける項目を以下の順序で進める。各 step は独立 PR、step 間で SDK が壊れない状態を維持する。
+
+**Step A — legacy Image Manifest build path の撤去** (§12.2 行 3 Dir 半分、行 11 code 部分)。
+
+`rust/dataset/{miplib2017,qplib}` を `LocalArtifactBuilder::new_ommx` + 明示的 `add_source` に切り替え、出力 image name を `ghcr.io/jij-inc/ommx/v3/{miplib2017,qplib}:<tag>` とする。唯一の caller が消えた `rust/ommx/src/artifact/builder.rs` の `Builder<OciDirBuilder>::{new, for_github}` を削除。既存 `ghcr.io/jij-inc/ommx/{miplib2017,qplib}:*` は触らない (freeze、format flip なし) — SQLite registry は両 namespace を identity-preserving に保持できるため user 影響なし。step B 前は v3 namespace への push 不可だが、これは release workflow のタイミング問題で user 影響はない。
+
+**Step B — SQLite → remote の native push 実装** (§12.2 行 4、行 11 publish 部分)。
+
+`LocalArtifact::push()` を SQLite + CAS から `Remote` に直接 stream する。Python `ArtifactInner::Local::push` の "legacy disk dir 経由 fallback" を撤去。step B 後に `ghcr.io/jij-inc/ommx/v3/{miplib2017,qplib}:*` を初回 publish (v3 dataset release event)。
+
+**Step C — lazy auto-migration の legacy double-write 撤廃** (§12.2 行 5、行 3 Archive 半分)。
+
+`Artifact.load(image)` / `ommx load` の auto-migration を "remote/archive → legacy disk OCI dir → SQLite" の 2-stage から "remote/archive → SQLite" 直結に変更。Python `ArtifactInner::Dir` 分岐を削除し、`{Archive, Local}` 2-variant に。`Artifact<OciDir>` は `import::*` の temp scratch でしか使われない実装詳細に格下げ。
+
+A / B / C 後に残る ocipkg seam は `Builder<OciArchiveBuilder>` (archive 出力) と `import::{archive, remote}` 内の temp staging のみ。§12.2 行 1 (native streamer 置換) と行 2 (ocipkg 公開 surface 撤去) はその次の milestone series。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
  "serde",
  "tracing",
  "tracing-subscriber",
+ "url",
  "zip",
 ]
 

--- a/python/ommx/src/artifact.rs
+++ b/python/ommx/src/artifact.rs
@@ -752,7 +752,7 @@ impl PyArtifactBuilder {
     #[staticmethod]
     pub fn new(image_name: &str) -> Result<Self> {
         let image_name = ocipkg::ImageName::parse(image_name)?;
-        let builder = ommx::artifact::LocalArtifactBuilder::new_ommx(image_name);
+        let builder = ommx::artifact::LocalArtifactBuilder::new(image_name);
         Ok(Self(BuilderInner::Dir(Some(Box::new(builder)))))
     }
 

--- a/python/ommx/src/artifact.rs
+++ b/python/ommx/src/artifact.rs
@@ -614,7 +614,7 @@ fn assert_media_type(descriptor: &PyDescriptor, expected: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 enum BuilderInner {
-    Archive(Option<Box<ommx::artifact::Builder<ocipkg::image::OciArchiveBuilder>>>),
+    Archive(Option<Box<ommx::artifact::Builder>>),
     Dir(Option<Box<ommx::artifact::LocalArtifactBuilder>>),
 }
 

--- a/python/ommx/src/artifact.rs
+++ b/python/ommx/src/artifact.rs
@@ -614,7 +614,7 @@ fn assert_media_type(descriptor: &PyDescriptor, expected: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 enum BuilderInner {
-    Archive(Option<Box<ommx::artifact::Builder>>),
+    Archive(Option<Box<ommx::artifact::ArchiveArtifactBuilder>>),
     Dir(Option<Box<ommx::artifact::LocalArtifactBuilder>>),
 }
 
@@ -722,7 +722,7 @@ impl PyArtifactBuilder {
     /// ```
     #[staticmethod]
     pub fn new_archive_unnamed(path: PathBuf) -> Result<Self> {
-        let builder = ommx::artifact::Builder::new_archive_unnamed(path)?;
+        let builder = ommx::artifact::ArchiveArtifactBuilder::new_archive_unnamed(path)?;
         Ok(Self(BuilderInner::Archive(Some(Box::new(builder)))))
     }
 
@@ -730,7 +730,7 @@ impl PyArtifactBuilder {
     #[staticmethod]
     pub fn new_archive(path: PathBuf, image_name: &str) -> Result<Self> {
         let image_name = ocipkg::ImageName::parse(image_name)?;
-        let builder = ommx::artifact::Builder::new_archive(path, image_name)?;
+        let builder = ommx::artifact::ArchiveArtifactBuilder::new_archive(path, image_name)?;
         Ok(Self(BuilderInner::Archive(Some(Box::new(builder)))))
     }
 
@@ -769,7 +769,7 @@ impl PyArtifactBuilder {
     /// ```
     #[staticmethod]
     pub fn temp() -> Result<Self> {
-        let builder = ommx::artifact::Builder::temp_archive()?;
+        let builder = ommx::artifact::ArchiveArtifactBuilder::temp_archive()?;
         Ok(Self(BuilderInner::Archive(Some(Box::new(builder)))))
     }
 

--- a/rust/dataset/Cargo.toml
+++ b/rust/dataset/Cargo.toml
@@ -15,4 +15,5 @@ ommx = { path = "../ommx" }
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+url.workspace = true
 zip.workspace = true

--- a/rust/dataset/src/miplib2017.rs
+++ b/rust/dataset/src/miplib2017.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result};
-use ommx::artifact::Builder;
+use ommx::{
+    artifact::{LocalArtifact, LocalArtifactBuilder},
+    ocipkg::ImageName,
+};
 use std::{fs, path::Path};
+use url::Url;
 use zip::ZipArchive;
 
 pub fn package(path: &Path) -> Result<()> {
@@ -8,6 +12,8 @@ pub fn package(path: &Path) -> Result<()> {
     tracing::info!("Input Archive: {}", path.display());
     let f = fs::File::open(path).with_context(|| format!("File not found: {path:?}"))?;
     let mut ar = ZipArchive::new(f).with_context(|| format!("Not a ZIP archive: {path:?}"))?;
+
+    let source_url = Url::parse("https://github.com/Jij-Inc/ommx")?;
 
     // Input archive is expected to contain `*.mps.gz` files on the root level.
     for i in 0..ar.len() {
@@ -20,10 +26,11 @@ pub fn package(path: &Path) -> Result<()> {
             continue;
         };
 
-        let Ok(mut builder) = Builder::for_github("Jij-Inc", "ommx", "miplib2017", &name) else {
-            tracing::warn!("Skip: container already exists for '{name}'");
+        let image_name = ImageName::parse(&format!("ghcr.io/jij-inc/ommx/v3/miplib2017:{name}"))?;
+        if LocalArtifact::try_open(image_name.clone())?.is_some() {
+            tracing::info!("Skip: {image_name} already in the v3 local registry");
             continue;
-        };
+        }
 
         tracing::info!("Loading: {name}");
         let instance = match ommx::mps::parse(file) {
@@ -44,6 +51,9 @@ pub fn package(path: &Path) -> Result<()> {
 
         let mut annotations = annotations.clone();
         annotations.set_created_now();
+
+        let mut builder = LocalArtifactBuilder::new_ommx(image_name);
+        builder.add_source(&source_url);
         builder.add_instance(instance.into(), annotations)?;
         let _artifact = builder.build()?;
         // Do not push here. Use `ommx push` command to upload the artifacts.

--- a/rust/dataset/src/miplib2017.rs
+++ b/rust/dataset/src/miplib2017.rs
@@ -26,7 +26,14 @@ pub fn package(path: &Path) -> Result<()> {
             continue;
         };
 
-        let image_name = ImageName::parse(&format!("ghcr.io/jij-inc/ommx/v3/miplib2017:{name}"))?;
+        let image_name =
+            match ImageName::parse(&format!("ghcr.io/jij-inc/ommx/v3/miplib2017:{name}")) {
+                Ok(name) => name,
+                Err(err) => {
+                    tracing::warn!("Skip: invalid image name for '{name}': {err}");
+                    continue;
+                }
+            };
         if LocalArtifact::try_open(image_name.clone())?.is_some() {
             tracing::info!("Skip: {image_name} already in the v3 local registry");
             continue;

--- a/rust/dataset/src/miplib2017.rs
+++ b/rust/dataset/src/miplib2017.rs
@@ -52,7 +52,7 @@ pub fn package(path: &Path) -> Result<()> {
         let mut annotations = annotations.clone();
         annotations.set_created_now();
 
-        let mut builder = LocalArtifactBuilder::new_ommx(image_name);
+        let mut builder = LocalArtifactBuilder::new(image_name);
         builder.add_source(&source_url);
         builder.add_instance(instance.into(), annotations)?;
         let _artifact = builder.build()?;

--- a/rust/dataset/src/qplib.rs
+++ b/rust/dataset/src/qplib.rs
@@ -81,7 +81,7 @@ pub fn package(path: &Path) -> Result<()> {
             ncons
         );
 
-        let mut builder = LocalArtifactBuilder::new_ommx(image_name);
+        let mut builder = LocalArtifactBuilder::new(image_name);
         builder.add_source(&source_url);
         builder.add_instance(instance.into(), annotations)?;
         let _artifact = builder.build()?;

--- a/rust/dataset/src/qplib.rs
+++ b/rust/dataset/src/qplib.rs
@@ -1,6 +1,10 @@
 use anyhow::{anyhow, Context, Result};
-use ommx::artifact::Builder;
+use ommx::{
+    artifact::{LocalArtifact, LocalArtifactBuilder},
+    ocipkg::ImageName,
+};
 use std::{fs, path::Path};
+use url::Url;
 use zip::ZipArchive;
 
 pub fn package(path: &Path) -> Result<()> {
@@ -14,6 +18,8 @@ pub fn package(path: &Path) -> Result<()> {
         "Loaded {} QPLIB metadata entries from CSV",
         csv_annotations.len()
     );
+
+    let source_url = Url::parse("https://github.com/Jij-Inc/ommx")?;
 
     // Input archive is expected to contain `*.qplib` files.
     for i in 0..ar.len() {
@@ -35,10 +41,11 @@ pub fn package(path: &Path) -> Result<()> {
             .strip_prefix("QPLIB_")
             .ok_or_else(|| anyhow!("Expected QPLIB_ prefix in filename: {}", name))?;
 
-        let Ok(mut builder) = Builder::for_github("Jij-Inc", "ommx", "qplib", tag) else {
-            tracing::warn!("Skip: container already exists for '{name}'");
+        let image_name = ImageName::parse(&format!("ghcr.io/jij-inc/ommx/v3/qplib:{tag}"))?;
+        if LocalArtifact::try_open(image_name.clone())?.is_some() {
+            tracing::info!("Skip: {image_name} already in the v3 local registry");
             continue;
-        };
+        }
 
         tracing::info!("Loading: {name}");
 
@@ -74,6 +81,8 @@ pub fn package(path: &Path) -> Result<()> {
             ncons
         );
 
+        let mut builder = LocalArtifactBuilder::new_ommx(image_name);
+        builder.add_source(&source_url);
         builder.add_instance(instance.into(), annotations)?;
         let _artifact = builder.build()?;
         // Do not push here. Use `ommx push` command to upload the artifacts.

--- a/rust/dataset/src/qplib.rs
+++ b/rust/dataset/src/qplib.rs
@@ -41,7 +41,13 @@ pub fn package(path: &Path) -> Result<()> {
             .strip_prefix("QPLIB_")
             .ok_or_else(|| anyhow!("Expected QPLIB_ prefix in filename: {}", name))?;
 
-        let image_name = ImageName::parse(&format!("ghcr.io/jij-inc/ommx/v3/qplib:{tag}"))?;
+        let image_name = match ImageName::parse(&format!("ghcr.io/jij-inc/ommx/v3/qplib:{tag}")) {
+            Ok(name) => name,
+            Err(err) => {
+                tracing::warn!("Skip: invalid image name for '{name}': {err}");
+                continue;
+            }
+        };
         if LocalArtifact::try_open(image_name.clone())?.is_some() {
             tracing::info!("Skip: {image_name} already in the v3 local registry");
             continue;

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -592,9 +592,7 @@ pub struct ConstraintMetadata {
 This section covers the Artifact / Local Registry API changes for users
 moving from `ommx` v2 to v3. The v3 Local Registry is SQLite-backed
 (IndexStore + filesystem CAS BlobStore) rather than an on-disk OCI
-Image Layout per `image:tag`; see the
-[Artifact v3 design](https://github.com/Jij-Inc/ommx/blob/main/ARTIFACT_V3.md)
-for the full model.
+Image Layout per `image:tag`.
 
 ## Overview
 

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -589,11 +589,12 @@ pub struct ConstraintMetadata {
 
 # Rust SDK v3 Artifact API Migration Guide
 
-This section covers the Artifact / Local Registry API changes landed
-across `3.0.0-alpha.2` and later. The v3 Local Registry foundation
-(SQLite-backed `IndexStore` + filesystem CAS `BlobStore`) was introduced
-in [#864](https://github.com/Jij-Inc/ommx/pull/864); subsequent PRs land
-the cleanup of the legacy ocipkg-based build / read paths.
+This section covers the Artifact / Local Registry API changes for users
+moving from `ommx` v2 to v3. The v3 Local Registry is SQLite-backed
+(IndexStore + filesystem CAS BlobStore) rather than an on-disk OCI
+Image Layout per `image:tag`; see the
+[Artifact v3 design](https://github.com/Jij-Inc/ommx/blob/main/ARTIFACT_V3.md)
+for the full model.
 
 ## Overview
 
@@ -649,32 +650,14 @@ use ommx::artifact::ArchiveArtifactBuilder;
 let mut builder = ArchiveArtifactBuilder::new_archive(path, image_name)?;
 ```
 
-After the local-registry constructors were split off, the remaining
-`Builder<Base: ImageBuilder>` was archive-only. It is now a non-generic
-`ArchiveArtifactBuilder` wrapping `OciArtifactBuilder<OciArchiveBuilder>`
-and producing `Artifact<OciArchive>`. The constructors (`new_archive`,
+`ArchiveArtifactBuilder` is a non-generic wrapper around
+`OciArtifactBuilder<OciArchiveBuilder>` and produces
+`Artifact<OciArchive>`. The constructors (`new_archive`,
 `new_archive_unnamed`, `temp_archive`) and the `add_*` / `build`
-signatures are unchanged.
-
-### 3. `LocalArtifactBuilder::new` signature
-
-```rust,ignore
-// ❌ Before (3.0.0-alpha.2 only)
-let mut builder = LocalArtifactBuilder::new_ommx(image_name);
-
-// ✅ After
-let mut builder = LocalArtifactBuilder::new(image_name);
-```
-
-`new_ommx` was a thin wrapper that defaulted `artifact_type` to
-`media_types::v1_artifact()`. The 2-arg generic
-`new(image_name, artifact_type)` had no callers (the OMMX SDK only
-builds OMMX artifacts), so both were merged into a single
-`new(image_name)`.
+signatures are unchanged from v2.
 
 ## Migration Checklist
 
 - [ ] Replace `ommx::artifact::Builder` with `LocalArtifactBuilder` (for local-registry output) or `ArchiveArtifactBuilder` (for `.ommx` archive output)
 - [ ] Replace `Builder::for_github` (local-registry path) with `LocalArtifactBuilder::for_github`
 - [ ] Replace `Builder::new_archive*` / `temp_archive` with `ArchiveArtifactBuilder::new_archive*` / `temp_archive`
-- [ ] Replace `LocalArtifactBuilder::new_ommx(name)` with `LocalArtifactBuilder::new(name)` (only relevant if you used `3.0.0-alpha.2`)

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -3,6 +3,7 @@
 This document covers migration of the OMMX Rust SDK (`ommx` crate) across major versions.
 
 - [v3 (Stage Pattern)](#rust-sdk-v3-stage-pattern-migration-guide) — Constraint lifecycle stage parameterization
+- [v3 (Artifact API)](#rust-sdk-v3-artifact-api-migration-guide) — Local registry / archive builder split and renames
 
 ---
 
@@ -583,3 +584,97 @@ pub struct ConstraintMetadata {
 - [ ] Remove any `getset` usage for constraint types
 - [ ] Update any `InstanceError` / `MpsParseError` / `QplibParseError` / `StateValidationError` / `LogEncodingError` / `UnknownSampleIDError` matches → inspect `err.to_string()` or use `err.downcast_ref::<T>()` for signal types
 - [ ] Replace `Result<T, UnknownSampleIDError>` key-lookup methods with `Option<T>` on the call site
+
+---
+
+# Rust SDK v3 Artifact API Migration Guide
+
+This section covers the Artifact / Local Registry API changes landed
+across `3.0.0-alpha.2` and later. The v3 Local Registry foundation
+(SQLite-backed `IndexStore` + filesystem CAS `BlobStore`) was introduced
+in [#864](https://github.com/Jij-Inc/ommx/pull/864); subsequent PRs land
+the cleanup of the legacy ocipkg-based build / read paths.
+
+## Overview
+
+Artifact construction was a single generic `Builder<Base: ImageBuilder>`
+that switched between `.ommx` archive output and a legacy on-disk
+"OCI Image Layout" local registry depending on the `Base` type. The new
+shape splits those by destination:
+
+| Output destination | v2 type | v3 type |
+|---|---|---|
+| v3 SQLite Local Registry | `Builder<OciDirBuilder>` | `LocalArtifactBuilder` |
+| `.ommx` OCI archive | `Builder<OciArchiveBuilder>` | `ArchiveArtifactBuilder` |
+
+The local-registry path now writes an OCI Artifact Manifest (per OCI 1.1
+spec) into a SQLite-backed registry instead of an on-disk OCI Image
+Layout directory. Existing legacy `<root>/<image>/<tag>/` directories
+are identity-preserved on import via `ommx artifact import` or the
+`import_legacy_local_registry*` SDK functions — pulled bytes (manifest
+digest and JSON) round-trip verbatim.
+
+## Breaking Changes
+
+### 1. Local Registry builder
+
+```rust,ignore
+// ❌ Before
+use ommx::artifact::Builder;
+let mut builder = Builder::for_github("Jij-Inc", "demo", "experiment", "v1")?;
+builder.add_instance(instance, annotations)?;
+let artifact = builder.build()?;
+
+// ✅ After
+use ommx::artifact::LocalArtifactBuilder;
+let mut builder = LocalArtifactBuilder::for_github("Jij-Inc", "demo", "experiment", "v1")?;
+builder.add_instance(instance, annotations)?;
+let artifact = builder.build()?;
+```
+
+`Builder<OciDirBuilder>::{new, for_github}` are removed. Use
+`LocalArtifactBuilder::{new, for_github}` instead. Output lands in the
+v3 SQLite registry rather than the legacy `<root>/<image>/<tag>/`
+OCI Image Layout directory.
+
+### 2. Archive builder rename
+
+```rust,ignore
+// ❌ Before
+use ommx::artifact::Builder;
+let mut builder = Builder::new_archive(path, image_name)?;
+
+// ✅ After
+use ommx::artifact::ArchiveArtifactBuilder;
+let mut builder = ArchiveArtifactBuilder::new_archive(path, image_name)?;
+```
+
+After the local-registry constructors were split off, the remaining
+`Builder<Base: ImageBuilder>` was archive-only. It is now a non-generic
+`ArchiveArtifactBuilder` wrapping `OciArtifactBuilder<OciArchiveBuilder>`
+and producing `Artifact<OciArchive>`. The constructors (`new_archive`,
+`new_archive_unnamed`, `temp_archive`) and the `add_*` / `build`
+signatures are unchanged.
+
+### 3. `LocalArtifactBuilder::new` signature
+
+```rust,ignore
+// ❌ Before (3.0.0-alpha.2 only)
+let mut builder = LocalArtifactBuilder::new_ommx(image_name);
+
+// ✅ After
+let mut builder = LocalArtifactBuilder::new(image_name);
+```
+
+`new_ommx` was a thin wrapper that defaulted `artifact_type` to
+`media_types::v1_artifact()`. The 2-arg generic
+`new(image_name, artifact_type)` had no callers (the OMMX SDK only
+builds OMMX artifacts), so both were merged into a single
+`new(image_name)`.
+
+## Migration Checklist
+
+- [ ] Replace `ommx::artifact::Builder` with `LocalArtifactBuilder` (for local-registry output) or `ArchiveArtifactBuilder` (for `.ommx` archive output)
+- [ ] Replace `Builder::for_github` (local-registry path) with `LocalArtifactBuilder::for_github`
+- [ ] Replace `Builder::new_archive*` / `temp_archive` with `ArchiveArtifactBuilder::new_archive*` / `temp_archive`
+- [ ] Replace `LocalArtifactBuilder::new_ommx(name)` with `LocalArtifactBuilder::new(name)` (only relevant if you used `3.0.0-alpha.2`)

--- a/rust/ommx/examples/create_artifact.rs
+++ b/rust/ommx/examples/create_artifact.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use ocipkg::ImageName;
 use ommx::{
-    artifact::{Builder, InstanceAnnotations},
+    artifact::{ArchiveArtifactBuilder, InstanceAnnotations},
     random::random_deterministic,
     InstanceParameters,
 };
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
     annotations.set_title("random_lp".to_string());
     annotations.set_created(chrono::Local::now());
 
-    let mut builder = Builder::new_archive(out.clone(), image_name)?;
+    let mut builder = ArchiveArtifactBuilder::new_archive(out.clone(), image_name)?;
     builder.add_instance(lp, annotations)?;
     builder.add_source(&Url::parse("https://github.com/Jij-Inc/ommx")?);
     builder.add_description("Test artifact created by examples/create_artifact.rs".to_string());

--- a/rust/ommx/src/artifact/builder.rs
+++ b/rust/ommx/src/artifact/builder.rs
@@ -23,22 +23,22 @@ use super::{ParametricInstanceAnnotations, SampleSetAnnotations};
 /// [`super::LocalArtifactBuilder`] instead; this type is the
 /// archive-only legacy path retained for `PyArtifactBuilder.new_archive*`
 /// / `temp` and the test suite.
-pub struct Builder(OciArtifactBuilder<OciArchiveBuilder>);
+pub struct ArchiveArtifactBuilder(OciArtifactBuilder<OciArchiveBuilder>);
 
-impl Deref for Builder {
+impl Deref for ArchiveArtifactBuilder {
     type Target = OciArtifactBuilder<OciArchiveBuilder>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for Builder {
+impl DerefMut for ArchiveArtifactBuilder {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl Builder {
+impl ArchiveArtifactBuilder {
     pub fn new_archive_unnamed(path: PathBuf) -> Result<Self> {
         let archive = OciArchiveBuilder::new_unnamed(path)?;
         Ok(Self(OciArtifactBuilder::new(

--- a/rust/ommx/src/artifact/builder.rs
+++ b/rust/ommx/src/artifact/builder.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use anyhow::Result;
 use ocipkg::{
-    image::{ImageBuilder, OciArchiveBuilder, OciArtifactBuilder},
+    image::{OciArchive, OciArchiveBuilder, OciArtifactBuilder},
     ImageName,
 };
 use prost::Message;
@@ -17,23 +17,28 @@ use uuid::Uuid;
 
 use super::{ParametricInstanceAnnotations, SampleSetAnnotations};
 
-/// Build [Artifact]
-pub struct Builder<Base: ImageBuilder>(OciArtifactBuilder<Base>);
+/// Build an [`Artifact<OciArchive>`] (`.ommx` OCI archive output).
+///
+/// v3-native build into the SQLite Local Registry uses
+/// [`super::LocalArtifactBuilder`] instead; this type is the
+/// archive-only legacy path retained for `PyArtifactBuilder.new_archive*`
+/// / `temp` and the test suite.
+pub struct Builder(OciArtifactBuilder<OciArchiveBuilder>);
 
-impl<Base: ImageBuilder> Deref for Builder<Base> {
-    type Target = OciArtifactBuilder<Base>;
+impl Deref for Builder {
+    type Target = OciArtifactBuilder<OciArchiveBuilder>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<Base: ImageBuilder> DerefMut for Builder<Base> {
+impl DerefMut for Builder {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl Builder<OciArchiveBuilder> {
+impl Builder {
     pub fn new_archive_unnamed(path: PathBuf) -> Result<Self> {
         let archive = OciArchiveBuilder::new_unnamed(path)?;
         Ok(Self(OciArtifactBuilder::new(
@@ -58,9 +63,7 @@ impl Builder<OciArchiveBuilder> {
             ImageName::parse(&format!("ttl.sh/{id}:1h"))?,
         )
     }
-}
 
-impl<Base: ImageBuilder> Builder<Base> {
     pub fn add_instance(
         &mut self,
         instance: v1::Instance,
@@ -115,7 +118,7 @@ impl<Base: ImageBuilder> Builder<Base> {
         Ok(())
     }
 
-    pub fn build(self) -> Result<Artifact<Base::Image>> {
+    pub fn build(self) -> Result<Artifact<OciArchive>> {
         Artifact::new(self.0.build()?)
     }
 }

--- a/rust/ommx/src/artifact/builder.rs
+++ b/rust/ommx/src/artifact/builder.rs
@@ -1,13 +1,10 @@
 use crate::{
-    artifact::{
-        get_local_registry_root, ghcr, media_types, Artifact, Config, InstanceAnnotations,
-        SolutionAnnotations,
-    },
+    artifact::{media_types, Artifact, Config, InstanceAnnotations, SolutionAnnotations},
     v1,
 };
 use anyhow::Result;
 use ocipkg::{
-    image::{ImageBuilder, OciArchiveBuilder, OciArtifactBuilder, OciDirBuilder},
+    image::{ImageBuilder, OciArchiveBuilder, OciArtifactBuilder},
     ImageName,
 };
 use prost::Message;
@@ -16,7 +13,6 @@ use std::{
     ops::{Deref, DerefMut},
     path::PathBuf,
 };
-use url::Url;
 use uuid::Uuid;
 
 use super::{ParametricInstanceAnnotations, SampleSetAnnotations};
@@ -61,28 +57,6 @@ impl Builder<OciArchiveBuilder> {
             std::env::temp_dir().join(format!("ommx-{id}")),
             ImageName::parse(&format!("ttl.sh/{id}:1h"))?,
         )
-    }
-}
-
-impl Builder<OciDirBuilder> {
-    pub fn new(image_name: ImageName) -> Result<Self> {
-        let dir = get_local_registry_root().join(image_name.as_path());
-        let layout = OciDirBuilder::new(dir, image_name)?;
-        Ok(Self(OciArtifactBuilder::new(
-            layout,
-            media_types::v1_artifact(),
-        )?))
-    }
-
-    /// Create a new artifact builder for a GitHub container registry image
-    pub fn for_github(org: &str, repo: &str, name: &str, tag: &str) -> Result<Self> {
-        let image_name = ghcr(org, repo, name, tag)?;
-        let source = Url::parse(&format!("https://github.com/{org}/{repo}"))?;
-
-        let mut builder = Self::new(image_name)?;
-        builder.add_source(&source);
-
-        Ok(builder)
     }
 }
 

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -616,7 +616,7 @@ fn local_artifact_subject_round_trips() -> Result<()> {
         .build()?;
 
     let child_image = ImageName::parse("ghcr.io/jij-inc/ommx/demo:child")?;
-    let mut builder = LocalArtifactBuilder::new_ommx(child_image.clone());
+    let mut builder = LocalArtifactBuilder::new(child_image.clone());
     builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         b"child-layer".to_vec(),
@@ -828,7 +828,7 @@ fn new_test_local_artifact_builder(
     image_name: ImageName,
     layer_bytes: &[u8],
 ) -> Result<(LocalArtifactBuilder, Descriptor)> {
-    let mut builder = LocalArtifactBuilder::new_ommx(image_name);
+    let mut builder = LocalArtifactBuilder::new(image_name);
     let descriptor = builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         layer_bytes.to_vec(),

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -765,8 +765,10 @@ fn import_oci_archive_re_extracts_when_legacy_dir_is_stale() -> Result<()> {
 
     let archive_path_a = dir.path().join("a.ommx");
     {
-        let mut builder =
-            crate::artifact::Builder::new_archive(archive_path_a.clone(), image_name.clone())?;
+        let mut builder = crate::artifact::ArchiveArtifactBuilder::new_archive(
+            archive_path_a.clone(),
+            image_name.clone(),
+        )?;
         builder.add_layer(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.into()),
             b"archive-A",
@@ -776,8 +778,10 @@ fn import_oci_archive_re_extracts_when_legacy_dir_is_stale() -> Result<()> {
     }
     let archive_path_b = dir.path().join("b.ommx");
     {
-        let mut builder =
-            crate::artifact::Builder::new_archive(archive_path_b.clone(), image_name.clone())?;
+        let mut builder = crate::artifact::ArchiveArtifactBuilder::new_archive(
+            archive_path_b.clone(),
+            image_name.clone(),
+        )?;
         builder.add_layer(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.into()),
             b"archive-B",

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -279,21 +279,14 @@ pub struct LocalArtifactBuilder {
 }
 
 impl LocalArtifactBuilder {
-    pub fn new(image_name: ocipkg::ImageName, artifact_type: MediaType) -> Self {
+    pub fn new(image_name: ocipkg::ImageName) -> Self {
         Self {
             image_name,
-            artifact_type,
+            artifact_type: MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()),
             blobs: Vec::new(),
             subject: None,
             annotations: HashMap::new(),
         }
-    }
-
-    pub fn new_ommx(image_name: ocipkg::ImageName) -> Self {
-        Self::new(
-            image_name,
-            MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()),
-        )
     }
 
     /// Create a new artifact builder for a GitHub container registry image name.
@@ -301,7 +294,7 @@ impl LocalArtifactBuilder {
         let image_name = ghcr(org, repo, name, tag)?;
         let source = Url::parse(&format!("https://github.com/{org}/{repo}"))?;
 
-        let mut builder = Self::new_ommx(image_name);
+        let mut builder = Self::new(image_name);
         builder.add_source(&source);
         Ok(builder)
     }
@@ -539,7 +532,7 @@ mod tests {
 
     #[test]
     fn builds_native_oci_artifact_manifest() -> Result<()> {
-        let mut builder = LocalArtifactBuilder::new_ommx(test_image_name("v1")?);
+        let mut builder = LocalArtifactBuilder::new(test_image_name("v1")?);
         let blob = builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),
@@ -588,7 +581,7 @@ mod tests {
             b"parent manifest",
             HashMap::new(),
         )?;
-        let mut builder = LocalArtifactBuilder::new_ommx(test_image_name("subject")?);
+        let mut builder = LocalArtifactBuilder::new(test_image_name("subject")?);
         builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),
@@ -610,7 +603,7 @@ mod tests {
         tag: &str,
         annotations: impl IntoIterator<Item = (&'static str, &'static str)>,
     ) -> Result<StagedArtifactManifest> {
-        let mut builder = LocalArtifactBuilder::new_ommx(test_image_name(tag)?);
+        let mut builder = LocalArtifactBuilder::new(test_image_name(tag)?);
         builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),


### PR DESCRIPTION
## Summary

Switches `rust/dataset/{miplib2017,qplib}` from the legacy `Builder<OciDirBuilder>` build path to the v3 SQLite Local Registry via `LocalArtifactBuilder::new`, and republishes the OMMX datasets under a new `ghcr.io/jij-inc/ommx/v3/{miplib2017,qplib}:<tag>` namespace so the Artifact Manifest format introduced in #864 lives separately from the existing Image-Manifest containers at `ghcr.io/jij-inc/ommx/{miplib2017,qplib}:*`. The legacy namespace stays frozen — no format flip on existing tags, no impact on users pulling `miplib2017` / `qplib` from the legacy path — and the SQLite registry can hold both side by side because import is identity-preserving.

With dataset packaging gone, `Builder<OciDirBuilder>::{new, for_github}` has no callers. This PR deletes that impl block, concretizes the remaining `Builder<Base: ImageBuilder>` to a non-generic wrapper around `OciArtifactBuilder<OciArchiveBuilder>`, and renames it to `ArchiveArtifactBuilder` so the archive-only intent lives on the type name and parallels `LocalArtifactBuilder`. `Builder<OciDirBuilder>` is no longer expressible as a type, not merely uninstantiable. Drops `LocalArtifactBuilder::new_ommx` for plain `new` after deleting the 2-arg `new(image_name, artifact_type)` that had no callers — the OMMX SDK only ever builds OMMX artifacts so the suffix was redundant.

`LocalArtifact::try_open` against the v3 image name preserves the original "skip if already packaged" optimization the loop got for free when `Builder::for_github` failed on existing OCI dirs. Invalid image name from a malformed zip entry is now caught with a `match` + `tracing::warn!` + `continue` rather than `?`, matching the existing skip patterns for missing metadata / parse errors / variable-count mismatches.

The Rust SDK breaking changes (`Builder` → `LocalArtifactBuilder` / `ArchiveArtifactBuilder` split, `new_ommx` → `new`) are documented in `rust/ommx/doc/migration_guide.md` under a new "Rust SDK v3 Artifact API Migration Guide" section. The v3 alpha series is the explicit breaking-change window, so the migration guide is the durable record rather than a temporary deprecated alias.

`ARTIFACT_V3.md` §12.3 documents this as the first of three planned structural cleanup milestones for the v3 Artifact implementation; §12.2 row 11 captures the namespace-separation policy so future contributors don't have to re-derive it from this PR.

## Follow-up required before publishing the v3 dataset namespace

Native SQLite-to-remote `push` (milestone B in §12.3) is not yet implemented, so packaging produces v3-native artifacts in the local SQLite registry that can't yet be pushed to ghcr.io. This affects the maintainer release workflow only — users pulling existing `ghcr.io/jij-inc/ommx/{miplib2017,qplib}:*` containers are unaffected by this PR.

## Test plan

- [x] `cargo check -p ommx --all-features` and `cargo check -p dataset`
- [x] `cargo clippy -p ommx -p dataset --no-deps` — no new warnings
- [x] `cargo test -p ommx --all-features --lib artifact` — 23/23 pass
- [x] `cargo build -p dataset` and `cargo run -p dataset -- --help`
- [x] `cargo run --release --example create_artifact --features cli` — exercises the renamed type (matches the CI `push` job that initially caught the missed example rename)
- [x] `task python:sync && task python:ommx:test` — 37/37 pass
- [x] `task format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)