### PR TITLE
Simplify Local Registry index to OCI descriptors

### DIFF
--- a/python/ommx-tests/tests/test_artifact_blob.py
+++ b/python/ommx-tests/tests/test_artifact_blob.py
@@ -1,0 +1,27 @@
+import pytest
+
+from ommx.artifact import (
+    ArtifactBuilder,
+    set_local_registry_root,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def isolated_local_registry(tmp_path_factory):
+    set_local_registry_root(tmp_path_factory.mktemp("artifact-blob") / "registry")
+
+
+def test_get_blob_accepts_descriptor_and_digest_string(isolated_local_registry):
+    builder = ArtifactBuilder.new_anonymous()
+    descriptor = builder.add_layer("application/octet-stream", b"hello", {})
+    artifact = builder.build()
+
+    assert artifact.get_blob(descriptor) == b"hello"
+    assert artifact.get_blob(descriptor.digest) == b"hello"
+
+
+def test_get_blob_rejects_invalid_digest_string(isolated_local_registry):
+    artifact = ArtifactBuilder.new_anonymous().build()
+
+    with pytest.raises(ValueError, match="Invalid digest"):
+        artifact.get_blob("sha256:../../outside")

--- a/python/ommx/src/artifact.rs
+++ b/python/ommx/src/artifact.rs
@@ -268,18 +268,18 @@ impl PyArtifact {
         digest_or_descriptor: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyBytes>> {
         let _guard = crate::TRACING.attach_parent_context(py);
-        let digest = if let Ok(desc) = digest_or_descriptor.extract::<PyRef<PyDescriptor>>() {
-            descriptor_digest(&desc)
+        let blob = if let Ok(desc) = digest_or_descriptor.extract::<PyRef<PyDescriptor>>() {
+            self.0
+                .get_blob(desc.as_oci_descriptor().digest())
                 .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
         } else {
             let digest = digest_or_descriptor.extract::<String>()?;
-            parse_digest(&digest)
+            let digest = parse_digest(&digest)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+            self.0
+                .get_blob(&digest)
                 .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
         };
-        let blob = self
-            .0
-            .get_blob(&digest)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         Ok(PyBytes::new(py, &blob))
     }
 
@@ -527,11 +527,9 @@ impl PyArtifact {
     ) -> PyResult<Bound<'py, PyAny>> {
         let _guard = crate::TRACING.attach_parent_context(py);
         assert_media_type(descriptor, "application/vnd.apache.parquet")?;
-        let digest = descriptor_digest(descriptor)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let blob = self
             .0
-            .get_blob(&digest)
+            .get_blob(descriptor.as_oci_descriptor().digest())
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let io = py.import("io")?;
         let pandas = py.import("pandas")?;
@@ -547,11 +545,9 @@ impl PyArtifact {
     ) -> PyResult<Bound<'py, PyAny>> {
         let _guard = crate::TRACING.attach_parent_context(py);
         assert_media_type(descriptor, "application/json")?;
-        let digest = descriptor_digest(descriptor)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let blob = self
             .0
-            .get_blob(&digest)
+            .get_blob(descriptor.as_oci_descriptor().digest())
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let json = py.import("json")?;
         json.call_method1("loads", (PyBytes::new(py, &blob),))
@@ -667,8 +663,7 @@ impl PyArchiveManifest {
 impl PyArtifact {
     fn get_instance_inner(&mut self, descriptor: &PyDescriptor) -> Result<crate::Instance> {
         assert_media_type(descriptor, "application/org.ommx.v1.instance")?;
-        let digest = descriptor_digest(descriptor)?;
-        let blob = self.0.get_blob(&digest)?;
+        let blob = self.0.get_blob(descriptor.as_oci_descriptor().digest())?;
         Ok(crate::Instance {
             inner: ommx::Instance::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -677,8 +672,7 @@ impl PyArtifact {
 
     fn get_solution_inner(&mut self, descriptor: &PyDescriptor) -> Result<crate::Solution> {
         assert_media_type(descriptor, "application/org.ommx.v1.solution")?;
-        let digest = descriptor_digest(descriptor)?;
-        let blob = self.0.get_blob(&digest)?;
+        let blob = self.0.get_blob(descriptor.as_oci_descriptor().digest())?;
         Ok(crate::Solution {
             inner: ommx::Solution::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -690,8 +684,7 @@ impl PyArtifact {
         descriptor: &PyDescriptor,
     ) -> Result<crate::ParametricInstance> {
         assert_media_type(descriptor, "application/org.ommx.v1.parametric-instance")?;
-        let digest = descriptor_digest(descriptor)?;
-        let blob = self.0.get_blob(&digest)?;
+        let blob = self.0.get_blob(descriptor.as_oci_descriptor().digest())?;
         Ok(crate::ParametricInstance {
             inner: ommx::ParametricInstance::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -700,8 +693,7 @@ impl PyArtifact {
 
     fn get_sample_set_inner(&mut self, descriptor: &PyDescriptor) -> Result<crate::SampleSet> {
         assert_media_type(descriptor, "application/org.ommx.v1.sample-set")?;
-        let digest = descriptor_digest(descriptor)?;
-        let blob = self.0.get_blob(&digest)?;
+        let blob = self.0.get_blob(descriptor.as_oci_descriptor().digest())?;
         Ok(crate::SampleSet {
             inner: ommx::SampleSet::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -714,11 +706,9 @@ impl PyArtifact {
         descriptor: &PyDescriptor,
     ) -> PyResult<Bound<'py, PyAny>> {
         assert_media_type(descriptor, "application/vnd.numpy")?;
-        let digest = descriptor_digest(descriptor)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let blob = self
             .0
-            .get_blob(&digest)
+            .get_blob(descriptor.as_oci_descriptor().digest())
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let io = py.import("io")?;
         let numpy = py.import("numpy")?;
@@ -729,10 +719,6 @@ impl PyArtifact {
 
 fn parse_digest(digest: &str) -> Result<Digest> {
     Digest::from_str(digest).with_context(|| format!("Invalid digest: {digest}"))
-}
-
-fn descriptor_digest(descriptor: &PyDescriptor) -> Result<Digest> {
-    parse_digest(&descriptor.digest())
 }
 
 fn assert_media_type(descriptor: &PyDescriptor, expected: &str) -> Result<()> {

--- a/python/ommx/src/artifact.rs
+++ b/python/ommx/src/artifact.rs
@@ -1,6 +1,7 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use oci_spec::image::Digest;
 use pyo3::{prelude::*, types::PyBytes};
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use crate::PyDescriptor;
 
@@ -267,11 +268,13 @@ impl PyArtifact {
         digest_or_descriptor: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyBytes>> {
         let _guard = crate::TRACING.attach_parent_context(py);
-        let digest: String = if let Ok(desc) = digest_or_descriptor.extract::<PyRef<PyDescriptor>>()
-        {
-            desc.digest()
+        let digest = if let Ok(desc) = digest_or_descriptor.extract::<PyRef<PyDescriptor>>() {
+            descriptor_digest(&desc)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
         } else {
-            digest_or_descriptor.extract::<String>()?
+            let digest = digest_or_descriptor.extract::<String>()?;
+            parse_digest(&digest)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?
         };
         let blob = self
             .0
@@ -524,9 +527,11 @@ impl PyArtifact {
     ) -> PyResult<Bound<'py, PyAny>> {
         let _guard = crate::TRACING.attach_parent_context(py);
         assert_media_type(descriptor, "application/vnd.apache.parquet")?;
+        let digest = descriptor_digest(descriptor)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let blob = self
             .0
-            .get_blob(&descriptor.digest())
+            .get_blob(&digest)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let io = py.import("io")?;
         let pandas = py.import("pandas")?;
@@ -542,9 +547,11 @@ impl PyArtifact {
     ) -> PyResult<Bound<'py, PyAny>> {
         let _guard = crate::TRACING.attach_parent_context(py);
         assert_media_type(descriptor, "application/json")?;
+        let digest = descriptor_digest(descriptor)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let blob = self
             .0
-            .get_blob(&descriptor.digest())
+            .get_blob(&digest)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let json = py.import("json")?;
         json.call_method1("loads", (PyBytes::new(py, &blob),))
@@ -582,7 +589,7 @@ impl From<ommx::artifact::local_registry::ArchiveInspectView> for PyArchiveManif
     fn from(view: ommx::artifact::local_registry::ArchiveInspectView) -> Self {
         Self {
             image_name: view.image_name.map(|n| n.to_string()),
-            manifest_digest: view.manifest_digest,
+            manifest_digest: view.manifest_digest.to_string(),
             layers: view
                 .manifest
                 .layers()
@@ -660,7 +667,8 @@ impl PyArchiveManifest {
 impl PyArtifact {
     fn get_instance_inner(&mut self, descriptor: &PyDescriptor) -> Result<crate::Instance> {
         assert_media_type(descriptor, "application/org.ommx.v1.instance")?;
-        let blob = self.0.get_blob(&descriptor.digest())?;
+        let digest = descriptor_digest(descriptor)?;
+        let blob = self.0.get_blob(&digest)?;
         Ok(crate::Instance {
             inner: ommx::Instance::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -669,7 +677,8 @@ impl PyArtifact {
 
     fn get_solution_inner(&mut self, descriptor: &PyDescriptor) -> Result<crate::Solution> {
         assert_media_type(descriptor, "application/org.ommx.v1.solution")?;
-        let blob = self.0.get_blob(&descriptor.digest())?;
+        let digest = descriptor_digest(descriptor)?;
+        let blob = self.0.get_blob(&digest)?;
         Ok(crate::Solution {
             inner: ommx::Solution::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -681,7 +690,8 @@ impl PyArtifact {
         descriptor: &PyDescriptor,
     ) -> Result<crate::ParametricInstance> {
         assert_media_type(descriptor, "application/org.ommx.v1.parametric-instance")?;
-        let blob = self.0.get_blob(&descriptor.digest())?;
+        let digest = descriptor_digest(descriptor)?;
+        let blob = self.0.get_blob(&digest)?;
         Ok(crate::ParametricInstance {
             inner: ommx::ParametricInstance::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -690,7 +700,8 @@ impl PyArtifact {
 
     fn get_sample_set_inner(&mut self, descriptor: &PyDescriptor) -> Result<crate::SampleSet> {
         assert_media_type(descriptor, "application/org.ommx.v1.sample-set")?;
-        let blob = self.0.get_blob(&descriptor.digest())?;
+        let digest = descriptor_digest(descriptor)?;
+        let blob = self.0.get_blob(&digest)?;
         Ok(crate::SampleSet {
             inner: ommx::SampleSet::from_bytes(&blob)?,
             annotations: descriptor.annotations(),
@@ -703,15 +714,25 @@ impl PyArtifact {
         descriptor: &PyDescriptor,
     ) -> PyResult<Bound<'py, PyAny>> {
         assert_media_type(descriptor, "application/vnd.numpy")?;
+        let digest = descriptor_digest(descriptor)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let blob = self
             .0
-            .get_blob(&descriptor.digest())
+            .get_blob(&digest)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         let io = py.import("io")?;
         let numpy = py.import("numpy")?;
         let bytes_io = io.call_method1("BytesIO", (PyBytes::new(py, &blob),))?;
         numpy.call_method1("load", (bytes_io,))
     }
+}
+
+fn parse_digest(digest: &str) -> Result<Digest> {
+    Digest::from_str(digest).with_context(|| format!("Invalid digest: {digest}"))
+}
+
+fn descriptor_digest(descriptor: &PyDescriptor) -> Result<Digest> {
+    parse_digest(&descriptor.digest())
 }
 
 fn assert_media_type(descriptor: &PyDescriptor, expected: &str) -> Result<()> {

--- a/python/ommx/src/descriptor.rs
+++ b/python/ommx/src/descriptor.rs
@@ -11,6 +11,12 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq, From, Deref)]
 pub struct PyDescriptor(Descriptor);
 
+impl PyDescriptor {
+    pub(crate) fn as_oci_descriptor(&self) -> &Descriptor {
+        &self.0
+    }
+}
+
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl PyDescriptor {

--- a/rust/ommx/src/artifact/local_registry/blob.rs
+++ b/rust/ommx/src/artifact/local_registry/blob.rs
@@ -1,10 +1,12 @@
 use super::{sha256_digest, ValidatedDigest, FILE_BLOB_STORE_DIR_NAME};
 use anyhow::{ensure, Context, Result};
+use oci_spec::image::Digest;
 use std::{
     fs,
     fs::OpenOptions,
     io::{ErrorKind, Write},
     path::{Path, PathBuf},
+    str::FromStr,
 };
 use uuid::Uuid;
 
@@ -29,22 +31,23 @@ impl FileBlobStore {
         &self.root
     }
 
-    pub fn put_bytes(&self, bytes: &[u8]) -> Result<String> {
-        let digest = sha256_digest(bytes);
+    pub fn put_bytes(&self, bytes: &[u8]) -> Result<Digest> {
+        let digest = Digest::from_str(&sha256_digest(bytes)).context("Failed to parse digest")?;
         let path = self.path_for_digest(&digest)?;
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("Failed to create {}", parent.display()))?;
         }
         if path.exists() {
-            verify_existing_blob(&path, bytes, &digest)?;
+            verify_existing_blob(&path, bytes, digest.as_ref())?;
         } else {
-            self.write_blob_atomically(bytes, &digest, &path)?;
+            self.write_blob_atomically(bytes, digest.as_ref(), &path)?;
         }
         Ok(digest)
     }
 
-    pub fn read_bytes(&self, digest: &str) -> Result<Vec<u8>> {
+    pub fn read_bytes(&self, digest: impl AsRef<str>) -> Result<Vec<u8>> {
+        let digest = digest.as_ref();
         let path = self.path_for_digest(digest)?;
         let bytes =
             fs::read(&path).with_context(|| format!("Failed to read blob {}", path.display()))?;
@@ -55,12 +58,12 @@ impl FileBlobStore {
         Ok(bytes)
     }
 
-    pub fn exists(&self, digest: &str) -> Result<bool> {
+    pub fn exists(&self, digest: impl AsRef<str>) -> Result<bool> {
         Ok(self.path_for_digest(digest)?.exists())
     }
 
-    pub fn path_for_digest(&self, digest: &str) -> Result<PathBuf> {
-        let digest = ValidatedDigest::parse(digest)?;
+    pub fn path_for_digest(&self, digest: impl AsRef<str>) -> Result<PathBuf> {
+        let digest = ValidatedDigest::parse(digest.as_ref())?;
         Ok(self.root.join(digest.algorithm()).join(digest.encoded()))
     }
 

--- a/rust/ommx/src/artifact/local_registry/blob.rs
+++ b/rust/ommx/src/artifact/local_registry/blob.rs
@@ -1,7 +1,4 @@
-use super::{
-    now_rfc3339, sha256_digest, BlobRecord, ValidatedDigest, BLOB_KIND_BLOB,
-    FILE_BLOB_STORE_DIR_NAME,
-};
+use super::{now_rfc3339, sha256_digest, BlobRecord, ValidatedDigest, FILE_BLOB_STORE_DIR_NAME};
 use anyhow::{ensure, Context, Result};
 use std::{
     fs,
@@ -47,9 +44,6 @@ impl FileBlobStore {
         Ok(BlobRecord {
             digest,
             size: bytes.len() as u64,
-            media_type: None,
-            storage_uri: path.to_string_lossy().into_owned(),
-            kind: BLOB_KIND_BLOB.to_string(),
             last_verified_at: Some(now_rfc3339()),
         })
     }

--- a/rust/ommx/src/artifact/local_registry/blob.rs
+++ b/rust/ommx/src/artifact/local_registry/blob.rs
@@ -1,4 +1,4 @@
-use super::{sha256_digest, ValidatedDigest, FILE_BLOB_STORE_DIR_NAME};
+use super::{sha256_digest, FILE_BLOB_STORE_DIR_NAME};
 use anyhow::{ensure, Context, Result};
 use oci_spec::image::Digest;
 use std::{
@@ -41,33 +41,34 @@ impl FileBlobStore {
         if path.exists() {
             verify_existing_blob(&path, bytes, digest.as_ref())?;
         } else {
-            self.write_blob_atomically(bytes, digest.as_ref(), &path)?;
+            self.write_blob_atomically(bytes, &digest, &path)?;
         }
         Ok(digest)
     }
 
-    pub fn read_bytes(&self, digest: impl AsRef<str>) -> Result<Vec<u8>> {
-        let digest = digest.as_ref();
+    pub fn read_bytes(&self, digest: &Digest) -> Result<Vec<u8>> {
         let path = self.path_for_digest(digest)?;
         let bytes =
             fs::read(&path).with_context(|| format!("Failed to read blob {}", path.display()))?;
         ensure!(
-            sha256_digest(&bytes) == digest,
+            sha256_digest(&bytes) == digest.as_ref(),
             "Blob digest verification failed for {digest}"
         );
         Ok(bytes)
     }
 
-    pub fn exists(&self, digest: impl AsRef<str>) -> Result<bool> {
+    pub fn exists(&self, digest: &Digest) -> Result<bool> {
         Ok(self.path_for_digest(digest)?.exists())
     }
 
-    pub fn path_for_digest(&self, digest: impl AsRef<str>) -> Result<PathBuf> {
-        let digest = ValidatedDigest::parse(digest.as_ref())?;
-        Ok(self.root.join(digest.algorithm()).join(digest.encoded()))
+    pub fn path_for_digest(&self, digest: &Digest) -> Result<PathBuf> {
+        Ok(self
+            .root
+            .join(digest.algorithm().as_ref())
+            .join(digest.digest()))
     }
 
-    fn write_blob_atomically(&self, bytes: &[u8], digest: &str, path: &Path) -> Result<()> {
+    fn write_blob_atomically(&self, bytes: &[u8], digest: &Digest, path: &Path) -> Result<()> {
         let temp_path = self.temp_path_for_digest(digest)?;
         let mut temp_file = OpenOptions::new()
             .write(true)
@@ -89,14 +90,14 @@ impl FileBlobStore {
             }
             Err(error) if error.kind() == ErrorKind::AlreadyExists => {
                 let _ = fs::remove_file(&temp_path);
-                verify_existing_blob(path, bytes, digest)
+                verify_existing_blob(path, bytes, digest.as_ref())
             }
             Err(error) => {
                 let _ = fs::remove_file(&temp_path);
                 Err(error).with_context(|| {
                     format!(
                         "Failed to publish blob {} from {} to {}",
-                        digest,
+                        digest.as_ref(),
                         temp_path.display(),
                         path.display()
                     )
@@ -105,7 +106,7 @@ impl FileBlobStore {
         }
     }
 
-    fn temp_path_for_digest(&self, digest: &str) -> Result<PathBuf> {
+    fn temp_path_for_digest(&self, digest: &Digest) -> Result<PathBuf> {
         let path = self.path_for_digest(digest)?;
         let encoded = path
             .file_name()

--- a/rust/ommx/src/artifact/local_registry/blob.rs
+++ b/rust/ommx/src/artifact/local_registry/blob.rs
@@ -1,4 +1,4 @@
-use super::{now_rfc3339, sha256_digest, BlobRecord, ValidatedDigest, FILE_BLOB_STORE_DIR_NAME};
+use super::{sha256_digest, ValidatedDigest, FILE_BLOB_STORE_DIR_NAME};
 use anyhow::{ensure, Context, Result};
 use std::{
     fs,
@@ -29,7 +29,7 @@ impl FileBlobStore {
         &self.root
     }
 
-    pub fn put_bytes(&self, bytes: &[u8]) -> Result<BlobRecord> {
+    pub fn put_bytes(&self, bytes: &[u8]) -> Result<String> {
         let digest = sha256_digest(bytes);
         let path = self.path_for_digest(&digest)?;
         if let Some(parent) = path.parent() {
@@ -41,11 +41,7 @@ impl FileBlobStore {
         } else {
             self.write_blob_atomically(bytes, &digest, &path)?;
         }
-        Ok(BlobRecord {
-            digest,
-            size: bytes.len() as u64,
-            last_verified_at: Some(now_rfc3339()),
-        })
+        Ok(digest)
     }
 
     pub fn read_bytes(&self, digest: &str) -> Result<Vec<u8>> {

--- a/rust/ommx/src/artifact/local_registry/import/archive.rs
+++ b/rust/ommx/src/artifact/local_registry/import/archive.rs
@@ -35,7 +35,7 @@ use super::super::{
 use super::oci_dir::OciDirImport;
 use crate::artifact::{media_types, ImageRef};
 use anyhow::{Context, Result};
-use oci_spec::image::{Descriptor, ImageIndex, ImageManifest, MediaType, OciLayout};
+use oci_spec::image::{Descriptor, Digest, ImageIndex, ImageManifest, MediaType, OciLayout};
 use std::{
     fs::File,
     io::{BufReader, Read},
@@ -53,7 +53,7 @@ use tar::Archive;
 pub struct ArchiveInspectView {
     pub image_name: Option<ImageRef>,
     pub manifest: ImageManifest,
-    pub manifest_digest: String,
+    pub manifest_digest: Digest,
 }
 
 /// Inspect a `.ommx` archive without importing it into the SQLite
@@ -81,7 +81,7 @@ pub fn inspect_archive(path: &Path) -> Result<ArchiveInspectView> {
 
 /// First-pass helper for [`inspect_archive`]: stream the tar to find
 /// `index.json` and return `(manifest_digest, ref_name)`.
-fn read_archive_index(path: &Path) -> Result<(String, Option<ImageRef>)> {
+fn read_archive_index(path: &Path) -> Result<(Digest, Option<ImageRef>)> {
     let file = File::open(path)
         .with_context(|| format!("Failed to open OCI archive {}", path.display()))?;
     let mut archive = Archive::new(BufReader::new(file));
@@ -118,7 +118,7 @@ fn read_archive_index(path: &Path) -> Result<(String, Option<ImageRef>)> {
         );
         let descriptor = image_index.manifests().first().unwrap();
         let image_name = image_name_from_index_descriptor(descriptor)?;
-        return Ok((descriptor.digest().to_string(), image_name));
+        return Ok((descriptor.digest().clone(), image_name));
     }
     anyhow::bail!("Missing index.json in {}", path.display())
 }
@@ -127,7 +127,7 @@ fn read_archive_index(path: &Path) -> Result<(String, Option<ImageRef>)> {
 /// second time to read the blob at `digest` from
 /// `blobs/<algorithm>/<encoded>`. Manifests are first in the v3
 /// native writer's output so the scan terminates quickly there.
-fn read_archive_blob(path: &Path, digest: &str) -> Result<Vec<u8>> {
+fn read_archive_blob(path: &Path, digest: &Digest) -> Result<Vec<u8>> {
     let file = File::open(path)
         .with_context(|| format!("Failed to open OCI archive {}", path.display()))?;
     let mut archive = Archive::new(BufReader::new(file));
@@ -147,13 +147,13 @@ fn read_archive_blob(path: &Path, digest: &str) -> Result<Vec<u8>> {
             continue;
         }
         if let Some(entry_digest) = blob_path_to_digest(path_str) {
-            if entry_digest == digest {
+            if entry_digest == digest.as_ref() {
                 let mut bytes = Vec::with_capacity(entry.header().size().unwrap_or(0) as usize);
                 entry.read_to_end(&mut bytes).with_context(|| {
                     format!("Failed to read blob {digest} from {}", path.display())
                 })?;
                 anyhow::ensure!(
-                    sha256_digest(&bytes) == digest,
+                    sha256_digest(&bytes) == digest.as_ref(),
                     "Blob {digest} in {} fails sha256 check",
                     path.display()
                 );
@@ -236,7 +236,7 @@ pub fn import_oci_archive(registry: &Arc<LocalRegistry>, path: &Path) -> Result<
         path.display()
     );
     let index_descriptor = image_index.manifests().first().unwrap();
-    let manifest_digest = index_descriptor.digest().to_string();
+    let manifest_digest = index_descriptor.digest().clone();
     // v2-era OMMX SDKs produced `.ommx` files whose `index.json`
     // descriptor lacks the `org.opencontainers.image.ref.name`
     // annotation (the v3 SDK always sets it). Rather than refuse to
@@ -400,7 +400,7 @@ fn scan_archive<R: Read>(reader: R, blobs: &FileBlobStore, archive_path: &Path) 
                 .put_bytes(&bytes)
                 .with_context(|| format!("Failed to write blob {digest} to FileBlobStore"))?;
             anyhow::ensure!(
-                actual_digest == digest,
+                actual_digest.as_ref() == digest,
                 "Blob digest mismatch in archive {}: entry path is {path_str}, sha256 is {}",
                 archive_path.display(),
                 actual_digest,

--- a/rust/ommx/src/artifact/local_registry/import/archive.rs
+++ b/rust/ommx/src/artifact/local_registry/import/archive.rs
@@ -456,9 +456,9 @@ fn ensure_blob_exists(
     descriptor: &Descriptor,
     archive_path: &Path,
 ) -> Result<()> {
-    let digest = descriptor.digest().to_string();
+    let digest = descriptor.digest();
     anyhow::ensure!(
-        blobs.exists(&digest)?,
+        blobs.exists(digest)?,
         "Blob {digest} referenced by manifest is missing from {}",
         archive_path.display()
     );

--- a/rust/ommx/src/artifact/local_registry/import/archive.rs
+++ b/rust/ommx/src/artifact/local_registry/import/archive.rs
@@ -23,16 +23,13 @@
 //!
 //! After the pass: parse `index.json`, locate the named manifest in
 //! [`super::super::FileBlobStore`] by digest, parse the manifest, and
-//! emit one [`super::super::SqliteIndexStore::publish_artifact_atomic`]
-//! call with the manifest / config / layer records under the
+//! write the manifest descriptor under the
 //! `org.opencontainers.image.ref.name` annotated ref. A crash between
-//! blob writes and publish leaves orphan CAS bytes recoverable by GC;
-//! a crash inside the SQLite transaction never leaves a partially-
-//! published ref.
+//! blob writes and ref publish leaves orphan CAS bytes recoverable by
+//! GC; the SQLite index never stores a manifest / layer cache.
 
 use super::super::{
-    annotations_json, now_rfc3339, sha256_digest, BlobRecord, FileBlobStore, LayerRecord,
-    LocalRegistry, ManifestRecord, RefConflictPolicy, RefUpdate, ValidatedDigest,
+    sha256_digest, FileBlobStore, LocalRegistry, RefConflictPolicy, RefUpdate, ValidatedDigest,
     OCI_IMAGE_REF_NAME_ANNOTATION,
 };
 use super::oci_dir::OciDirImport;
@@ -284,8 +281,8 @@ pub fn import_oci_archive(registry: &Arc<LocalRegistry>, path: &Path) -> Result<
         index_descriptor.size(),
         manifest_bytes.len()
     );
-    let media_type = match index_descriptor.media_type() {
-        MediaType::ImageManifest => MediaType::ImageManifest,
+    match index_descriptor.media_type() {
+        MediaType::ImageManifest => {}
         MediaType::ArtifactManifest => anyhow::bail!(
             "OCI archive in {} uses the deprecated OCI Artifact Manifest \
              (application/vnd.oci.artifact.manifest.v1+json), which is not supported. \
@@ -302,56 +299,26 @@ pub fn import_oci_archive(registry: &Arc<LocalRegistry>, path: &Path) -> Result<
         .with_context(|| format!("Failed to parse OCI image manifest in {}", path.display()))?;
     ensure_ommx_artifact_type(manifest.artifact_type().as_ref())?;
 
-    // Build the BlobRecord / LayerRecord / ManifestRecord trio. All
-    // referenced blobs are already in `FileBlobStore` (we wrote them
-    // during the tar scan); we just need to surface the records the
-    // SQLite publish wants.
-    let layer_count = manifest.layers().len();
-    let mut blob_records = Vec::with_capacity(layer_count + 2);
-    let mut layer_records = Vec::with_capacity(layer_count);
-
-    blob_records.push(record_for_blob(registry.blobs(), manifest.config(), path)?);
-    for (position, layer) in manifest.layers().iter().enumerate() {
-        blob_records.push(record_for_blob(registry.blobs(), layer, path)?);
-        layer_records.push(LayerRecord {
-            manifest_digest: manifest_digest.clone(),
-            position: u32::try_from(position).context("Layer position does not fit in u32")?,
-            digest: layer.digest().to_string(),
-            media_type: layer.media_type().to_string(),
-            size: layer.size(),
-            annotations_json: annotations_json(layer.annotations().as_ref())?,
-        });
+    // All referenced blobs are already in `FileBlobStore` (written
+    // during the tar scan). Verify the manifest is self-contained
+    // before publishing the ref descriptor.
+    ensure_blob_exists(registry.blobs(), manifest.config(), path)?;
+    for layer in manifest.layers() {
+        ensure_blob_exists(registry.blobs(), layer, path)?;
     }
-    let manifest_record_blob =
-        record_for_manifest_blob(&manifest_digest, manifest_bytes.len() as u64)?;
-    blob_records.push(manifest_record_blob);
 
-    let manifest_record = ManifestRecord {
-        digest: manifest_digest.clone(),
-        media_type: media_type.to_string(),
-        size: manifest_bytes.len() as u64,
-        subject_digest: manifest
-            .subject()
-            .as_ref()
-            .map(|subject| subject.digest().to_string()),
-        annotations_json: annotations_json(manifest.annotations().as_ref())?,
-        created_at: now_rfc3339(),
-    };
-
-    let outcome = registry.index().publish_artifact_atomic(
-        &blob_records,
-        &manifest_record,
-        &layer_records,
-        Some(&image_name),
+    let ref_update = registry.index().put_image_ref_with_policy(
+        &image_name,
+        index_descriptor,
         RefConflictPolicy::KeepExisting,
     )?;
     // Public entry point: surface a ref conflict as `Err`. Callers
     // that need batch / report-style handling (e.g. legacy import)
-    // drive `publish_artifact_atomic` directly with their own policy.
-    if let Some(RefUpdate::Conflicted {
+    // use the directory import path, which can return conflicts.
+    if let RefUpdate::Conflicted {
         existing_manifest_digest,
         incoming_manifest_digest,
-    }) = &outcome.ref_update
+    } = &ref_update
     {
         anyhow::bail!(
             "Local registry ref conflict for {image_name}: existing manifest \
@@ -362,7 +329,7 @@ pub fn import_oci_archive(registry: &Arc<LocalRegistry>, path: &Path) -> Result<
     Ok(OciDirImport {
         manifest_digest,
         image_name: Some(image_name),
-        ref_update: outcome.ref_update,
+        ref_update: Some(ref_update),
     })
 }
 
@@ -429,14 +396,14 @@ fn scan_archive<R: Read>(reader: R, blobs: &FileBlobStore, archive_path: &Path) 
             // digest of what it stored; comparing against the
             // expected `digest` (derived from the entry path) costs
             // one string compare instead of a second SHA-256 pass.
-            let record = blobs
+            let actual_digest = blobs
                 .put_bytes(&bytes)
                 .with_context(|| format!("Failed to write blob {digest} to FileBlobStore"))?;
             anyhow::ensure!(
-                record.digest == digest,
+                actual_digest == digest,
                 "Blob digest mismatch in archive {}: entry path is {path_str}, sha256 is {}",
                 archive_path.display(),
-                record.digest,
+                actual_digest,
             );
             continue;
         }
@@ -481,34 +448,21 @@ fn ensure_ommx_artifact_type(artifact_type: Option<&MediaType>) -> Result<()> {
     Ok(())
 }
 
-/// Build a [`BlobRecord`] for a manifest-referenced blob. The blob is
-/// already on disk in [`FileBlobStore`] (written during the tar scan);
-/// this is a metadata-only construction.
-fn record_for_blob(
+/// Verify a manifest-referenced blob is present in [`FileBlobStore`].
+/// The blob was written during the tar scan; the SQLite index only
+/// needs the manifest descriptor.
+fn ensure_blob_exists(
     blobs: &FileBlobStore,
     descriptor: &Descriptor,
     archive_path: &Path,
-) -> Result<BlobRecord> {
+) -> Result<()> {
     let digest = descriptor.digest().to_string();
     anyhow::ensure!(
         blobs.exists(&digest)?,
         "Blob {digest} referenced by manifest is missing from {}",
         archive_path.display()
     );
-    Ok(BlobRecord {
-        digest: digest.clone(),
-        size: descriptor.size(),
-        last_verified_at: Some(now_rfc3339()),
-    })
-}
-
-/// Build a [`BlobRecord`] for the manifest blob itself.
-fn record_for_manifest_blob(digest: &str, size: u64) -> Result<BlobRecord> {
-    Ok(BlobRecord {
-        digest: digest.to_string(),
-        size,
-        last_verified_at: Some(now_rfc3339()),
-    })
+    Ok(())
 }
 
 /// Extract the `org.opencontainers.image.ref.name` annotation from the

--- a/rust/ommx/src/artifact/local_registry/import/archive.rs
+++ b/rust/ommx/src/artifact/local_registry/import/archive.rs
@@ -32,11 +32,11 @@
 
 use super::super::{
     annotations_json, now_rfc3339, sha256_digest, BlobRecord, FileBlobStore, LayerRecord,
-    LocalRegistry, ManifestRecord, RefConflictPolicy, RefUpdate, ValidatedDigest, BLOB_KIND_BLOB,
-    BLOB_KIND_CONFIG, BLOB_KIND_MANIFEST, OCI_IMAGE_REF_NAME_ANNOTATION,
+    LocalRegistry, ManifestRecord, RefConflictPolicy, RefUpdate, ValidatedDigest,
+    OCI_IMAGE_REF_NAME_ANNOTATION,
 };
 use super::oci_dir::OciDirImport;
-use crate::artifact::{media_types, ImageRef, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
+use crate::artifact::{media_types, ImageRef};
 use anyhow::{Context, Result};
 use oci_spec::image::{Descriptor, ImageIndex, ImageManifest, MediaType, OciLayout};
 use std::{
@@ -310,19 +310,9 @@ pub fn import_oci_archive(registry: &Arc<LocalRegistry>, path: &Path) -> Result<
     let mut blob_records = Vec::with_capacity(layer_count + 2);
     let mut layer_records = Vec::with_capacity(layer_count);
 
-    blob_records.push(record_for_blob(
-        registry.blobs(),
-        manifest.config(),
-        BLOB_KIND_CONFIG,
-        path,
-    )?);
+    blob_records.push(record_for_blob(registry.blobs(), manifest.config(), path)?);
     for (position, layer) in manifest.layers().iter().enumerate() {
-        blob_records.push(record_for_blob(
-            registry.blobs(),
-            layer,
-            BLOB_KIND_BLOB,
-            path,
-        )?);
+        blob_records.push(record_for_blob(registry.blobs(), layer, path)?);
         layer_records.push(LayerRecord {
             manifest_digest: manifest_digest.clone(),
             position: u32::try_from(position).context("Layer position does not fit in u32")?,
@@ -332,11 +322,8 @@ pub fn import_oci_archive(registry: &Arc<LocalRegistry>, path: &Path) -> Result<
             annotations_json: annotations_json(layer.annotations().as_ref())?,
         });
     }
-    let manifest_record_blob = record_for_manifest_blob(
-        registry.blobs(),
-        &manifest_digest,
-        manifest_bytes.len() as u64,
-    )?;
+    let manifest_record_blob =
+        record_for_manifest_blob(&manifest_digest, manifest_bytes.len() as u64)?;
     blob_records.push(manifest_record_blob);
 
     let manifest_record = ManifestRecord {
@@ -500,39 +487,26 @@ fn ensure_ommx_artifact_type(artifact_type: Option<&MediaType>) -> Result<()> {
 fn record_for_blob(
     blobs: &FileBlobStore,
     descriptor: &Descriptor,
-    kind: &str,
     archive_path: &Path,
 ) -> Result<BlobRecord> {
     let digest = descriptor.digest().to_string();
     anyhow::ensure!(
         blobs.exists(&digest)?,
-        "{kind} blob {digest} referenced by manifest is missing from {}",
+        "Blob {digest} referenced by manifest is missing from {}",
         archive_path.display()
     );
     Ok(BlobRecord {
         digest: digest.clone(),
         size: descriptor.size(),
-        media_type: Some(descriptor.media_type().to_string()),
-        storage_uri: blobs
-            .path_for_digest(&digest)?
-            .to_string_lossy()
-            .into_owned(),
-        kind: kind.to_string(),
         last_verified_at: Some(now_rfc3339()),
     })
 }
 
 /// Build a [`BlobRecord`] for the manifest blob itself.
-fn record_for_manifest_blob(blobs: &FileBlobStore, digest: &str, size: u64) -> Result<BlobRecord> {
+fn record_for_manifest_blob(digest: &str, size: u64) -> Result<BlobRecord> {
     Ok(BlobRecord {
         digest: digest.to_string(),
         size,
-        media_type: Some(OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string()),
-        storage_uri: blobs
-            .path_for_digest(digest)?
-            .to_string_lossy()
-            .into_owned(),
-        kind: BLOB_KIND_MANIFEST.to_string(),
         last_verified_at: Some(now_rfc3339()),
     })
 }

--- a/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
+++ b/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
@@ -22,16 +22,14 @@
 //! primitives.
 
 use super::super::{
-    annotations_json, now_rfc3339, sha256_digest, BlobRecord, FileBlobStore, LayerRecord,
-    ManifestRecord, RefConflictPolicy, RefUpdate, SqliteIndexStore, ValidatedDigest,
+    sha256_digest, FileBlobStore, RefConflictPolicy, RefUpdate, SqliteIndexStore, ValidatedDigest,
     OCI_IMAGE_REF_NAME_ANNOTATION,
 };
-use crate::artifact::{media_types, ImageRef, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
+use crate::artifact::{media_types, ImageRef};
 use anyhow::{ensure, Context, Result};
 use oci_spec::image::{
     Descriptor, DescriptorBuilder, Digest, ImageIndex, ImageManifest, MediaType, OciLayout,
 };
-use std::collections::HashMap;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -137,8 +135,6 @@ struct StagedOciDir {
     manifest_bytes: Vec<u8>,
     manifest_descriptor: Descriptor,
     layers: Vec<Descriptor>,
-    annotations: Option<HashMap<String, String>>,
-    subject: Option<Descriptor>,
     image_config: (Descriptor, Vec<u8>),
 }
 
@@ -149,9 +145,9 @@ struct StagedOciDir {
 /// of how it was produced. The v3 registry does not keep `index.json` as
 /// mutable state; it only reads it to discover the single manifest, and
 /// then copies the exact content-addressed blobs into [`FileBlobStore`]
-/// while inserting the matching records into [`SqliteIndexStore`]. The
-/// manifest digest is preserved verbatim — import never rewrites the
-/// manifest.
+/// while inserting the manifest descriptor into [`SqliteIndexStore`].
+/// The manifest digest is preserved verbatim — import never rewrites
+/// the manifest.
 ///
 /// OCI Image Layouts that use the deprecated OCI Artifact Manifest
 /// (`application/vnd.oci.artifact.manifest.v1+json`) are rejected at
@@ -262,73 +258,45 @@ pub(super) fn import_oci_dir_inner(
     }
 
     // Stage 1: write CAS bytes for layers, optional config, and the
-    // manifest itself. These are idempotent so they don't need to
-    // share a SQLite transaction.
+    // manifest itself. These are idempotent and independent of the
+    // SQLite ref index.
     let layer_descriptors = staged.layers.as_slice();
-    let mut blob_records = Vec::with_capacity(layer_descriptors.len() + 2);
-    let mut layer_records = Vec::with_capacity(layer_descriptors.len());
-    for (position, layer) in layer_descriptors.iter().enumerate() {
-        let record = stage_oci_dir_descriptor_blob(blob_store, oci_dir_root, layer)?;
-        blob_records.push(record);
-        layer_records.push(LayerRecord {
-            manifest_digest: manifest_digest.clone(),
-            position: u32::try_from(position).context("Layer position does not fit in u32")?,
-            digest: digest_to_string(layer.digest()),
-            media_type: layer.media_type().to_string(),
-            size: layer.size(),
-            annotations_json: annotations_json(layer.annotations().as_ref())?,
-        });
+    for layer in layer_descriptors {
+        stage_oci_dir_descriptor_blob(blob_store, oci_dir_root, layer)?;
     }
     let (config_descriptor, config_bytes) = &staged.image_config;
-    blob_records.push(stage_descriptor_bytes(
-        blob_store,
-        config_descriptor,
-        config_bytes,
-    )?);
-    blob_records.push(stage_descriptor_bytes(
+    stage_descriptor_bytes(blob_store, config_descriptor, config_bytes)?;
+    stage_descriptor_bytes(
         blob_store,
         &staged.manifest_descriptor,
         &staged.manifest_bytes,
-    )?);
-
-    let manifest_record = ManifestRecord {
-        digest: manifest_digest.clone(),
-        media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string(),
-        size: staged.manifest_descriptor.size(),
-        subject_digest: staged
-            .subject
-            .as_ref()
-            .map(|d| digest_to_string(d.digest())),
-        annotations_json: annotations_json(staged.annotations.as_ref())?,
-        created_at: now_rfc3339(),
-    };
-
-    // Stage 2: one SQLite transaction commits blob records + manifest
-    // + ref. A crash or conflict between stages can never leave
-    // committed manifest / blob rows under a ref the caller did not
-    // actually publish.
-    let outcome = index_store.publish_artifact_atomic(
-        &blob_records,
-        &manifest_record,
-        &layer_records,
-        effective_image_name.as_ref(),
-        policy,
     )?;
-    let ref_update = match outcome.ref_update {
-        Some(RefUpdate::Conflicted {
-            existing_manifest_digest,
-            incoming_manifest_digest,
-        }) if conflict_handling == RefConflictHandling::Error => {
-            anyhow::bail!(
-                "Local registry ref conflict for {}: existing manifest {}, incoming manifest {}",
-                effective_image_name
-                    .as_ref()
-                    .expect("Conflicted requires an effective image_name"),
+
+    // Stage 2: publish the OCI manifest descriptor into the SQLite
+    // ref index. If no ref annotation / target ref exists, the import
+    // is digest-only and the CAS bytes remain reachable by digest.
+    let ref_update = if let Some(image_name) = effective_image_name.as_ref() {
+        let update = index_store.put_image_ref_with_policy(
+            image_name,
+            &staged.manifest_descriptor,
+            policy,
+        )?;
+        match update {
+            RefUpdate::Conflicted {
                 existing_manifest_digest,
-                incoming_manifest_digest
-            )
+                incoming_manifest_digest,
+            } if conflict_handling == RefConflictHandling::Error => {
+                anyhow::bail!(
+                    "Local registry ref conflict for {}: existing manifest {}, incoming manifest {}",
+                    image_name,
+                    existing_manifest_digest,
+                    incoming_manifest_digest
+                )
+            }
+            update => Some(update),
         }
-        update => update,
+    } else {
+        None
     };
 
     Ok((
@@ -422,7 +390,7 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
 
     // v3 supports only OCI Image Manifest. The deprecated OCI Artifact
     // Manifest is rejected at parse time.
-    let (layers, annotations, subject, image_config) = match index_descriptor.media_type() {
+    let (layers, image_config) = match index_descriptor.media_type() {
         MediaType::ImageManifest => stage_image_manifest(oci_dir_root, &manifest_bytes)?,
         MediaType::ArtifactManifest => anyhow::bail!(
             "OCI dir uses the deprecated OCI Artifact Manifest \
@@ -450,19 +418,12 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
         manifest_bytes,
         manifest_descriptor,
         layers,
-        annotations,
-        subject,
         image_config,
     })
 }
 
 /// Manifest-derived fields filled into [`StagedOciDir`] by `stage_oci_dir`.
-type StagedManifestFields = (
-    Vec<Descriptor>,
-    Option<HashMap<String, String>>,
-    Option<Descriptor>,
-    (Descriptor, Vec<u8>),
-);
+type StagedManifestFields = (Vec<Descriptor>, (Descriptor, Vec<u8>));
 
 fn stage_image_manifest(
     oci_dir_root: &Path,
@@ -487,8 +448,6 @@ fn stage_image_manifest(
 
     Ok((
         manifest.layers().to_vec(),
-        manifest.annotations().clone(),
-        manifest.subject().clone(),
         (config_descriptor, config_bytes),
     ))
 }
@@ -505,16 +464,13 @@ fn ensure_ommx_artifact_type(artifact_type: Option<&MediaType>) -> Result<()> {
 }
 
 /// Read a layer / config blob out of the legacy OCI dir, write it to
-/// the v3 [`FileBlobStore`] under its content digest, and return the
-/// matching [`BlobRecord`] for the IndexStore. The DB row is *not*
-/// inserted here — the caller hands the records to
-/// [`SqliteIndexStore::publish_artifact_atomic`] so all blob /
-/// manifest / ref inserts share one transaction.
+/// the v3 [`FileBlobStore`] under its content digest, and verify it
+/// matches the descriptor from the source layout.
 fn stage_oci_dir_descriptor_blob(
     blob_store: &FileBlobStore,
     oci_dir_root: &Path,
     desc: &Descriptor,
-) -> Result<BlobRecord> {
+) -> Result<()> {
     let digest = digest_to_string(desc.digest());
     let bytes = read_oci_dir_blob(oci_dir_root, &digest)
         .with_context(|| format!("Failed to read blob {digest}"))?;
@@ -527,28 +483,27 @@ fn stage_oci_dir_descriptor_blob(
     stage_descriptor_bytes(blob_store, desc, &bytes)
 }
 
-/// CAS-write `bytes` for `desc` and return the matching
-/// [`BlobRecord`] (no DB write).
+/// CAS-write `bytes` for `desc` and verify the written content address.
 fn stage_descriptor_bytes(
     blob_store: &FileBlobStore,
     desc: &Descriptor,
     bytes: &[u8],
-) -> Result<BlobRecord> {
-    let record = blob_store.put_bytes(bytes)?;
+) -> Result<()> {
+    let digest = blob_store.put_bytes(bytes)?;
     ensure!(
-        record.digest == digest_to_string(desc.digest()),
+        digest == digest_to_string(desc.digest()),
         "Blob digest mismatch: descriptor={}, actual={}",
         desc.digest(),
-        record.digest
+        digest
     );
     ensure!(
-        record.size == desc.size(),
+        bytes.len() as u64 == desc.size(),
         "Blob size mismatch for {}: descriptor={}, actual={}",
         desc.digest(),
         desc.size(),
-        record.size
+        bytes.len()
     );
-    Ok(record)
+    Ok(())
 }
 
 fn read_oci_dir_blob(oci_dir_root: &Path, digest: &str) -> Result<Vec<u8>> {

--- a/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
+++ b/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
@@ -27,9 +27,7 @@ use super::super::{
 };
 use crate::artifact::{media_types, ImageRef};
 use anyhow::{ensure, Context, Result};
-use oci_spec::image::{
-    Descriptor, DescriptorBuilder, Digest, ImageIndex, ImageManifest, MediaType, OciLayout,
-};
+use oci_spec::image::{Descriptor, Digest, ImageIndex, ImageManifest, MediaType, OciLayout};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -402,18 +400,11 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
         ),
     };
 
-    let manifest_descriptor = DescriptorBuilder::default()
-        .media_type(MediaType::ImageManifest)
-        .digest(manifest_digest.clone())
-        .size(manifest_bytes.len() as u64)
-        .build()
-        .context("Failed to build OCI manifest descriptor")?;
-
     Ok(StagedOciDir {
         manifest_digest,
         image_name,
         manifest_bytes,
-        manifest_descriptor,
+        manifest_descriptor: index_descriptor.clone(),
         layers,
         image_config,
     })

--- a/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
+++ b/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
@@ -24,7 +24,7 @@
 use super::super::{
     annotations_json, now_rfc3339, sha256_digest, BlobRecord, FileBlobStore, LayerRecord,
     ManifestRecord, RefConflictPolicy, RefUpdate, SqliteIndexStore, ValidatedDigest,
-    BLOB_KIND_BLOB, BLOB_KIND_CONFIG, BLOB_KIND_MANIFEST, OCI_IMAGE_REF_NAME_ANNOTATION,
+    OCI_IMAGE_REF_NAME_ANNOTATION,
 };
 use crate::artifact::{media_types, ImageRef, OCI_IMAGE_MANIFEST_MEDIA_TYPE};
 use anyhow::{ensure, Context, Result};
@@ -268,8 +268,7 @@ pub(super) fn import_oci_dir_inner(
     let mut blob_records = Vec::with_capacity(layer_descriptors.len() + 2);
     let mut layer_records = Vec::with_capacity(layer_descriptors.len());
     for (position, layer) in layer_descriptors.iter().enumerate() {
-        let record =
-            stage_oci_dir_descriptor_blob(blob_store, oci_dir_root, layer, BLOB_KIND_BLOB)?;
+        let record = stage_oci_dir_descriptor_blob(blob_store, oci_dir_root, layer)?;
         blob_records.push(record);
         layer_records.push(LayerRecord {
             manifest_digest: manifest_digest.clone(),
@@ -285,13 +284,11 @@ pub(super) fn import_oci_dir_inner(
         blob_store,
         config_descriptor,
         config_bytes,
-        BLOB_KIND_CONFIG,
     )?);
     blob_records.push(stage_descriptor_bytes(
         blob_store,
         &staged.manifest_descriptor,
         &staged.manifest_bytes,
-        BLOB_KIND_MANIFEST,
     )?);
 
     let manifest_record = ManifestRecord {
@@ -517,18 +514,17 @@ fn stage_oci_dir_descriptor_blob(
     blob_store: &FileBlobStore,
     oci_dir_root: &Path,
     desc: &Descriptor,
-    kind: &str,
 ) -> Result<BlobRecord> {
     let digest = digest_to_string(desc.digest());
     let bytes = read_oci_dir_blob(oci_dir_root, &digest)
-        .with_context(|| format!("Failed to read {kind} blob {digest}"))?;
+        .with_context(|| format!("Failed to read blob {digest}"))?;
     ensure!(
         bytes.len() as u64 == desc.size(),
-        "{kind} blob size mismatch for {digest}: descriptor={}, actual={}",
+        "Blob size mismatch for {digest}: descriptor={}, actual={}",
         desc.size(),
         bytes.len()
     );
-    stage_descriptor_bytes(blob_store, desc, &bytes, kind)
+    stage_descriptor_bytes(blob_store, desc, &bytes)
 }
 
 /// CAS-write `bytes` for `desc` and return the matching
@@ -537,24 +533,21 @@ fn stage_descriptor_bytes(
     blob_store: &FileBlobStore,
     desc: &Descriptor,
     bytes: &[u8],
-    kind: &str,
 ) -> Result<BlobRecord> {
-    let mut record = blob_store.put_bytes(bytes)?;
+    let record = blob_store.put_bytes(bytes)?;
     ensure!(
         record.digest == digest_to_string(desc.digest()),
-        "{kind} blob digest mismatch: descriptor={}, actual={}",
+        "Blob digest mismatch: descriptor={}, actual={}",
         desc.digest(),
         record.digest
     );
     ensure!(
         record.size == desc.size(),
-        "{kind} blob size mismatch for {}: descriptor={}, actual={}",
+        "Blob size mismatch for {}: descriptor={}, actual={}",
         desc.digest(),
         desc.size(),
         record.size
     );
-    record.media_type = Some(desc.media_type().to_string());
-    record.kind = kind.to_string();
     Ok(record)
 }
 

--- a/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
+++ b/rust/ommx/src/artifact/local_registry/import/oci_dir.rs
@@ -33,7 +33,6 @@ use oci_spec::image::{
 use std::{
     fs,
     path::{Path, PathBuf},
-    str::FromStr,
 };
 
 /// Identity of an OCI Image Layout directory entry: the manifest
@@ -46,13 +45,12 @@ use std::{
 /// describing what happened to the SQLite ref.
 ///
 /// Marked `#[non_exhaustive]` so future identity attributes (for
-/// example a parsed `oci_spec::image::Digest` or a typed media type)
-/// can be added without breaking exhaustive destructuring at call
-/// sites.
+/// example a typed media type) can be added without breaking
+/// exhaustive destructuring at call sites.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OciDirRef {
-    pub manifest_digest: String,
+    pub manifest_digest: Digest,
     pub image_name: Option<ImageRef>,
 }
 
@@ -84,7 +82,7 @@ pub struct OciDirRef {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OciDirImport {
-    pub manifest_digest: String,
+    pub manifest_digest: Digest,
     pub image_name: Option<ImageRef>,
     pub ref_update: Option<RefUpdate>,
 }
@@ -130,7 +128,7 @@ pub(super) enum RefConflictHandling {
 /// set to the OMMX artifact media type); the deprecated OCI Artifact
 /// Manifest is rejected at parse time.
 struct StagedOciDir {
-    manifest_digest: String,
+    manifest_digest: Digest,
     image_name: Option<ImageRef>,
     manifest_bytes: Vec<u8>,
     manifest_descriptor: Descriptor,
@@ -231,19 +229,19 @@ pub(super) fn import_oci_dir_inner(
     // path for the common single-writer case.
     if policy == RefConflictPolicy::KeepExisting {
         if let Some(image_name) = effective_image_name.as_ref() {
-            if let Some(existing_manifest_digest) = index_store.resolve_image_name(image_name)? {
-                if existing_manifest_digest != manifest_digest {
+            if let Some(existing_descriptor) = index_store.resolve_image_descriptor(image_name)? {
+                if existing_descriptor.digest() != staged.manifest_descriptor.digest() {
                     if conflict_handling == RefConflictHandling::Error {
                         anyhow::bail!(
                             "Local registry ref conflict for {}: existing manifest {}, incoming manifest {}",
                             image_name,
-                            existing_manifest_digest,
-                            manifest_digest,
+                            existing_descriptor.digest(),
+                            staged.manifest_descriptor.digest(),
                         );
                     }
                     let conflict = RefUpdate::Conflicted {
-                        existing_manifest_digest,
-                        incoming_manifest_digest: manifest_digest.clone(),
+                        existing_manifest_digest: existing_descriptor.digest().clone(),
+                        incoming_manifest_digest: staged.manifest_descriptor.digest().clone(),
                     };
                     return Ok((
                         OciDirRef {
@@ -378,8 +376,9 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
     );
     let index_descriptor = image_index.manifests().first().unwrap();
     let image_name = image_name_from_index_descriptor(index_descriptor)?;
-    let manifest_digest = digest_to_string(index_descriptor.digest());
-    let manifest_bytes = read_oci_dir_blob(oci_dir_root, &manifest_digest)
+    let manifest_digest = index_descriptor.digest().clone();
+    let manifest_digest_str = digest_to_string(&manifest_digest);
+    let manifest_bytes = read_oci_dir_blob(oci_dir_root, &manifest_digest_str)
         .with_context(|| format!("Failed to read manifest blob {manifest_digest}"))?;
     ensure!(
         manifest_bytes.len() as u64 == index_descriptor.size(),
@@ -403,11 +402,9 @@ fn stage_oci_dir(oci_dir_root: impl AsRef<Path>) -> Result<StagedOciDir> {
         ),
     };
 
-    let manifest_digest_parsed = Digest::from_str(&manifest_digest)
-        .with_context(|| format!("Invalid manifest digest: {manifest_digest}"))?;
     let manifest_descriptor = DescriptorBuilder::default()
         .media_type(MediaType::ImageManifest)
-        .digest(manifest_digest_parsed)
+        .digest(manifest_digest.clone())
         .size(manifest_bytes.len() as u64)
         .build()
         .context("Failed to build OCI manifest descriptor")?;
@@ -491,7 +488,7 @@ fn stage_descriptor_bytes(
 ) -> Result<()> {
     let digest = blob_store.put_bytes(bytes)?;
     ensure!(
-        digest == digest_to_string(desc.digest()),
+        &digest == desc.digest(),
         "Blob digest mismatch: descriptor={}, actual={}",
         desc.digest(),
         digest

--- a/rust/ommx/src/artifact/local_registry/import/remote.rs
+++ b/rust/ommx/src/artifact/local_registry/import/remote.rs
@@ -53,8 +53,7 @@
 
 use super::super::{
     annotations_json, now_rfc3339, BlobRecord, FileBlobStore, LayerRecord, LocalRegistry,
-    ManifestRecord, RefConflictPolicy, RefUpdate, BLOB_KIND_BLOB, BLOB_KIND_CONFIG,
-    BLOB_KIND_MANIFEST,
+    ManifestRecord, RefConflictPolicy, RefUpdate,
 };
 use super::oci_dir::OciDirImport;
 use crate::artifact::{
@@ -136,7 +135,6 @@ pub fn pull_image(registry: &Arc<LocalRegistry>, image_name: &ImageRef) -> Resul
         registry.blobs(),
         image_name,
         config_descriptor,
-        BLOB_KIND_CONFIG,
     )?);
 
     for (position, layer) in manifest.layers().iter().enumerate() {
@@ -145,7 +143,6 @@ pub fn pull_image(registry: &Arc<LocalRegistry>, image_name: &ImageRef) -> Resul
             registry.blobs(),
             image_name,
             layer,
-            BLOB_KIND_BLOB,
         )?);
         layer_records.push(LayerRecord {
             manifest_digest: manifest_digest.clone(),
@@ -243,7 +240,6 @@ fn pull_descriptor_blob(
     blob_store: &FileBlobStore,
     image_name: &ImageRef,
     descriptor: &Descriptor,
-    kind: &str,
 ) -> Result<BlobRecord> {
     let digest = descriptor.digest().to_string();
     // The manifest descriptor's `size` bounds the network read: the
@@ -253,18 +249,16 @@ fn pull_descriptor_blob(
     let bytes = transport.pull_blob_to_vec(image_name, &digest, descriptor.size())?;
     anyhow::ensure!(
         bytes.len() as u64 == descriptor.size(),
-        "{kind} blob size mismatch for {digest}: descriptor={}, actual={}",
+        "Blob size mismatch for {digest}: descriptor={}, actual={}",
         descriptor.size(),
         bytes.len()
     );
-    let mut record = blob_store.put_bytes(&bytes)?;
+    let record = blob_store.put_bytes(&bytes)?;
     anyhow::ensure!(
         record.digest == digest,
-        "{kind} blob digest mismatch: descriptor={digest}, actual={}",
+        "Blob digest mismatch: descriptor={digest}, actual={}",
         record.digest
     );
-    record.media_type = Some(descriptor.media_type().to_string());
-    record.kind = kind.to_string();
     Ok(record)
 }
 
@@ -279,14 +273,12 @@ fn stage_manifest_blob(
     manifest_bytes: &[u8],
     expected_digest: &str,
 ) -> Result<BlobRecord> {
-    let mut record = blob_store.put_bytes(manifest_bytes)?;
+    let record = blob_store.put_bytes(manifest_bytes)?;
     anyhow::ensure!(
         record.digest == expected_digest,
         "Manifest blob digest mismatch: registry reported {expected_digest}, sha256 of \
          pulled bytes is {}",
         record.digest
     );
-    record.media_type = Some(OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string());
-    record.kind = BLOB_KIND_MANIFEST.to_string();
     Ok(record)
 }

--- a/rust/ommx/src/artifact/local_registry/import/remote.rs
+++ b/rust/ommx/src/artifact/local_registry/import/remote.rs
@@ -31,18 +31,13 @@
 //!    offered, expressed against the canonical SQLite ref store.
 //! 2. Open a [`RemoteTransport`], authenticate for `Pull`, fetch the
 //!    manifest bytes verbatim, then walk the manifest's config +
-//!    layer descriptors. Each blob is pulled into memory, written to
-//!    [`FileBlobStore`], and the matching [`BlobRecord`] / [`LayerRecord`]
-//!    is staged. The manifest is staged last so it sits behind its
-//!    blobs in the BlobStore (matching the OCI distribution publish
-//!    order).
-//! 3. One SQLite transaction (`publish_artifact_atomic`) commits every
-//!    [`BlobRecord`] + the [`ManifestRecord`] + the ref update under
-//!    the requested `image_name`. A crash between blob writes and the
-//!    publish leaves orphan CAS bytes (recovered by GC, not visible
-//!    through the index); a crash inside the SQLite transaction never
-//!    leaves a partially-published ref. Concurrent first-miss pulls
-//!    for the same image converge inside this transaction.
+//!    layer descriptors. Each blob is pulled into memory and written
+//!    to [`FileBlobStore`]. The manifest is staged last so it sits
+//!    behind its blobs in the BlobStore (matching the OCI distribution
+//!    publish order).
+//! 3. SQLite publishes only the manifest descriptor under the requested
+//!    `image_name`. A crash between blob writes and ref publish leaves
+//!    orphan CAS bytes (recovered by GC, not visible through the index).
 //!
 //! v3 has no on-disk OCI Image Layout intermediate for pulls — SQLite
 //! plus [`FileBlobStore`] are the sole post-import home of the bytes.
@@ -51,18 +46,15 @@
 //! is, and because this is the only place in `local_registry` that
 //! touches the network.
 
-use super::super::{
-    annotations_json, now_rfc3339, BlobRecord, FileBlobStore, LayerRecord, LocalRegistry,
-    ManifestRecord, RefConflictPolicy, RefUpdate,
-};
+use super::super::{FileBlobStore, LocalRegistry, RefConflictPolicy, RefUpdate};
 use super::oci_dir::OciDirImport;
 use crate::artifact::{
     media_types, remote_transport::RemoteTransport, ImageRef, OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 use anyhow::{Context, Result};
 use oci_client::RegistryOperation;
-use oci_spec::image::{Descriptor, ImageManifest, MediaType};
-use std::sync::Arc;
+use oci_spec::image::{Descriptor, DescriptorBuilder, Digest, ImageManifest, MediaType};
+use std::{str::FromStr, sync::Arc};
 
 /// Pull `image_name` from its remote registry into the v3 SQLite
 /// Local Registry.
@@ -76,18 +68,17 @@ use std::sync::Arc;
 /// to a fresh pull rather than handing back a stale `Unchanged` — that
 /// would surface later as an opaque `get_blob` failure with no
 /// recovery hint. Layer-blob completeness is not probed: if the
-/// manifest is present, layers are assumed to follow from the same
-/// publish transaction (`publish_artifact_atomic`); a layer-only gap
-/// is a strict registry-corruption case and out of scope for this
-/// fast path.
+/// manifest is present, layer completeness is checked when the
+/// artifact is opened; a layer-only gap is a strict registry
+/// corruption case and out of scope for this fast path.
 ///
 /// Otherwise the manifest and each blob are pulled through
-/// `RemoteTransport` straight into [`FileBlobStore`], and a single
-/// SQLite transaction publishes the ref. There is no on-disk OCI Image
-/// Layout intermediate.
+/// `RemoteTransport` straight into [`FileBlobStore`], and a SQLite
+/// transaction publishes the ref descriptor. There is no on-disk OCI
+/// Image Layout intermediate.
 ///
 /// Concurrent first-miss pulls for the same image race at the SQLite
-/// `publish_artifact_atomic` boundary. **Assuming the remote registry
+/// ref publish boundary. **Assuming the remote registry
 /// returns byte-identical manifests across both requests**, the second
 /// writer sees `Unchanged`. If the remote serves non-deterministic
 /// manifest bytes (field reorder, whitespace drift) the two digests
@@ -125,58 +116,28 @@ pub fn pull_image(registry: &Arc<LocalRegistry>, image_name: &ImageRef) -> Resul
         .context("Failed to parse OCI image manifest pulled from the remote registry")?;
     ensure_ommx_image_manifest(&manifest)?;
 
-    let blob_count = manifest.layers().len() + 2;
-    let mut blob_records = Vec::with_capacity(blob_count);
-    let mut layer_records = Vec::with_capacity(manifest.layers().len());
+    let manifest_descriptor = DescriptorBuilder::default()
+        .media_type(MediaType::ImageManifest)
+        .digest(
+            Digest::from_str(&manifest_digest)
+                .with_context(|| format!("Invalid remote manifest digest: {manifest_digest}"))?,
+        )
+        .size(manifest_bytes.len() as u64)
+        .build()
+        .context("Failed to build remote manifest descriptor")?;
 
     let config_descriptor = manifest.config();
-    blob_records.push(pull_descriptor_blob(
-        &transport,
-        registry.blobs(),
-        image_name,
-        config_descriptor,
-    )?);
+    pull_descriptor_blob(&transport, registry.blobs(), image_name, config_descriptor)?;
 
-    for (position, layer) in manifest.layers().iter().enumerate() {
-        blob_records.push(pull_descriptor_blob(
-            &transport,
-            registry.blobs(),
-            image_name,
-            layer,
-        )?);
-        layer_records.push(LayerRecord {
-            manifest_digest: manifest_digest.clone(),
-            position: u32::try_from(position).context("Layer position does not fit in u32")?,
-            digest: layer.digest().to_string(),
-            media_type: layer.media_type().to_string(),
-            size: layer.size(),
-            annotations_json: annotations_json(layer.annotations().as_ref())?,
-        });
+    for layer in manifest.layers() {
+        pull_descriptor_blob(&transport, registry.blobs(), image_name, layer)?;
     }
 
-    blob_records.push(stage_manifest_blob(
-        registry.blobs(),
-        &manifest_bytes,
-        &manifest_digest,
-    )?);
+    stage_manifest_blob(registry.blobs(), &manifest_bytes, &manifest_digest)?;
 
-    let manifest_record = ManifestRecord {
-        digest: manifest_digest.clone(),
-        media_type: OCI_IMAGE_MANIFEST_MEDIA_TYPE.to_string(),
-        size: manifest_bytes.len() as u64,
-        subject_digest: manifest
-            .subject()
-            .as_ref()
-            .map(|subject| subject.digest().to_string()),
-        annotations_json: annotations_json(manifest.annotations().as_ref())?,
-        created_at: now_rfc3339(),
-    };
-
-    let outcome = registry.index().publish_artifact_atomic(
-        &blob_records,
-        &manifest_record,
-        &layer_records,
-        Some(image_name),
+    let ref_update = registry.index().put_image_ref_with_policy(
+        image_name,
+        &manifest_descriptor,
         RefConflictPolicy::KeepExisting,
     )?;
     // Surface a ref conflict as `Err` rather than `Ok(Conflicted)`:
@@ -188,10 +149,10 @@ pub fn pull_image(registry: &Arc<LocalRegistry>, image_name: &ImageRef) -> Resul
     // silently surface the local cache, not the remote bytes. Forcing
     // an explicit error lets callers decide between `--replace`
     // semantics and aborting.
-    if let Some(RefUpdate::Conflicted {
+    if let RefUpdate::Conflicted {
         existing_manifest_digest,
         incoming_manifest_digest,
-    }) = &outcome.ref_update
+    } = &ref_update
     {
         anyhow::bail!(
             "Local registry ref conflict for {image_name}: existing manifest \
@@ -204,7 +165,7 @@ pub fn pull_image(registry: &Arc<LocalRegistry>, image_name: &ImageRef) -> Resul
     Ok(OciDirImport {
         manifest_digest,
         image_name: Some(image_name.clone()),
-        ref_update: outcome.ref_update,
+        ref_update: Some(ref_update),
     })
 }
 
@@ -231,16 +192,14 @@ fn ensure_ommx_image_manifest(manifest: &ImageManifest) -> Result<()> {
 }
 
 /// Pull a single descriptor's blob from the registry, write it into
-/// [`FileBlobStore`] under its content digest, and produce the matching
-/// [`BlobRecord`]. The DB row is *not* inserted here — the caller hands
-/// the record to [`SqliteIndexStore::publish_artifact_atomic`] so blob /
-/// manifest / ref inserts share one transaction.
+/// [`FileBlobStore`] under its content digest, and verify the written
+/// bytes match the descriptor.
 fn pull_descriptor_blob(
     transport: &RemoteTransport,
     blob_store: &FileBlobStore,
     image_name: &ImageRef,
     descriptor: &Descriptor,
-) -> Result<BlobRecord> {
+) -> Result<()> {
     let digest = descriptor.digest().to_string();
     // The manifest descriptor's `size` bounds the network read: the
     // transport's pull helper allocates from this value (not from the
@@ -253,13 +212,13 @@ fn pull_descriptor_blob(
         descriptor.size(),
         bytes.len()
     );
-    let record = blob_store.put_bytes(&bytes)?;
+    let actual_digest = blob_store.put_bytes(&bytes)?;
     anyhow::ensure!(
-        record.digest == digest,
+        actual_digest == digest,
         "Blob digest mismatch: descriptor={digest}, actual={}",
-        record.digest
+        actual_digest
     );
-    Ok(record)
+    Ok(())
 }
 
 /// Stage the manifest bytes into [`FileBlobStore`] under their
@@ -272,13 +231,13 @@ fn stage_manifest_blob(
     blob_store: &FileBlobStore,
     manifest_bytes: &[u8],
     expected_digest: &str,
-) -> Result<BlobRecord> {
-    let record = blob_store.put_bytes(manifest_bytes)?;
+) -> Result<()> {
+    let actual_digest = blob_store.put_bytes(manifest_bytes)?;
     anyhow::ensure!(
-        record.digest == expected_digest,
+        actual_digest == expected_digest,
         "Manifest blob digest mismatch: registry reported {expected_digest}, sha256 of \
          pulled bytes is {}",
-        record.digest
+        actual_digest
     );
-    Ok(record)
+    Ok(())
 }

--- a/rust/ommx/src/artifact/local_registry/import/remote.rs
+++ b/rust/ommx/src/artifact/local_registry/import/remote.rs
@@ -116,12 +116,11 @@ pub fn pull_image(registry: &Arc<LocalRegistry>, image_name: &ImageRef) -> Resul
         .context("Failed to parse OCI image manifest pulled from the remote registry")?;
     ensure_ommx_image_manifest(&manifest)?;
 
+    let manifest_digest = Digest::from_str(&manifest_digest)
+        .with_context(|| format!("Invalid remote manifest digest: {manifest_digest}"))?;
     let manifest_descriptor = DescriptorBuilder::default()
         .media_type(MediaType::ImageManifest)
-        .digest(
-            Digest::from_str(&manifest_digest)
-                .with_context(|| format!("Invalid remote manifest digest: {manifest_digest}"))?,
-        )
+        .digest(manifest_digest.clone())
         .size(manifest_bytes.len() as u64)
         .build()
         .context("Failed to build remote manifest descriptor")?;
@@ -214,7 +213,7 @@ fn pull_descriptor_blob(
     );
     let actual_digest = blob_store.put_bytes(&bytes)?;
     anyhow::ensure!(
-        actual_digest == digest,
+        actual_digest.as_ref() == digest,
         "Blob digest mismatch: descriptor={digest}, actual={}",
         actual_digest
     );
@@ -230,11 +229,11 @@ fn pull_descriptor_blob(
 fn stage_manifest_blob(
     blob_store: &FileBlobStore,
     manifest_bytes: &[u8],
-    expected_digest: &str,
+    expected_digest: &Digest,
 ) -> Result<()> {
     let actual_digest = blob_store.put_bytes(manifest_bytes)?;
     anyhow::ensure!(
-        actual_digest == expected_digest,
+        actual_digest == *expected_digest,
         "Manifest blob digest mismatch: registry reported {expected_digest}, sha256 of \
          pulled bytes is {}",
         actual_digest

--- a/rust/ommx/src/artifact/local_registry/index.rs
+++ b/rust/ommx/src/artifact/local_registry/index.rs
@@ -1,41 +1,33 @@
 use super::{
-    now_rfc3339, validate_digest, BlobRecord, LayerRecord, ManifestRecord, RefConflictPolicy,
-    RefRecord, RefUpdate, SQLITE_INDEX_FILE_NAME,
+    now_rfc3339, validate_digest, RefConflictPolicy, RefRecord, RefUpdate, SQLITE_INDEX_FILE_NAME,
 };
 use crate::artifact::ImageRef;
 use anyhow::{ensure, Context, Result};
-use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use oci_spec::image::{Descriptor, DescriptorBuilder, Digest, MediaType};
+use rusqlite::{params, types::Type, Connection, OptionalExtension, TransactionBehavior};
 use std::{
+    collections::HashMap,
     fs,
     path::Path,
+    str::FromStr,
     sync::{Mutex, MutexGuard},
     time::Duration,
 };
 
-/// Public outcome of [`SqliteIndexStore::publish_artifact_atomic`].
-///
-/// `ref_update` is `None` when the caller did not pass an `image_name`
-/// (digest-only publish, no SQLite ref written). Otherwise it carries
-/// the [`RefUpdate`] for that ref.
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PublishOutcome {
-    pub ref_update: Option<RefUpdate>,
-}
-
 /// SQLite Local Registry schema version. Bumped whenever the schema
 /// changes in a way that needs distinct identification (new tables,
-/// new columns, semantic changes to existing rows). The current
-/// migration strategy is "open the registry and let `init_schema` run
-/// `CREATE TABLE IF NOT EXISTS` for every table"; bumping the version
-/// records the change so future incompatible migrations (column drop,
-/// type change) can branch on the stored version. The SQLite Local
+/// new columns, semantic changes to existing rows). The SQLite Local
 /// Registry has not been released yet, so incompatible development
 /// schema changes fail fast instead of carrying an in-place migration.
-const SCHEMA_VERSION: i64 = 2;
+const SCHEMA_VERSION: i64 = 3;
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// SQLite-backed index store for the v3 Local Registry.
+///
+/// This store is the concurrency-safe equivalent of an OCI `index.json`:
+/// it stores refs and their target manifest descriptors. Content bytes
+/// live in [`super::FileBlobStore`], and manifests / layers are read
+/// from that CAS by descriptor digest instead of being cached here.
 ///
 /// `rusqlite::Connection` is `Send` but `!Sync`, so it lives behind a
 /// [`Mutex`] here. That makes [`SqliteIndexStore`] (and the enclosing
@@ -80,12 +72,9 @@ impl SqliteIndexStore {
 
     /// Acquire the connection guard. If the mutex was poisoned by an
     /// earlier panic, fall back to the wrapped `Connection` (rusqlite's
-    /// internal state isn't damaged by Rust-level poisoning — the lock
+    /// internal state isn't damaged by Rust-level poisoning; the lock
     /// flag just records that some other thread paniced while holding
-    /// it) and log a warning. Better than letting one rogue panic
-    /// abort every subsequent registry call, which matters for the
-    /// Python bindings where the same process may run many independent
-    /// operations.
+    /// it) and log a warning.
     fn lock(&self) -> MutexGuard<'_, Connection> {
         match self.conn.lock() {
             Ok(guard) => guard,
@@ -109,218 +98,50 @@ impl SqliteIndexStore {
             .context("Failed to read local registry schema version")
     }
 
-    pub fn put_blob(&self, record: &BlobRecord) -> Result<()> {
-        let conn = self.lock();
-        Self::put_blob_in(&conn, record)
-    }
-
-    /// Connection-scoped variant of [`Self::put_blob`]. Lets callers
-    /// compose blob inserts with manifest / ref inserts inside one
-    /// transaction (see [`Self::publish_artifact_atomic`]). The
-    /// existence-and-size guard is run inside the same `conn`/`tx`
-    /// so the check + insert are read-after-write consistent.
-    fn put_blob_in(conn: &Connection, record: &BlobRecord) -> Result<()> {
-        validate_digest(&record.digest)?;
-        if let Some(existing_size) = conn
-            .query_row(
-                "SELECT size FROM blobs WHERE digest = ?1",
-                params![record.digest],
-                |row| read_u64(row, 0),
-            )
-            .optional()
-            .context("Failed to query existing blob size")?
-        {
-            ensure!(
-                existing_size == record.size,
-                "Blob size mismatch for digest {}: existing={}, new={}",
-                record.digest,
-                existing_size,
-                record.size
-            );
-        }
-        let now = now_rfc3339();
-        conn.execute(
-            r#"
-            INSERT INTO blobs (digest, size, created_at, last_verified_at)
-            VALUES (?1, ?2, ?3, ?4)
-            ON CONFLICT(digest) DO UPDATE SET
-                size = excluded.size,
-                last_verified_at = excluded.last_verified_at
-            "#,
-            params![
-                record.digest,
-                i64::try_from(record.size).context("Blob size does not fit in i64")?,
-                now,
-                record.last_verified_at,
-            ],
-        )?;
-        Ok(())
-    }
-
-    pub fn get_blob(&self, digest: &str) -> Result<Option<BlobRecord>> {
-        validate_digest(digest)?;
-        self.lock()
-            .query_row(
-                r#"
-                SELECT digest, size, last_verified_at
-                FROM blobs
-                WHERE digest = ?1
-                "#,
-                params![digest],
-                |row| {
-                    Ok(BlobRecord {
-                        digest: row.get(0)?,
-                        size: read_u64(row, 1)?,
-                        last_verified_at: row.get(2)?,
-                    })
-                },
-            )
-            .optional()
-            .context("Failed to query blob record")
-    }
-
-    pub fn put_manifest(&self, record: &ManifestRecord, layers: &[LayerRecord]) -> Result<()> {
+    pub fn put_ref(&self, name: &str, reference: &str, descriptor: &Descriptor) -> Result<()> {
         let mut conn = self.lock();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        Self::put_manifest_in(&tx, record, layers)?;
+        Self::put_ref_in(&tx, name, reference, descriptor)?;
         tx.commit()?;
         Ok(())
-    }
-
-    /// Connection-scoped variant of [`Self::put_manifest`]. Caller is
-    /// responsible for opening / committing the transaction so the
-    /// manifest insert can be composed with other writes (blob
-    /// records, ref publish) atomically.
-    fn put_manifest_in(
-        conn: &Connection,
-        record: &ManifestRecord,
-        layers: &[LayerRecord],
-    ) -> Result<()> {
-        validate_digest(&record.digest)?;
-        conn.execute(
-            r#"
-            INSERT INTO manifests (digest, media_type, size, subject_digest, annotations_json, created_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-            ON CONFLICT(digest) DO UPDATE SET
-                media_type = excluded.media_type,
-                size = excluded.size,
-                subject_digest = excluded.subject_digest,
-                annotations_json = excluded.annotations_json
-            "#,
-            params![
-                record.digest,
-                record.media_type,
-                i64::try_from(record.size).context("Manifest size does not fit in i64")?,
-                record.subject_digest,
-                record.annotations_json,
-                record.created_at,
-            ],
-        )?;
-        conn.execute(
-            "DELETE FROM manifest_layers WHERE manifest_digest = ?1",
-            params![record.digest],
-        )?;
-        for layer in layers {
-            ensure!(
-                layer.manifest_digest == record.digest,
-                "Layer manifest digest mismatch: {} != {}",
-                layer.manifest_digest,
-                record.digest
-            );
-            validate_digest(&layer.digest)?;
-            conn.execute(
-                r#"
-                INSERT INTO manifest_layers
-                    (manifest_digest, position, digest, media_type, size, annotations_json)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                "#,
-                params![
-                    layer.manifest_digest,
-                    i64::from(layer.position),
-                    layer.digest,
-                    layer.media_type,
-                    i64::try_from(layer.size).context("Layer size does not fit in i64")?,
-                    layer.annotations_json,
-                ],
-            )?;
-        }
-        Ok(())
-    }
-
-    pub fn get_manifest(&self, digest: &str) -> Result<Option<ManifestRecord>> {
-        validate_digest(digest)?;
-        self.lock()
-            .query_row(
-                r#"
-                SELECT digest, media_type, size, subject_digest, annotations_json, created_at
-                FROM manifests
-                WHERE digest = ?1
-                "#,
-                params![digest],
-                |row| {
-                    Ok(ManifestRecord {
-                        digest: row.get(0)?,
-                        media_type: row.get(1)?,
-                        size: read_u64(row, 2)?,
-                        subject_digest: row.get(3)?,
-                        annotations_json: row.get(4)?,
-                        created_at: row.get(5)?,
-                    })
-                },
-            )
-            .optional()
-            .context("Failed to query manifest record")
-    }
-
-    pub fn get_layers(&self, manifest_digest: &str) -> Result<Vec<LayerRecord>> {
-        validate_digest(manifest_digest)?;
-        let conn = self.lock();
-        let mut stmt = conn.prepare(
-            r#"
-            SELECT manifest_digest, position, digest, media_type, size, annotations_json
-            FROM manifest_layers
-            WHERE manifest_digest = ?1
-            ORDER BY position
-            "#,
-        )?;
-        let rows = stmt.query_map(params![manifest_digest], |row| {
-            Ok(LayerRecord {
-                manifest_digest: row.get(0)?,
-                position: read_u32(row, 1)?,
-                digest: row.get(2)?,
-                media_type: row.get(3)?,
-                size: read_u64(row, 4)?,
-                annotations_json: row.get(5)?,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
-    }
-
-    pub fn put_ref(&self, name: &str, reference: &str, manifest_digest: &str) -> Result<()> {
-        let conn = self.lock();
-        Self::put_ref_in(&conn, name, reference, manifest_digest)
     }
 
     fn put_ref_in(
         conn: &Connection,
         name: &str,
         reference: &str,
-        manifest_digest: &str,
+        descriptor: &Descriptor,
     ) -> Result<()> {
-        validate_digest(manifest_digest)?;
+        validate_digest(descriptor.digest().as_ref())?;
+        let annotations_json = descriptor_annotations_json(descriptor)?;
         conn.execute(
             r#"
-            INSERT INTO refs (name, reference, manifest_digest, updated_at)
-            VALUES (?1, ?2, ?3, ?4)
+            INSERT INTO refs (
+                name,
+                reference,
+                manifest_media_type,
+                manifest_digest,
+                manifest_size,
+                manifest_annotations_json,
+                updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             ON CONFLICT(name, reference) DO UPDATE SET
+                manifest_media_type = excluded.manifest_media_type,
                 manifest_digest = excluded.manifest_digest,
+                manifest_size = excluded.manifest_size,
+                manifest_annotations_json = excluded.manifest_annotations_json,
                 updated_at = excluded.updated_at
             "#,
-            params![name, reference, manifest_digest, now_rfc3339()],
+            params![
+                name,
+                reference,
+                descriptor.media_type().to_string(),
+                descriptor.digest().to_string(),
+                i64::try_from(descriptor.size()).context("Manifest size does not fit in i64")?,
+                annotations_json,
+                now_rfc3339(),
+            ],
         )?;
         Ok(())
     }
@@ -329,50 +150,69 @@ impl SqliteIndexStore {
         &self,
         name: &str,
         reference: &str,
-        manifest_digest: &str,
+        descriptor: &Descriptor,
         policy: RefConflictPolicy,
     ) -> Result<RefUpdate> {
-        let conn = self.lock();
-        Self::put_ref_with_policy_in(&conn, name, reference, manifest_digest, policy)
+        let mut conn = self.lock();
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let update = Self::put_ref_with_policy_in(&tx, name, reference, descriptor, policy)?;
+        tx.commit()?;
+        Ok(update)
     }
 
-    /// Connection-scoped variant of [`Self::put_ref_with_policy`].
-    /// Lets callers compose ref publish with blob / manifest inserts
-    /// inside one transaction (see [`Self::publish_artifact_atomic`]).
     fn put_ref_with_policy_in(
         conn: &Connection,
         name: &str,
         reference: &str,
-        manifest_digest: &str,
+        descriptor: &Descriptor,
         policy: RefConflictPolicy,
     ) -> Result<RefUpdate> {
-        validate_digest(manifest_digest)?;
+        validate_digest(descriptor.digest().as_ref())?;
         if policy == RefConflictPolicy::Replace {
-            return Self::replace_ref_in(conn, name, reference, manifest_digest);
+            return Self::replace_ref_in(conn, name, reference, descriptor);
         }
 
+        let annotations_json = descriptor_annotations_json(descriptor)?;
         let inserted = conn.execute(
             r#"
-            INSERT INTO refs (name, reference, manifest_digest, updated_at)
-            VALUES (?1, ?2, ?3, ?4)
+            INSERT INTO refs (
+                name,
+                reference,
+                manifest_media_type,
+                manifest_digest,
+                manifest_size,
+                manifest_annotations_json,
+                updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             ON CONFLICT(name, reference) DO NOTHING
             "#,
-            params![name, reference, manifest_digest, now_rfc3339()],
+            params![
+                name,
+                reference,
+                descriptor.media_type().to_string(),
+                descriptor.digest().to_string(),
+                i64::try_from(descriptor.size()).context("Manifest size does not fit in i64")?,
+                annotations_json,
+                now_rfc3339(),
+            ],
         )?;
         if inserted == 1 {
             return Ok(RefUpdate::Inserted);
         }
 
-        let existing_manifest_digest =
+        let existing_descriptor =
             Self::resolve_ref_in(conn, name, reference)?.with_context(|| {
                 format!("Ref disappeared while resolving conflict: {name}:{reference}")
             })?;
-        if existing_manifest_digest == manifest_digest {
+        let existing_manifest_digest = existing_descriptor.digest().to_string();
+        let incoming_manifest_digest = descriptor.digest().to_string();
+        if existing_manifest_digest == incoming_manifest_digest {
             Ok(RefUpdate::Unchanged)
         } else {
             Ok(RefUpdate::Conflicted {
                 existing_manifest_digest,
-                incoming_manifest_digest: manifest_digest.to_string(),
+                incoming_manifest_digest,
             })
         }
     }
@@ -381,116 +221,48 @@ impl SqliteIndexStore {
         conn: &Connection,
         name: &str,
         reference: &str,
-        manifest_digest: &str,
+        descriptor: &Descriptor,
     ) -> Result<RefUpdate> {
-        let previous_manifest_digest = Self::resolve_ref_in(conn, name, reference)?;
-        if previous_manifest_digest.as_deref() == Some(manifest_digest) {
+        let previous_descriptor = Self::resolve_ref_in(conn, name, reference)?;
+        if previous_descriptor.as_ref().map(|d| d.digest()) == Some(descriptor.digest()) {
             return Ok(RefUpdate::Unchanged);
         }
 
-        Self::put_ref_in(conn, name, reference, manifest_digest)?;
-        Ok(match previous_manifest_digest {
-            Some(previous_manifest_digest) => RefUpdate::Replaced {
-                previous_manifest_digest,
+        Self::put_ref_in(conn, name, reference, descriptor)?;
+        Ok(match previous_descriptor {
+            Some(previous_descriptor) => RefUpdate::Replaced {
+                previous_manifest_digest: previous_descriptor.digest().to_string(),
             },
             None => RefUpdate::Inserted,
         })
     }
 
-    fn resolve_ref_in(conn: &Connection, name: &str, reference: &str) -> Result<Option<String>> {
+    fn resolve_ref_in(
+        conn: &Connection,
+        name: &str,
+        reference: &str,
+    ) -> Result<Option<Descriptor>> {
         conn.query_row(
-            "SELECT manifest_digest FROM refs WHERE name = ?1 AND reference = ?2",
+            r#"
+            SELECT manifest_media_type, manifest_digest, manifest_size, manifest_annotations_json
+            FROM refs
+            WHERE name = ?1 AND reference = ?2
+            "#,
             params![name, reference],
-            |row| row.get(0),
+            descriptor_from_row,
         )
         .optional()
         .context("Failed to resolve local registry ref")
     }
 
-    pub fn resolve_ref(&self, name: &str, reference: &str) -> Result<Option<String>> {
+    pub fn resolve_ref(&self, name: &str, reference: &str) -> Result<Option<Descriptor>> {
         let conn = self.lock();
         Self::resolve_ref_in(&conn, name, reference)
-    }
-
-    /// Atomic publish: in one SQLite transaction, insert all `blobs`
-    /// records, the `manifest` + `layers`, and (if `image_name` is
-    /// `Some`) the corresponding ref under `policy`. CAS bytes must
-    /// already have been written to [`super::FileBlobStore`] before
-    /// this call — only the IndexStore rows are batched here.
-    ///
-    /// On a `Replace` policy the function still returns
-    /// `RefUpdate::Replaced { previous_manifest_digest }` so callers
-    /// can record the prior state. A `Conflicted` outcome under
-    /// `KeepExisting` aborts the transaction (so the manifest /
-    /// layers / blob rows are not committed) and returns
-    /// `Ok(PublishOutcome { ref_update: Some(Conflicted { .. }) })`;
-    /// callers that prefer to bail can match on the variant.
-    pub fn publish_artifact_atomic(
-        &self,
-        blobs: &[BlobRecord],
-        manifest: &ManifestRecord,
-        layers: &[LayerRecord],
-        image_name: Option<&ImageRef>,
-        policy: RefConflictPolicy,
-    ) -> Result<PublishOutcome> {
-        // BEGIN IMMEDIATE acquires the RESERVED lock at the start so
-        // `busy_timeout` waits cleanly when another writer is active,
-        // instead of upgrading mid-transaction and risking SQLITE_BUSY
-        // from two writers each holding a SHARED lock.
-        let mut conn = self.lock();
-        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        for blob in blobs {
-            Self::put_blob_in(&tx, blob)?;
-        }
-        Self::put_manifest_in(&tx, manifest, layers)?;
-        let ref_update = if let Some(image_name) = image_name {
-            let name = image_name.repository_key();
-            let reference = image_name.reference();
-            let update =
-                Self::put_ref_with_policy_in(&tx, &name, reference, &manifest.digest, policy)?;
-            // KeepExisting + different incoming digest → conflict.
-            // Roll back the manifest / blob inserts so we don't leave
-            // unreferenced rows committed under a ref that resolved
-            // to a different artifact.
-            if let RefUpdate::Conflicted { .. } = &update {
-                drop(tx);
-                return Ok(PublishOutcome {
-                    ref_update: Some(update),
-                });
-            }
-            Some(update)
-        } else {
-            None
-        };
-        tx.commit()?;
-        Ok(PublishOutcome { ref_update })
     }
 
     /// Per-registry stable identifier. Generated as a random UUID v4
     /// (32 hex chars) on the first `init_schema` call and stored
     /// verbatim in the `ommx_local_registry_metadata` table.
-    /// Anonymous artifact ref synthesis truncates the stored value to
-    /// the first `super::super::manifest::ANONYMOUS_REGISTRY_ID_HOST_LEN`
-    /// hex chars for the hostname prefix
-    /// (`<registry-id>.ommx.local/anonymous`), so two artifacts built
-    /// against the same registry share a prefix and can be told apart
-    /// from artifacts imported from a different registry. Reading
-    /// this is a single indexed SELECT; cheap enough to call at
-    /// every anonymous build.
-    ///
-    /// Random per-registry (not per-host) means: (1) no host hardware
-    /// identifier leaks through the registry; (2) cloning a registry
-    /// directory to another machine keeps the prefix stable (a clone
-    /// of a registry is still "the same registry"); (3) a fresh
-    /// registry gets a fresh prefix, matching user intent of "this is
-    /// a new home for artifacts".
-    ///
-    /// **Privacy note**: the identifier IS stable per registry; a
-    /// recipient of two SQLite Local Registry exports from the same
-    /// source can correlate them via this column. The identifier
-    /// carries no PII or hardware fingerprint, but is itself a unique
-    /// correlator. Treat the SQLite registry file the same as any
-    /// other user-data export when sharing.
     pub fn registry_id(&self) -> Result<String> {
         let conn = self.lock();
         let row: Option<String> = conn
@@ -503,18 +275,12 @@ impl SqliteIndexStore {
         match row {
             Some(id) => Ok(id),
             None => {
-                // First read on a freshly-initialised registry.
-                // Generate a random UUID v4 and insert; concurrent
-                // racers converge on the first-write-wins via
-                // `OR IGNORE`.
                 let new_id = random_registry_id();
                 conn.execute(
                     r#"INSERT OR IGNORE INTO ommx_local_registry_metadata (key, value)
                        VALUES ('registry_id', ?1)"#,
                     params![&new_id],
                 )?;
-                // Re-read to pick up the winning value if another
-                // writer beat us to the insert.
                 conn.query_row(
                     r#"SELECT value FROM ommx_local_registry_metadata WHERE key = 'registry_id'"#,
                     [],
@@ -526,16 +292,17 @@ impl SqliteIndexStore {
     }
 
     /// Delete a single ref row by `(name, reference)`. Returns `true`
-    /// when a row was actually removed. Manifest / blob CAS records the
-    /// ref pointed at are **not** touched; an orphan manifest is the
-    /// expected post-state for a deleted ref and is reclaimed by a
-    /// future GC sweep, not by this primitive.
+    /// when a row was actually removed. Content blobs are not touched;
+    /// unreferenced CAS bytes are reclaimed by a future GC sweep, not
+    /// by this primitive.
     pub fn delete_ref(&self, name: &str, reference: &str) -> Result<bool> {
-        let conn = self.lock();
-        let affected = conn.execute(
+        let mut conn = self.lock();
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let affected = tx.execute(
             r#"DELETE FROM refs WHERE name = ?1 AND reference = ?2"#,
             params![name, reference],
         )?;
+        tx.commit()?;
         Ok(affected > 0)
     }
 
@@ -547,7 +314,14 @@ impl SqliteIndexStore {
                 .context("Ref prefix length does not fit in i64")?;
             let mut stmt = conn.prepare(
                 r#"
-                SELECT name, reference, manifest_digest, updated_at
+                SELECT
+                    name,
+                    reference,
+                    manifest_media_type,
+                    manifest_digest,
+                    manifest_size,
+                    manifest_annotations_json,
+                    updated_at
                 FROM refs
                 WHERE substr(name, 1, ?1) = ?2
                 ORDER BY name, reference
@@ -560,7 +334,14 @@ impl SqliteIndexStore {
         } else {
             let mut stmt = conn.prepare(
                 r#"
-                SELECT name, reference, manifest_digest, updated_at
+                SELECT
+                    name,
+                    reference,
+                    manifest_media_type,
+                    manifest_digest,
+                    manifest_size,
+                    manifest_annotations_json,
+                    updated_at
                 FROM refs
                 ORDER BY name, reference
                 "#,
@@ -583,7 +364,7 @@ impl SqliteIndexStore {
             );
 
             INSERT INTO ommx_local_registry_schema (version)
-            SELECT 2
+            SELECT 3
             WHERE NOT EXISTS (SELECT 1 FROM ommx_local_registry_schema);
 
             CREATE TABLE IF NOT EXISTS ommx_local_registry_metadata (
@@ -591,46 +372,18 @@ impl SqliteIndexStore {
                 value TEXT NOT NULL
             );
 
-            CREATE TABLE IF NOT EXISTS blobs (
-                digest TEXT PRIMARY KEY,
-                size INTEGER NOT NULL CHECK(size >= 0),
-                created_at TEXT NOT NULL,
-                last_verified_at TEXT
-            );
-
-            CREATE TABLE IF NOT EXISTS manifests (
-                digest TEXT PRIMARY KEY,
-                media_type TEXT NOT NULL,
-                size INTEGER NOT NULL CHECK(size >= 0),
-                subject_digest TEXT,
-                annotations_json TEXT NOT NULL DEFAULT '{}',
-                created_at TEXT NOT NULL,
-                FOREIGN KEY(digest) REFERENCES blobs(digest)
-            );
-
-            CREATE TABLE IF NOT EXISTS manifest_layers (
-                manifest_digest TEXT NOT NULL,
-                position INTEGER NOT NULL CHECK(position >= 0),
-                digest TEXT NOT NULL,
-                media_type TEXT NOT NULL,
-                size INTEGER NOT NULL CHECK(size >= 0),
-                annotations_json TEXT NOT NULL DEFAULT '{}',
-                PRIMARY KEY(manifest_digest, position),
-                FOREIGN KEY(manifest_digest) REFERENCES manifests(digest) ON DELETE CASCADE,
-                FOREIGN KEY(digest) REFERENCES blobs(digest)
-            );
-
             CREATE TABLE IF NOT EXISTS refs (
                 name TEXT NOT NULL,
                 reference TEXT NOT NULL,
+                manifest_media_type TEXT NOT NULL,
                 manifest_digest TEXT NOT NULL,
+                manifest_size INTEGER NOT NULL CHECK(manifest_size >= 0),
+                manifest_annotations_json TEXT NOT NULL DEFAULT '{}',
                 updated_at TEXT NOT NULL,
-                PRIMARY KEY(name, reference),
-                FOREIGN KEY(manifest_digest) REFERENCES manifests(digest)
+                PRIMARY KEY(name, reference)
             );
 
             CREATE INDEX IF NOT EXISTS idx_refs_name ON refs(name);
-            CREATE INDEX IF NOT EXISTS idx_manifest_layers_digest ON manifest_layers(digest);
             "#,
         )?;
         let version = self.schema_version()?;
@@ -643,30 +396,36 @@ impl SqliteIndexStore {
 }
 
 impl SqliteIndexStore {
-    pub fn put_image_ref(&self, image_name: &ImageRef, manifest_digest: &str) -> Result<()> {
+    pub fn put_image_ref(&self, image_name: &ImageRef, descriptor: &Descriptor) -> Result<()> {
         self.put_ref(
             &image_name.repository_key(),
             image_name.reference(),
-            manifest_digest,
+            descriptor,
         )
     }
 
     pub fn put_image_ref_with_policy(
         &self,
         image_name: &ImageRef,
-        manifest_digest: &str,
+        descriptor: &Descriptor,
         policy: RefConflictPolicy,
     ) -> Result<RefUpdate> {
         self.put_ref_with_policy(
             &image_name.repository_key(),
             image_name.reference(),
-            manifest_digest,
+            descriptor,
             policy,
         )
     }
 
-    pub fn resolve_image_name(&self, image_name: &ImageRef) -> Result<Option<String>> {
+    pub fn resolve_image_descriptor(&self, image_name: &ImageRef) -> Result<Option<Descriptor>> {
         self.resolve_ref(&image_name.repository_key(), image_name.reference())
+    }
+
+    pub fn resolve_image_name(&self, image_name: &ImageRef) -> Result<Option<String>> {
+        Ok(self
+            .resolve_image_descriptor(image_name)?
+            .map(|descriptor| descriptor.digest().to_string()))
     }
 }
 
@@ -674,9 +433,65 @@ fn ref_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RefRecord> {
     Ok(RefRecord {
         name: row.get(0)?,
         reference: row.get(1)?,
-        manifest_digest: row.get(2)?,
-        updated_at: row.get(3)?,
+        descriptor: descriptor_from_ref_row(row, 2)?,
+        updated_at: row.get(6)?,
     })
+}
+
+fn descriptor_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Descriptor> {
+    descriptor_from_ref_row(row, 0)
+}
+
+fn descriptor_from_ref_row(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<Descriptor> {
+    let media_type: String = row.get(offset)?;
+    let digest: String = row.get(offset + 1)?;
+    let size = read_u64(row, offset + 2)?;
+    let annotations_json: String = row.get(offset + 3)?;
+    let annotations = parse_annotations_json(&annotations_json, offset + 3)?;
+    let digest = Digest::from_str(&digest).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(offset + 1, Type::Text, Box::new(err))
+    })?;
+    let mut builder = DescriptorBuilder::default()
+        .media_type(media_type_from_string(media_type))
+        .digest(digest)
+        .size(size);
+    if !annotations.is_empty() {
+        builder = builder.annotations(annotations);
+    }
+    builder
+        .build()
+        .map_err(|err| rusqlite::Error::FromSqlConversionFailure(offset, Type::Text, err.into()))
+}
+
+fn descriptor_annotations_json(descriptor: &Descriptor) -> Result<String> {
+    match descriptor.annotations() {
+        Some(annotations) => String::from_utf8(crate::artifact::stable_json_bytes(annotations)?)
+            .context("Stable descriptor annotation JSON is not UTF-8"),
+        None => Ok("{}".to_string()),
+    }
+}
+
+fn parse_annotations_json(
+    json: &str,
+    column_index: usize,
+) -> rusqlite::Result<HashMap<String, String>> {
+    serde_json::from_str(json).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(column_index, Type::Text, Box::new(err))
+    })
+}
+
+fn media_type_from_string(media_type: String) -> MediaType {
+    if media_type == MediaType::ImageManifest.to_string() {
+        MediaType::ImageManifest
+    } else if media_type == MediaType::ImageIndex.to_string() {
+        MediaType::ImageIndex
+    } else if media_type == MediaType::EmptyJSON.to_string() {
+        MediaType::EmptyJSON
+    } else if media_type == MediaType::ArtifactManifest.to_string() {
+        MediaType::ArtifactManifest
+    } else {
+        MediaType::Other(media_type)
+    }
 }
 
 fn read_u64(row: &rusqlite::Row<'_>, idx: usize) -> rusqlite::Result<u64> {
@@ -684,18 +499,6 @@ fn read_u64(row: &rusqlite::Row<'_>, idx: usize) -> rusqlite::Result<u64> {
     u64::try_from(value).map_err(|_| rusqlite::Error::IntegralValueOutOfRange(idx, value))
 }
 
-fn read_u32(row: &rusqlite::Row<'_>, idx: usize) -> rusqlite::Result<u32> {
-    let value: i64 = row.get(idx)?;
-    u32::try_from(value).map_err(|_| rusqlite::Error::IntegralValueOutOfRange(idx, value))
-}
-
-/// Full UUID v4 (32 hex chars, no dashes) seeded on first registry
-/// init. The metadata column stores the full UUID; only the hostname
-/// rendering in [`super::super::anonymous_artifact_image_name`]
-/// truncates to 8 hex chars. Keeping the full UUID on disk leaves
-/// room to widen the rendered prefix later (or expose the full
-/// identifier through a different surface) without rewriting
-/// existing registry data.
 fn random_registry_id() -> String {
     uuid::Uuid::new_v4().simple().to_string()
 }

--- a/rust/ommx/src/artifact/local_registry/index.rs
+++ b/rust/ommx/src/artifact/local_registry/index.rs
@@ -2,7 +2,7 @@ use super::{
     now_rfc3339, validate_digest, RefConflictPolicy, RefRecord, RefUpdate, SQLITE_INDEX_FILE_NAME,
 };
 use crate::artifact::ImageRef;
-use anyhow::{ensure, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use oci_spec::image::{Descriptor, DescriptorBuilder, Digest, MediaType};
 use rusqlite::{params, types::Type, Connection, OptionalExtension, TransactionBehavior};
 use std::{
@@ -14,12 +14,10 @@ use std::{
     time::Duration,
 };
 
-/// SQLite Local Registry schema version. Bumped whenever the schema
-/// changes in a way that needs distinct identification (new tables,
-/// new columns, semantic changes to existing rows). The SQLite Local
-/// Registry has not been released yet, so incompatible development
-/// schema changes fail fast instead of carrying an in-place migration.
-const SCHEMA_VERSION: i64 = 3;
+/// SQLite Local Registry schema version stored in `PRAGMA user_version`.
+/// The SQLite Local Registry has not been released yet, so incompatible
+/// development schemas fail fast instead of carrying in-place migrations.
+const SCHEMA_VERSION: i64 = 1;
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// SQLite-backed index store for the v3 Local Registry.
@@ -73,7 +71,7 @@ impl SqliteIndexStore {
     /// Acquire the connection guard. If the mutex was poisoned by an
     /// earlier panic, fall back to the wrapped `Connection` (rusqlite's
     /// internal state isn't damaged by Rust-level poisoning; the lock
-    /// flag just records that some other thread paniced while holding
+    /// flag just records that some other thread panicked while holding
     /// it) and log a warning.
     fn lock(&self) -> MutexGuard<'_, Connection> {
         match self.conn.lock() {
@@ -90,11 +88,7 @@ impl SqliteIndexStore {
 
     pub fn schema_version(&self) -> Result<i64> {
         self.lock()
-            .query_row(
-                "SELECT version FROM ommx_local_registry_schema LIMIT 1",
-                [],
-                |row| row.get(0),
-            )
+            .pragma_query_value(None, "user_version", |row| row.get(0))
             .context("Failed to read local registry schema version")
     }
 
@@ -355,18 +349,28 @@ impl SqliteIndexStore {
     }
 
     fn init_schema(&self) -> Result<()> {
-        self.lock().execute_batch(
-            r#"
-            PRAGMA foreign_keys = ON;
+        let conn = self.lock();
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
 
-            CREATE TABLE IF NOT EXISTS ommx_local_registry_schema (
-                version INTEGER NOT NULL
+        let version = conn
+            .pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+            .context("Failed to read local registry schema version")?;
+        if version == 0 {
+            if has_user_tables(&conn)? {
+                bail!(
+                    "Unsupported local registry schema version: 0. \
+                     Remove the development local registry and recreate it."
+                );
+            }
+        } else {
+            ensure!(
+                version == SCHEMA_VERSION,
+                "Unsupported local registry schema version: {version}"
             );
+        }
 
-            INSERT INTO ommx_local_registry_schema (version)
-            SELECT 3
-            WHERE NOT EXISTS (SELECT 1 FROM ommx_local_registry_schema);
-
+        conn.execute_batch(
+            r#"
             CREATE TABLE IF NOT EXISTS ommx_local_registry_metadata (
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL
@@ -384,13 +388,10 @@ impl SqliteIndexStore {
             );
 
             CREATE INDEX IF NOT EXISTS idx_refs_name ON refs(name);
+
+            PRAGMA user_version = 1;
             "#,
         )?;
-        let version = self.schema_version()?;
-        ensure!(
-            version == SCHEMA_VERSION,
-            "Unsupported local registry schema version: {version}"
-        );
         Ok(())
     }
 }
@@ -440,6 +441,22 @@ fn ref_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RefRecord> {
 
 fn descriptor_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Descriptor> {
     descriptor_from_ref_row(row, 0)
+}
+
+fn has_user_tables(conn: &Connection) -> Result<bool> {
+    let count: i64 = conn
+        .query_row(
+            r#"
+            SELECT COUNT(*)
+            FROM sqlite_master
+            WHERE type = 'table'
+              AND name NOT LIKE 'sqlite_%'
+            "#,
+            [],
+            |row| row.get(0),
+        )
+        .context("Failed to inspect local registry schema tables")?;
+    Ok(count > 0)
 }
 
 fn descriptor_from_ref_row(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<Descriptor> {

--- a/rust/ommx/src/artifact/local_registry/index.rs
+++ b/rust/ommx/src/artifact/local_registry/index.rs
@@ -30,10 +30,9 @@ pub struct PublishOutcome {
 /// `CREATE TABLE IF NOT EXISTS` for every table"; bumping the version
 /// records the change so future incompatible migrations (column drop,
 /// type change) can branch on the stored version. The SQLite Local
-/// Registry has not been released yet, so v1 is the only version
-/// shipped to date — the metadata table (`ommx_local_registry_metadata`)
-/// is part of v1.
-const SCHEMA_VERSION: i64 = 1;
+/// Registry has not been released yet, so incompatible development
+/// schema changes fail fast instead of carrying an in-place migration.
+const SCHEMA_VERSION: i64 = 2;
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// SQLite-backed index store for the v3 Local Registry.
@@ -142,21 +141,15 @@ impl SqliteIndexStore {
         let now = now_rfc3339();
         conn.execute(
             r#"
-            INSERT INTO blobs (digest, size, media_type, storage_uri, kind, created_at, last_verified_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            INSERT INTO blobs (digest, size, created_at, last_verified_at)
+            VALUES (?1, ?2, ?3, ?4)
             ON CONFLICT(digest) DO UPDATE SET
                 size = excluded.size,
-                media_type = excluded.media_type,
-                storage_uri = excluded.storage_uri,
-                kind = excluded.kind,
                 last_verified_at = excluded.last_verified_at
             "#,
             params![
                 record.digest,
                 i64::try_from(record.size).context("Blob size does not fit in i64")?,
-                record.media_type,
-                record.storage_uri,
-                record.kind,
                 now,
                 record.last_verified_at,
             ],
@@ -169,7 +162,7 @@ impl SqliteIndexStore {
         self.lock()
             .query_row(
                 r#"
-                SELECT digest, size, media_type, storage_uri, kind, last_verified_at
+                SELECT digest, size, last_verified_at
                 FROM blobs
                 WHERE digest = ?1
                 "#,
@@ -178,10 +171,7 @@ impl SqliteIndexStore {
                     Ok(BlobRecord {
                         digest: row.get(0)?,
                         size: read_u64(row, 1)?,
-                        media_type: row.get(2)?,
-                        storage_uri: row.get(3)?,
-                        kind: row.get(4)?,
-                        last_verified_at: row.get(5)?,
+                        last_verified_at: row.get(2)?,
                     })
                 },
             )
@@ -593,7 +583,7 @@ impl SqliteIndexStore {
             );
 
             INSERT INTO ommx_local_registry_schema (version)
-            SELECT 1
+            SELECT 2
             WHERE NOT EXISTS (SELECT 1 FROM ommx_local_registry_schema);
 
             CREATE TABLE IF NOT EXISTS ommx_local_registry_metadata (
@@ -604,9 +594,6 @@ impl SqliteIndexStore {
             CREATE TABLE IF NOT EXISTS blobs (
                 digest TEXT PRIMARY KEY,
                 size INTEGER NOT NULL CHECK(size >= 0),
-                media_type TEXT,
-                storage_uri TEXT NOT NULL,
-                kind TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 last_verified_at TEXT
             );

--- a/rust/ommx/src/artifact/local_registry/index.rs
+++ b/rust/ommx/src/artifact/local_registry/index.rs
@@ -362,6 +362,14 @@ impl SqliteIndexStore {
                      Remove the development local registry and recreate it."
                 );
             }
+            // Mark the fresh database before creating tables. Multiple
+            // processes may open a new registry concurrently; setting
+            // `user_version` first prevents another opener from
+            // observing newly-created tables while the version still
+            // reads as 0 and misclassifying the registry as an old
+            // development schema.
+            conn.pragma_update(None, "user_version", SCHEMA_VERSION)
+                .context("Failed to initialize local registry schema version")?;
         } else {
             ensure!(
                 version == SCHEMA_VERSION,
@@ -388,8 +396,6 @@ impl SqliteIndexStore {
             );
 
             CREATE INDEX IF NOT EXISTS idx_refs_name ON refs(name);
-
-            PRAGMA user_version = 1;
             "#,
         )?;
         Ok(())

--- a/rust/ommx/src/artifact/local_registry/index.rs
+++ b/rust/ommx/src/artifact/local_registry/index.rs
@@ -205,8 +205,8 @@ impl SqliteIndexStore {
             Self::resolve_ref_in(conn, name, reference)?.with_context(|| {
                 format!("Ref disappeared while resolving conflict: {name}:{reference}")
             })?;
-        let existing_manifest_digest = existing_descriptor.digest().to_string();
-        let incoming_manifest_digest = descriptor.digest().to_string();
+        let existing_manifest_digest = existing_descriptor.digest().clone();
+        let incoming_manifest_digest = descriptor.digest().clone();
         if existing_manifest_digest == incoming_manifest_digest {
             Ok(RefUpdate::Unchanged)
         } else {
@@ -231,7 +231,7 @@ impl SqliteIndexStore {
         Self::put_ref_in(conn, name, reference, descriptor)?;
         Ok(match previous_descriptor {
             Some(previous_descriptor) => RefUpdate::Replaced {
-                previous_manifest_digest: previous_descriptor.digest().to_string(),
+                previous_manifest_digest: previous_descriptor.digest().clone(),
             },
             None => RefUpdate::Inserted,
         })
@@ -422,10 +422,10 @@ impl SqliteIndexStore {
         self.resolve_ref(&image_name.repository_key(), image_name.reference())
     }
 
-    pub fn resolve_image_name(&self, image_name: &ImageRef) -> Result<Option<String>> {
+    pub fn resolve_image_name(&self, image_name: &ImageRef) -> Result<Option<Digest>> {
         Ok(self
             .resolve_image_descriptor(image_name)?
-            .map(|descriptor| descriptor.digest().to_string()))
+            .map(|descriptor| descriptor.digest().clone()))
     }
 }
 

--- a/rust/ommx/src/artifact/local_registry/mod.rs
+++ b/rust/ommx/src/artifact/local_registry/mod.rs
@@ -1,10 +1,9 @@
 //! v3 OMMX Local Registry.
 //!
-//! The Local Registry stores artifacts as content-addressed blobs in
-//! [`FileBlobStore`] plus index records in [`SqliteIndexStore`]. It
-//! does **not** keep anything in OCI Image Layout (`oci-layout` +
-//! `index.json` + `blobs/`) form internally; that format is purely an
-//! interchange boundary handled in the `import` submodule.
+//! The Local Registry stores artifact bytes as content-addressed blobs
+//! in [`FileBlobStore`]. [`SqliteIndexStore`] is the concurrency-safe
+//! equivalent of OCI `index.json`: it stores refs and their target
+//! manifest descriptors, not a cache of blobs, manifests, or layers.
 //!
 //! Two distinct layers live here:
 //!
@@ -32,9 +31,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-use anyhow::{Context, Result};
 use chrono::Utc;
-use std::collections::HashMap;
 
 pub use crate::artifact::digest::sha256_digest;
 pub(crate) use crate::artifact::digest::{validate_digest, ValidatedDigest};
@@ -51,30 +48,13 @@ pub use import::oci_dir::{
 };
 #[cfg(feature = "remote-artifact")]
 pub use import::remote::pull_image;
-pub use index::{PublishOutcome, SqliteIndexStore};
+pub use index::SqliteIndexStore;
 pub use registry::LocalRegistry;
 pub use types::{
-    BlobRecord, LayerRecord, ManifestRecord, RefConflictPolicy, RefRecord, RefUpdate,
-    FILE_BLOB_STORE_DIR_NAME, OCI_IMAGE_REF_NAME_ANNOTATION, SQLITE_INDEX_FILE_NAME,
+    RefConflictPolicy, RefRecord, RefUpdate, FILE_BLOB_STORE_DIR_NAME,
+    OCI_IMAGE_REF_NAME_ANNOTATION, SQLITE_INDEX_FILE_NAME,
 };
 
 fn now_rfc3339() -> String {
     Utc::now().to_rfc3339()
-}
-
-/// Encode an optional annotation map as a stable JSON string.
-///
-/// Stable (key-sorted) encoding is required because the same annotation
-/// map must round-trip to the same bytes regardless of insertion order;
-/// otherwise the digest of any blob whose descriptor includes
-/// annotations would depend on a HashMap iteration order, and rows in
-/// `manifests.annotations_json` / `manifest_layers.annotations_json`
-/// would not be comparable across the legacy import path and the v3
-/// native build path.
-pub(super) fn annotations_json(annotations: Option<&HashMap<String, String>>) -> Result<String> {
-    match annotations {
-        Some(annotations) => String::from_utf8(crate::artifact::stable_json_bytes(annotations)?)
-            .context("Stable JSON bytes are not UTF-8"),
-        None => Ok("{}".to_string()),
-    }
 }

--- a/rust/ommx/src/artifact/local_registry/mod.rs
+++ b/rust/ommx/src/artifact/local_registry/mod.rs
@@ -55,7 +55,6 @@ pub use index::{PublishOutcome, SqliteIndexStore};
 pub use registry::LocalRegistry;
 pub use types::{
     BlobRecord, LayerRecord, ManifestRecord, RefConflictPolicy, RefRecord, RefUpdate,
-    BLOB_KIND_BLOB, BLOB_KIND_CONFIG, BLOB_KIND_LAYER, BLOB_KIND_MANIFEST,
     FILE_BLOB_STORE_DIR_NAME, OCI_IMAGE_REF_NAME_ANNOTATION, SQLITE_INDEX_FILE_NAME,
 };
 

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -2,8 +2,7 @@ use super::{
     annotations_json, import_legacy_local_registry, import_legacy_local_registry_ref,
     import_legacy_local_registry_ref_with_policy, import_legacy_local_registry_with_policy,
     now_rfc3339, BlobRecord, FileBlobStore, LayerRecord, LegacyImportReport, ManifestRecord,
-    OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore, BLOB_KIND_BLOB, BLOB_KIND_CONFIG,
-    BLOB_KIND_MANIFEST,
+    OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore,
 };
 use crate::artifact::{media_types, ImageRef, StagedArtifactBlob};
 use anyhow::{ensure, Context, Result};
@@ -219,27 +218,11 @@ impl LocalRegistry {
         // committed manifest / blob rows under a ref that wasn't
         // actually published.
         //
-        // Tag the manifest's `config` descriptor with `BLOB_KIND_CONFIG`
-        // (matching the OCI-dir import path) and everything else with
-        // `BLOB_KIND_BLOB`. Without this dispatch the empty config blob
-        // built by `LocalArtifactBuilder::stage` would be persisted as a
-        // generic layer, diverging from imports of legacy v2 dirs and
-        // breaking GC / query logic that filters on `kind`.
-        let config_digest = manifest.config().digest();
         let mut blob_records = Vec::with_capacity(blobs.len() + 1);
         for blob in blobs {
-            let kind = if blob.descriptor().digest() == config_digest {
-                BLOB_KIND_CONFIG
-            } else {
-                BLOB_KIND_BLOB
-            };
-            blob_records.push(self.stage_blob_record(blob.descriptor(), blob.bytes(), kind)?);
+            blob_records.push(self.stage_blob_record(blob.descriptor(), blob.bytes())?);
         }
-        blob_records.push(self.stage_blob_record(
-            manifest_descriptor,
-            manifest_bytes,
-            BLOB_KIND_MANIFEST,
-        )?);
+        blob_records.push(self.stage_blob_record(manifest_descriptor, manifest_bytes)?);
 
         let layer_records = manifest
             .layers()
@@ -288,13 +271,8 @@ impl LocalRegistry {
     /// the IndexStore. The DB row is *not* inserted here; the caller
     /// passes the records to [`SqliteIndexStore::publish_artifact_atomic`]
     /// so the inserts happen inside the publish transaction.
-    fn stage_blob_record(
-        &self,
-        descriptor: &Descriptor,
-        bytes: &[u8],
-        kind: &str,
-    ) -> Result<BlobRecord> {
-        let mut record = self.blobs.put_bytes(bytes)?;
+    fn stage_blob_record(&self, descriptor: &Descriptor, bytes: &[u8]) -> Result<BlobRecord> {
+        let record = self.blobs.put_bytes(bytes)?;
         ensure!(
             record.digest == descriptor.digest().to_string(),
             "Descriptor digest mismatch: descriptor={}, actual={}",
@@ -308,8 +286,6 @@ impl LocalRegistry {
             descriptor.size(),
             record.size
         );
-        record.media_type = Some(descriptor.media_type().to_string());
-        record.kind = kind.to_string();
         Ok(record)
     }
 }

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -1,8 +1,8 @@
 use super::{
-    annotations_json, import_legacy_local_registry, import_legacy_local_registry_ref,
+    import_legacy_local_registry, import_legacy_local_registry_ref,
     import_legacy_local_registry_ref_with_policy, import_legacy_local_registry_with_policy,
-    now_rfc3339, BlobRecord, FileBlobStore, LayerRecord, LegacyImportReport, ManifestRecord,
-    OciDirImport, RefConflictPolicy, RefUpdate, SqliteIndexStore,
+    FileBlobStore, LegacyImportReport, OciDirImport, RefConflictPolicy, RefUpdate,
+    SqliteIndexStore,
 };
 use crate::artifact::{media_types, ImageRef, StagedArtifactBlob};
 use anyhow::{ensure, Context, Result};
@@ -213,79 +213,36 @@ impl LocalRegistry {
         }
 
         // Stage 1: write CAS bytes (idempotent, outside any SQLite tx).
-        // Stage 2: a single SQLite transaction covers all blob records
-        // + manifest + ref so a crash or conflict can never leave
-        // committed manifest / blob rows under a ref that wasn't
-        // actually published.
-        //
-        let mut blob_records = Vec::with_capacity(blobs.len() + 1);
+        // Stage 2: publish only the OCI manifest descriptor into the
+        // SQLite ref index. If stage 2 conflicts or crashes, the CAS
+        // may contain unreferenced bytes; that is the expected state
+        // for GC, not an index-storage cache entry.
         for blob in blobs {
-            blob_records.push(self.stage_blob_record(blob.descriptor(), blob.bytes())?);
+            self.stage_blob(blob.descriptor(), blob.bytes())?;
         }
-        blob_records.push(self.stage_blob_record(manifest_descriptor, manifest_bytes)?);
+        self.stage_blob(manifest_descriptor, manifest_bytes)?;
 
-        let layer_records = manifest
-            .layers()
-            .iter()
-            .enumerate()
-            .map(|(position, layer)| -> Result<LayerRecord> {
-                Ok(LayerRecord {
-                    manifest_digest: manifest_digest.clone(),
-                    position: u32::try_from(position)
-                        .context("Layer position does not fit in u32")?,
-                    digest: layer.digest().to_string(),
-                    media_type: layer.media_type().to_string(),
-                    size: layer.size(),
-                    annotations_json: annotations_json(layer.annotations().as_ref())
-                        .context("Failed to encode layer annotations")?,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let manifest_record = ManifestRecord {
-            digest: manifest_digest.clone(),
-            media_type: manifest_descriptor.media_type().to_string(),
-            size: manifest_descriptor.size(),
-            subject_digest: manifest
-                .subject()
-                .as_ref()
-                .map(|subject| subject.digest().to_string()),
-            annotations_json: annotations_json(manifest.annotations().as_ref())
-                .context("Failed to encode manifest annotations")?,
-            created_at: now_rfc3339(),
-        };
-
-        let outcome = self.index.publish_artifact_atomic(
-            &blob_records,
-            &manifest_record,
-            &layer_records,
-            Some(image_name),
-            policy,
-        )?;
-        outcome.ref_update.context(
-            "publish_artifact_atomic returned no RefUpdate for an explicit image_name; \
-             this is a bug",
-        )
+        self.index
+            .put_image_ref_with_policy(image_name, manifest_descriptor, policy)
     }
 
-    /// CAS-write a descriptor's bytes and produce a [`BlobRecord`] for
-    /// the IndexStore. The DB row is *not* inserted here; the caller
-    /// passes the records to [`SqliteIndexStore::publish_artifact_atomic`]
-    /// so the inserts happen inside the publish transaction.
-    fn stage_blob_record(&self, descriptor: &Descriptor, bytes: &[u8]) -> Result<BlobRecord> {
-        let record = self.blobs.put_bytes(bytes)?;
+    /// CAS-write a descriptor's bytes and verify the concrete bytes
+    /// match the descriptor the manifest will reference.
+    fn stage_blob(&self, descriptor: &Descriptor, bytes: &[u8]) -> Result<()> {
+        let digest = self.blobs.put_bytes(bytes)?;
         ensure!(
-            record.digest == descriptor.digest().to_string(),
+            digest == descriptor.digest().to_string(),
             "Descriptor digest mismatch: descriptor={}, actual={}",
             descriptor.digest(),
-            record.digest
+            digest
         );
         ensure!(
-            record.size == descriptor.size(),
+            bytes.len() as u64 == descriptor.size(),
             "Descriptor size mismatch for {}: descriptor={}, actual={}",
             descriptor.digest(),
             descriptor.size(),
-            record.size
+            bytes.len()
         );
-        Ok(record)
+        Ok(())
     }
 }

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::artifact::{media_types, ImageRef, StagedArtifactBlob};
 use anyhow::{ensure, Context, Result};
-use oci_spec::image::{Descriptor, ImageManifest, MediaType};
+use oci_spec::image::{Descriptor, Digest, ImageManifest, MediaType};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
@@ -69,7 +69,7 @@ impl LocalRegistry {
         import_legacy_local_registry_with_policy(&self.index, &self.blobs, &self.root, policy)
     }
 
-    pub fn resolve_image_name(&self, image_name: &ImageRef) -> Result<Option<String>> {
+    pub fn resolve_image_name(&self, image_name: &ImageRef) -> Result<Option<Digest>> {
         self.index.resolve_image_name(image_name)
     }
 
@@ -194,19 +194,17 @@ impl LocalRegistry {
             );
         }
 
-        let manifest_digest = manifest_descriptor.digest().to_string();
-
         // Pre-check: under `KeepExisting`, return the conflict before
         // we waste any CAS writes. The atomic publish in stage 2
         // re-validates the same condition inside the SQLite
         // transaction, so concurrent racers can't slip through; this
         // is purely a fast path for the common single-writer case.
         if policy == RefConflictPolicy::KeepExisting {
-            if let Some(existing_manifest_digest) = self.resolve_image_name(image_name)? {
-                if existing_manifest_digest != manifest_digest.as_str() {
+            if let Some(existing_descriptor) = self.index.resolve_image_descriptor(image_name)? {
+                if existing_descriptor.digest() != manifest_descriptor.digest() {
                     return Ok(RefUpdate::Conflicted {
-                        existing_manifest_digest,
-                        incoming_manifest_digest: manifest_digest,
+                        existing_manifest_digest: existing_descriptor.digest().clone(),
+                        incoming_manifest_digest: manifest_descriptor.digest().clone(),
                     });
                 }
             }
@@ -231,7 +229,7 @@ impl LocalRegistry {
     fn stage_blob(&self, descriptor: &Descriptor, bytes: &[u8]) -> Result<()> {
         let digest = self.blobs.put_bytes(bytes)?;
         ensure!(
-            digest == descriptor.digest().to_string(),
+            &digest == descriptor.digest(),
             "Descriptor digest mismatch: descriptor={}, actual={}",
             descriptor.digest(),
             digest

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -45,8 +45,7 @@ fn file_blob_store_round_trip() -> Result<()> {
     );
     assert!(store.exists(&digest)?);
     assert_eq!(store.read_bytes(&digest)?, b"hello");
-    assert!(store.path_for_digest("sha256:../../outside").is_err());
-    assert!(store.exists("sha256:../../outside").is_err());
+    assert!(Digest::from_str("sha256:../../outside").is_err());
     Ok(())
 }
 
@@ -179,7 +178,7 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
         Some(imported.manifest_digest.clone())
     );
     assert!(blob_store.exists(&imported.manifest_digest)?);
-    assert!(blob_store.exists(layer.digest().as_ref())?);
+    assert!(blob_store.exists(layer.digest())?);
 
     // Strict identity: the manifest bytes the v3 BlobStore returns must
     // be exactly the bytes that lived in the legacy OCI dir. Digest
@@ -201,7 +200,7 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
         legacy_manifest_bytes.len() as u64
     );
     assert_eq!(
-        blob_store.read_bytes(layer.digest().as_ref())?.len() as u64,
+        blob_store.read_bytes(layer.digest())?.len() as u64,
         layer.size()
     );
 
@@ -217,7 +216,7 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
         OCI_IMAGE_MANIFEST_MEDIA_TYPE
     );
     assert_eq!(artifact.layers()?, vec![layer.clone()]);
-    assert_eq!(artifact.get_blob(layer.digest().as_ref())?, b"instance");
+    assert_eq!(artifact.get_blob(layer.digest())?, b"instance");
     Ok(())
 }
 
@@ -500,16 +499,16 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
         manifest.layers()[0].media_type(),
         &media_types::v1_instance()
     );
-    assert_eq!(artifact.get_blob(layer.digest().as_ref())?, b"instance");
+    assert_eq!(artifact.get_blob(layer.digest())?, b"instance");
 
     // Empty config blob must be readable from the registry CAS.
     assert_eq!(
-        artifact.get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?,
+        artifact.get_blob(&Digest::from_str(media_types::OCI_EMPTY_CONFIG_DIGEST)?)?,
         media_types::OCI_EMPTY_CONFIG_BYTES
     );
     assert!(registry
         .blobs()
-        .exists(media_types::OCI_EMPTY_CONFIG_DIGEST)?);
+        .exists(&Digest::from_str(media_types::OCI_EMPTY_CONFIG_DIGEST)?)?);
     Ok(())
 }
 
@@ -529,7 +528,7 @@ fn local_registry_build_keep_existing_skips_conflicting_manifest() -> Result<()>
         registry.resolve_image_name(&image_name)?,
         Some(first.manifest_digest().clone())
     );
-    assert!(!registry.blobs().exists(second_blob.digest().as_ref())?);
+    assert!(!registry.blobs().exists(second_blob.digest())?);
     Ok(())
 }
 
@@ -739,12 +738,12 @@ fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
 
     assert_eq!(imported.image_name, Some(image_name.clone()));
     assert!(blob_store.exists(&imported.manifest_digest)?);
-    assert!(blob_store.exists(layer_descriptor.digest().as_ref())?);
+    assert!(blob_store.exists(layer_descriptor.digest())?);
 
     // OMMX-specific config blob is preserved in the BlobStore.
-    let config_digest_str = config_descriptor.digest().to_string();
-    assert!(blob_store.exists(&config_digest_str)?);
-    assert_eq!(blob_store.read_bytes(&config_digest_str)?, v2_config_bytes);
+    let config_digest = config_descriptor.digest();
+    assert!(blob_store.exists(config_digest)?);
+    assert_eq!(blob_store.read_bytes(config_digest)?, v2_config_bytes);
 
     // LocalArtifact reads the legacy manifest (parse-time check is on
     // artifactType only, so the OMMX-specific config is not rejected).
@@ -860,8 +859,8 @@ fn concurrent_blob_writes_publish_one_complete_blob() -> Result<()> {
         .map(|handle| handle.join().expect("blob writer thread panicked"))
         .collect::<Result<_>>()?;
 
-    let digest = sha256_digest(&bytes);
-    assert!(records.iter().all(|record| record.as_ref() == digest));
+    let digest = Digest::from_str(&sha256_digest(&bytes))?;
+    assert!(records.iter().all(|record| record == &digest));
     let store = FileBlobStore::open(&root)?;
     assert_eq!(store.read_bytes(&digest)?, bytes);
     Ok(())
@@ -1116,7 +1115,7 @@ fn pull_image_does_not_short_circuit_when_manifest_blob_is_missing() -> Result<(
 
     // Simulate corruption: remove the manifest blob file under the
     // FileBlobStore while keeping the SQLite ref intact.
-    let manifest_digest = local_artifact.manifest_digest().to_string();
+    let manifest_digest = local_artifact.manifest_digest().clone();
     let blob_path = registry.blobs().path_for_digest(&manifest_digest)?;
     std::fs::remove_file(&blob_path)
         .with_context(|| format!("Failed to remove manifest blob at {}", blob_path.display()))?;

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -53,7 +53,7 @@ fn file_blob_store_round_trip() -> Result<()> {
 fn sqlite_index_store_round_trip() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let store = SqliteIndexStore::open(dir.path().join(SQLITE_INDEX_FILE_NAME))?;
-    assert_eq!(store.schema_version()?, 3);
+    assert_eq!(store.schema_version()?, 1);
 
     let manifest_descriptor = test_manifest_descriptor(b"manifest")?;
     store.put_ref(

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -4,7 +4,7 @@ use crate::artifact::{
     OCI_IMAGE_MANIFEST_MEDIA_TYPE,
 };
 use anyhow::{Context, Result};
-use oci_spec::image::{Descriptor, DescriptorBuilder, ImageManifestBuilder, MediaType};
+use oci_spec::image::{Descriptor, DescriptorBuilder, Digest, ImageManifestBuilder, MediaType};
 use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -37,14 +37,14 @@ fn save_test_archive(
 fn file_blob_store_round_trip() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let store = FileBlobStore::open(dir.path().join("blobs"))?;
-    let record = store.put_bytes(b"hello")?;
+    let digest = store.put_bytes(b"hello")?;
 
     assert_eq!(
-        record.digest,
+        digest,
         "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     );
-    assert!(store.exists(&record.digest)?);
-    assert_eq!(store.read_bytes(&record.digest)?, b"hello");
+    assert!(store.exists(&digest)?);
+    assert_eq!(store.read_bytes(&digest)?, b"hello");
     assert!(store.path_for_digest("sha256:../../outside").is_err());
     assert!(store.exists("sha256:../../outside").is_err());
     Ok(())
@@ -54,61 +54,34 @@ fn file_blob_store_round_trip() -> Result<()> {
 fn sqlite_index_store_round_trip() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let store = SqliteIndexStore::open(dir.path().join(SQLITE_INDEX_FILE_NAME))?;
-    assert_eq!(store.schema_version()?, 2);
+    assert_eq!(store.schema_version()?, 3);
 
-    let manifest_digest = sha256_digest(b"manifest");
-    let layer_digest = sha256_digest(b"layer");
-
-    store.put_blob(&BlobRecord {
-        digest: manifest_digest.clone(),
-        size: b"manifest".len() as u64,
-        last_verified_at: None,
-    })?;
-    store.put_blob(&BlobRecord {
-        digest: layer_digest.clone(),
-        size: b"layer".len() as u64,
-        last_verified_at: None,
-    })?;
-
-    let manifest = ManifestRecord {
-        digest: manifest_digest.clone(),
-        media_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
-        size: b"manifest".len() as u64,
-        subject_digest: None,
-        annotations_json: "{}".to_string(),
-        created_at: now_rfc3339(),
-    };
-    let layers = [LayerRecord {
-        manifest_digest: manifest_digest.clone(),
-        position: 0,
-        digest: layer_digest.clone(),
-        media_type: "application/octet-stream".to_string(),
-        size: b"layer".len() as u64,
-        annotations_json: "{}".to_string(),
-    }];
-    store.put_manifest(&manifest, &layers)?;
-    store.put_ref("example.com/ommx/experiment", "latest", &manifest_digest)?;
-
-    assert_eq!(
-        store.get_blob(&layer_digest)?.unwrap().size,
-        b"layer".len() as u64
-    );
-    assert_eq!(
-        store.get_manifest(&manifest_digest)?.unwrap().media_type,
-        "application/vnd.oci.image.manifest.v1+json"
-    );
-    let stored_layers = store.get_layers(&manifest_digest)?;
-    assert_eq!(stored_layers, layers);
+    let manifest_descriptor = test_manifest_descriptor(b"manifest")?;
+    store.put_ref(
+        "example.com/ommx/experiment",
+        "latest",
+        &manifest_descriptor,
+    )?;
     assert_eq!(
         store.resolve_ref("example.com/ommx/experiment", "latest")?,
-        Some(manifest_digest.clone())
+        Some(manifest_descriptor.clone())
     );
     let refs = store.list_refs(Some("example.com/ommx"))?;
     assert_eq!(refs.len(), 1);
     assert_eq!(refs[0].reference, "latest");
+    assert_eq!(refs[0].descriptor, manifest_descriptor);
 
-    store.put_ref("example.com/foo_bar/experiment", "latest", &manifest_digest)?;
-    store.put_ref("example.com/fooXbar/experiment", "latest", &manifest_digest)?;
+    let manifest_descriptor = test_manifest_descriptor(b"other-manifest")?;
+    store.put_ref(
+        "example.com/foo_bar/experiment",
+        "latest",
+        &manifest_descriptor,
+    )?;
+    store.put_ref(
+        "example.com/fooXbar/experiment",
+        "latest",
+        &manifest_descriptor,
+    )?;
     let refs = store.list_refs(Some("example.com/foo_bar"))?;
     assert_eq!(refs.len(), 1);
     assert_eq!(refs[0].name, "example.com/foo_bar/experiment");
@@ -122,20 +95,22 @@ fn concurrent_keep_existing_ref_publish_keeps_one_digest() -> Result<()> {
     let index_store = SqliteIndexStore::open_in_registry_root(&root)?;
     let blob_store = FileBlobStore::open_in_registry_root(&root)?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:race")?;
-    let first_digest = put_test_manifest(&index_store, &blob_store, b"first-manifest")?;
-    let second_digest = put_test_manifest(&index_store, &blob_store, b"second-manifest")?;
+    let first_descriptor = put_test_manifest(&index_store, &blob_store, b"first-manifest")?;
+    let second_descriptor = put_test_manifest(&index_store, &blob_store, b"second-manifest")?;
+    let first_digest = first_descriptor.digest().to_string();
+    let second_digest = second_descriptor.digest().to_string();
     assert_ne!(first_digest, second_digest);
 
-    let handles: Vec<_> = [first_digest.clone(), second_digest.clone()]
+    let handles: Vec<_> = [first_descriptor.clone(), second_descriptor.clone()]
         .into_iter()
-        .map(|manifest_digest| {
+        .map(|manifest_descriptor| {
             let root = root.clone();
             let image_name = image_name.clone();
             std::thread::spawn(move || -> Result<RefUpdate> {
                 let index_store = SqliteIndexStore::open_in_registry_root(root)?;
                 index_store.put_image_ref_with_policy(
                     &image_name,
-                    &manifest_digest,
+                    &manifest_descriptor,
                     RefConflictPolicy::KeepExisting,
                 )
             })
@@ -215,21 +190,22 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
         legacy_manifest_bytes
     );
 
-    let manifest = index_store
-        .get_manifest(&imported.manifest_digest)?
-        .context("Imported manifest is missing")?;
-    assert_eq!(manifest.media_type, OCI_IMAGE_MANIFEST_MEDIA_TYPE);
-    let manifest_blob = index_store
-        .get_blob(&manifest.digest)?
-        .context("Imported manifest blob is missing")?;
-    assert_eq!(manifest_blob.size, legacy_manifest_bytes.len() as u64);
-    let layers = index_store.get_layers(&imported.manifest_digest)?;
-    assert_eq!(layers.len(), 1);
-    assert_eq!(layers[0].digest, layer.digest().to_string());
-    let layer_blob = index_store
-        .get_blob(&layers[0].digest)?
-        .context("Imported layer blob is missing")?;
-    assert_eq!(layer_blob.size, layer.size());
+    let manifest_descriptor = index_store
+        .resolve_image_descriptor(&image_name)?
+        .context("Imported ref descriptor is missing")?;
+    assert_eq!(manifest_descriptor.media_type(), &MediaType::ImageManifest);
+    assert_eq!(
+        manifest_descriptor.digest().to_string(),
+        imported.manifest_digest
+    );
+    assert_eq!(
+        manifest_descriptor.size(),
+        legacy_manifest_bytes.len() as u64
+    );
+    assert_eq!(
+        blob_store.read_bytes(layer.digest().as_ref())?.len() as u64,
+        layer.size()
+    );
 
     let artifact = LocalArtifact::open_in_registry(
         Arc::new(LocalRegistry::open(&registry_root)?),
@@ -457,7 +433,15 @@ fn local_registry_imports_legacy_refs_when_requested() -> Result<()> {
         .resolve_image_name(&image_name)?
         .context("Legacy local registry ref was not imported")?;
     assert!(registry.blobs().exists(&imported_digest)?);
-    assert!(registry.index().get_manifest(&imported_digest)?.is_some());
+    assert_eq!(
+        registry
+            .index()
+            .resolve_image_descriptor(&image_name)?
+            .context("Legacy local registry descriptor was not imported")?
+            .digest()
+            .to_string(),
+        imported_digest
+    );
     Ok(())
 }
 
@@ -480,15 +464,15 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
         .first()
         .context("Published layer is missing")?;
 
-    let manifest_record = registry
+    let manifest_descriptor = registry
         .index()
-        .get_manifest(&manifest_digest)?
-        .context("Published manifest is missing")?;
-    assert_eq!(manifest_record.media_type, OCI_IMAGE_MANIFEST_MEDIA_TYPE);
-    assert_eq!(manifest_record.size, manifest_bytes.len() as u64);
+        .resolve_image_descriptor(&image_name)?
+        .context("Published manifest descriptor is missing")?;
+    assert_eq!(manifest_descriptor.media_type(), &MediaType::ImageManifest);
+    assert_eq!(manifest_descriptor.size(), manifest_bytes.len() as u64);
     // Manifest's own `mediaType` field is left unset to match the v2 /
-    // ArchiveArtifactBuilder shape; the IndexStore record's `media_type`
-    // column carries the format for query / dispatch purposes.
+    // ArchiveArtifactBuilder shape; the ref descriptor carries the
+    // format for query / dispatch purposes.
     assert_eq!(manifest.media_type().as_ref(), None);
     assert_eq!(
         manifest.artifact_type().as_ref(),
@@ -513,26 +497,22 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
         &MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string())
     );
 
-    let layers = registry.index().get_layers(&manifest_digest)?;
-    assert_eq!(layers.len(), 1);
-    assert_eq!(layers[0].digest, layer.digest().to_string());
-    assert_eq!(layers[0].media_type, media_types::V1_INSTANCE_MEDIA_TYPE);
+    assert_eq!(manifest.layers().len(), 1);
+    assert_eq!(manifest.layers()[0].digest(), layer.digest());
+    assert_eq!(
+        manifest.layers()[0].media_type(),
+        &media_types::v1_instance()
+    );
     assert_eq!(artifact.get_blob(layer.digest().as_ref())?, b"instance");
 
-    // Empty config blob must be readable from the registry and present
-    // in the blob index.
+    // Empty config blob must be readable from the registry CAS.
     assert_eq!(
         artifact.get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?,
         media_types::OCI_EMPTY_CONFIG_BYTES
     );
-    let config_record = registry
-        .index()
-        .get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?
-        .context("Empty config blob record is missing")?;
-    assert_eq!(
-        config_record.size,
-        media_types::OCI_EMPTY_CONFIG_BYTES.len() as u64
-    );
+    assert!(registry
+        .blobs()
+        .exists(media_types::OCI_EMPTY_CONFIG_DIGEST)?);
     Ok(())
 }
 
@@ -764,14 +744,9 @@ fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
     assert!(blob_store.exists(&imported.manifest_digest)?);
     assert!(blob_store.exists(layer_descriptor.digest().as_ref())?);
 
-    // OMMX-specific config blob is preserved in the BlobStore and blob
-    // index.
+    // OMMX-specific config blob is preserved in the BlobStore.
     let config_digest_str = config_descriptor.digest().to_string();
     assert!(blob_store.exists(&config_digest_str)?);
-    let config_blob = index_store
-        .get_blob(&config_digest_str)?
-        .context("Imported config blob is missing")?;
-    assert_eq!(config_blob.size, v2_config_bytes.len() as u64);
     assert_eq!(blob_store.read_bytes(&config_digest_str)?, v2_config_bytes);
 
     // LocalArtifact reads the legacy manifest (parse-time check is on
@@ -876,7 +851,7 @@ fn concurrent_blob_writes_publish_one_complete_blob() -> Result<()> {
         .map(|_| {
             let root = root.clone();
             let bytes = bytes.clone();
-            std::thread::spawn(move || -> Result<BlobRecord> {
+            std::thread::spawn(move || -> Result<String> {
                 let store = FileBlobStore::open(root)?;
                 store.put_bytes(&bytes)
             })
@@ -889,7 +864,7 @@ fn concurrent_blob_writes_publish_one_complete_blob() -> Result<()> {
         .collect::<Result<_>>()?;
 
     let digest = sha256_digest(&bytes);
-    assert!(records.iter().all(|record| record.digest == digest));
+    assert!(records.iter().all(|record| record == &digest));
     let store = FileBlobStore::open(&root)?;
     assert_eq!(store.read_bytes(&digest)?, bytes);
     Ok(())
@@ -1295,30 +1270,31 @@ fn put_test_manifest_ref(
     image_name: &ImageRef,
     bytes: &[u8],
 ) -> Result<String> {
-    let digest = put_test_manifest(index_store, blob_store, bytes)?;
-    index_store.put_image_ref(image_name, &digest)?;
-    Ok(digest)
+    let descriptor = put_test_manifest(index_store, blob_store, bytes)?;
+    index_store.put_image_ref(image_name, &descriptor)?;
+    Ok(descriptor.digest().to_string())
 }
 
 fn put_test_manifest(
-    index_store: &SqliteIndexStore,
+    _index_store: &SqliteIndexStore,
     blob_store: &FileBlobStore,
     bytes: &[u8],
-) -> Result<String> {
-    let blob = blob_store.put_bytes(bytes)?;
-    index_store.put_blob(&blob)?;
-    index_store.put_manifest(
-        &ManifestRecord {
-            digest: blob.digest.clone(),
-            media_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
-            size: bytes.len() as u64,
-            subject_digest: None,
-            annotations_json: "{}".to_string(),
-            created_at: now_rfc3339(),
-        },
-        &[],
-    )?;
-    Ok(blob.digest)
+) -> Result<Descriptor> {
+    let digest = blob_store.put_bytes(bytes)?;
+    test_manifest_descriptor_with_digest(&digest, bytes.len() as u64)
+}
+
+fn test_manifest_descriptor(bytes: &[u8]) -> Result<Descriptor> {
+    test_manifest_descriptor_with_digest(&sha256_digest(bytes), bytes.len() as u64)
+}
+
+fn test_manifest_descriptor_with_digest(digest: &str, size: u64) -> Result<Descriptor> {
+    DescriptorBuilder::default()
+        .media_type(MediaType::ImageManifest)
+        .digest(Digest::from_str(digest)?)
+        .size(size)
+        .build()
+        .context("Failed to build test manifest descriptor")
 }
 
 fn build_test_oci_dir(legacy_dir: PathBuf, image_name: ImageRef) -> Result<Descriptor> {

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -40,7 +40,7 @@ fn file_blob_store_round_trip() -> Result<()> {
     let digest = store.put_bytes(b"hello")?;
 
     assert_eq!(
-        digest,
+        digest.as_ref(),
         "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     );
     assert!(store.exists(&digest)?);
@@ -97,8 +97,8 @@ fn concurrent_keep_existing_ref_publish_keeps_one_digest() -> Result<()> {
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:race")?;
     let first_descriptor = put_test_manifest(&index_store, &blob_store, b"first-manifest")?;
     let second_descriptor = put_test_manifest(&index_store, &blob_store, b"second-manifest")?;
-    let first_digest = first_descriptor.digest().to_string();
-    let second_digest = second_descriptor.digest().to_string();
+    let first_digest = first_descriptor.digest().clone();
+    let second_digest = second_descriptor.digest().clone();
     assert_ne!(first_digest, second_digest);
 
     let handles: Vec<_> = [first_descriptor.clone(), second_descriptor.clone()]
@@ -160,6 +160,7 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
     // Snapshot the original legacy manifest bytes so we can assert
     // byte-for-byte equality with what ends up in the v3 BlobStore.
     let (legacy_algorithm, legacy_encoded) = expected_digest
+        .as_ref()
         .split_once(':')
         .expect("manifest digest is `algorithm:encoded`");
     let legacy_manifest_bytes = std::fs::read(
@@ -194,10 +195,7 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
         .resolve_image_descriptor(&image_name)?
         .context("Imported ref descriptor is missing")?;
     assert_eq!(manifest_descriptor.media_type(), &MediaType::ImageManifest);
-    assert_eq!(
-        manifest_descriptor.digest().to_string(),
-        imported.manifest_digest
-    );
+    assert_eq!(manifest_descriptor.digest(), &imported.manifest_digest);
     assert_eq!(
         manifest_descriptor.size(),
         legacy_manifest_bytes.len() as u64
@@ -328,7 +326,7 @@ fn imports_legacy_docker_hub_short_name_via_normalisation_shim() -> Result<()> {
             .resolve_image_name(&parsed)?
             .with_context(|| format!("post-import resolve missed for spelling {spelling}"))?;
         assert!(
-            resolved.starts_with("sha256:"),
+            resolved.as_ref().starts_with("sha256:"),
             "resolved digest must be sha256 for {spelling}, got {resolved}",
         );
     }
@@ -438,9 +436,8 @@ fn local_registry_imports_legacy_refs_when_requested() -> Result<()> {
             .index()
             .resolve_image_descriptor(&image_name)?
             .context("Legacy local registry descriptor was not imported")?
-            .digest()
-            .to_string(),
-        imported_digest
+            .digest(),
+        &imported_digest
     );
     Ok(())
 }
@@ -456,7 +453,7 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
     let manifest_digest = registry
         .resolve_image_name(&image_name)?
         .context("Published ref is missing")?;
-    assert_eq!(manifest_digest, artifact.manifest_digest());
+    assert_eq!(&manifest_digest, artifact.manifest_digest());
     let manifest_bytes = registry.blobs().read_bytes(&manifest_digest)?;
     let manifest: oci_spec::image::ImageManifest = serde_json::from_slice(&manifest_bytes)?;
     let layer = manifest
@@ -530,7 +527,7 @@ fn local_registry_build_keep_existing_skips_conflicting_manifest() -> Result<()>
     assert!(error.to_string().contains("already points to"));
     assert_eq!(
         registry.resolve_image_name(&image_name)?,
-        Some(first.manifest_digest().to_string())
+        Some(first.manifest_digest().clone())
     );
     assert!(!registry.blobs().exists(second_blob.digest().as_ref())?);
     Ok(())
@@ -835,7 +832,7 @@ fn concurrent_publish_different_digests_keeps_one_winner() -> Result<()> {
         .resolve_image_name(&image_name)?
         .context("ref disappeared after concurrent publish")?;
     assert!(
-        !resolved.is_empty(),
+        !resolved.as_ref().is_empty(),
         "ref must still resolve to the winning manifest digest"
     );
     Ok(())
@@ -851,7 +848,7 @@ fn concurrent_blob_writes_publish_one_complete_blob() -> Result<()> {
         .map(|_| {
             let root = root.clone();
             let bytes = bytes.clone();
-            std::thread::spawn(move || -> Result<String> {
+            std::thread::spawn(move || -> Result<Digest> {
                 let store = FileBlobStore::open(root)?;
                 store.put_bytes(&bytes)
             })
@@ -864,7 +861,7 @@ fn concurrent_blob_writes_publish_one_complete_blob() -> Result<()> {
         .collect::<Result<_>>()?;
 
     let digest = sha256_digest(&bytes);
-    assert!(records.iter().all(|record| record == &digest));
+    assert!(records.iter().all(|record| record.as_ref() == digest));
     let store = FileBlobStore::open(&root)?;
     assert_eq!(store.read_bytes(&digest)?, bytes);
     Ok(())
@@ -899,7 +896,7 @@ fn import_oci_archive_surfaces_digest_conflict_for_same_ref() -> Result<()> {
         .expect_err("second import with a different manifest digest must surface a conflict");
     let msg = err.to_string();
     assert!(
-        msg.contains(&digest_a),
+        msg.contains(digest_a.as_ref()),
         "conflict message should mention archive A's existing digest, got: {msg}",
     );
     // The "incoming" side of the conflict must be a digest distinct
@@ -1087,7 +1084,7 @@ fn pull_image_short_circuits_when_ref_is_present_with_blob() -> Result<()> {
     let image_name = ImageRef::parse("does-not-resolve.invalid/jij-inc/ommx/demo:short-circuit")?;
     let local_artifact =
         build_test_local_artifact(&registry, &image_name, b"step-c-pull-short-circuit")?;
-    let expected_digest = local_artifact.manifest_digest().to_string();
+    let expected_digest = local_artifact.manifest_digest().clone();
 
     let outcome = super::import::remote::pull_image(&registry, &image_name)?;
     assert_eq!(outcome.image_name.as_ref(), Some(&image_name));
@@ -1163,7 +1160,7 @@ fn local_artifact_save_round_trip_preserves_layers() -> Result<()> {
     // reader, recomputes the manifest digest from its blob payload,
     // and would fail loudly if the bytes drifted — so the digest
     // returned here is exactly the saved bytes' digest.
-    let expected_manifest_digest = local_artifact.manifest_digest().to_string();
+    let expected_manifest_digest = local_artifact.manifest_digest().clone();
     let view = crate::artifact::local_registry::inspect_archive(&archive_path)?;
     assert_eq!(
         view.manifest_digest, expected_manifest_digest,
@@ -1269,10 +1266,10 @@ fn put_test_manifest_ref(
     blob_store: &FileBlobStore,
     image_name: &ImageRef,
     bytes: &[u8],
-) -> Result<String> {
+) -> Result<Digest> {
     let descriptor = put_test_manifest(index_store, blob_store, bytes)?;
     index_store.put_image_ref(image_name, &descriptor)?;
-    Ok(descriptor.digest().to_string())
+    Ok(descriptor.digest().clone())
 }
 
 fn put_test_manifest(
@@ -1281,17 +1278,20 @@ fn put_test_manifest(
     bytes: &[u8],
 ) -> Result<Descriptor> {
     let digest = blob_store.put_bytes(bytes)?;
-    test_manifest_descriptor_with_digest(&digest, bytes.len() as u64)
+    test_manifest_descriptor_with_digest(digest, bytes.len() as u64)
 }
 
 fn test_manifest_descriptor(bytes: &[u8]) -> Result<Descriptor> {
-    test_manifest_descriptor_with_digest(&sha256_digest(bytes), bytes.len() as u64)
+    test_manifest_descriptor_with_digest(
+        Digest::from_str(&sha256_digest(bytes))?,
+        bytes.len() as u64,
+    )
 }
 
-fn test_manifest_descriptor_with_digest(digest: &str, size: u64) -> Result<Descriptor> {
+fn test_manifest_descriptor_with_digest(digest: Digest, size: u64) -> Result<Descriptor> {
     DescriptorBuilder::default()
         .media_type(MediaType::ImageManifest)
-        .digest(Digest::from_str(digest)?)
+        .digest(digest)
         .size(size)
         .build()
         .context("Failed to build test manifest descriptor")

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -221,6 +221,54 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
 }
 
 #[test]
+fn imports_oci_dir_preserves_index_descriptor_annotations() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let oci_dir = dir.path().join("oci-dir");
+    let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:descriptor-annotation")?;
+    let mut builder = TestOciDirBuilder::new(oci_dir.clone(), Some(image_name.clone()))?;
+    builder.add_index_descriptor_annotation("org.ommx.test.descriptor", "preserved");
+
+    let config = builder.add_empty_json()?;
+    let (layer_digest, layer_size) = builder.add_blob(b"instance")?;
+    let layer = DescriptorBuilder::default()
+        .media_type(media_types::v1_instance())
+        .digest(layer_digest)
+        .size(layer_size)
+        .build()?;
+    let manifest = ImageManifestBuilder::default()
+        .schema_version(2_u32)
+        .artifact_type(media_types::v1_artifact())
+        .config(config)
+        .layers(vec![layer])
+        .build()?;
+    builder.finish(manifest)?;
+
+    let registry_root = dir.path().join("registry");
+    let index_store = SqliteIndexStore::open_in_registry_root(&registry_root)?;
+    let blob_store = FileBlobStore::open_in_registry_root(&registry_root)?;
+    import_oci_dir(&index_store, &blob_store, &oci_dir)?;
+
+    let descriptor = index_store
+        .resolve_image_descriptor(&image_name)?
+        .context("Imported ref descriptor is missing")?;
+    let annotations = descriptor
+        .annotations()
+        .as_ref()
+        .context("Imported ref descriptor should preserve index.json descriptor annotations")?;
+    assert_eq!(
+        annotations
+            .get("org.ommx.test.descriptor")
+            .map(String::as_str),
+        Some("preserved")
+    );
+    assert_eq!(
+        annotations.get(OCI_IMAGE_REF_NAME_ANNOTATION),
+        Some(&image_name.to_string())
+    );
+    Ok(())
+}
+
+#[test]
 fn imports_legacy_local_registry_explicitly() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let legacy_registry_root = dir.path().join("legacy-registry");
@@ -723,7 +771,7 @@ fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
     // the v3 builder's OCI 1.1 empty descriptor). v3 import / read must
     // preserve such manifests verbatim: parse-time check is artifactType
     // only (no config-shape requirement), and the config blob lands in
-    // both the BlobStore and blob index.
+    // the BlobStore.
     let dir = tempfile::tempdir()?;
     let legacy_dir = dir.path().join("v2-legacy");
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:v2-config")?;
@@ -1363,6 +1411,7 @@ fn build_test_oci_dir_with_v2_config(
 struct TestOciDirBuilder {
     oci_dir_root: PathBuf,
     ref_name_annotation: Option<String>,
+    index_descriptor_annotations: HashMap<String, String>,
     is_finished: bool,
 }
 
@@ -1394,8 +1443,14 @@ impl TestOciDirBuilder {
         Ok(Self {
             oci_dir_root,
             ref_name_annotation,
+            index_descriptor_annotations: HashMap::new(),
             is_finished: false,
         })
+    }
+
+    fn add_index_descriptor_annotation(&mut self, key: &str, value: &str) {
+        self.index_descriptor_annotations
+            .insert(key.to_string(), value.to_string());
     }
 
     fn add_blob(&mut self, data: &[u8]) -> Result<(oci_spec::image::Digest, u64)> {
@@ -1429,12 +1484,14 @@ impl TestOciDirBuilder {
             .media_type(MediaType::ImageManifest)
             .size(size)
             .digest(digest);
+        let mut annotations = self.index_descriptor_annotations.clone();
         if let Some(name) = &self.ref_name_annotation {
-            let mut annotations = HashMap::new();
             annotations.insert(
                 "org.opencontainers.image.ref.name".to_string(),
                 name.clone(),
             );
+        }
+        if !annotations.is_empty() {
             descriptor_builder = descriptor_builder.annotations(annotations);
         }
         let descriptor = descriptor_builder.build()?;

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -54,7 +54,7 @@ fn file_blob_store_round_trip() -> Result<()> {
 fn sqlite_index_store_round_trip() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let store = SqliteIndexStore::open(dir.path().join(SQLITE_INDEX_FILE_NAME))?;
-    assert_eq!(store.schema_version()?, 1);
+    assert_eq!(store.schema_version()?, 2);
 
     let manifest_digest = sha256_digest(b"manifest");
     let layer_digest = sha256_digest(b"layer");
@@ -62,17 +62,11 @@ fn sqlite_index_store_round_trip() -> Result<()> {
     store.put_blob(&BlobRecord {
         digest: manifest_digest.clone(),
         size: b"manifest".len() as u64,
-        media_type: Some("application/vnd.oci.image.manifest.v1+json".to_string()),
-        storage_uri: "blobs/sha256/manifest".to_string(),
-        kind: BLOB_KIND_MANIFEST.to_string(),
         last_verified_at: None,
     })?;
     store.put_blob(&BlobRecord {
         digest: layer_digest.clone(),
         size: b"layer".len() as u64,
-        media_type: Some("application/octet-stream".to_string()),
-        storage_uri: "blobs/sha256/layer".to_string(),
-        kind: BLOB_KIND_LAYER.to_string(),
         last_verified_at: None,
     })?;
 
@@ -95,7 +89,10 @@ fn sqlite_index_store_round_trip() -> Result<()> {
     store.put_manifest(&manifest, &layers)?;
     store.put_ref("example.com/ommx/experiment", "latest", &manifest_digest)?;
 
-    assert_eq!(store.get_blob(&layer_digest)?.unwrap().kind, "layer");
+    assert_eq!(
+        store.get_blob(&layer_digest)?.unwrap().size,
+        b"layer".len() as u64
+    );
     assert_eq!(
         store.get_manifest(&manifest_digest)?.unwrap().media_type,
         "application/vnd.oci.image.manifest.v1+json"
@@ -225,14 +222,14 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
     let manifest_blob = index_store
         .get_blob(&manifest.digest)?
         .context("Imported manifest blob is missing")?;
-    assert_eq!(manifest_blob.kind, BLOB_KIND_MANIFEST);
+    assert_eq!(manifest_blob.size, legacy_manifest_bytes.len() as u64);
     let layers = index_store.get_layers(&imported.manifest_digest)?;
     assert_eq!(layers.len(), 1);
     assert_eq!(layers[0].digest, layer.digest().to_string());
     let layer_blob = index_store
         .get_blob(&layers[0].digest)?
         .context("Imported layer blob is missing")?;
-    assert_eq!(layer_blob.kind, BLOB_KIND_BLOB);
+    assert_eq!(layer_blob.size, layer.size());
 
     let artifact = LocalArtifact::open_in_registry(
         Arc::new(LocalRegistry::open(&registry_root)?),
@@ -522,11 +519,8 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
     assert_eq!(layers[0].media_type, media_types::V1_INSTANCE_MEDIA_TYPE);
     assert_eq!(artifact.get_blob(layer.digest().as_ref())?, b"instance");
 
-    // Empty config blob must be readable from the registry and persisted
-    // with `BLOB_KIND_CONFIG`, matching the OCI dir import path. A
-    // mis-classified config blob (e.g. recorded as `BLOB_KIND_BLOB`)
-    // would break GC reachability analysis and queries that filter by
-    // blob kind.
+    // Empty config blob must be readable from the registry and present
+    // in the blob index.
     assert_eq!(
         artifact.get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?,
         media_types::OCI_EMPTY_CONFIG_BYTES
@@ -535,7 +529,10 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
         .index()
         .get_blob(media_types::OCI_EMPTY_CONFIG_DIGEST)?
         .context("Empty config blob record is missing")?;
-    assert_eq!(config_record.kind, BLOB_KIND_CONFIG);
+    assert_eq!(
+        config_record.size,
+        media_types::OCI_EMPTY_CONFIG_BYTES.len() as u64
+    );
     Ok(())
 }
 
@@ -749,9 +746,8 @@ fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
     // OMMX-specific `application/org.ommx.v1.config+json` (instead of
     // the v3 builder's OCI 1.1 empty descriptor). v3 import / read must
     // preserve such manifests verbatim: parse-time check is artifactType
-    // only (no config-shape requirement), and the config blob lands as
-    // `BLOB_KIND_CONFIG` in the IndexStore so GC reachability and
-    // queries treat it consistently with the v3 empty-config path.
+    // only (no config-shape requirement), and the config blob lands in
+    // both the BlobStore and blob index.
     let dir = tempfile::tempdir()?;
     let legacy_dir = dir.path().join("v2-legacy");
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:v2-config")?;
@@ -768,17 +764,14 @@ fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
     assert!(blob_store.exists(&imported.manifest_digest)?);
     assert!(blob_store.exists(layer_descriptor.digest().as_ref())?);
 
-    // OMMX-specific config blob is preserved with `BLOB_KIND_CONFIG`.
+    // OMMX-specific config blob is preserved in the BlobStore and blob
+    // index.
     let config_digest_str = config_descriptor.digest().to_string();
     assert!(blob_store.exists(&config_digest_str)?);
     let config_blob = index_store
         .get_blob(&config_digest_str)?
         .context("Imported config blob is missing")?;
-    assert_eq!(config_blob.kind, BLOB_KIND_CONFIG);
-    assert_eq!(
-        config_blob.media_type.as_deref(),
-        Some(media_types::V1_CONFIG_MEDIA_TYPE)
-    );
+    assert_eq!(config_blob.size, v2_config_bytes.len() as u64);
     assert_eq!(blob_store.read_bytes(&config_digest_str)?, v2_config_bytes);
 
     // LocalArtifact reads the legacy manifest (parse-time check is on
@@ -1312,9 +1305,7 @@ fn put_test_manifest(
     blob_store: &FileBlobStore,
     bytes: &[u8],
 ) -> Result<String> {
-    let mut blob = blob_store.put_bytes(bytes)?;
-    blob.media_type = Some("application/vnd.oci.image.manifest.v1+json".to_string());
-    blob.kind = BLOB_KIND_MANIFEST.to_string();
+    let blob = blob_store.put_bytes(bytes)?;
     index_store.put_blob(&blob)?;
     index_store.put_manifest(
         &ManifestRecord {

--- a/rust/ommx/src/artifact/local_registry/types.rs
+++ b/rust/ommx/src/artifact/local_registry/types.rs
@@ -2,7 +2,7 @@ pub const SQLITE_INDEX_FILE_NAME: &str = "index.sqlite3";
 pub const FILE_BLOB_STORE_DIR_NAME: &str = "blobs";
 pub const OCI_IMAGE_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
 
-use oci_spec::image::Descriptor;
+use oci_spec::image::{Descriptor, Digest};
 
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -24,10 +24,10 @@ pub enum RefUpdate {
     Inserted,
     Unchanged,
     Replaced {
-        previous_manifest_digest: String,
+        previous_manifest_digest: Digest,
     },
     Conflicted {
-        existing_manifest_digest: String,
-        incoming_manifest_digest: String,
+        existing_manifest_digest: Digest,
+        incoming_manifest_digest: Digest,
     },
 }

--- a/rust/ommx/src/artifact/local_registry/types.rs
+++ b/rust/ommx/src/artifact/local_registry/types.rs
@@ -2,11 +2,6 @@ pub const SQLITE_INDEX_FILE_NAME: &str = "index.sqlite3";
 pub const FILE_BLOB_STORE_DIR_NAME: &str = "blobs";
 pub const OCI_IMAGE_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
 
-pub const BLOB_KIND_BLOB: &str = "blob";
-pub const BLOB_KIND_CONFIG: &str = "config";
-pub const BLOB_KIND_LAYER: &str = "layer";
-pub const BLOB_KIND_MANIFEST: &str = "manifest";
-
 // Record structs reflect SQLite row shapes that are still evolving (we
 // expect to add columns such as a typed `oci_spec::image::Digest`,
 // per-row checksums, etc.). `#[non_exhaustive]` keeps in-crate struct
@@ -18,9 +13,6 @@ pub const BLOB_KIND_MANIFEST: &str = "manifest";
 pub struct BlobRecord {
     pub digest: String,
     pub size: u64,
-    pub media_type: Option<String>,
-    pub storage_uri: String,
-    pub kind: String,
     pub last_verified_at: Option<String>,
 }
 

--- a/rust/ommx/src/artifact/local_registry/types.rs
+++ b/rust/ommx/src/artifact/local_registry/types.rs
@@ -2,49 +2,15 @@ pub const SQLITE_INDEX_FILE_NAME: &str = "index.sqlite3";
 pub const FILE_BLOB_STORE_DIR_NAME: &str = "blobs";
 pub const OCI_IMAGE_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
 
-// Record structs reflect SQLite row shapes that are still evolving (we
-// expect to add columns such as a typed `oci_spec::image::Digest`,
-// per-row checksums, etc.). `#[non_exhaustive]` keeps in-crate struct
-// literal construction working while preventing downstream code from
-// breaking when we add a field.
-
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BlobRecord {
-    pub digest: String,
-    pub size: u64,
-    pub last_verified_at: Option<String>,
-}
-
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ManifestRecord {
-    pub digest: String,
-    pub media_type: String,
-    pub size: u64,
-    pub subject_digest: Option<String>,
-    pub annotations_json: String,
-    pub created_at: String,
-}
+use oci_spec::image::Descriptor;
 
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RefRecord {
     pub name: String,
     pub reference: String,
-    pub manifest_digest: String,
+    pub descriptor: Descriptor,
     pub updated_at: String,
-}
-
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LayerRecord {
-    pub manifest_digest: String,
-    pub position: u32,
-    pub digest: String,
-    pub media_type: String,
-    pub size: u64,
-    pub annotations_json: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -72,7 +72,7 @@ impl StagedArtifactBlob {
 pub struct LocalArtifact {
     registry: Arc<LocalRegistry>,
     image_name: ImageRef,
-    manifest_digest: String,
+    manifest_digest: Digest,
     manifest_cache: Arc<OnceLock<LocalManifest>>,
 }
 
@@ -80,7 +80,7 @@ impl LocalArtifact {
     pub(crate) fn from_parts(
         registry: Arc<LocalRegistry>,
         image_name: ImageRef,
-        manifest_digest: String,
+        manifest_digest: Digest,
     ) -> Self {
         Self {
             registry,
@@ -128,7 +128,7 @@ impl LocalArtifact {
         &self.image_name
     }
 
-    pub fn manifest_digest(&self) -> &str {
+    pub fn manifest_digest(&self) -> &Digest {
         &self.manifest_digest
     }
 
@@ -163,7 +163,7 @@ impl LocalArtifact {
         Ok(self.get_manifest()?.subject())
     }
 
-    pub fn get_blob(&self, digest: &str) -> Result<Vec<u8>> {
+    pub fn get_blob(&self, digest: impl AsRef<str>) -> Result<Vec<u8>> {
         self.registry.blobs().read_bytes(digest)
     }
 }
@@ -440,7 +440,7 @@ impl LocalArtifactBuilder {
         Ok(LocalArtifact::from_parts(
             registry,
             staged.image_name,
-            staged.manifest_descriptor.digest().to_string(),
+            staged.manifest_descriptor.digest().clone(),
         ))
     }
 

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -163,7 +163,7 @@ impl LocalArtifact {
         Ok(self.get_manifest()?.subject())
     }
 
-    pub fn get_blob(&self, digest: impl AsRef<str>) -> Result<Vec<u8>> {
+    pub fn get_blob(&self, digest: &Digest) -> Result<Vec<u8>> {
         self.registry.blobs().read_bytes(digest)
     }
 }

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -147,33 +147,6 @@ impl LocalArtifact {
     }
 
     fn read_manifest_uncached(&self) -> Result<LocalManifest> {
-        // Verify the IndexStore has a manifest record for this digest so a
-        // missing index entry surfaces as a clear "manifest not found"
-        // error instead of bubbling up as a parse failure or stale-cache
-        // hit. The record's `media_type` column is informational for the
-        // common Image Manifest case, but is also used here to detect
-        // entries written by earlier v3-alpha builds (`#864` / `#866`)
-        // as OCI Artifact Manifest and surface a targeted error instead
-        // of an opaque image-manifest parse failure.
-        let record = self
-            .registry
-            .index()
-            .get_manifest(&self.manifest_digest)?
-            .with_context(|| {
-                format!(
-                    "Manifest record {} not found in IndexStore",
-                    self.manifest_digest
-                )
-            })?;
-        if record.media_type != media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE {
-            bail!(
-                "Manifest {} was persisted as `{}`, which is not supported in this build. \
-                 Only OCI Image Manifest (`{}`) is read from the SQLite Local Registry.",
-                self.manifest_digest,
-                record.media_type,
-                media_types::OCI_IMAGE_MANIFEST_MEDIA_TYPE,
-            );
-        }
         let bytes = self.registry.blobs().read_bytes(&self.manifest_digest)?;
         LocalManifest::parse(&bytes)
     }

--- a/rust/ommx/src/artifact/push.rs
+++ b/rust/ommx/src/artifact/push.rs
@@ -38,7 +38,7 @@ impl LocalArtifact {
 
         for descriptor in &blob_descriptors {
             let digest = descriptor.digest().to_string();
-            let bytes = self.get_blob(&digest)?;
+            let bytes = self.get_blob(descriptor.digest())?;
             tracing::debug!(
                 size = bytes.len(),
                 "Pushing blob {digest} of {}",

--- a/rust/ommx/src/artifact/save.rs
+++ b/rust/ommx/src/artifact/save.rs
@@ -20,10 +20,7 @@
 //! `Vec<u8>` allocation with a fixed 64 KB copy buffer; left as a
 //! future refinement.
 
-use super::{
-    local_registry::{ValidatedDigest, OCI_IMAGE_REF_NAME_ANNOTATION},
-    LocalArtifact,
-};
+use super::{local_registry::OCI_IMAGE_REF_NAME_ANNOTATION, LocalArtifact};
 use anyhow::Context;
 use oci_spec::image::{
     Descriptor, DescriptorBuilder, Digest, ImageIndexBuilder, ImageManifest, MediaType,
@@ -34,7 +31,6 @@ use std::{
     fs::OpenOptions,
     io::{BufWriter, Cursor, Write},
     path::Path,
-    str::FromStr,
 };
 use tar::{EntryType, Header};
 
@@ -51,7 +47,7 @@ impl LocalArtifact {
     /// produced archive. Importing the archive back into a fresh
     /// registry round-trips to the same digest.
     pub fn save(&self, output: &Path) -> crate::Result<()> {
-        let manifest_digest = self.manifest_digest().to_string();
+        let manifest_digest = self.manifest_digest().clone();
         let manifest_bytes = self.get_blob(&manifest_digest)?;
         let manifest: ImageManifest = serde_json::from_slice(&manifest_bytes)
             .context("Failed to parse manifest from SQLite Local Registry")?;
@@ -91,26 +87,24 @@ impl LocalArtifact {
         //    contain"), then config, then layers. Order is not
         //    semantically significant — OCI Image Layout readers index
         //    by `blobs/<algorithm>/<encoded>` regardless of tar order.
-        append_blob_entry(&mut tar, &manifest_digest, &manifest_bytes, "manifest")?;
+        append_blob_entry(&mut tar, &manifest_digest, &manifest_bytes)?;
         let config = manifest.config();
-        let config_bytes = self.get_blob(config.digest().as_ref())?;
+        let config_bytes = self.get_blob(config.digest())?;
         verify_blob(config, config_bytes.len(), "config")?;
-        append_blob_entry(&mut tar, config.digest().as_ref(), &config_bytes, "config")?;
+        append_blob_entry(&mut tar, config.digest(), &config_bytes)?;
         for layer in manifest.layers() {
-            let layer_bytes = self.get_blob(layer.digest().as_ref())?;
+            let layer_bytes = self.get_blob(layer.digest())?;
             verify_blob(layer, layer_bytes.len(), "layer")?;
-            append_blob_entry(&mut tar, layer.digest().as_ref(), &layer_bytes, "layer")?;
+            append_blob_entry(&mut tar, layer.digest(), &layer_bytes)?;
         }
 
         // 3. `index.json` — single-entry ImageIndex pointing at the
         //    manifest, annotated with the image ref so the archive can
         //    be imported back under the same name without a side
         //    channel.
-        let manifest_digest_parsed = Digest::from_str(&manifest_digest)
-            .with_context(|| format!("Invalid manifest digest: {manifest_digest}"))?;
         let manifest_descriptor = DescriptorBuilder::default()
             .media_type(MediaType::ImageManifest)
-            .digest(manifest_digest_parsed)
+            .digest(manifest_digest)
             .size(manifest_bytes.len() as u64)
             .annotations({
                 let mut map = HashMap::new();
@@ -164,14 +158,10 @@ fn append_tar_file<W: Write>(
 /// the full `algorithm:encoded` form the manifest stores.
 fn append_blob_entry<W: Write>(
     tar: &mut tar::Builder<W>,
-    digest: &str,
+    digest: &Digest,
     bytes: &[u8],
-    kind: &str,
 ) -> crate::Result<()> {
-    let parsed = ValidatedDigest::parse(digest).with_context(|| {
-        format!("Invalid {kind} digest while writing archive blob entry: {digest}")
-    })?;
-    let path = format!("blobs/{}/{}", parsed.algorithm(), parsed.encoded());
+    let path = format!("blobs/{}/{}", digest.algorithm().as_ref(), digest.digest());
     append_tar_file(tar, &path, bytes)
 }
 

--- a/rust/ommx/src/bin/ommx.rs
+++ b/rust/ommx/src/bin/ommx.rs
@@ -152,10 +152,12 @@ impl ImageRefOrPath {
             // disk. Avoids importing into SQLite for a read-only op.
             ImageRefOrPath::OciDir(path) => {
                 let dir_ref = oci_dir_ref(path)?;
-                let manifest_blob_path = path
-                    .join("blobs")
-                    .join("sha256")
-                    .join(dir_ref.manifest_digest.trim_start_matches("sha256:"));
+                let manifest_blob_path = path.join("blobs").join("sha256").join(
+                    dir_ref
+                        .manifest_digest
+                        .as_ref()
+                        .trim_start_matches("sha256:"),
+                );
                 let bytes = std::fs::read(&manifest_blob_path).with_context(|| {
                     format!(
                         "Failed to read manifest blob at {}",

--- a/rust/ommx/src/bin/ommx.rs
+++ b/rust/ommx/src/bin/ommx.rs
@@ -152,12 +152,10 @@ impl ImageRefOrPath {
             // disk. Avoids importing into SQLite for a read-only op.
             ImageRefOrPath::OciDir(path) => {
                 let dir_ref = oci_dir_ref(path)?;
-                let manifest_blob_path = path.join("blobs").join("sha256").join(
-                    dir_ref
-                        .manifest_digest
-                        .as_ref()
-                        .trim_start_matches("sha256:"),
-                );
+                let manifest_blob_path = path
+                    .join("blobs")
+                    .join(dir_ref.manifest_digest.algorithm().as_ref())
+                    .join(dir_ref.manifest_digest.digest());
                 let bytes = std::fs::read(&manifest_blob_path).with_context(|| {
                     format!(
                         "Failed to read manifest blob at {}",

--- a/rust/ommx/src/bin/ommx.rs
+++ b/rust/ommx/src/bin/ommx.rs
@@ -367,7 +367,7 @@ fn main() -> Result<()> {
                         to_remove.len()
                     );
                     for r in &to_remove {
-                        println!("  {}:{}  →  {}", r.name, r.reference, r.manifest_digest);
+                        println!("  {}:{}  →  {}", r.name, r.reference, r.descriptor.digest());
                     }
                     println!("(--dry-run: registry unchanged)");
                 } else {

--- a/rust/ommx/src/dataset/miplib2017.rs
+++ b/rust/ommx/src/dataset/miplib2017.rs
@@ -271,7 +271,7 @@ pub fn load(name: &str) -> Result<(Instance, InstanceAnnotations)> {
         instance_layers.next().is_none(),
         "MIPLIB2017 Artifact should contain exactly one instance"
     );
-    let bytes = artifact.get_blob(layer.digest().as_ref())?;
+    let bytes = artifact.get_blob(layer.digest())?;
     let instance =
         Instance::decode(bytes.as_slice()).context("Failed to decode MIPLIB2017 instance layer")?;
     Ok((

--- a/rust/ommx/src/dataset/qplib.rs
+++ b/rust/ommx/src/dataset/qplib.rs
@@ -307,7 +307,7 @@ pub fn load(tag: &str) -> Result<(Instance, InstanceAnnotations)> {
         instance_layers.next().is_none(),
         "QPLIB Artifact should contain exactly one instance"
     );
-    let bytes = artifact.get_blob(layer.digest().as_ref())?;
+    let bytes = artifact.get_blob(layer.digest())?;
     let instance =
         Instance::decode(bytes.as_slice()).context("Failed to decode QPLIB instance layer")?;
     Ok((

--- a/rust/ommx/tests/auth_e2e.rs
+++ b/rust/ommx/tests/auth_e2e.rs
@@ -408,7 +408,7 @@ fn pull_image_round_trips_through_anonymous_registry() -> Result<()> {
     let expected_layer_bytes = {
         let layers = sender_local.layers()?;
         assert_eq!(layers.len(), 1);
-        sender_local.get_blob(layers[0].digest().as_ref())?
+        sender_local.get_blob(layers[0].digest())?
     };
     sender_local.push()?;
 
@@ -426,7 +426,7 @@ fn pull_image_round_trips_through_anonymous_registry() -> Result<()> {
     assert_eq!(pulled.manifest_digest(), &outcome.manifest_digest);
     let layers = pulled.layers()?;
     assert_eq!(layers.len(), 1);
-    let pulled_bytes = pulled.get_blob(layers[0].digest().as_ref())?;
+    let pulled_bytes = pulled.get_blob(layers[0].digest())?;
     assert_eq!(pulled_bytes, expected_layer_bytes);
     Ok(())
 }

--- a/rust/ommx/tests/auth_e2e.rs
+++ b/rust/ommx/tests/auth_e2e.rs
@@ -423,7 +423,7 @@ fn pull_image_round_trips_through_anonymous_registry() -> Result<()> {
     // these assertions means the native pull lost data on the way
     // through `RemoteTransport` + `publish_artifact_atomic`.
     let pulled = LocalArtifact::open_in_registry(receiver, image_name)?;
-    assert_eq!(pulled.manifest_digest(), outcome.manifest_digest);
+    assert_eq!(pulled.manifest_digest(), &outcome.manifest_digest);
     let layers = pulled.layers()?;
     assert_eq!(layers.len(), 1);
     let pulled_bytes = pulled.get_blob(layers[0].digest().as_ref())?;


### PR DESCRIPTION
## Summary
- simplify Local Registry IndexStorage to the OCI index.json responsibility: refs map to OCI manifest descriptors only
- remove BlobRecord / ManifestRecord / LayerRecord and the manifest/layer/blob cache tables from SQLite
- write CAS bytes directly to FileBlobStore, then publish only the manifest descriptor into the SQLite ref index
- use oci_spec::image::Digest for Local Registry ref updates, import outcomes, BlobStore access, and LocalArtifact manifest identity
- keep Python Artifact.get_blob accepting Descriptor or digest string, while passing Descriptor digests to Rust without reparsing through str

## Verification
- env -u RUSTC_WRAPPER cargo build --bin ommx --features cli
- env -u RUSTC_WRAPPER cargo check -p ommx --all-targets --features remote-artifact,cli,built
- env -u RUSTC_WRAPPER cargo test -p ommx artifact::local_registry --lib --features remote-artifact
- env -u RUSTC_WRAPPER cargo clippy -p ommx --all-targets --features remote-artifact,cli,built -- -D warnings
- uv sync --all-extras --reinstall-package ommx
- uv run pytest -vv python/ommx-tests/tests/test_artifact_blob.py
- task python:ommx:lint
- git diff --check