### PR TITLE
fix(login): allow ommx login to bootstrap credentials on a fresh machine

### DIFF
--- a/rust/ommx/src/bin/ommx.rs
+++ b/rust/ommx/src/bin/ommx.rs
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
             password,
         } => {
             let url = url::Url::parse(registry)?;
-            let mut auth = ocipkg::distribution::StoredAuth::load_all()?;
+            let mut auth = ocipkg::distribution::StoredAuth::load_all().unwrap_or_default();
             match (username, password) {
                 (Some(username), Some(password)) => {
                     auth.add(url.domain().unwrap(), username, password);

--- a/rust/ommx/tests/login_no_auth.rs
+++ b/rust/ommx/tests/login_no_auth.rs
@@ -1,0 +1,44 @@
+//! Reproduces a known limitation of `ommx login` on 2.x: the command
+//! delegates to `ocipkg::distribution::StoredAuth::load_all`, which errors
+//! with `No valid auth info found` when none of Docker's, podman's, or
+//! ocipkg's auth files exist. As a result, `ommx login` cannot bootstrap
+//! credentials on a fresh machine and the user must run `docker login`
+//! (or similar) first.
+//!
+//! This test pins that current behavior on dev-2.x. In v3 the `login`
+//! subcommand is being replaced by docker-credential helpers, so this
+//! limitation will no longer be relevant.
+//!
+//! Run with: `cargo test -p ommx --test login_no_auth`
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn login_fails_when_no_auth_file_exists() {
+    let home = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("login_no_auth_home");
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).expect("create empty HOME for test");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ommx"))
+        .args(["login", "https://ghcr.invalid", "-u", "user", "-p", "pass"])
+        .env("HOME", &home)
+        .env_remove("XDG_RUNTIME_DIR")
+        .env_remove("XDG_CONFIG_HOME")
+        .output()
+        .expect("spawn ommx binary");
+
+    assert!(
+        !output.status.success(),
+        "ommx login should fail on a fresh environment; status={:?} stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No valid auth info found"),
+        "expected 'No valid auth info found' in stderr, got: {stderr}",
+    );
+}

--- a/rust/ommx/tests/login_no_auth.rs
+++ b/rust/ommx/tests/login_no_auth.rs
@@ -1,13 +1,11 @@
-//! Reproduces a known limitation of `ommx login` on 2.x: the command
-//! delegates to `ocipkg::distribution::StoredAuth::load_all`, which errors
-//! with `No valid auth info found` when none of Docker's, podman's, or
-//! ocipkg's auth files exist. As a result, `ommx login` cannot bootstrap
-//! credentials on a fresh machine and the user must run `docker login`
-//! (or similar) first.
+//! Regression test for `ommx login` on a fresh environment.
 //!
-//! This test pins that current behavior on dev-2.x. In v3 the `login`
-//! subcommand is being replaced by docker-credential helpers, so this
-//! limitation will no longer be relevant.
+//! Previously, `ommx login` propagated `StoredAuth::load_all`'s failure
+//! and exited with `No valid auth info found` when none of Docker's,
+//! podman's, or ocipkg's auth files existed — making it impossible to
+//! bootstrap credentials via `ommx login` alone. The CLI now falls back
+//! to an empty auth store in that case, so the command can proceed to
+//! the registry challenge step.
 //!
 //! Run with: `cargo test -p ommx --test login_no_auth`
 
@@ -15,7 +13,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 #[test]
-fn login_fails_when_no_auth_file_exists() {
+fn login_proceeds_without_existing_auth_files() {
     let home = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("login_no_auth_home");
     let _ = std::fs::remove_dir_all(&home);
     std::fs::create_dir_all(&home).expect("create empty HOME for test");
@@ -28,17 +26,21 @@ fn login_fails_when_no_auth_file_exists() {
         .output()
         .expect("spawn ommx binary");
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
     assert!(
-        !output.status.success(),
-        "ommx login should fail on a fresh environment; status={:?} stdout={} stderr={}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
+        !stderr.contains("No valid auth info found"),
+        "login must not bail out on the auth-loading step; stderr={stderr}",
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The bogus `ghcr.invalid` URL guarantees the command still fails
+    // at the network step, which proves we got past `load_all`.
     assert!(
-        stderr.contains("No valid auth info found"),
-        "expected 'No valid auth info found' in stderr, got: {stderr}",
+        !output.status.success(),
+        "expected the bogus registry URL to fail at the network step; \
+         status={:?} stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        stderr,
     );
 }


### PR DESCRIPTION
## Summary

On 2.x, `ommx login` propagated `ocipkg::distribution::StoredAuth::load_all`'s failure and exited with `Error: No valid auth info found` whenever none of `~/.docker/config.json`, podman's `auth.json`, or ocipkg's own auth file existed. As a result, a user on a fresh machine could not bootstrap credentials through `ommx login` alone — they first had to run `docker login <registry>` (or hand-write `~/.docker/config.json`).

Fix: recover from `load_all` failure with `unwrap_or_default()` so login starts from an empty `StoredAuth` and the new credentials get written to ocipkg's own auth file.

Trade-off accepted: this also swallows the (much rarer) case where one of the auth files exists but is malformed. The bootstrap pain outweighs that, and a malformed config will surface clearly through other tools.

Includes an integration test that drives the compiled `ommx` binary with an empty `HOME` and no `XDG_RUNTIME_DIR` / `XDG_CONFIG_HOME`, and asserts the failure mode no longer mentions `No valid auth info found`. The bogus `ghcr.invalid` URL keeps the network step honest so the test still proves we exercised the post-load path.

v3 is replacing the subcommand with docker-credential helpers, so the 2.x line gets this minimal patch and no further investment.

## Test plan

- [x] `cargo test --manifest-path Cargo.toml -p ommx --test login_no_auth` passes on this branch
- [ ] Manual: on a machine with no auth file, `ommx login ghcr.io -u <user> -p <PAT>` succeeds and writes `~/.ocipkg/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)