### PR TITLE
LocalArtifactBuilder builds OCI Image Manifest with artifactType

### DIFF
--- a/ARTIFACT_V3.md
+++ b/ARTIFACT_V3.md
@@ -221,7 +221,7 @@ Local Registry 内部では IndexStore が refs / manifests / entries の source
 
 ### 5.5 Manifest format
 
-SQLite Local Registry の native manifest format は OCI Image Manifest (`application/vnd.oci.image.manifest.v1+json`) のみとする。OMMX 固有 artifact の type 識別は manifest 内の `artifactType` field (例: `application/org.ommx.v1.artifact`) と `application/vnd.oci.empty.v1+json` empty config descriptor で行う。
+SQLite Local Registry の native manifest format は OCI Image Manifest (`application/vnd.oci.image.manifest.v1+json`) のみとする。OMMX 固有 artifact の識別は manifest top-level の `artifactType` field (`application/org.ommx.v1.artifact`) で行う。parse 時に検証するのはこの field のみで、`config` blob は実装上のデフォルトを定めるだけの非識別情報とする。
 
 OCI Image Spec v1.1 で deprecated / removed 化された OCI Artifact Manifest (`application/vnd.oci.artifact.manifest.v1+json`) はサポートしない。次の理由による。
 
@@ -231,7 +231,14 @@ OCI Image Spec v1.1 で deprecated / removed 化された OCI Artifact Manifest 
 
 build / import / pull のいずれの経路でも、Local Registry に保存される manifest は Image Manifest である。import 時に旧 v2 OMMX が生成済みの Image Manifest はそのまま identity-preserving に取り込む (manifest bytes / digest を保持)。万一外部由来の Artifact Manifest を import しようとした場合は、未サポート format として明示 error にする (sloppy fallback はしない)。
 
-format 変換のための「convert」操作は v3 では提供しない。v2 で生成された Image Manifest と v3 で生成される Image Manifest は同じ format であり、`artifactType` field の有無による semantic 差分があるだけで、format conversion API は不要である。
+native build path (v3 `LocalArtifactBuilder`) は SDK v2 の archive build path (`ocipkg::OciArtifactBuilder::new` 経由) と byte-level に整合する manifest shape を採用する。具体的には:
+
+- `schemaVersion: 2`、`artifactType: application/org.ommx.v1.artifact`、`config` は OCI 1.1 empty descriptor (`application/vnd.oci.empty.v1+json` の 2-byte JSON `{}`)、`layers[]` は各 entry に `annotations` field を持つ (空 object でも render する)。manifest top-level の `mediaType` field は意図的に出力しない (v2 SDK と同様、HTTP Content-Type は push 時に transport が個別に付与する)。
+- v3 SQLite registry が出力する manifest と v2 archive build が出力する manifest の唯一の差分は JSON field 順序で、v3 は reproducible digest のため `stable_json_bytes` で alphabetical sort する (v2 SDK は struct 宣言順)。
+
+import 経路で v2 SDK が生成した OMMX-specific config (`application/org.ommx.v1.config+json`) を持つ legacy Image Manifest は、parse-time check が `artifactType` だけなので識別 / read に支障なく取り込める。
+
+format 変換のための「convert」操作は v3 では提供しない。v2 で生成された Image Manifest と v3 で生成される Image Manifest は同じ format であり、`config` blob の中身が違うだけで format conversion API は不要である。
 
 ## 6. Local Registry model
 
@@ -548,7 +555,6 @@ Phase 2 は span / event schema を変更せず、同じ OTel signal を読む r
 ```jsonc
 {
   "schemaVersion": 2,
-  "mediaType": "application/vnd.oci.image.manifest.v1+json",
   "artifactType": "application/org.ommx.v1.experiment",
   "config": {
     "mediaType": "application/vnd.oci.empty.v1+json",
@@ -563,6 +569,8 @@ Phase 2 は span / event schema を変更せず、同じ OTel signal を読む r
   }
 }
 ```
+
+manifest top-level の `mediaType` field は v2 SDK と同様に出力しない (5.5)。Content-Type は push 時に transport が個別に付与する。`subject` descriptor の `mediaType` は OCI Image Manifest 固定 (9.1)。
 
 ### 9.2 Linear history
 
@@ -643,7 +651,7 @@ v3 PR #864 で landing する範囲。
 - 並行 publish primitive (`RefConflictPolicy::{KeepExisting, Replace}`、`RefUpdate::{Inserted, Unchanged, Replaced, Conflicted}` 4 状態)。
 - `import::archive` / `import::remote` は `registry.root().join(image_name.as_path())` に staging する (`get_image_dir` の global default に縛られない)。
 
-設計上 deprecated 化された OCI Artifact Manifest (5.5 参照) に関する実装は #864 / #866 時点でコードに残っているが (`LocalManifest::Artifact` variant、`OCI_ARTIFACT_MANIFEST_MEDIA_TYPE`、`LocalArtifactBuilder` の Artifact Manifest 生成 path、`ensure_ommx_artifact_manifest` validator 等)、これらは未使用の dead code 扱いとし、§12.2 / §12.3 Step B' で撤去する。
+PR #868 で本書の Image Manifest 一本化方針 (5.5) と Step A → B' → B → C milestone 構成 (12.3) も merged。design doc 上は Image Manifest only に統一されたが、#864 / #866 が landing した時点では `LocalArtifactBuilder` は依然として deprecated 化された OCI Artifact Manifest を生成しており (`LocalManifest::Artifact` variant、`OCI_ARTIFACT_MANIFEST_MEDIA_TYPE`、`ensure_ommx_artifact_manifest` validator 等が残存)、これらの撤去は §12.3 Step B' で扱う。
 
 ### 12.2 後続 PR に残す TODO
 
@@ -651,7 +659,7 @@ v3 PR #864 で landing する範囲。
 |---|---|---|
 | `import::archive` / `import::remote` の stage 1 を ocipkg ベースから native streamer に置換 | 5.1, 6.6 | 現状は `ocipkg → legacy OCI dir → import_oci_dir_as_ref → SQLite` の 2-stage。public 関数 signature は変えない |
 | `ommx::ocipkg` re-export と、Rust / Python の `Descriptor` / `Digest` / `MediaType` / `ImageReference` public surface の撤去 | 5.1, 5.2 | OMMX-owned public types への置き換え。migration note を別途用意 |
-| `LocalArtifactBuilder` を OCI Image Manifest with `artifactType` + empty config に refactor | 5.5 | 現状は deprecated 化された OCI Artifact Manifest (`application/vnd.oci.artifact.manifest.v1+json`) を生成しており、`distribution/distribution` v2 系で `MANIFEST_INVALID` reject される。`LocalManifest::Artifact` variant / `OCI_ARTIFACT_MANIFEST_MEDIA_TYPE` 関連 dead code もこの PR で撤去 (§12.3 Step B') |
+| `LocalArtifactBuilder` を OCI Image Manifest with `artifactType` + empty config に refactor | 5.5 | 現状は deprecated 化された OCI Artifact Manifest (`application/vnd.oci.artifact.manifest.v1+json`) を生成しており、`distribution/distribution` v2 系で `MANIFEST_INVALID` reject される。`LocalManifest::Artifact` variant / `OCI_ARTIFACT_MANIFEST_MEDIA_TYPE` 関連 dead code もこの PR で撤去 (§12.3 Step B')。**進行中: PR #869 (in review)** |
 | Archive build path (`ArtifactBuilder.new_archive*`, `temp()`, `Artifact.load_archive`) の v3 pipeline 化 | 5.5, 7.4 | 現状は ocipkg-based Image Manifest pipeline。SQLite registry を経由しない。v3 native build と同じ Image Manifest with `artifactType` を生成する |
 | SQLite registry から remote への native `push` | 6.4, 6.6 | 現状の Python `Artifact.push()` は legacy OCI dir 経由の transitional path。v3-native build artifact (legacy 不在) は明示 error。transport crate は `oci-client` (ORAS, [oras-project/rust-oci-client](https://github.com/oras-project/rust-oci-client)) を採用予定 |
 | `Artifact.load(image)` / `ommx load` の legacy double-write 撤廃 | 6.5 | `push` / `save` / Python archive 読み出しが SQLite から直接読めるようになり、かつ native stage 1 が landing したら |
@@ -670,9 +678,13 @@ v3 PR #864 で landing する範囲。
 
 `rust/dataset/{miplib2017,qplib}` を `LocalArtifactBuilder::new` + 明示的 `add_source` に切り替え、出力 image name を `ghcr.io/jij-inc/ommx/v3/{miplib2017,qplib}:<tag>` とする。唯一の caller が消えた `rust/ommx/src/artifact/builder.rs` の `Builder<OciDirBuilder>::{new, for_github}` を削除。既存 `ghcr.io/jij-inc/ommx/{miplib2017,qplib}:*` は触らない (freeze) — SQLite registry は両 namespace を identity-preserving に保持できるため user 影響なし。Step A landing 時点では builder が deprecated Artifact Manifest を生成していたため、v3 namespace への初回 publish は Step B' / B 後に持ち越し。
 
-**Step B' — `LocalArtifactBuilder` の OCI Image Manifest 化** (§12.2 行 3)。
+**Step B' — `LocalArtifactBuilder` の OCI Image Manifest 化** (§12.2 行 3)。**進行中: PR #869 (in review)。**
 
 `LocalArtifactBuilder` を `OciArtifactManifestBuilder` ベースから `OciImageManifestBuilder` ベースに切り替え、`artifactType` field と `application/vnd.oci.empty.v1+json` empty config descriptor で OMMX artifact を表現する (5.5)。同時に dead code 化する `LocalManifest::Artifact` variant、`OCI_ARTIFACT_MANIFEST_MEDIA_TYPE` 定数、`ensure_ommx_artifact_manifest` validator、`local_registry::import` 系の Artifact Manifest dispatch を撤去する。Local Registry の persisted manifest は Image Manifest 単形式になり、reader / writer / tests が単純化される。
+
+生成する manifest は SDK v2 archive build (`ocipkg::OciArtifactBuilder::new` 経由) と byte-level に整合する shape を採用する (5.5): top-level の `mediaType` field は出力せず、各 layer descriptor は空でも `annotations` field を render し、empty config descriptor は `annotations` を持たない。registry に publish する際の Content-Type は transport が個別に付与する。残差は JSON field 順序 (v3 は `stable_json_bytes` で alphabetical sort、v2 SDK は struct 宣言順) のみで、これは reproducible digest のための意図的な前進。
+
+`publish_artifact_manifest` の SQLite 側 blob 分類は manifest の `config().digest()` 一致を見て empty config blob のみ `BLOB_KIND_CONFIG`、他は `BLOB_KIND_BLOB` で記録する (OCI dir import path との整合)。
 
 なお、draft PR #867 (Step B 着手) は当時 deprecated 化された Artifact Manifest 前提で書かれており、本 Step B' の前提変更を受けて一旦保留。Step B' landing 後に再開する。
 

--- a/rust/ommx/src/artifact.rs
+++ b/rust/ommx/src/artifact.rs
@@ -14,7 +14,7 @@ pub use config::*;
 pub use digest::sha256_digest;
 pub(crate) use manifest::{stable_json_bytes, StagedArtifactBlob};
 pub use manifest::{LocalArtifact, LocalArtifactBuilder, LocalManifest};
-pub use media_types::{OCI_ARTIFACT_MANIFEST_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
+pub use media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE;
 
 use crate::v1;
 use anyhow::{bail, ensure, Context, Result};

--- a/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
+++ b/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
@@ -117,8 +117,8 @@ pub(super) enum RefConflictHandling {
 /// All the read-only state that a single OCI Image Layout directory
 /// contributes to a v3 import: identity (digest + ref-name annotation),
 /// the manifest bytes / descriptor that get persisted verbatim, the
-/// format tag, the layer descriptors enumerated from the manifest,
-/// and (Image Manifest only) the config blob.
+/// layer descriptors enumerated from the manifest, and the config
+/// blob.
 ///
 /// "Staged" parallels the build-side vocabulary
 /// ([`crate::artifact::StagedArtifactBlob`],
@@ -145,16 +145,18 @@ struct StagedOciDir {
 
 /// Import a standard OCI Image Layout directory into the v3 local registry.
 ///
-/// Works for any OCI Image Layout (`oci-layout` + `index.json` + `blobs/`),
-/// regardless of how it was produced. The v3 registry does not keep
-/// `index.json` as mutable state; it only reads it to discover the single
-/// manifest, and then copies the exact content-addressed blobs into
-/// [`FileBlobStore`] while inserting the matching records into
-/// [`SqliteIndexStore`]. The manifest digest is preserved verbatim — import
-/// never rewrites the manifest. Reformatting an Image Manifest into an
-/// Artifact Manifest is a separate explicit `convert` operation that
-/// produces a new artifact under a new digest / new ref, intentionally not
-/// a side effect of import.
+/// Works for any OCI Image Layout (`oci-layout` + `index.json` + `blobs/`)
+/// that uses OCI Image Manifest (with the OMMX `artifactType` set), regardless
+/// of how it was produced. The v3 registry does not keep `index.json` as
+/// mutable state; it only reads it to discover the single manifest, and
+/// then copies the exact content-addressed blobs into [`FileBlobStore`]
+/// while inserting the matching records into [`SqliteIndexStore`]. The
+/// manifest digest is preserved verbatim — import never rewrites the
+/// manifest.
+///
+/// OCI Image Layouts that use the deprecated OCI Artifact Manifest
+/// (`application/vnd.oci.artifact.manifest.v1+json`) are rejected at
+/// import time; no format conversion is performed as a side effect.
 pub fn import_oci_dir(
     index_store: &SqliteIndexStore,
     blob_store: &FileBlobStore,

--- a/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
+++ b/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
@@ -143,12 +143,6 @@ struct StagedOciDir {
     image_config: (Descriptor, Vec<u8>),
 }
 
-impl StagedOciDir {
-    fn manifest_media_type(&self) -> &'static str {
-        OCI_IMAGE_MANIFEST_MEDIA_TYPE
-    }
-}
-
 /// Import a standard OCI Image Layout directory into the v3 local registry.
 ///
 /// Works for any OCI Image Layout (`oci-layout` + `index.json` + `blobs/`),
@@ -301,7 +295,7 @@ pub(super) fn import_oci_dir_inner(
 
     let manifest_record = ManifestRecord {
         digest: manifest_digest.clone(),
-        media_type: staged.manifest_media_type().to_string(),
+        media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string(),
         size: staged.manifest_descriptor.size(),
         subject_digest: staged
             .subject
@@ -428,8 +422,8 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
         manifest_bytes.len()
     );
 
-    // v3 supports only OCI Image Manifest (ARTIFACT_V3.md §5.5). The
-    // deprecated OCI Artifact Manifest is rejected at parse time.
+    // v3 supports only OCI Image Manifest. The deprecated OCI Artifact
+    // Manifest is rejected at parse time.
     let (layers, annotations, subject, image_config) = match index_descriptor.media_type() {
         MediaType::ImageManifest => stage_image_manifest(oci_dir_root, &manifest_bytes)?,
         MediaType::ArtifactManifest => anyhow::bail!(

--- a/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
+++ b/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
@@ -26,13 +26,10 @@ use super::super::{
     ManifestRecord, RefConflictPolicy, RefUpdate, SqliteIndexStore, ValidatedDigest,
     BLOB_KIND_BLOB, BLOB_KIND_CONFIG, BLOB_KIND_MANIFEST, OCI_IMAGE_REF_NAME_ANNOTATION,
 };
-use crate::artifact::{
-    media_types, OCI_ARTIFACT_MANIFEST_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
-};
+use crate::artifact::{media_types, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
 use anyhow::{ensure, Context, Result};
 use oci_spec::image::{
-    ArtifactManifest, Descriptor, DescriptorBuilder, Digest, ImageIndex, ImageManifest, MediaType,
-    OciLayout,
+    Descriptor, DescriptorBuilder, Digest, ImageIndex, ImageManifest, MediaType, OciLayout,
 };
 use ocipkg::ImageName;
 use std::collections::HashMap;
@@ -131,45 +128,24 @@ pub(super) enum RefConflictHandling {
 ///
 /// Built once by [`stage_oci_dir`] and consumed by
 /// [`import_oci_dir_inner`]. v3 import is identity-preserving:
-/// `manifest_bytes` and `manifest_digest` are stored verbatim, and
-/// reformatting Image Manifest into Artifact Manifest is a separate
-/// explicit `convert` operation, never a side effect of import.
+/// `manifest_bytes` and `manifest_digest` are stored verbatim. The only
+/// supported manifest format is OCI Image Manifest (with `artifactType`
+/// set to the OMMX artifact media type); the deprecated OCI Artifact
+/// Manifest is rejected at parse time.
 struct StagedOciDir {
     manifest_digest: String,
     image_name: Option<ImageName>,
     manifest_bytes: Vec<u8>,
     manifest_descriptor: Descriptor,
-    format: OciManifestFormat,
     layers: Vec<Descriptor>,
     annotations: Option<HashMap<String, String>>,
     subject: Option<Descriptor>,
-    /// `Some` only when `format == Image`. Artifact Manifest has no
-    /// `config` field, so this is `None` and stage 1 of the import
-    /// skips the config CAS write.
-    image_config: Option<(Descriptor, Vec<u8>)>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OciManifestFormat {
-    Image,
-    Artifact,
+    image_config: (Descriptor, Vec<u8>),
 }
 
 impl StagedOciDir {
     fn manifest_media_type(&self) -> &'static str {
-        match self.format {
-            OciManifestFormat::Image => OCI_IMAGE_MANIFEST_MEDIA_TYPE,
-            OciManifestFormat::Artifact => OCI_ARTIFACT_MANIFEST_MEDIA_TYPE,
-        }
-    }
-}
-
-impl OciManifestFormat {
-    fn descriptor_media_type(self) -> MediaType {
-        match self {
-            Self::Image => MediaType::ImageManifest,
-            Self::Artifact => MediaType::ArtifactManifest,
-        }
+        OCI_IMAGE_MANIFEST_MEDIA_TYPE
     }
 }
 
@@ -309,14 +285,13 @@ pub(super) fn import_oci_dir_inner(
             annotations_json: annotations_json(layer.annotations().as_ref())?,
         });
     }
-    if let Some((config_descriptor, config_bytes)) = staged.image_config.as_ref() {
-        blob_records.push(stage_descriptor_bytes(
-            blob_store,
-            config_descriptor,
-            config_bytes,
-            BLOB_KIND_CONFIG,
-        )?);
-    }
+    let (config_descriptor, config_bytes) = &staged.image_config;
+    blob_records.push(stage_descriptor_bytes(
+        blob_store,
+        config_descriptor,
+        config_bytes,
+        BLOB_KIND_CONFIG,
+    )?);
     blob_records.push(stage_descriptor_bytes(
         blob_store,
         &staged.manifest_descriptor,
@@ -453,24 +428,25 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
         manifest_bytes.len()
     );
 
-    // Dispatch on the index descriptor's media type so an OCI Artifact
-    // Manifest layout (no Image config, layers in `blobs[]`) imports
-    // identity-preservingly alongside the more common Image Manifest
-    // layout. v3 import never rewrites the manifest.
-    let (format, layers, annotations, subject, image_config) = match index_descriptor.media_type() {
+    // v3 supports only OCI Image Manifest (ARTIFACT_V3.md §5.5). The
+    // deprecated OCI Artifact Manifest is rejected at parse time.
+    let (layers, annotations, subject, image_config) = match index_descriptor.media_type() {
         MediaType::ImageManifest => stage_image_manifest(oci_dir_root, &manifest_bytes)?,
-        MediaType::ArtifactManifest => stage_artifact_manifest(&manifest_bytes)?,
+        MediaType::ArtifactManifest => anyhow::bail!(
+            "OCI dir uses the deprecated OCI Artifact Manifest \
+             (application/vnd.oci.artifact.manifest.v1+json), which is not supported. \
+             v3 OMMX accepts only OCI Image Manifest with artifactType."
+        ),
         other => anyhow::bail!(
-            "OCI dir manifest descriptor has unsupported media type: {}. \
-             Expected an OMMX Image Manifest or Artifact Manifest.",
-            other
+            "OCI dir manifest descriptor has unsupported media type: {other}. \
+             Expected an OMMX Image Manifest."
         ),
     };
 
     let manifest_digest_parsed = Digest::from_str(&manifest_digest)
         .with_context(|| format!("Invalid manifest digest: {manifest_digest}"))?;
     let manifest_descriptor = DescriptorBuilder::default()
-        .media_type(format.descriptor_media_type())
+        .media_type(MediaType::ImageManifest)
         .digest(manifest_digest_parsed)
         .size(manifest_bytes.len() as u64)
         .build()
@@ -481,7 +457,6 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
         image_name,
         manifest_bytes,
         manifest_descriptor,
-        format,
         layers,
         annotations,
         subject,
@@ -489,13 +464,12 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
     })
 }
 
-/// Format-specific fields filled into [`StagedOciDir`] by `stage_oci_dir`.
+/// Manifest-derived fields filled into [`StagedOciDir`] by `stage_oci_dir`.
 type StagedManifestFields = (
-    OciManifestFormat,
     Vec<Descriptor>,
     Option<HashMap<String, String>>,
     Option<Descriptor>,
-    Option<(Descriptor, Vec<u8>)>,
+    (Descriptor, Vec<u8>),
 );
 
 fn stage_image_manifest(
@@ -520,24 +494,10 @@ fn stage_image_manifest(
     );
 
     Ok((
-        OciManifestFormat::Image,
         manifest.layers().to_vec(),
         manifest.annotations().clone(),
         manifest.subject().clone(),
-        Some((config_descriptor, config_bytes)),
-    ))
-}
-
-fn stage_artifact_manifest(manifest_bytes: &[u8]) -> Result<StagedManifestFields> {
-    let manifest: ArtifactManifest =
-        serde_json::from_slice(manifest_bytes).context("Failed to parse OCI artifact manifest")?;
-    ensure_ommx_artifact_type(Some(manifest.artifact_type()))?;
-    Ok((
-        OciManifestFormat::Artifact,
-        manifest.blobs().to_vec(),
-        manifest.annotations().clone(),
-        manifest.subject().clone(),
-        None,
+        (config_descriptor, config_bytes),
     ))
 }
 

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -2,7 +2,7 @@ use super::{
     annotations_json, import_legacy_local_registry, import_legacy_local_registry_ref,
     import_legacy_local_registry_ref_with_policy, import_legacy_local_registry_with_policy,
     now_rfc3339, BlobRecord, FileBlobStore, LayerRecord, LegacyImportReport, ManifestRecord,
-    OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore, BLOB_KIND_BLOB,
+    OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore, BLOB_KIND_BLOB, BLOB_KIND_CONFIG,
     BLOB_KIND_MANIFEST,
 };
 use crate::artifact::StagedArtifactBlob;
@@ -147,13 +147,22 @@ impl LocalRegistry {
         // + manifest + ref so a crash or conflict can never leave
         // committed manifest / blob rows under a ref that wasn't
         // actually published.
+        //
+        // Tag the manifest's `config` descriptor with `BLOB_KIND_CONFIG`
+        // (matching the OCI-dir import path) and everything else with
+        // `BLOB_KIND_BLOB`. Without this dispatch the empty config blob
+        // built by `LocalArtifactBuilder::stage` would be persisted as a
+        // generic layer, diverging from imports of legacy v2 dirs and
+        // breaking GC / query logic that filters on `kind`.
+        let config_digest = manifest.config().digest();
         let mut blob_records = Vec::with_capacity(blobs.len() + 1);
         for blob in blobs {
-            blob_records.push(self.stage_blob_record(
-                blob.descriptor(),
-                blob.bytes(),
-                BLOB_KIND_BLOB,
-            )?);
+            let kind = if blob.descriptor().digest() == config_digest {
+                BLOB_KIND_CONFIG
+            } else {
+                BLOB_KIND_BLOB
+            };
+            blob_records.push(self.stage_blob_record(blob.descriptor(), blob.bytes(), kind)?);
         }
         blob_records.push(self.stage_blob_record(
             manifest_descriptor,

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -5,9 +5,9 @@ use super::{
     OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore, BLOB_KIND_BLOB,
     BLOB_KIND_MANIFEST,
 };
-use crate::artifact::{StagedArtifactBlob, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
+use crate::artifact::StagedArtifactBlob;
 use anyhow::{ensure, Context, Result};
-use oci_spec::image::{Descriptor, ImageManifest, MediaType};
+use oci_spec::image::{Descriptor, ImageManifest};
 use ocipkg::ImageName;
 use std::path::{Path, PathBuf};
 
@@ -75,6 +75,13 @@ impl LocalRegistry {
         self.index.resolve_image_name(image_name)
     }
 
+    /// Publish a staged OCI Image Manifest bundle to the SQLite Local
+    /// Registry. Callers must construct `manifest` and `manifest_descriptor`
+    /// via [`crate::artifact::LocalArtifactBuilder`] or the import paths
+    /// in `local_registry::import::*`, both of which produce an OCI
+    /// Image Manifest with the OMMX `artifactType` field set. The
+    /// publish path does not dispatch on manifest format — the SQLite
+    /// Local Registry stores OCI Image Manifest exclusively.
     pub(crate) fn publish_artifact_manifest(
         &self,
         image_name: &ImageName,
@@ -84,20 +91,6 @@ impl LocalRegistry {
         blobs: &[StagedArtifactBlob],
         policy: RefConflictPolicy,
     ) -> Result<RefUpdate> {
-        let manifest_media_type = manifest
-            .media_type()
-            .as_ref()
-            .map(|m| m.to_string())
-            .unwrap_or_default();
-        ensure!(
-            manifest_media_type == OCI_IMAGE_MANIFEST_MEDIA_TYPE,
-            "Manifest is not an OCI image manifest: {manifest_media_type}",
-        );
-        ensure!(
-            manifest_descriptor.media_type() == &MediaType::ImageManifest,
-            "Manifest descriptor is not an OCI image manifest descriptor: {}",
-            manifest_descriptor.media_type()
-        );
         ensure!(
             manifest_descriptor.digest().to_string()
                 == crate::artifact::sha256_digest(manifest_bytes),

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -5,9 +5,9 @@ use super::{
     OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore, BLOB_KIND_BLOB,
     BLOB_KIND_MANIFEST,
 };
-use crate::artifact::{StagedArtifactBlob, OCI_ARTIFACT_MANIFEST_MEDIA_TYPE};
+use crate::artifact::{StagedArtifactBlob, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
 use anyhow::{ensure, Context, Result};
-use oci_spec::image::{ArtifactManifest, Descriptor, MediaType};
+use oci_spec::image::{Descriptor, ImageManifest, MediaType};
 use ocipkg::ImageName;
 use std::path::{Path, PathBuf};
 
@@ -78,20 +78,24 @@ impl LocalRegistry {
     pub(crate) fn publish_artifact_manifest(
         &self,
         image_name: &ImageName,
-        manifest: &ArtifactManifest,
+        manifest: &ImageManifest,
         manifest_descriptor: &Descriptor,
         manifest_bytes: &[u8],
         blobs: &[StagedArtifactBlob],
         policy: RefConflictPolicy,
     ) -> Result<RefUpdate> {
+        let manifest_media_type = manifest
+            .media_type()
+            .as_ref()
+            .map(|m| m.to_string())
+            .unwrap_or_default();
         ensure!(
-            manifest.media_type().as_ref() == OCI_ARTIFACT_MANIFEST_MEDIA_TYPE,
-            "Manifest is not an OCI artifact manifest: {}",
-            manifest.media_type()
+            manifest_media_type == OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+            "Manifest is not an OCI image manifest: {manifest_media_type}",
         );
         ensure!(
-            manifest_descriptor.media_type() == &MediaType::ArtifactManifest,
-            "Manifest descriptor is not an OCI artifact manifest descriptor: {}",
+            manifest_descriptor.media_type() == &MediaType::ImageManifest,
+            "Manifest descriptor is not an OCI image manifest descriptor: {}",
             manifest_descriptor.media_type()
         );
         ensure!(
@@ -103,14 +107,27 @@ impl LocalRegistry {
             manifest_descriptor.size() == manifest_bytes.len() as u64,
             "Manifest descriptor size does not match manifest bytes"
         );
+        // OCI Image Manifest `blobs` = manifest layers + the `config`
+        // descriptor (which is the OCI 1.1 empty config blob in OMMX's
+        // builder). Callers stage all of these in `blobs[]`.
+        let manifest_descriptor_count = manifest.layers().len() + 1;
         ensure!(
-            manifest.blobs().len() == blobs.len(),
-            "Manifest blob descriptor count does not match pending blob count"
+            manifest_descriptor_count == blobs.len(),
+            "Manifest descriptor count ({manifest_descriptor_count}) does not match pending blob count ({})",
+            blobs.len()
         );
-        for (manifest_blob, pending_blob) in manifest.blobs().iter().zip(blobs) {
+        let staged_descriptors: Vec<&Descriptor> =
+            blobs.iter().map(|blob| blob.descriptor()).collect();
+        let descriptor_is_staged = |d: &Descriptor| staged_descriptors.contains(&d);
+        ensure!(
+            descriptor_is_staged(manifest.config()),
+            "Manifest config descriptor is not staged for upload"
+        );
+        for layer in manifest.layers() {
             ensure!(
-                manifest_blob == pending_blob.descriptor(),
-                "Manifest blob descriptor does not match pending blob descriptor"
+                descriptor_is_staged(layer),
+                "Manifest layer descriptor is not staged for upload: {}",
+                layer.digest()
             );
         }
 
@@ -152,7 +169,7 @@ impl LocalRegistry {
         )?);
 
         let layer_records = manifest
-            .blobs()
+            .layers()
             .iter()
             .enumerate()
             .map(|(position, layer)| -> Result<LayerRecord> {

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -5,9 +5,9 @@ use super::{
     OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore, BLOB_KIND_BLOB, BLOB_KIND_CONFIG,
     BLOB_KIND_MANIFEST,
 };
-use crate::artifact::StagedArtifactBlob;
+use crate::artifact::{media_types, StagedArtifactBlob};
 use anyhow::{ensure, Context, Result};
-use oci_spec::image::{Descriptor, ImageManifest};
+use oci_spec::image::{Descriptor, ImageManifest, MediaType};
 use ocipkg::ImageName;
 use std::path::{Path, PathBuf};
 
@@ -92,6 +92,12 @@ impl LocalRegistry {
         policy: RefConflictPolicy,
     ) -> Result<RefUpdate> {
         ensure!(
+            manifest_descriptor.media_type() == &MediaType::ImageManifest,
+            "Manifest descriptor must be `{:?}`, got `{}`",
+            MediaType::ImageManifest,
+            manifest_descriptor.media_type(),
+        );
+        ensure!(
             manifest_descriptor.digest().to_string()
                 == crate::artifact::sha256_digest(manifest_bytes),
             "Manifest descriptor digest does not match manifest bytes"
@@ -99,6 +105,16 @@ impl LocalRegistry {
         ensure!(
             manifest_descriptor.size() == manifest_bytes.len() as u64,
             "Manifest descriptor size does not match manifest bytes"
+        );
+        let artifact_type = manifest
+            .artifact_type()
+            .as_ref()
+            .context("Manifest does not carry the OMMX `artifactType` field")?;
+        ensure!(
+            artifact_type == &MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()),
+            "Manifest `artifactType` must be `{}`, got `{}`",
+            media_types::V1_ARTIFACT_MEDIA_TYPE,
+            artifact_type,
         );
         // OCI Image Manifest `blobs` = manifest layers + the `config`
         // descriptor (which is the OCI 1.1 empty config blob in OMMX's

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -399,18 +399,18 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
         .context("Published manifest is missing")?;
     assert_eq!(manifest_record.media_type, OCI_IMAGE_MANIFEST_MEDIA_TYPE);
     assert_eq!(manifest_record.size, manifest_bytes.len() as u64);
-    assert_eq!(
-        manifest.media_type().as_ref(),
-        Some(&MediaType::ImageManifest)
-    );
+    // Manifest's own `mediaType` field is left unset to match the v2 /
+    // ArchiveArtifactBuilder shape; the IndexStore record's `media_type`
+    // column carries the format for query / dispatch purposes.
+    assert_eq!(manifest.media_type().as_ref(), None);
     assert_eq!(
         manifest.artifact_type().as_ref(),
         Some(&MediaType::Other(
             media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()
         ))
     );
-    // OCI 1.1 empty config descriptor is required for `artifactType` to be
-    // honoured by registries.
+    // Empty config descriptor matches what `ocipkg::OciArtifactBuilder::new`
+    // produces by default; OMMX v2 SDK output and v3 SQLite registry agree.
     assert_eq!(manifest.config().media_type(), &MediaType::EmptyJSON);
     assert_eq!(
         manifest.config().digest().to_string(),

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -654,6 +654,56 @@ fn local_artifact_subject_round_trips() -> Result<()> {
 }
 
 #[test]
+fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
+    // v2 SDK can produce Image Manifests whose `config` blob is an
+    // OMMX-specific `application/org.ommx.v1.config+json` (instead of
+    // the v3 builder's OCI 1.1 empty descriptor). v3 import / read must
+    // preserve such manifests verbatim: parse-time check is artifactType
+    // only (no config-shape requirement), and the config blob lands as
+    // `BLOB_KIND_CONFIG` in the IndexStore so GC reachability and
+    // queries treat it consistently with the v3 empty-config path.
+    let dir = tempfile::tempdir()?;
+    let legacy_dir = dir.path().join("v2-legacy");
+    let image_name = ImageName::parse("ghcr.io/jij-inc/ommx/demo:v2-config")?;
+    let v2_config_bytes = br#"{"description":"v2 legacy config"}"#;
+    let (config_descriptor, layer_descriptor) =
+        build_test_oci_dir_with_v2_config(legacy_dir.clone(), image_name.clone(), v2_config_bytes)?;
+
+    let registry_root = dir.path().join("registry-v3");
+    let index_store = SqliteIndexStore::open_in_registry_root(&registry_root)?;
+    let blob_store = FileBlobStore::open_in_registry_root(&registry_root)?;
+    let imported = import_oci_dir(&index_store, &blob_store, &legacy_dir)?;
+
+    assert_eq!(imported.image_name, Some(image_name.clone()));
+    assert!(blob_store.exists(&imported.manifest_digest)?);
+    assert!(blob_store.exists(&layer_descriptor.digest().to_string())?);
+
+    // OMMX-specific config blob is preserved with `BLOB_KIND_CONFIG`.
+    let config_digest_str = config_descriptor.digest().to_string();
+    assert!(blob_store.exists(&config_digest_str)?);
+    let config_blob = index_store
+        .get_blob(&config_digest_str)?
+        .context("Imported config blob is missing")?;
+    assert_eq!(config_blob.kind, BLOB_KIND_CONFIG);
+    assert_eq!(
+        config_blob.media_type.as_deref(),
+        Some(media_types::V1_CONFIG_MEDIA_TYPE)
+    );
+    assert_eq!(blob_store.read_bytes(&config_digest_str)?, v2_config_bytes);
+
+    // LocalArtifact reads the legacy manifest (parse-time check is on
+    // artifactType only, so the OMMX-specific config is not rejected).
+    let registry = Arc::new(LocalRegistry::open(&registry_root)?);
+    let artifact = LocalArtifact::open_in_registry(registry, image_name)?;
+    assert_eq!(
+        artifact.get_manifest()?.media_type(),
+        OCI_IMAGE_MANIFEST_MEDIA_TYPE
+    );
+    assert_eq!(artifact.layers()?, vec![layer_descriptor]);
+    Ok(())
+}
+
+#[test]
 fn rejects_import_of_deprecated_artifact_manifest_layout() -> Result<()> {
     // v3 does not support OCI Artifact Manifest
     // (`application/vnd.oci.artifact.manifest.v1+json`); import must
@@ -904,6 +954,42 @@ fn build_test_oci_dir(legacy_dir: PathBuf, image_name: ImageName) -> Result<Desc
         .build()?;
     let _oci_dir = builder.build(manifest)?;
     Ok(layer)
+}
+
+/// Build an OCI Image Layout whose Image Manifest carries an
+/// OMMX-specific config blob (`application/org.ommx.v1.config+json`)
+/// rather than the OCI 1.1 empty descriptor. Mirrors the manifest shape
+/// that SDK v2 produced when the user explicitly called
+/// `ArchiveArtifactBuilder::add_config`, so the v3 import path can be
+/// exercised against the legacy variant the SDK still has to read.
+fn build_test_oci_dir_with_v2_config(
+    legacy_dir: PathBuf,
+    image_name: ImageName,
+    config_bytes: &[u8],
+) -> Result<(Descriptor, Descriptor)> {
+    let mut builder = OciDirBuilder::new(legacy_dir, image_name)?;
+    let (config_digest, config_size) = builder.add_blob(config_bytes)?;
+    let config = DescriptorBuilder::default()
+        .media_type(MediaType::Other(media_types::V1_CONFIG_MEDIA_TYPE.into()))
+        .digest(config_digest)
+        .size(config_size)
+        .build()?;
+    let (layer_digest, layer_size) = builder.add_blob(b"v2-instance")?;
+    let layer = DescriptorBuilder::default()
+        .media_type(MediaType::Other(
+            media_types::V1_INSTANCE_MEDIA_TYPE.to_string(),
+        ))
+        .digest(layer_digest)
+        .size(layer_size)
+        .build()?;
+    let manifest = ImageManifestBuilder::default()
+        .schema_version(2_u32)
+        .artifact_type(media_types::v1_artifact())
+        .config(config.clone())
+        .layers(vec![layer.clone()])
+        .build()?;
+    let _oci_dir = builder.build(manifest)?;
+    Ok((config, layer))
 }
 
 /// Build a v3-shaped OCI Image Layout directory whose manifest is an

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -432,11 +432,20 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
     assert_eq!(layers[0].media_type, media_types::V1_INSTANCE_MEDIA_TYPE);
     assert_eq!(artifact.get_blob(&layer.digest().to_string())?, b"instance");
 
-    // Empty config blob must also be readable from the registry.
+    // Empty config blob must be readable from the registry and persisted
+    // with `BLOB_KIND_CONFIG`, matching the OCI dir import path. A
+    // mis-classified config blob (e.g. recorded as `BLOB_KIND_BLOB`)
+    // would break GC reachability analysis and queries that filter by
+    // blob kind.
     assert_eq!(
         artifact.get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?,
         media_types::OCI_EMPTY_CONFIG_BYTES
     );
+    let config_record = registry
+        .index()
+        .get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?
+        .context("Empty config blob record is missing")?;
+    assert_eq!(config_record.kind, BLOB_KIND_CONFIG);
     Ok(())
 }
 

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -647,9 +647,8 @@ fn local_artifact_subject_round_trips() -> Result<()> {
 #[test]
 fn rejects_import_of_deprecated_artifact_manifest_layout() -> Result<()> {
     // v3 does not support OCI Artifact Manifest
-    // (`application/vnd.oci.artifact.manifest.v1+json`); see
-    // ARTIFACT_V3.md §5.5. import must reject such layouts with a
-    // clear error, not silently fall back.
+    // (`application/vnd.oci.artifact.manifest.v1+json`); import must
+    // reject such layouts with a clear error, not silently fall back.
     let dir = tempfile::tempdir()?;
     let oci_dir = dir.path().join("oci-art");
     let image_name = ImageName::parse("ghcr.io/jij-inc/ommx/demo:art")?;

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -1,10 +1,9 @@
 use super::*;
 use crate::artifact::{
-    media_types, LocalArtifact, LocalArtifactBuilder, LocalManifest,
-    OCI_ARTIFACT_MANIFEST_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+    media_types, LocalArtifact, LocalArtifactBuilder, LocalManifest, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 use anyhow::{Context, Result};
-use oci_spec::image::{ArtifactManifest, MediaType};
+use oci_spec::image::MediaType;
 use ocipkg::ImageName;
 use ocipkg::{
     image::{ImageBuilder, OciDirBuilder},
@@ -223,7 +222,10 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
     // LocalArtifact must dispatch on the stored manifest media type and
     // surface the legacy Image Manifest's layer descriptors through the
     // common LocalManifest view.
-    assert!(matches!(artifact.get_manifest()?, LocalManifest::Image(_)));
+    assert_eq!(
+        artifact.get_manifest()?.media_type(),
+        OCI_IMAGE_MANIFEST_MEDIA_TYPE
+    );
     assert_eq!(artifact.layers()?, vec![layer.clone()]);
     assert_eq!(artifact.get_blob(&layer.digest().to_string())?, b"instance");
     Ok(())
@@ -373,7 +375,7 @@ fn local_registry_imports_legacy_refs_when_requested() -> Result<()> {
 }
 
 #[test]
-fn local_registry_builds_native_artifact_manifest() -> Result<()> {
+fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let registry = Arc::new(LocalRegistry::open(dir.path())?);
     let image_name = ImageName::parse("ghcr.io/jij-inc/ommx/demo:built")?;
@@ -385,32 +387,40 @@ fn local_registry_builds_native_artifact_manifest() -> Result<()> {
         .context("Published ref is missing")?;
     assert_eq!(manifest_digest, artifact.manifest_digest());
     let manifest_bytes = registry.blobs().read_bytes(&manifest_digest)?;
-    let manifest: ArtifactManifest = serde_json::from_slice(&manifest_bytes)?;
-    let blob = manifest
-        .blobs()
+    let manifest: oci_spec::image::ImageManifest = serde_json::from_slice(&manifest_bytes)?;
+    let layer = manifest
+        .layers()
         .first()
-        .context("Published blob is missing")?;
+        .context("Published layer is missing")?;
 
     let manifest_record = registry
         .index()
         .get_manifest(&manifest_digest)?
         .context("Published manifest is missing")?;
-    assert_eq!(manifest_record.media_type, OCI_ARTIFACT_MANIFEST_MEDIA_TYPE);
+    assert_eq!(manifest_record.media_type, OCI_IMAGE_MANIFEST_MEDIA_TYPE);
     assert_eq!(manifest_record.size, manifest_bytes.len() as u64);
-    assert_eq!(manifest.media_type(), &MediaType::ArtifactManifest);
     assert_eq!(
-        manifest.artifact_type(),
-        &MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string())
+        manifest.media_type().as_ref(),
+        Some(&MediaType::ImageManifest)
     );
-    assert_eq!(artifact.layers()?, manifest.blobs().to_vec());
-    // LocalArtifact must dispatch on the stored manifest media type and
-    // surface the v3 native Artifact Manifest's blob descriptors through
-    // the common LocalManifest view (symmetric to the legacy import
-    // test that exercises LocalManifest::Image).
-    assert!(matches!(
-        artifact.get_manifest()?,
-        LocalManifest::Artifact(_)
-    ));
+    assert_eq!(
+        manifest.artifact_type().as_ref(),
+        Some(&MediaType::Other(
+            media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()
+        ))
+    );
+    // OCI 1.1 empty config descriptor is required for `artifactType` to be
+    // honoured by registries.
+    assert_eq!(manifest.config().media_type(), &MediaType::EmptyJSON);
+    assert_eq!(
+        manifest.config().digest().to_string(),
+        media_types::OCI_EMPTY_CONFIG_DIGEST
+    );
+    assert_eq!(artifact.layers()?, manifest.layers().to_vec());
+    assert_eq!(
+        artifact.get_manifest()?.media_type(),
+        OCI_IMAGE_MANIFEST_MEDIA_TYPE
+    );
     assert_eq!(
         artifact.get_manifest()?.artifact_type(),
         &MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string())
@@ -418,9 +428,15 @@ fn local_registry_builds_native_artifact_manifest() -> Result<()> {
 
     let layers = registry.index().get_layers(&manifest_digest)?;
     assert_eq!(layers.len(), 1);
-    assert_eq!(layers[0].digest, blob.digest().to_string());
+    assert_eq!(layers[0].digest, layer.digest().to_string());
     assert_eq!(layers[0].media_type, media_types::V1_INSTANCE_MEDIA_TYPE);
-    assert_eq!(artifact.get_blob(&blob.digest().to_string())?, b"instance");
+    assert_eq!(artifact.get_blob(&layer.digest().to_string())?, b"instance");
+
+    // Empty config blob must also be readable from the registry.
+    assert_eq!(
+        artifact.get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?,
+        media_types::OCI_EMPTY_CONFIG_BYTES
+    );
     Ok(())
 }
 
@@ -608,7 +624,7 @@ fn local_artifact_subject_round_trips() -> Result<()> {
     assert_eq!(plain.subject()?, None);
 
     let subject_descriptor = oci_spec::image::DescriptorBuilder::default()
-        .media_type(MediaType::ArtifactManifest)
+        .media_type(MediaType::ImageManifest)
         .digest(oci_spec::image::Digest::from_str(&sha256_digest(
             b"parent-manifest-bytes",
         ))?)
@@ -629,37 +645,26 @@ fn local_artifact_subject_round_trips() -> Result<()> {
 }
 
 #[test]
-fn imports_oci_dir_with_artifact_manifest_layout() -> Result<()> {
-    // OCI dir whose manifest is an Artifact Manifest (no Image
-    // config, layers in `blobs[]`) must import as identity-preserving
-    // and surface as `LocalManifest::Artifact` on read.
+fn rejects_import_of_deprecated_artifact_manifest_layout() -> Result<()> {
+    // v3 does not support OCI Artifact Manifest
+    // (`application/vnd.oci.artifact.manifest.v1+json`); see
+    // ARTIFACT_V3.md §5.5. import must reject such layouts with a
+    // clear error, not silently fall back.
     let dir = tempfile::tempdir()?;
     let oci_dir = dir.path().join("oci-art");
     let image_name = ImageName::parse("ghcr.io/jij-inc/ommx/demo:art")?;
-    let (layer, expected_manifest_digest) =
-        build_test_oci_dir_with_artifact_manifest(&oci_dir, &image_name, b"art-instance")?;
+    build_test_oci_dir_with_artifact_manifest(&oci_dir, &image_name, b"art-instance")?;
 
     let registry_root = dir.path().join("registry-v3");
     let index_store = SqliteIndexStore::open_in_registry_root(&registry_root)?;
     let blob_store = FileBlobStore::open_in_registry_root(&registry_root)?;
-    let imported = import_oci_dir(&index_store, &blob_store, &oci_dir)?;
-
-    assert_eq!(imported.manifest_digest, expected_manifest_digest);
-    assert_eq!(imported.image_name.as_ref(), Some(&image_name));
-    let manifest_record = index_store
-        .get_manifest(&imported.manifest_digest)?
-        .context("Imported manifest is missing")?;
-    assert_eq!(manifest_record.media_type, OCI_ARTIFACT_MANIFEST_MEDIA_TYPE);
-    assert!(blob_store.exists(&imported.manifest_digest)?);
-    assert!(blob_store.exists(&layer.digest().to_string())?);
-
-    let registry = LocalRegistry::open(&registry_root)?;
-    let artifact = LocalArtifact::open_in_registry(Arc::new(registry), image_name)?;
-    assert!(matches!(
-        artifact.get_manifest()?,
-        LocalManifest::Artifact(_)
-    ));
-    assert_eq!(artifact.layers()?, vec![layer]);
+    let err = import_oci_dir(&index_store, &blob_store, &oci_dir)
+        .expect_err("Artifact Manifest import must error");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("OCI Artifact Manifest"),
+        "Error must mention the rejected format; got: {message}"
+    );
     Ok(())
 }
 

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -159,9 +159,13 @@ impl LocalArtifact {
     }
 
     fn read_manifest_uncached(&self) -> Result<LocalManifest> {
-        let bytes = self.registry.blobs().read_bytes(&self.manifest_digest)?;
-        let record = self
-            .registry
+        // Verify the IndexStore has a manifest record for this digest so a
+        // missing index entry surfaces as a clear "manifest not found"
+        // error instead of bubbling up as a parse failure or stale-cache
+        // hit. The record's `media_type` column is informational — the
+        // SQLite Local Registry only stores OCI Image Manifest, so no
+        // per-call dispatch is needed.
+        self.registry
             .index()
             .get_manifest(&self.manifest_digest)?
             .with_context(|| {
@@ -170,7 +174,8 @@ impl LocalArtifact {
                     self.manifest_digest
                 )
             })?;
-        LocalManifest::parse(&record.media_type, &bytes)
+        let bytes = self.registry.blobs().read_bytes(&self.manifest_digest)?;
+        LocalManifest::parse(&bytes)
     }
 
     pub fn annotations(&self) -> Result<HashMap<String, String>> {
@@ -191,12 +196,11 @@ impl LocalArtifact {
 }
 
 /// A manifest read from the SQLite Local Registry. v3 stores OCI Image
-/// Manifest as the only native format (ARTIFACT_V3.md §5.5); OMMX
-/// artifacts are identified by the `artifactType` field plus the
-/// `application/vnd.oci.empty.v1+json` empty config descriptor. The
-/// deprecated OCI Artifact Manifest media type
-/// (`application/vnd.oci.artifact.manifest.v1+json`) is rejected at
-/// parse time rather than supported via a second enum variant.
+/// Manifest as the only native format; OMMX artifacts are identified
+/// by the `artifactType` field plus the `application/vnd.oci.empty.v1+json`
+/// empty config descriptor. The deprecated OCI Artifact Manifest media
+/// type (`application/vnd.oci.artifact.manifest.v1+json`) is rejected
+/// at parse time rather than supported via a second enum variant.
 ///
 /// Boxed because `oci_spec`'s `ImageManifest` is large (~800 bytes) and
 /// callers move `LocalManifest` around inside `Arc<OnceLock<...>>`.
@@ -204,20 +208,11 @@ impl LocalArtifact {
 pub struct LocalManifest(Box<ImageManifest>);
 
 impl LocalManifest {
-    fn parse(media_type: &str, bytes: &[u8]) -> Result<Self> {
-        match media_type {
-            media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE => {
-                let manifest: ImageManifest =
-                    serde_json::from_slice(bytes).context("Failed to parse OCI image manifest")?;
-                ensure_ommx_image_manifest(&manifest)?;
-                Ok(Self(Box::new(manifest)))
-            }
-            other => bail!(
-                "Unsupported manifest media type for OMMX artifact: {other} \
-                 (only `{}` is accepted; OCI Artifact Manifest is deprecated and not supported)",
-                media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE,
-            ),
-        }
+    fn parse(bytes: &[u8]) -> Result<Self> {
+        let manifest: ImageManifest =
+            serde_json::from_slice(bytes).context("Failed to parse OCI image manifest")?;
+        ensure_ommx_image_manifest(&manifest)?;
+        Ok(Self(Box::new(manifest)))
     }
 
     pub fn media_type(&self) -> &'static str {
@@ -251,8 +246,8 @@ impl LocalManifest {
 ///
 /// Produces an OCI Image Manifest with `artifactType` set to the OMMX
 /// artifact media type and the OCI 1.1 empty config descriptor as
-/// `config` (per ARTIFACT_V3.md §1.12 / §5.5). The layer blobs land in
-/// the Image Manifest's `layers[]` field.
+/// `config`. The layer blobs land in the Image Manifest's `layers[]`
+/// field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalArtifactBuilder {
     image_name: ocipkg::ImageName,

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -197,8 +197,12 @@ impl LocalArtifact {
 
 /// A manifest read from the SQLite Local Registry. v3 stores OCI Image
 /// Manifest as the only native format; OMMX artifacts are identified
-/// by the `artifactType` field plus the `application/vnd.oci.empty.v1+json`
-/// empty config descriptor. The deprecated OCI Artifact Manifest media
+/// at parse time by the `artifactType` field (validated against
+/// `application/org.ommx.v1.artifact`). The native build path also
+/// writes an `application/vnd.oci.empty.v1+json` empty config descriptor
+/// — matching the SDK v2 archive build — but `parse` does not assert
+/// on the config blob, so legacy v2 imports that carry an OMMX-specific
+/// config remain readable. The deprecated OCI Artifact Manifest media
 /// type (`application/vnd.oci.artifact.manifest.v1+json`) is rejected
 /// at parse time rather than supported via a second enum variant.
 ///

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -383,24 +383,40 @@ impl LocalArtifactBuilder {
     /// [`StagedArtifactManifest`] that the registry can later publish.
     /// Pure: no I/O, no registry interaction.
     ///
-    /// Materialises the OCI 1.1 empty config blob as one of the staged
-    /// blobs so the publish path uploads it alongside the layers. The
-    /// caller does not need to know about empty-config bookkeeping.
+    /// Materialises the empty config blob as one of the staged blobs so
+    /// the publish path uploads it alongside the layers. Matches the
+    /// SDK v2 / `ArchiveArtifactBuilder` manifest shape (see
+    /// `ocipkg::image::OciArtifactBuilder::new`): `schemaVersion: 2` +
+    /// `artifactType` + empty config + layers, with the manifest's
+    /// own `mediaType` field intentionally absent so `LocalArtifactBuilder`
+    /// and the archive build path produce structurally identical
+    /// manifests.
     fn stage(self) -> Result<StagedArtifactManifest> {
         let mut blobs = self.layers;
-        let config_blob = StagedArtifactBlob::new(
-            MediaType::EmptyJSON,
-            OCI_EMPTY_CONFIG_BYTES.to_vec(),
-            HashMap::new(),
-        )?;
-        let config_descriptor = config_blob.descriptor.clone();
+        // V2 SDK's `ocipkg::OciArtifactBuilder::add_empty_json` emits the
+        // empty config descriptor without an `annotations` field; build
+        // it directly here (bypassing `descriptor_from_bytes`, which
+        // always renders `annotations` even when empty for layer
+        // descriptors) so the resulting manifest matches v2 byte-for-byte.
+        let empty_config_bytes = OCI_EMPTY_CONFIG_BYTES.to_vec();
+        let config_descriptor = DescriptorBuilder::default()
+            .media_type(MediaType::EmptyJSON)
+            .digest(
+                Digest::from_str(&sha256_digest(&empty_config_bytes))
+                    .context("Failed to parse empty config digest")?,
+            )
+            .size(empty_config_bytes.len() as u64)
+            .build()
+            .context("Failed to build empty config descriptor")?;
         let layer_descriptors: Vec<Descriptor> =
             blobs.iter().map(|blob| blob.descriptor.clone()).collect();
-        blobs.push(config_blob);
+        blobs.push(StagedArtifactBlob {
+            descriptor: config_descriptor.clone(),
+            bytes: empty_config_bytes,
+        });
 
         let mut builder = OciImageManifestBuilder::default()
             .schema_version(2u32)
-            .media_type(MediaType::ImageManifest)
             .artifact_type(self.artifact_type)
             .config(config_descriptor)
             .layers(layer_descriptors);
@@ -459,14 +475,19 @@ pub(crate) fn descriptor_from_bytes(
     annotations: HashMap<String, String>,
 ) -> Result<Descriptor> {
     let digest = Digest::from_str(&sha256_digest(bytes)).context("Failed to parse blob digest")?;
-    let mut builder = DescriptorBuilder::default()
+    // `annotations` is always set, even when empty, matching SDK v2 /
+    // `ocipkg::OciArtifactBuilder::add_layer` which renders the field as
+    // `"annotations": {}` in the manifest JSON. Preserving this shape
+    // keeps layer descriptor bytes (and therefore the manifest digest)
+    // byte-for-byte compatible with v2 OMMX artifacts.
+    let descriptor = DescriptorBuilder::default()
         .media_type(media_type)
         .digest(digest)
-        .size(bytes.len() as u64);
-    if !annotations.is_empty() {
-        builder = builder.annotations(annotations);
-    }
-    builder.build().context("Failed to build OCI descriptor")
+        .size(bytes.len() as u64)
+        .annotations(annotations)
+        .build()
+        .context("Failed to build OCI descriptor")?;
+    Ok(descriptor)
 }
 
 pub(crate) fn stable_json_bytes(value: &impl Serialize) -> Result<Vec<u8>> {
@@ -520,10 +541,10 @@ mod tests {
         builder.add_annotation("org.opencontainers.image.ref.name", "example.com/demo:v1");
 
         let staged = builder.stage()?;
-        assert_eq!(
-            staged.manifest.media_type().as_ref(),
-            Some(&MediaType::ImageManifest)
-        );
+        // Manifest's own `mediaType` field is intentionally not set, matching
+        // the v2 / `ArchiveArtifactBuilder` shape; the OCI Distribution
+        // Content-Type header is supplied separately at push time.
+        assert_eq!(staged.manifest.media_type().as_ref(), None);
         assert_eq!(
             staged.manifest.artifact_type().as_ref(),
             Some(&MediaType::Other(

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -2,14 +2,14 @@ use super::{
     digest::sha256_digest,
     ghcr,
     local_registry::{LocalRegistry, RefConflictPolicy, RefUpdate},
-    media_types::{self, OCI_ARTIFACT_MANIFEST_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE},
+    media_types::{self, OCI_EMPTY_CONFIG_BYTES},
     InstanceAnnotations, ParametricInstanceAnnotations, SampleSetAnnotations, SolutionAnnotations,
 };
 use crate::v1;
 use anyhow::{bail, Context, Result};
 use oci_spec::image::{
-    ArtifactManifest, ArtifactManifestBuilder as OciArtifactManifestBuilder, Descriptor,
-    DescriptorBuilder, Digest, ImageManifest, MediaType,
+    Descriptor, DescriptorBuilder, Digest, ImageManifest,
+    ImageManifestBuilder as OciImageManifestBuilder, MediaType,
 };
 use prost::Message;
 use serde::Serialize;
@@ -190,90 +190,74 @@ impl LocalArtifact {
     }
 }
 
-/// A manifest read from the SQLite Local Registry, dispatched on its OCI media
-/// type. v3 stores both Image Manifest (legacy import path) and Artifact
-/// Manifest (native build path) and identifies each by its bytes digest.
+/// A manifest read from the SQLite Local Registry. v3 stores OCI Image
+/// Manifest as the only native format (ARTIFACT_V3.md §5.5); OMMX
+/// artifacts are identified by the `artifactType` field plus the
+/// `application/vnd.oci.empty.v1+json` empty config descriptor. The
+/// deprecated OCI Artifact Manifest media type
+/// (`application/vnd.oci.artifact.manifest.v1+json`) is rejected at
+/// parse time rather than supported via a second enum variant.
 ///
-/// Both variants are boxed because `oci_spec`'s `ImageManifest` (~800 bytes)
-/// and `ArtifactManifest` (~460 bytes) are large structs — keeping them
-/// inline would either trip `clippy::large_enum_variant` or pad the smaller
-/// variant up to the larger one. The boxed indirection costs one allocation
-/// per `get_manifest()` call but keeps both the enum and the surrounding
-/// `Result<LocalManifest>` cheap to move around.
+/// Boxed because `oci_spec`'s `ImageManifest` is large (~800 bytes) and
+/// callers move `LocalManifest` around inside `Arc<OnceLock<...>>`.
 #[derive(Debug, Clone)]
-pub enum LocalManifest {
-    Image(Box<ImageManifest>),
-    Artifact(Box<ArtifactManifest>),
-}
+pub struct LocalManifest(Box<ImageManifest>);
 
 impl LocalManifest {
     fn parse(media_type: &str, bytes: &[u8]) -> Result<Self> {
         match media_type {
-            OCI_ARTIFACT_MANIFEST_MEDIA_TYPE => {
-                let manifest: ArtifactManifest = serde_json::from_slice(bytes)
-                    .context("Failed to parse OCI artifact manifest")?;
-                ensure_ommx_artifact_manifest(&manifest)?;
-                Ok(LocalManifest::Artifact(Box::new(manifest)))
-            }
-            OCI_IMAGE_MANIFEST_MEDIA_TYPE => {
+            media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE => {
                 let manifest: ImageManifest =
                     serde_json::from_slice(bytes).context("Failed to parse OCI image manifest")?;
                 ensure_ommx_image_manifest(&manifest)?;
-                Ok(LocalManifest::Image(Box::new(manifest)))
+                Ok(Self(Box::new(manifest)))
             }
-            other => bail!("Unsupported manifest media type for OMMX artifact: {other}"),
+            other => bail!(
+                "Unsupported manifest media type for OMMX artifact: {other} \
+                 (only `{}` is accepted; OCI Artifact Manifest is deprecated and not supported)",
+                media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+            ),
         }
     }
 
     pub fn media_type(&self) -> &'static str {
-        match self {
-            LocalManifest::Image(_) => OCI_IMAGE_MANIFEST_MEDIA_TYPE,
-            LocalManifest::Artifact(_) => OCI_ARTIFACT_MANIFEST_MEDIA_TYPE,
-        }
+        media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE
     }
 
     /// Always returns the OMMX `artifactType` discriminator. `parse`
-    /// rejects manifests without one (see `ensure_ommx_image_manifest`
-    /// / `ensure_ommx_artifact_manifest`), so this method does not
-    /// surface an `Option`.
+    /// rejects manifests without one (see `ensure_ommx_image_manifest`),
+    /// so this method does not surface an `Option`.
     pub fn artifact_type(&self) -> &MediaType {
-        match self {
-            LocalManifest::Image(m) => m.artifact_type().as_ref().expect(
-                "ensure_ommx_image_manifest guarantees Image Manifest carries an artifactType",
-            ),
-            LocalManifest::Artifact(m) => m.artifact_type(),
-        }
+        self.0
+            .artifact_type()
+            .as_ref()
+            .expect("ensure_ommx_image_manifest guarantees Image Manifest carries an artifactType")
     }
 
     pub fn layers(&self) -> Vec<Descriptor> {
-        match self {
-            LocalManifest::Image(m) => m.layers().to_vec(),
-            LocalManifest::Artifact(m) => m.blobs().to_vec(),
-        }
+        self.0.layers().to_vec()
     }
 
     pub fn annotations(&self) -> HashMap<String, String> {
-        let raw = match self {
-            LocalManifest::Image(m) => m.annotations().clone(),
-            LocalManifest::Artifact(m) => m.annotations().clone(),
-        };
-        raw.unwrap_or_default()
+        self.0.annotations().clone().unwrap_or_default()
     }
 
     pub fn subject(&self) -> Option<Descriptor> {
-        match self {
-            LocalManifest::Image(m) => m.subject().clone(),
-            LocalManifest::Artifact(m) => m.subject().clone(),
-        }
+        self.0.subject().clone()
     }
 }
 
 /// Builder for OMMX Artifacts stored in the SQLite-backed Local Registry.
+///
+/// Produces an OCI Image Manifest with `artifactType` set to the OMMX
+/// artifact media type and the OCI 1.1 empty config descriptor as
+/// `config` (per ARTIFACT_V3.md §1.12 / §5.5). The layer blobs land in
+/// the Image Manifest's `layers[]` field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalArtifactBuilder {
     image_name: ocipkg::ImageName,
     artifact_type: MediaType,
-    blobs: Vec<StagedArtifactBlob>,
+    layers: Vec<StagedArtifactBlob>,
     subject: Option<Descriptor>,
     annotations: HashMap<String, String>,
 }
@@ -283,7 +267,7 @@ impl LocalArtifactBuilder {
         Self {
             image_name,
             artifact_type: MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()),
-            blobs: Vec::new(),
+            layers: Vec::new(),
             subject: None,
             annotations: HashMap::new(),
         }
@@ -307,7 +291,7 @@ impl LocalArtifactBuilder {
     ) -> Result<Descriptor> {
         let blob = StagedArtifactBlob::new(media_type, bytes, annotations)?;
         let descriptor = blob.descriptor.clone();
-        self.blobs.push(blob);
+        self.layers.push(blob);
         Ok(descriptor)
     }
 
@@ -403,15 +387,28 @@ impl LocalArtifactBuilder {
     /// descriptor from the in-memory builder state, returning a
     /// [`StagedArtifactManifest`] that the registry can later publish.
     /// Pure: no I/O, no registry interaction.
+    ///
+    /// Materialises the OCI 1.1 empty config blob as one of the staged
+    /// blobs so the publish path uploads it alongside the layers. The
+    /// caller does not need to know about empty-config bookkeeping.
     fn stage(self) -> Result<StagedArtifactManifest> {
-        let mut builder = OciArtifactManifestBuilder::default()
+        let mut blobs = self.layers;
+        let config_blob = StagedArtifactBlob::new(
+            MediaType::EmptyJSON,
+            OCI_EMPTY_CONFIG_BYTES.to_vec(),
+            HashMap::new(),
+        )?;
+        let config_descriptor = config_blob.descriptor.clone();
+        let layer_descriptors: Vec<Descriptor> =
+            blobs.iter().map(|blob| blob.descriptor.clone()).collect();
+        blobs.push(config_blob);
+
+        let mut builder = OciImageManifestBuilder::default()
+            .schema_version(2u32)
+            .media_type(MediaType::ImageManifest)
             .artifact_type(self.artifact_type)
-            .blobs(
-                self.blobs
-                    .iter()
-                    .map(|blob| blob.descriptor.clone())
-                    .collect::<Vec<_>>(),
-            );
+            .config(config_descriptor)
+            .layers(layer_descriptors);
         if let Some(subject) = self.subject {
             builder = builder.subject(subject);
         }
@@ -420,24 +417,25 @@ impl LocalArtifactBuilder {
         }
         let manifest = builder
             .build()
-            .context("Failed to build OCI artifact manifest")?;
+            .context("Failed to build OCI image manifest")?;
         let manifest_bytes = stable_json_bytes(&manifest)?;
         let manifest_descriptor =
-            descriptor_from_bytes(MediaType::ArtifactManifest, &manifest_bytes, HashMap::new())?;
+            descriptor_from_bytes(MediaType::ImageManifest, &manifest_bytes, HashMap::new())?;
         Ok(StagedArtifactManifest {
             image_name: self.image_name,
             manifest,
             manifest_bytes,
             manifest_descriptor,
-            blobs: self.blobs,
+            blobs,
         })
     }
 }
 
 /// The whole-artifact analogue of [`StagedArtifactBlob`]: bundles the
-/// `OCI ArtifactManifest` together with its stable JSON bytes, the
-/// matching `Descriptor` (digest / size / media type), every layer
-/// blob staged for upload, and the target `ImageName`.
+/// `OCI ImageManifest` together with its stable JSON bytes, the
+/// matching `Descriptor` (digest / size / media type), every blob
+/// staged for upload (layers + the OCI 1.1 empty config), and the
+/// target `ImageName`.
 ///
 /// Produced purely by in-memory computation (`LocalArtifactBuilder::stage`)
 /// and consumed by the registry publish path
@@ -454,7 +452,7 @@ impl LocalArtifactBuilder {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StagedArtifactManifest {
     image_name: ocipkg::ImageName,
-    manifest: ArtifactManifest,
+    manifest: ImageManifest,
     manifest_bytes: Vec<u8>,
     manifest_descriptor: Descriptor,
     blobs: Vec<StagedArtifactBlob>,
@@ -496,20 +494,6 @@ fn reject_conflicting_ref(image_name: &ocipkg::ImageName, ref_update: RefUpdate)
     Ok(())
 }
 
-fn ensure_ommx_artifact_manifest(manifest: &ArtifactManifest) -> Result<()> {
-    anyhow::ensure!(
-        manifest.media_type().as_ref() == OCI_ARTIFACT_MANIFEST_MEDIA_TYPE,
-        "Manifest is not an OCI artifact manifest: {}",
-        manifest.media_type()
-    );
-    anyhow::ensure!(
-        manifest.artifact_type() == &media_types::v1_artifact(),
-        "Not an OMMX Artifact: {}",
-        manifest.artifact_type()
-    );
-    Ok(())
-}
-
 fn ensure_ommx_image_manifest(manifest: &ImageManifest) -> Result<()> {
     let artifact_type = manifest
         .artifact_type()
@@ -531,9 +515,9 @@ mod tests {
     }
 
     #[test]
-    fn builds_native_oci_artifact_manifest() -> Result<()> {
+    fn builds_native_oci_image_manifest_with_artifact_type() -> Result<()> {
         let mut builder = LocalArtifactBuilder::new(test_image_name("v1")?);
-        let blob = builder.add_layer_bytes(
+        let layer = builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),
             HashMap::from([("org.ommx.v1.instance.title".to_string(), "demo".to_string())]),
@@ -541,22 +525,45 @@ mod tests {
         builder.add_annotation("org.opencontainers.image.ref.name", "example.com/demo:v1");
 
         let staged = builder.stage()?;
-        assert_eq!(staged.manifest.media_type(), &MediaType::ArtifactManifest);
         assert_eq!(
-            staged.manifest.artifact_type(),
-            &MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string())
+            staged.manifest.media_type().as_ref(),
+            Some(&MediaType::ImageManifest)
         );
-        assert_eq!(staged.manifest.blobs(), &[blob]);
+        assert_eq!(
+            staged.manifest.artifact_type().as_ref(),
+            Some(&MediaType::Other(
+                media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()
+            ))
+        );
+        assert_eq!(staged.manifest.layers(), &[layer]);
+
+        // OCI 1.1 empty config descriptor is set as the manifest's config and
+        // staged for upload alongside the layers.
+        let config = staged.manifest.config();
+        assert_eq!(config.media_type(), &MediaType::EmptyJSON);
+        assert_eq!(
+            config.size(),
+            media_types::OCI_EMPTY_CONFIG_BYTES.len() as u64
+        );
+        assert_eq!(
+            config.digest().to_string(),
+            media_types::OCI_EMPTY_CONFIG_DIGEST
+        );
+        assert!(staged
+            .blobs
+            .iter()
+            .any(|blob| blob.descriptor.digest() == config.digest()));
+
         assert_eq!(
             staged.manifest_descriptor.media_type(),
-            &MediaType::ArtifactManifest
+            &MediaType::ImageManifest
         );
         assert_eq!(
             staged.manifest_descriptor.digest().to_string(),
             sha256_digest(&staged.manifest_bytes)
         );
 
-        let parsed: ArtifactManifest = serde_json::from_slice(&staged.manifest_bytes)?;
+        let parsed: ImageManifest = serde_json::from_slice(&staged.manifest_bytes)?;
         assert_eq!(parsed, staged.manifest);
         Ok(())
     }
@@ -576,11 +583,8 @@ mod tests {
 
     #[test]
     fn builds_manifest_with_subject() -> Result<()> {
-        let subject = descriptor_from_bytes(
-            MediaType::ArtifactManifest,
-            b"parent manifest",
-            HashMap::new(),
-        )?;
+        let subject =
+            descriptor_from_bytes(MediaType::ImageManifest, b"parent manifest", HashMap::new())?;
         let mut builder = LocalArtifactBuilder::new(test_image_name("subject")?);
         builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -162,10 +162,13 @@ impl LocalArtifact {
         // Verify the IndexStore has a manifest record for this digest so a
         // missing index entry surfaces as a clear "manifest not found"
         // error instead of bubbling up as a parse failure or stale-cache
-        // hit. The record's `media_type` column is informational — the
-        // SQLite Local Registry only stores OCI Image Manifest, so no
-        // per-call dispatch is needed.
-        self.registry
+        // hit. The record's `media_type` column is informational for the
+        // common Image Manifest case, but is also used here to detect
+        // entries written by earlier v3-alpha builds (`#864` / `#866`)
+        // as OCI Artifact Manifest and surface a targeted error instead
+        // of an opaque image-manifest parse failure.
+        let record = self
+            .registry
             .index()
             .get_manifest(&self.manifest_digest)?
             .with_context(|| {
@@ -174,6 +177,15 @@ impl LocalArtifact {
                     self.manifest_digest
                 )
             })?;
+        if record.media_type != media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE {
+            bail!(
+                "Manifest {} was persisted as `{}`, which is not supported in this build. \
+                 Only OCI Image Manifest (`{}`) is read from the SQLite Local Registry.",
+                self.manifest_digest,
+                record.media_type,
+                media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+            );
+        }
         let bytes = self.registry.blobs().read_bytes(&self.manifest_digest)?;
         LocalManifest::parse(&bytes)
     }

--- a/rust/ommx/src/artifact/media_types.rs
+++ b/rust/ommx/src/artifact/media_types.rs
@@ -1,7 +1,17 @@
 use oci_spec::image::MediaType;
 
 pub const OCI_IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
-pub const OCI_ARTIFACT_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.artifact.manifest.v1+json";
+
+/// Media type of the OCI 1.1 "empty descriptor" used as the `config`
+/// blob for OMMX Image Manifests. See
+/// <https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidance-for-an-empty-descriptor>.
+pub const OCI_EMPTY_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.empty.v1+json";
+/// Body of the OCI empty descriptor: the two-byte JSON document `{}`.
+pub const OCI_EMPTY_CONFIG_BYTES: &[u8] = b"{}";
+/// SHA-256 digest of [`OCI_EMPTY_CONFIG_BYTES`]. Hard-coded so the
+/// constant can be used in `const` contexts without re-hashing.
+pub const OCI_EMPTY_CONFIG_DIGEST: &str =
+    "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a";
 
 pub const V1_ARTIFACT_MEDIA_TYPE: &str = "application/org.ommx.v1.artifact";
 pub const V1_CONFIG_MEDIA_TYPE: &str = "application/org.ommx.v1.config+json";


### PR DESCRIPTION
## Summary

- Switch the SQLite Local Registry's native manifest format from the deprecated OCI Artifact Manifest (`application/vnd.oci.artifact.manifest.v1+json`, removed in OCI Image Spec v1.1) to OCI Image Manifest with the OCI 1.1 `artifactType` field plus the `application/vnd.oci.empty.v1+json` empty config descriptor, per the design unified in PR #868 (ARTIFACT_V3.md §5.5).
- This is the §12.3 **Step B'** milestone that unblocks the paused native push work in draft PR #867. `distribution/distribution` v2 (`registry:2`) rejected the Artifact Manifest with `MANIFEST_INVALID`; Image Manifest with `artifactType` is what mainstream registries accept.

## Implementation notes

- `LocalArtifactBuilder.stage()` now produces an `OciImageManifestBuilder` manifest and materialises the OCI empty config blob (`{}` / `sha256:44136fa3...`) as one of the staged blobs so the publish path uploads `config + layers` as a single batch. The in-builder field rename `blobs` → `layers` matches OCI Image Manifest terminology.
- `LocalManifest` collapses from a 2-variant enum (`Image | Artifact`) to a `LocalManifest(Box<ImageManifest>)` newtype. `LocalManifest::parse` accepts only the Image Manifest media type and rejects the deprecated Artifact Manifest at parse time with a clear error.
- `LocalRegistry::publish_artifact_manifest` now validates an `&ImageManifest`. The descriptor count check matches `manifest.layers().len() + 1` (the empty config) against the staged blob count, and the upload manifest is verified against the staged set.
- `import::oci_dir` no longer carries an `OciManifestFormat` dispatch; encountering a deprecated Artifact Manifest is now a hard error rather than a sloppy fallback.
- Drops `OCI_ARTIFACT_MANIFEST_MEDIA_TYPE` constant + crate-level re-export and the `ensure_ommx_artifact_manifest` validator. Adds `OCI_EMPTY_CONFIG_{MEDIA_TYPE,BYTES,DIGEST}` constants.
- Tests:
  - `builds_native_oci_image_manifest_with_artifact_type` replaces the old Artifact Manifest builder test.
  - `local_registry_builds_native_image_manifest_with_artifact_type` replaces the symmetric integration test.
  - `rejects_import_of_deprecated_artifact_manifest_layout` asserts the import rejection path.

## Follow-up

- Draft PR #867 (Step B — native SQLite → remote push via `oci-client`) can resume on top of this change.

## Test plan

- [x] `cargo test -p ommx --features remote-artifact` — 508 unit tests, 44 integration / doctests pass.
- [x] `cargo clippy -p ommx --features remote-artifact --lib` — no new warnings on touched files.
- [x] `task python:test` on the package — 37 tests pass (Python binding unaffected because it does not dispatch on manifest format).
- [ ] Step B PR #867 reopened on top of this branch and pushed to a local `registry:2` to confirm the `MANIFEST_INVALID` failure is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)