### PR TITLE
Bind local registry handles to artifact views

### DIFF
--- a/python/ommx/src/artifact.rs
+++ b/python/ommx/src/artifact.rs
@@ -33,7 +33,7 @@ use crate::PyDescriptor;
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
 #[pyo3(module = "ommx._ommx_rust", name = "Artifact")]
-pub struct PyArtifact(ommx::artifact::LocalArtifact);
+pub struct PyArtifact(ommx::artifact::LocalArtifact<'static>);
 
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
@@ -69,8 +69,7 @@ impl PyArtifact {
     #[staticmethod]
     pub fn import_archive(py: Python<'_>, path: PathBuf) -> Result<Self> {
         let _guard = crate::TRACING.attach_parent_context(py);
-        let registry =
-            std::sync::Arc::new(ommx::artifact::local_registry::LocalRegistry::open_default()?);
+        let registry = ommx::artifact::local_registry::LocalRegistry::shared_default()?;
 
         let image_name = if path.is_file() {
             // `import_oci_archive` synthesizes an anonymous ref name
@@ -78,7 +77,7 @@ impl PyArtifact {
             // `org.opencontainers.image.ref.name` annotation (v2-era
             // unnamed `.ommx` files), so the returned `image_name`
             // is always `Some(...)`.
-            let outcome = ommx::artifact::local_registry::import_oci_archive(&registry, &path)?;
+            let outcome = ommx::artifact::local_registry::import_oci_archive(registry, &path)?;
             outcome.image_name.ok_or_else(|| {
                 anyhow::anyhow!(
                     "import_oci_archive returned no image_name despite synthesizing on \
@@ -202,9 +201,8 @@ impl PyArtifact {
         // SQLite miss — pull from the remote registry directly into
         // SQLite via the v3 native `pull_image` (no on-disk OCI dir
         // intermediate; blobs land straight in FileBlobStore).
-        let registry =
-            std::sync::Arc::new(ommx::artifact::local_registry::LocalRegistry::open_default()?);
-        ommx::artifact::local_registry::pull_image(&registry, &image_name_parsed)?;
+        let registry = ommx::artifact::local_registry::LocalRegistry::shared_default()?;
+        ommx::artifact::local_registry::pull_image(registry, &image_name_parsed)?;
         let artifact =
             ommx::artifact::LocalArtifact::open_in_registry(registry, image_name_parsed)?;
         Ok(Self(artifact))
@@ -742,14 +740,14 @@ fn assert_media_type(descriptor: &PyDescriptor, expected: &str) -> Result<()> {
 // `.ommx` file. The `Option` is consumed on `commit()` so a second
 // call surfaces "Already committed artifact".
 
-struct DraftInner(Option<Box<ommx::artifact::ArtifactDraft>>);
+struct DraftInner(Option<Box<ommx::artifact::ArtifactDraft<'static>>>);
 
 impl DraftInner {
-    fn new(builder: ommx::artifact::ArtifactDraft) -> Self {
+    fn new(builder: ommx::artifact::ArtifactDraft<'static>) -> Self {
         Self(Some(Box::new(builder)))
     }
 
-    fn as_mut(&mut self) -> Result<&mut ommx::artifact::ArtifactDraft> {
+    fn as_mut(&mut self) -> Result<&mut ommx::artifact::ArtifactDraft<'static>> {
         self.0
             .as_mut()
             .map(|b| b.as_mut())
@@ -773,7 +771,7 @@ impl DraftInner {
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<ommx::artifact::LocalArtifact> {
+    fn commit(&mut self) -> Result<ommx::artifact::LocalArtifact<'static>> {
         let builder = self
             .0
             .take()

--- a/rust/ommx/examples/pull_artifact.rs
+++ b/rust/ommx/examples/pull_artifact.rs
@@ -3,7 +3,6 @@ use ommx::artifact::{
     local_registry::{pull_image, LocalRegistry},
     media_types, ImageRef, LocalArtifact,
 };
-use std::sync::Arc;
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -18,8 +17,8 @@ fn main() -> Result<()> {
 
     // Pull the artifact from the remote registry into the v3 SQLite
     // Local Registry, then open it for read by ref.
-    let registry = Arc::new(LocalRegistry::open_default()?);
-    pull_image(&registry, &image_name)?;
+    let registry = LocalRegistry::shared_default()?;
+    pull_image(registry, &image_name)?;
     let local = LocalArtifact::open_in_registry(registry, image_name)?;
 
     // Print the digest of each instance layer.

--- a/rust/ommx/src/artifact/local_registry/import/archive.rs
+++ b/rust/ommx/src/artifact/local_registry/import/archive.rs
@@ -40,7 +40,6 @@ use std::{
     fs::File,
     io::{BufReader, Read},
     path::Path,
-    sync::Arc,
 };
 use tar::Archive;
 
@@ -195,7 +194,7 @@ fn read_archive_blob(path: &Path, digest: &Digest) -> Result<Vec<u8>> {
 /// an idempotent re-import of the same digest under the same ref, or
 /// `Err` for a ref conflict when the new archive's manifest digest
 /// differs from the SQLite-recorded one).
-pub fn import_oci_archive(registry: &Arc<LocalRegistry>, path: &Path) -> Result<OciDirImport> {
+pub fn import_oci_archive(registry: &LocalRegistry, path: &Path) -> Result<OciDirImport> {
     let file = File::open(path)
         .with_context(|| format!("Failed to open OCI archive {}", path.display()))?;
     let scanned = scan_archive(BufReader::new(file), registry.blobs(), path)?;

--- a/rust/ommx/src/artifact/local_registry/import/remote.rs
+++ b/rust/ommx/src/artifact/local_registry/import/remote.rs
@@ -54,7 +54,7 @@ use crate::artifact::{
 use anyhow::{Context, Result};
 use oci_client::RegistryOperation;
 use oci_spec::image::{Descriptor, DescriptorBuilder, Digest, ImageManifest, MediaType};
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 /// Pull `image_name` from its remote registry into the v3 SQLite
 /// Local Registry.
@@ -83,7 +83,7 @@ use std::{str::FromStr, sync::Arc};
 /// writer sees `Unchanged`. If the remote serves non-deterministic
 /// manifest bytes (field reorder, whitespace drift) the two digests
 /// differ and the loser surfaces a conflict.
-pub fn pull_image(registry: &Arc<LocalRegistry>, image_name: &ImageRef) -> Result<OciDirImport> {
+pub fn pull_image(registry: &LocalRegistry, image_name: &ImageRef) -> Result<OciDirImport> {
     if let Some(manifest_digest) = registry.index().resolve_image_name(image_name)? {
         if registry.blobs().exists(&manifest_digest)? {
             return Ok(OciDirImport {

--- a/rust/ommx/src/artifact/local_registry/index.rs
+++ b/rust/ommx/src/artifact/local_registry/index.rs
@@ -27,9 +27,9 @@ const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 ///
 /// `rusqlite::Connection` is `Send` but `!Sync`, so it lives behind a
 /// [`Mutex`] here. That makes [`SqliteIndexStore`] (and the enclosing
-/// [`super::LocalRegistry`]) `Sync`, which lets a single registry be
-/// shared via [`std::sync::Arc`] across PyO3 wrappers without
-/// per-artifact connection duplication.
+/// [`super::LocalRegistry`]) `Sync`, which lets the process-wide
+/// default registry be shared as a `&'static LocalRegistry` across
+/// PyO3 wrappers without per-artifact connection duplication.
 #[derive(Debug)]
 pub struct SqliteIndexStore {
     conn: Mutex<Connection>,

--- a/rust/ommx/src/artifact/local_registry/mod.rs
+++ b/rust/ommx/src/artifact/local_registry/mod.rs
@@ -95,7 +95,7 @@ pub use import::oci_dir::{
 pub use import::remote::pull_image;
 pub use index::SqliteIndexStore;
 pub(crate) use registry::UnsealedArtifact;
-pub use registry::{LocalRegistry, StoredDescriptor};
+pub use registry::{LocalRegistry, StoredDescriptor, TempLocalRegistry};
 pub use types::{
     RefRecord, RefUpdate, FILE_BLOB_STORE_DIR_NAME, OCI_IMAGE_REF_NAME_ANNOTATION,
     SQLITE_INDEX_FILE_NAME,

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -10,6 +10,9 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::OnceLock;
+
+static DEFAULT_LOCAL_REGISTRY: OnceLock<LocalRegistry> = OnceLock::new();
 
 /// OCI descriptor whose referenced bytes are known to exist in this
 /// Local Registry's BlobStore.
@@ -118,6 +121,29 @@ impl LocalRegistry {
 
     pub fn open_default() -> Result<Self> {
         Self::open(crate::artifact::get_local_registry_root())
+    }
+
+    /// Return the process-wide default Local Registry.
+    ///
+    /// The default registry is opened lazily on the first call and then
+    /// reused for the rest of the process. Call
+    /// [`crate::artifact::set_local_registry_root`] before this method
+    /// if a non-default root is needed.
+    pub fn shared_default() -> Result<&'static Self> {
+        if let Some(registry) = DEFAULT_LOCAL_REGISTRY.get() {
+            return Ok(registry);
+        }
+
+        // OnceLock::get_or_try_init is still unstable on the supported
+        // toolchain. This open-then-set sequence can briefly open two
+        // SQLite connections if multiple threads race on the first
+        // call, but only one registry is retained. Replace this with
+        // get_or_try_init once it is stable.
+        let registry = Self::open_default()?;
+        let _ = DEFAULT_LOCAL_REGISTRY.set(registry);
+        Ok(DEFAULT_LOCAL_REGISTRY
+            .get()
+            .expect("default Local Registry was initialized"))
     }
 
     pub fn root(&self) -> &Path {

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -21,6 +21,13 @@ static DEFAULT_LOCAL_REGISTRY: OnceLock<LocalRegistry> = OnceLock::new();
 /// [`oci_spec::image::Descriptor`] itself. Values are created only by
 /// [`LocalRegistry`] operations that have written or verified the
 /// content-addressed blob.
+///
+/// The invariant is tied to the concrete [`LocalRegistry`] instance,
+/// not merely to an equivalent registry root path or SQLite database.
+/// Re-opening the same directory yields a different `LocalRegistry`
+/// instance, and descriptors from that instance are not treated as
+/// stored in this one until they are explicitly verified or written
+/// through this instance.
 #[derive(Debug, Clone)]
 pub struct StoredDescriptor<'reg> {
     registry: &'reg LocalRegistry,
@@ -29,6 +36,10 @@ pub struct StoredDescriptor<'reg> {
 
 impl StoredDescriptor<'_> {
     fn is_stored_in(&self, registry: &LocalRegistry) -> bool {
+        // This intentionally checks registry-instance identity. Two
+        // LocalRegistry values may point at the same on-disk SQLite /
+        // BlobStore root, but a StoredDescriptor is only proven stored
+        // for the instance that created or verified it.
         std::ptr::eq(self.registry, registry)
     }
 

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -14,32 +14,39 @@ use std::sync::OnceLock;
 
 static DEFAULT_LOCAL_REGISTRY: OnceLock<LocalRegistry> = OnceLock::new();
 
-/// OCI descriptor whose referenced bytes are known to exist in this
-/// Local Registry's BlobStore.
+/// OCI descriptor whose referenced bytes are known to exist in the
+/// referenced Local Registry's BlobStore.
 ///
 /// This is an OMMX / Local Registry invariant, not an invariant of
 /// [`oci_spec::image::Descriptor`] itself. Values are created only by
 /// [`LocalRegistry`] operations that have written or verified the
 /// content-addressed blob.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StoredDescriptor(Descriptor);
+#[derive(Debug, Clone)]
+pub struct StoredDescriptor<'reg> {
+    registry: &'reg LocalRegistry,
+    descriptor: Descriptor,
+}
 
-impl StoredDescriptor {
+impl StoredDescriptor<'_> {
+    fn is_stored_in(&self, registry: &LocalRegistry) -> bool {
+        std::ptr::eq(self.registry, registry)
+    }
+
     fn into_inner(self) -> Descriptor {
-        self.0
+        self.descriptor
     }
 }
 
-impl Deref for StoredDescriptor {
+impl Deref for StoredDescriptor<'_> {
     type Target = Descriptor;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.descriptor
     }
 }
 
-impl From<StoredDescriptor> for Descriptor {
-    fn from(value: StoredDescriptor) -> Self {
+impl From<StoredDescriptor<'_>> for Descriptor {
+    fn from(value: StoredDescriptor<'_>) -> Self {
         value.into_inner()
     }
 }
@@ -48,11 +55,11 @@ impl From<StoredDescriptor> for Descriptor {
 ///
 /// The inner descriptor is stored in this registry, and it is known to
 /// be the root manifest descriptor produced by [`LocalRegistry::seal_artifact`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SealedArtifact(StoredDescriptor);
+#[derive(Debug, Clone)]
+pub(crate) struct SealedArtifact<'reg>(StoredDescriptor<'reg>);
 
-impl Deref for SealedArtifact {
-    type Target = StoredDescriptor;
+impl<'reg> Deref for SealedArtifact<'reg> {
+    type Target = StoredDescriptor<'reg>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -60,19 +67,19 @@ impl Deref for SealedArtifact {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct UnsealedArtifact {
+pub(crate) struct UnsealedArtifact<'reg> {
     artifact_type: MediaType,
-    config: StoredDescriptor,
-    layers: Vec<StoredDescriptor>,
+    config: StoredDescriptor<'reg>,
+    layers: Vec<StoredDescriptor<'reg>>,
     subject: Option<Descriptor>,
     annotations: HashMap<String, String>,
 }
 
-impl UnsealedArtifact {
+impl<'reg> UnsealedArtifact<'reg> {
     pub(crate) fn new(
         artifact_type: MediaType,
-        config: StoredDescriptor,
-        layers: Vec<StoredDescriptor>,
+        config: StoredDescriptor<'reg>,
+        layers: Vec<StoredDescriptor<'reg>>,
         subject: Option<Descriptor>,
         annotations: HashMap<String, String>,
     ) -> Self {
@@ -101,6 +108,20 @@ impl UnsealedArtifact {
         builder
             .build()
             .context("Failed to build OCI image manifest")
+    }
+
+    fn ensure_stored_in(&self, registry: &LocalRegistry) -> Result<()> {
+        ensure!(
+            self.config.is_stored_in(registry),
+            "Artifact config descriptor belongs to a different Local Registry"
+        );
+        ensure!(
+            self.layers
+                .iter()
+                .all(|descriptor| descriptor.is_stored_in(registry)),
+            "Artifact layer descriptor belongs to a different Local Registry"
+        );
+        Ok(())
     }
 }
 
@@ -241,7 +262,11 @@ impl LocalRegistry {
     /// does not re-validate dependency blob existence. It serializes
     /// and stores only the root manifest blob, yielding its root
     /// [`SealedArtifact`].
-    pub(crate) fn seal_artifact(&self, artifact: UnsealedArtifact) -> Result<SealedArtifact> {
+    pub(crate) fn seal_artifact<'reg>(
+        &'reg self,
+        artifact: UnsealedArtifact<'reg>,
+    ) -> Result<SealedArtifact<'reg>> {
+        artifact.ensure_stored_in(self)?;
         let manifest = artifact.into_oci_image_manifest()?;
         Self::validate_manifest(&manifest)?;
         let manifest_bytes = stable_json_bytes(&manifest)?;
@@ -257,7 +282,7 @@ impl LocalRegistry {
     pub(crate) fn publish_manifest_ref(
         &self,
         image_name: &ImageRef,
-        sealed_artifact: &SealedArtifact,
+        sealed_artifact: &SealedArtifact<'_>,
     ) -> Result<RefUpdate> {
         self.index.publish_image_ref(image_name, &sealed_artifact.0)
     }
@@ -269,7 +294,7 @@ impl LocalRegistry {
     pub(crate) fn replace_manifest_ref(
         &self,
         image_name: &ImageRef,
-        sealed_artifact: &SealedArtifact,
+        sealed_artifact: &SealedArtifact<'_>,
     ) -> Result<RefUpdate> {
         self.index.replace_image_ref(image_name, &sealed_artifact.0)
     }
@@ -307,7 +332,7 @@ impl LocalRegistry {
         &self,
         descriptor: Descriptor,
         bytes: &[u8],
-    ) -> Result<StoredDescriptor> {
+    ) -> Result<StoredDescriptor<'_>> {
         let digest = self.blobs.put_bytes(bytes)?;
         ensure!(
             &digest == descriptor.digest(),
@@ -322,6 +347,9 @@ impl LocalRegistry {
             descriptor.size(),
             bytes.len()
         );
-        Ok(StoredDescriptor(descriptor))
+        Ok(StoredDescriptor {
+            registry: self,
+            descriptor,
+        })
     }
 }

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -77,6 +77,12 @@ impl<'reg> Deref for SealedArtifact<'reg> {
     }
 }
 
+impl SealedArtifact<'_> {
+    fn is_stored_in(&self, registry: &LocalRegistry) -> bool {
+        self.0.is_stored_in(registry)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct UnsealedArtifact<'reg> {
     artifact_type: MediaType,
@@ -141,6 +147,25 @@ pub struct LocalRegistry {
     root: PathBuf,
     index: SqliteIndexStore,
     blobs: FileBlobStore,
+}
+
+/// Temporary Local Registry for tests and examples.
+///
+/// The temporary directory is owned by this value and is deleted when
+/// the value is dropped. Borrow `registry` while the `TempLocalRegistry`
+/// value is alive.
+#[derive(Debug)]
+pub struct TempLocalRegistry {
+    pub tempdir: tempfile::TempDir,
+    pub registry: LocalRegistry,
+}
+
+impl TempLocalRegistry {
+    pub fn new() -> Result<Self> {
+        let tempdir = tempfile::tempdir().context("Failed to create temporary Local Registry")?;
+        let registry = LocalRegistry::open(tempdir.path())?;
+        Ok(Self { tempdir, registry })
+    }
 }
 
 impl LocalRegistry {
@@ -295,6 +320,10 @@ impl LocalRegistry {
         image_name: &ImageRef,
         sealed_artifact: &SealedArtifact<'_>,
     ) -> Result<RefUpdate> {
+        ensure!(
+            sealed_artifact.is_stored_in(self),
+            "Sealed artifact descriptor belongs to a different Local Registry"
+        );
         self.index.publish_image_ref(image_name, &sealed_artifact.0)
     }
 
@@ -307,6 +336,10 @@ impl LocalRegistry {
         image_name: &ImageRef,
         sealed_artifact: &SealedArtifact<'_>,
     ) -> Result<RefUpdate> {
+        ensure!(
+            sealed_artifact.is_stored_in(self),
+            "Sealed artifact descriptor belongs to a different Local Registry"
+        );
         self.index.replace_image_ref(image_name, &sealed_artifact.0)
     }
 

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -152,12 +152,12 @@ pub struct LocalRegistry {
 /// Temporary Local Registry for tests and examples.
 ///
 /// The temporary directory is owned by this value and is deleted when
-/// the value is dropped. Borrow `registry` while the `TempLocalRegistry`
+/// the value is dropped. Borrow the registry while the `TempLocalRegistry`
 /// value is alive.
 #[derive(Debug)]
 pub struct TempLocalRegistry {
-    pub registry: LocalRegistry,
-    pub tempdir: tempfile::TempDir,
+    registry: LocalRegistry,
+    tempdir: tempfile::TempDir,
 }
 
 impl TempLocalRegistry {
@@ -165,6 +165,14 @@ impl TempLocalRegistry {
         let tempdir = tempfile::tempdir().context("Failed to create temporary Local Registry")?;
         let registry = LocalRegistry::open(tempdir.path())?;
         Ok(Self { registry, tempdir })
+    }
+
+    pub fn registry(&self) -> &LocalRegistry {
+        &self.registry
+    }
+
+    pub fn path(&self) -> &Path {
+        self.tempdir.path()
     }
 }
 

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -156,15 +156,15 @@ pub struct LocalRegistry {
 /// value is alive.
 #[derive(Debug)]
 pub struct TempLocalRegistry {
-    pub tempdir: tempfile::TempDir,
     pub registry: LocalRegistry,
+    pub tempdir: tempfile::TempDir,
 }
 
 impl TempLocalRegistry {
     pub fn new() -> Result<Self> {
         let tempdir = tempfile::tempdir().context("Failed to create temporary Local Registry")?;
         let registry = LocalRegistry::open(tempdir.path())?;
-        Ok(Self { tempdir, registry })
+        Ok(Self { registry, tempdir })
     }
 }
 

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -1289,7 +1289,7 @@ fn read_archive_blobs(path: &Path) -> Result<HashMap<String, Vec<u8>>> {
 }
 
 fn build_test_local_artifact<'reg>(
-    registry: &'reg Arc<LocalRegistry>,
+    registry: &'reg LocalRegistry,
     image_name: &ImageRef,
     layer_bytes: &[u8],
 ) -> Result<LocalArtifact<'reg>> {
@@ -1298,11 +1298,11 @@ fn build_test_local_artifact<'reg>(
 }
 
 fn new_test_local_artifact_builder<'reg>(
-    registry: &'reg Arc<LocalRegistry>,
+    registry: &'reg LocalRegistry,
     image_name: ImageRef,
     layer_bytes: &[u8],
 ) -> Result<(ArtifactDraft<'reg>, Descriptor)> {
-    let mut builder = ArtifactDraft::with_registry(registry.as_ref(), image_name);
+    let mut builder = ArtifactDraft::with_registry(registry, image_name);
     let descriptor = builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         layer_bytes.to_vec(),

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
 /// Build a tiny single-layer artifact in a fresh temp SQLite registry,
 /// save it to `archive_path` via the v3 native save writer, and drop
@@ -21,8 +20,8 @@ fn save_test_archive(
     layer_bytes: Vec<u8>,
 ) -> Result<()> {
     let sender_dir = tempfile::tempdir()?;
-    let sender_registry = Arc::new(LocalRegistry::open(sender_dir.path())?);
-    let mut builder = ArtifactDraft::with_registry(sender_registry.as_ref(), image_name);
+    let sender_registry = LocalRegistry::open(sender_dir.path())?;
+    let mut builder = ArtifactDraft::with_registry(&sender_registry, image_name);
     builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.into()),
         layer_bytes,
@@ -481,7 +480,7 @@ fn local_registry_imports_legacy_refs_when_requested() -> Result<()> {
 #[test]
 fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()> {
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:built")?;
 
     let artifact = build_test_local_artifact(&registry, &image_name, b"instance")?;
@@ -552,7 +551,7 @@ fn local_registry_builds_native_image_manifest_with_artifact_type() -> Result<()
 #[test]
 fn local_registry_build_publish_skips_conflicting_manifest() -> Result<()> {
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:keep")?;
     let first = build_test_local_artifact(&registry, &image_name, b"first")?;
     let (second, second_blob) =
@@ -576,7 +575,7 @@ fn local_registry_build_publish_skips_conflicting_manifest() -> Result<()> {
 #[test]
 fn local_registry_build_replace_moves_conflicting_ref() -> Result<()> {
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:replace-build")?;
     let first = build_test_local_artifact(&registry, &image_name, b"first")?;
     let (second_builder, _) =
@@ -714,7 +713,7 @@ fn local_artifact_caches_manifest_across_clones() -> Result<()> {
     // returned by one handle and another reference returned by its
     // clone must point at the same cached value.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:cache")?;
 
     let artifact = build_test_local_artifact(&registry, &image_name, b"cache-test")?;
@@ -737,7 +736,7 @@ fn local_artifact_subject_round_trips() -> Result<()> {
     // and surfaces the Descriptor that ArtifactDraft set via
     // `set_subject`. None when no subject is set.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let plain_image = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:plain")?;
     let plain = build_test_local_artifact(&registry, &plain_image, b"no-subject")?;
     assert_eq!(plain.subject()?, None);
@@ -751,7 +750,7 @@ fn local_artifact_subject_round_trips() -> Result<()> {
         .build()?;
 
     let child_image = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:child")?;
-    let mut builder = ArtifactDraft::with_registry(registry.as_ref(), child_image.clone());
+    let mut builder = ArtifactDraft::with_registry(&registry, child_image.clone());
     builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         b"child-layer".to_vec(),
@@ -794,8 +793,8 @@ fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
 
     // LocalArtifact reads the legacy manifest (parse-time check is on
     // artifactType only, so the OMMX-specific config is not rejected).
-    let registry = Arc::new(LocalRegistry::open(&registry_root)?);
-    let artifact = LocalArtifact::open_in_registry(registry.as_ref(), image_name)?;
+    let registry = LocalRegistry::open(&registry_root)?;
+    let artifact = LocalArtifact::open_in_registry(&registry, image_name)?;
     assert_eq!(
         artifact.get_manifest()?.media_type(),
         OCI_IMAGE_MANIFEST_MEDIA_TYPE
@@ -844,7 +843,7 @@ fn concurrent_publish_different_digests_keeps_one_winner() -> Result<()> {
             let registry_root = registry_root.clone();
             let image_name = image_name.clone();
             std::thread::spawn(move || -> Result<bool> {
-                let registry = Arc::new(LocalRegistry::open(registry_root)?);
+                let registry = LocalRegistry::open(registry_root)?;
                 let bytes = format!("racer-{i}");
                 let (builder, _) = new_test_local_artifact_builder(
                     &registry,
@@ -926,7 +925,7 @@ fn import_oci_archive_surfaces_digest_conflict_for_same_ref() -> Result<()> {
     // conflict check sees the new archive's freshly hashed manifest
     // digest rather than the prior archive's bytes.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:reextract")?;
 
     let archive_path_a = dir.path().join("a.ommx");
@@ -967,7 +966,7 @@ fn import_oci_archive_does_not_leave_legacy_dir_behind() -> Result<()> {
     // registry root and dropped before the function returns; SQLite +
     // FileBlobStore are the sole post-import home.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:no-legacy-dir")?;
     let archive_path = dir.path().join("artifact.ommx");
     save_test_archive(
@@ -1005,7 +1004,7 @@ fn import_oci_archive_synthesizes_anonymous_name_for_unnamed_input() -> Result<(
     use std::str::FromStr;
 
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
 
     // Build a normal named archive first, then surgically rewrite its
     // `index.json` to drop the ref.name annotation — that is the
@@ -1080,7 +1079,7 @@ fn import_oci_archive_normalizes_dot_slash_prefixed_entries() -> Result<()> {
     // them. Build a canonical archive, repack it with every entry's
     // path re-rooted under `./`, and confirm import succeeds.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:dot-slash")?;
     let archive_path = dir.path().join("canonical.ommx");
     save_test_archive(
@@ -1129,7 +1128,7 @@ fn pull_image_short_circuits_when_ref_is_present_with_blob() -> Result<()> {
     // the short-circuit ever regresses, the call would attempt a DNS
     // lookup against a `.invalid` TLD and fail.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("does-not-resolve.invalid/jij-inc/ommx/demo:short-circuit")?;
     let local_artifact =
         build_test_local_artifact(&registry, &image_name, b"step-c-pull-short-circuit")?;
@@ -1158,7 +1157,7 @@ fn pull_image_does_not_short_circuit_when_manifest_blob_is_missing() -> Result<(
     // error (i.e., the function did attempt the pull) rather than the
     // happy-path `Unchanged` it would return without the blob check.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("does-not-resolve.invalid/jij-inc/ommx/demo:blob-missing")?;
     let local_artifact =
         build_test_local_artifact(&registry, &image_name, b"step-c-blob-corruption")?;
@@ -1190,7 +1189,7 @@ fn local_artifact_save_round_trip_preserves_layers() -> Result<()> {
     // writes the SQLite manifest bytes verbatim, so the saved
     // archive's manifest digest must match the registry's.
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
+    let registry = LocalRegistry::open(dir.path())?;
     let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:save-round-trip")?;
     let layer_bytes = b"step-c-save-round-trip-payload";
     let local_artifact = build_test_local_artifact(&registry, &image_name, layer_bytes)?;

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -22,7 +22,7 @@ fn save_test_archive(
 ) -> Result<()> {
     let sender_dir = tempfile::tempdir()?;
     let sender_registry = Arc::new(LocalRegistry::open(sender_dir.path())?);
-    let mut builder = ArtifactDraft::with_registry(sender_registry.clone(), image_name);
+    let mut builder = ArtifactDraft::with_registry(sender_registry.as_ref(), image_name);
     builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.into()),
         layer_bytes,
@@ -200,10 +200,8 @@ fn imports_oci_dir_into_sqlite_registry_preserving_image_manifest() -> Result<()
         layer.size()
     );
 
-    let artifact = LocalArtifact::open_in_registry(
-        Arc::new(LocalRegistry::open(&registry_root)?),
-        image_name,
-    )?;
+    let registry = LocalRegistry::open(&registry_root)?;
+    let artifact = LocalArtifact::open_in_registry(&registry, image_name)?;
     // LocalArtifact must dispatch on the stored manifest media type and
     // surface the legacy Image Manifest's layer descriptors through the
     // common LocalManifest view.
@@ -753,7 +751,7 @@ fn local_artifact_subject_round_trips() -> Result<()> {
         .build()?;
 
     let child_image = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:child")?;
-    let mut builder = ArtifactDraft::with_registry(registry.clone(), child_image.clone());
+    let mut builder = ArtifactDraft::with_registry(registry.as_ref(), child_image.clone());
     builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         b"child-layer".to_vec(),
@@ -797,7 +795,7 @@ fn imports_legacy_v2_oci_dir_with_ommx_config_blob() -> Result<()> {
     // LocalArtifact reads the legacy manifest (parse-time check is on
     // artifactType only, so the OMMX-specific config is not rejected).
     let registry = Arc::new(LocalRegistry::open(&registry_root)?);
-    let artifact = LocalArtifact::open_in_registry(registry, image_name)?;
+    let artifact = LocalArtifact::open_in_registry(registry.as_ref(), image_name)?;
     assert_eq!(
         artifact.get_manifest()?.media_type(),
         OCI_IMAGE_MANIFEST_MEDIA_TYPE
@@ -1290,21 +1288,21 @@ fn read_archive_blobs(path: &Path) -> Result<HashMap<String, Vec<u8>>> {
     Ok(blobs)
 }
 
-fn build_test_local_artifact(
-    registry: &Arc<LocalRegistry>,
+fn build_test_local_artifact<'reg>(
+    registry: &'reg Arc<LocalRegistry>,
     image_name: &ImageRef,
     layer_bytes: &[u8],
-) -> Result<LocalArtifact> {
+) -> Result<LocalArtifact<'reg>> {
     let (builder, _) = new_test_local_artifact_builder(registry, image_name.clone(), layer_bytes)?;
     builder.commit()
 }
 
-fn new_test_local_artifact_builder(
-    registry: &Arc<LocalRegistry>,
+fn new_test_local_artifact_builder<'reg>(
+    registry: &'reg Arc<LocalRegistry>,
     image_name: ImageRef,
     layer_bytes: &[u8],
-) -> Result<(ArtifactDraft, Descriptor)> {
-    let mut builder = ArtifactDraft::with_registry(Arc::clone(registry), image_name);
+) -> Result<(ArtifactDraft<'reg>, Descriptor)> {
+    let mut builder = ArtifactDraft::with_registry(registry.as_ref(), image_name);
     let descriptor = builder.add_layer_bytes(
         MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         layer_bytes.to_vec(),

--- a/rust/ommx/src/artifact/local_registry/tests.rs
+++ b/rust/ommx/src/artifact/local_registry/tests.rs
@@ -591,6 +591,47 @@ fn local_registry_build_replace_moves_conflicting_ref() -> Result<()> {
 }
 
 #[test]
+fn publish_rejects_sealed_artifact_from_different_registry_instance() -> Result<()> {
+    let source_dir = tempfile::tempdir()?;
+    let target_dir = tempfile::tempdir()?;
+    let source = LocalRegistry::open(source_dir.path())?;
+    let target = LocalRegistry::open(target_dir.path())?;
+
+    let config = DescriptorBuilder::default()
+        .media_type(MediaType::EmptyJSON)
+        .digest(Digest::from_str(media_types::OCI_EMPTY_CONFIG_DIGEST)?)
+        .size(media_types::OCI_EMPTY_CONFIG_BYTES.len() as u64)
+        .build()?;
+    let config = source.store_blob(config, media_types::OCI_EMPTY_CONFIG_BYTES)?;
+
+    let layer_bytes = b"instance";
+    let layer = DescriptorBuilder::default()
+        .media_type(media_types::v1_instance())
+        .digest(Digest::from_str(&sha256_digest(layer_bytes))?)
+        .size(layer_bytes.len() as u64)
+        .build()?;
+    let layer = source.store_blob(layer, layer_bytes)?;
+
+    let artifact = UnsealedArtifact::new(
+        MediaType::Other(media_types::V1_ARTIFACT_MEDIA_TYPE.to_string()),
+        config,
+        vec![layer],
+        None,
+        HashMap::new(),
+    );
+    let sealed = source.seal_artifact(artifact)?;
+    let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/demo:foreign-sealed")?;
+
+    let err = target
+        .publish_manifest_ref(&image_name, &sealed)
+        .expect_err("foreign sealed artifact must not be publishable");
+    assert!(err
+        .to_string()
+        .contains("belongs to a different Local Registry"));
+    Ok(())
+}
+
+#[test]
 fn concurrent_legacy_imports_are_idempotent() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let root = dir.path().to_path_buf();

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -726,9 +726,9 @@ mod tests {
     #[test]
     fn anonymous_build_in_same_second_does_not_fail() -> Result<()> {
         let dir = tempfile::tempdir()?;
-        let registry = Arc::new(LocalRegistry::open(dir.path())?);
+        let registry = LocalRegistry::open(dir.path())?;
         for tag in ["a", "b"] {
-            let mut builder = ArtifactDraft::new_anonymous_in_registry(registry.as_ref())?;
+            let mut builder = ArtifactDraft::new_anonymous_in_registry(&registry)?;
             builder.add_layer_bytes(
                 MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
                 format!("anon-{tag}").into_bytes(),
@@ -742,8 +742,8 @@ mod tests {
     #[test]
     fn builds_native_oci_image_manifest_with_artifact_type() -> Result<()> {
         let dir = tempfile::tempdir()?;
-        let registry = Arc::new(LocalRegistry::open(dir.path())?);
-        let mut builder = ArtifactDraft::with_registry(registry.as_ref(), test_image_name("v1")?);
+        let registry = LocalRegistry::open(dir.path())?;
+        let mut builder = ArtifactDraft::with_registry(&registry, test_image_name("v1")?);
         let layer = builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),
@@ -815,9 +815,8 @@ mod tests {
         let subject =
             descriptor_from_bytes(MediaType::ImageManifest, b"parent manifest", HashMap::new())?;
         let dir = tempfile::tempdir()?;
-        let registry = Arc::new(LocalRegistry::open(dir.path())?);
-        let mut builder =
-            ArtifactDraft::with_registry(registry.as_ref(), test_image_name("subject")?);
+        let registry = LocalRegistry::open(dir.path())?;
+        let mut builder = ArtifactDraft::with_registry(&registry, test_image_name("subject")?);
         builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),
@@ -842,8 +841,8 @@ mod tests {
         annotations: impl IntoIterator<Item = (&'static str, &'static str)>,
     ) -> Result<ImageManifest> {
         let dir = tempfile::tempdir()?;
-        let registry = Arc::new(LocalRegistry::open(dir.path())?);
-        let mut builder = ArtifactDraft::with_registry(registry.as_ref(), test_image_name(tag)?);
+        let registry = LocalRegistry::open(dir.path())?;
+        let mut builder = ArtifactDraft::with_registry(&registry, test_image_name(tag)?);
         builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -20,12 +20,10 @@ use url::Url;
 
 /// OMMX Artifact stored in the SQLite-backed Local Registry.
 ///
-/// Holds an [`Arc`]ed [`LocalRegistry`] so that several artifacts opened
-/// from the same registry share a single SQLite connection and blob
-/// store handle. Combined with the `Mutex<Connection>` inside
-/// [`super::local_registry::SqliteIndexStore`], this makes
-/// `LocalArtifact` `Sync` and `Clone`-friendly without any per-artifact
-/// connection duplication.
+/// Holds a reference to the [`LocalRegistry`] that stores the manifest
+/// and layer blobs. `LocalArtifact` is a lazy view: it owns the image
+/// name and manifest digest, but reads payload bytes through the
+/// registry reference on demand.
 ///
 /// The parsed manifest is memoised in an `Arc<OnceLock<LocalManifest>>`
 /// so repeated calls to [`Self::layers`] / [`Self::annotations`] /
@@ -34,16 +32,28 @@ use url::Url;
 /// time. Clones of the artifact share the same cell, so any clone that
 /// reads the manifest first warms it for the rest.
 #[derive(Debug, Clone)]
-pub struct LocalArtifact {
-    registry: Arc<LocalRegistry>,
+pub struct LocalArtifact<'reg> {
+    registry: &'reg LocalRegistry,
     image_name: ImageRef,
     manifest_digest: Digest,
     manifest_cache: Arc<OnceLock<LocalManifest>>,
 }
 
-impl LocalArtifact {
+impl LocalArtifact<'static> {
+    pub fn open(image_name: ImageRef) -> Result<Self> {
+        let registry = LocalRegistry::shared_default()?;
+        Self::open_in_registry(registry, image_name)
+    }
+
+    pub fn try_open(image_name: ImageRef) -> Result<Option<Self>> {
+        let registry = LocalRegistry::shared_default()?;
+        Self::try_open_in_registry(registry, image_name)
+    }
+}
+
+impl<'reg> LocalArtifact<'reg> {
     pub(crate) fn from_parts(
-        registry: Arc<LocalRegistry>,
+        registry: &'reg LocalRegistry,
         image_name: ImageRef,
         manifest_digest: Digest,
     ) -> Self {
@@ -55,12 +65,7 @@ impl LocalArtifact {
         }
     }
 
-    pub fn open(image_name: ImageRef) -> Result<Self> {
-        let registry = Arc::new(LocalRegistry::open_default()?);
-        Self::open_in_registry(registry, image_name)
-    }
-
-    pub fn open_in_registry(registry: Arc<LocalRegistry>, image_name: ImageRef) -> Result<Self> {
+    pub fn open_in_registry(registry: &'reg LocalRegistry, image_name: ImageRef) -> Result<Self> {
         Self::try_open_in_registry(registry, image_name.clone())?.with_context(|| {
             format!(
                 "Artifact not found in the SQLite-backed local registry: {image_name}. \
@@ -70,13 +75,8 @@ impl LocalArtifact {
         })
     }
 
-    pub fn try_open(image_name: ImageRef) -> Result<Option<Self>> {
-        let registry = Arc::new(LocalRegistry::open_default()?);
-        Self::try_open_in_registry(registry, image_name)
-    }
-
     pub fn try_open_in_registry(
-        registry: Arc<LocalRegistry>,
+        registry: &'reg LocalRegistry,
         image_name: ImageRef,
     ) -> Result<Option<Self>> {
         let Some(manifest_digest) = registry.resolve_image_name(&image_name)? else {
@@ -205,8 +205,8 @@ impl LocalManifest {
 /// `config`. The layer blobs land in the Image Manifest's `layers[]`
 /// field.
 #[derive(Debug, Clone)]
-pub struct ArtifactDraft {
-    registry: Arc<LocalRegistry>,
+pub struct ArtifactDraft<'reg> {
+    registry: &'reg LocalRegistry,
     image_name: ImageRef,
     artifact_type: MediaType,
     layers: Vec<StoredDescriptor>,
@@ -214,13 +214,38 @@ pub struct ArtifactDraft {
     annotations: HashMap<String, String>,
 }
 
-impl ArtifactDraft {
+impl ArtifactDraft<'static> {
     pub fn new(image_name: ImageRef) -> Result<Self> {
-        let registry = Arc::new(LocalRegistry::open_default()?);
+        let registry = LocalRegistry::shared_default()?;
         Ok(Self::with_registry(registry, image_name))
     }
 
-    pub fn with_registry(registry: Arc<LocalRegistry>, image_name: ImageRef) -> Self {
+    pub fn new_anonymous() -> Result<Self> {
+        let registry = LocalRegistry::shared_default()?;
+        Self::new_anonymous_in_registry(registry)
+    }
+
+    /// Draft under a random `ttl.sh/<uuid>:1h` image name. Insecure;
+    /// for tests only.
+    pub fn temp() -> Result<Self> {
+        let id = uuid::Uuid::new_v4();
+        let image_name = ImageRef::parse(&format!("ttl.sh/{id}:1h"))?;
+        Self::new(image_name)
+    }
+
+    /// Create a new artifact draft for a GitHub container registry image name.
+    pub fn for_github(org: &str, repo: &str, name: &str, tag: &str) -> Result<Self> {
+        let image_name = ghcr(org, repo, name, tag)?;
+        let source = Url::parse(&format!("https://github.com/{org}/{repo}"))?;
+
+        let mut draft = Self::new(image_name)?;
+        draft.add_source(&source);
+        Ok(draft)
+    }
+}
+
+impl<'reg> ArtifactDraft<'reg> {
+    pub fn with_registry(registry: &'reg LocalRegistry, image_name: ImageRef) -> Self {
         Self {
             registry,
             image_name,
@@ -247,33 +272,10 @@ impl ArtifactDraft {
     /// `anonymous_artifact_image_name` makes collisions astronomically
     /// rare in practice; if one still occurs, commit surfaces it as a
     /// normal ref conflict.
-    pub fn new_anonymous() -> Result<Self> {
-        let registry = Arc::new(LocalRegistry::open_default()?);
-        Self::new_anonymous_in_registry(registry)
-    }
-
-    pub fn new_anonymous_in_registry(registry: Arc<LocalRegistry>) -> Result<Self> {
+    pub fn new_anonymous_in_registry(registry: &'reg LocalRegistry) -> Result<Self> {
         let registry_id = registry.index().registry_id()?;
         let image_name = anonymous_artifact_image_name(&registry_id)?;
         Ok(Self::with_registry(registry, image_name))
-    }
-
-    /// Draft under a random `ttl.sh/<uuid>:1h` image name. Insecure;
-    /// for tests only.
-    pub fn temp() -> Result<Self> {
-        let id = uuid::Uuid::new_v4();
-        let image_name = ImageRef::parse(&format!("ttl.sh/{id}:1h"))?;
-        Self::new(image_name)
-    }
-
-    /// Create a new artifact draft for a GitHub container registry image name.
-    pub fn for_github(org: &str, repo: &str, name: &str, tag: &str) -> Result<Self> {
-        let image_name = ghcr(org, repo, name, tag)?;
-        let source = Url::parse(&format!("https://github.com/{org}/{repo}"))?;
-
-        let mut draft = Self::new(image_name)?;
-        draft.add_source(&source);
-        Ok(draft)
     }
 
     pub fn add_layer_bytes(
@@ -349,16 +351,16 @@ impl ArtifactDraft {
         self.add_annotation("org.opencontainers.image.source", url.to_string());
     }
 
-    pub fn commit(self) -> Result<LocalArtifact> {
+    pub fn commit(self) -> Result<LocalArtifact<'reg>> {
         self.commit_inner(false)
     }
 
-    pub fn commit_replace(self) -> Result<LocalArtifact> {
+    pub fn commit_replace(self) -> Result<LocalArtifact<'reg>> {
         self.commit_inner(true)
     }
 
-    fn commit_inner(self, replace_ref: bool) -> Result<LocalArtifact> {
-        let registry = Arc::clone(&self.registry);
+    fn commit_inner(self, replace_ref: bool) -> Result<LocalArtifact<'reg>> {
+        let registry = self.registry;
         let image_name = self.image_name.clone();
         let artifact = self.into_unsealed_artifact()?;
         let sealed_artifact = registry.seal_artifact(artifact)?;
@@ -726,7 +728,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let registry = Arc::new(LocalRegistry::open(dir.path())?);
         for tag in ["a", "b"] {
-            let mut builder = ArtifactDraft::new_anonymous_in_registry(registry.clone())?;
+            let mut builder = ArtifactDraft::new_anonymous_in_registry(registry.as_ref())?;
             builder.add_layer_bytes(
                 MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
                 format!("anon-{tag}").into_bytes(),
@@ -741,7 +743,7 @@ mod tests {
     fn builds_native_oci_image_manifest_with_artifact_type() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let registry = Arc::new(LocalRegistry::open(dir.path())?);
-        let mut builder = ArtifactDraft::with_registry(registry, test_image_name("v1")?);
+        let mut builder = ArtifactDraft::with_registry(registry.as_ref(), test_image_name("v1")?);
         let layer = builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),
@@ -814,7 +816,8 @@ mod tests {
             descriptor_from_bytes(MediaType::ImageManifest, b"parent manifest", HashMap::new())?;
         let dir = tempfile::tempdir()?;
         let registry = Arc::new(LocalRegistry::open(dir.path())?);
-        let mut builder = ArtifactDraft::with_registry(registry, test_image_name("subject")?);
+        let mut builder =
+            ArtifactDraft::with_registry(registry.as_ref(), test_image_name("subject")?);
         builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),
@@ -840,7 +843,7 @@ mod tests {
     ) -> Result<ImageManifest> {
         let dir = tempfile::tempdir()?;
         let registry = Arc::new(LocalRegistry::open(dir.path())?);
-        let mut builder = ArtifactDraft::with_registry(registry, test_image_name(tag)?);
+        let mut builder = ArtifactDraft::with_registry(registry.as_ref(), test_image_name(tag)?);
         builder.add_layer_bytes(
             MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"instance".to_vec(),

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -209,7 +209,7 @@ pub struct ArtifactDraft<'reg> {
     registry: &'reg LocalRegistry,
     image_name: ImageRef,
     artifact_type: MediaType,
-    layers: Vec<StoredDescriptor>,
+    layers: Vec<StoredDescriptor<'reg>>,
     subject: Option<Descriptor>,
     annotations: HashMap<String, String>,
 }
@@ -283,7 +283,7 @@ impl<'reg> ArtifactDraft<'reg> {
         media_type: MediaType,
         bytes: Vec<u8>,
         annotations: HashMap<String, String>,
-    ) -> Result<StoredDescriptor> {
+    ) -> Result<StoredDescriptor<'reg>> {
         let descriptor = descriptor_from_bytes(media_type, &bytes, annotations)?;
         let stored_descriptor = self.registry.store_blob(descriptor, &bytes)?;
         self.layers.push(stored_descriptor.clone());
@@ -294,7 +294,7 @@ impl<'reg> ArtifactDraft<'reg> {
         &mut self,
         instance: v1::Instance,
         annotations: InstanceAnnotations,
-    ) -> Result<StoredDescriptor> {
+    ) -> Result<StoredDescriptor<'reg>> {
         self.add_layer_bytes(
             media_types::v1_instance(),
             instance.encode_to_vec(),
@@ -306,7 +306,7 @@ impl<'reg> ArtifactDraft<'reg> {
         &mut self,
         solution: v1::State,
         annotations: SolutionAnnotations,
-    ) -> Result<StoredDescriptor> {
+    ) -> Result<StoredDescriptor<'reg>> {
         self.add_layer_bytes(
             media_types::v1_solution(),
             solution.encode_to_vec(),
@@ -318,7 +318,7 @@ impl<'reg> ArtifactDraft<'reg> {
         &mut self,
         instance: v1::ParametricInstance,
         annotations: ParametricInstanceAnnotations,
-    ) -> Result<StoredDescriptor> {
+    ) -> Result<StoredDescriptor<'reg>> {
         self.add_layer_bytes(
             media_types::v1_parametric_instance(),
             instance.encode_to_vec(),
@@ -330,7 +330,7 @@ impl<'reg> ArtifactDraft<'reg> {
         &mut self,
         sample_set: v1::SampleSet,
         annotations: SampleSetAnnotations,
-    ) -> Result<StoredDescriptor> {
+    ) -> Result<StoredDescriptor<'reg>> {
         self.add_layer_bytes(
             media_types::v1_sample_set(),
             sample_set.encode_to_vec(),
@@ -386,7 +386,7 @@ impl<'reg> ArtifactDraft<'reg> {
     /// own `mediaType` field intentionally absent so `ArtifactDraft`
     /// and the archive build path produce structurally identical
     /// manifests.
-    fn into_unsealed_artifact(self) -> Result<UnsealedArtifact> {
+    fn into_unsealed_artifact(self) -> Result<UnsealedArtifact<'reg>> {
         // V2 SDK's `ocipkg::OciArtifactBuilder::add_empty_json` emits the
         // empty config descriptor without an `annotations` field; build
         // it directly here (bypassing `descriptor_from_bytes`, which

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -254,7 +254,7 @@ impl<'reg> ArtifactDraft<'reg> {
     /// This is intended for Rust SDK tests that need to exercise the
     /// Local Registry-backed artifact path without writing to the
     /// user's persistent registry.
-    pub fn on_temp_local_registry<T>(
+    pub fn with_temp_local_registry<T>(
         image_name: ImageRef,
         f: impl FnOnce(ArtifactDraft<'_>) -> Result<T>,
     ) -> Result<T> {

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -259,7 +259,7 @@ impl<'reg> ArtifactDraft<'reg> {
         f: impl FnOnce(ArtifactDraft<'_>) -> Result<T>,
     ) -> Result<T> {
         let temp = TempLocalRegistry::new()?;
-        let draft = ArtifactDraft::with_registry(&temp.registry, image_name);
+        let draft = ArtifactDraft::with_registry(temp.registry(), image_name);
         f(draft)
     }
 

--- a/rust/ommx/src/artifact/manifest.rs
+++ b/rust/ommx/src/artifact/manifest.rs
@@ -1,7 +1,9 @@
 use super::{
     digest::sha256_digest,
     ghcr,
-    local_registry::{LocalRegistry, RefUpdate, StoredDescriptor, UnsealedArtifact},
+    local_registry::{
+        LocalRegistry, RefUpdate, StoredDescriptor, TempLocalRegistry, UnsealedArtifact,
+    },
     media_types::{self, OCI_EMPTY_CONFIG_BYTES},
     ImageRef, InstanceAnnotations, ParametricInstanceAnnotations, SampleSetAnnotations,
     SolutionAnnotations,
@@ -245,6 +247,22 @@ impl ArtifactDraft<'static> {
 }
 
 impl<'reg> ArtifactDraft<'reg> {
+    /// Create a temporary Local Registry, create an artifact draft
+    /// under `image_name`, and run a callback while the registry is
+    /// alive.
+    ///
+    /// This is intended for Rust SDK tests that need to exercise the
+    /// Local Registry-backed artifact path without writing to the
+    /// user's persistent registry.
+    pub fn on_temp_local_registry<T>(
+        image_name: ImageRef,
+        f: impl FnOnce(ArtifactDraft<'_>) -> Result<T>,
+    ) -> Result<T> {
+        let temp = TempLocalRegistry::new()?;
+        let draft = ArtifactDraft::with_registry(&temp.registry, image_name);
+        f(draft)
+    }
+
     pub fn with_registry(registry: &'reg LocalRegistry, image_name: ImageRef) -> Self {
         Self {
             registry,

--- a/rust/ommx/src/artifact/push.rs
+++ b/rust/ommx/src/artifact/push.rs
@@ -15,7 +15,7 @@
 use super::{remote_transport::RemoteTransport, LocalArtifact, LocalManifest};
 use oci_spec::image::Descriptor;
 
-impl LocalArtifact {
+impl LocalArtifact<'_> {
     /// Push this artifact to its OCI registry. Credentials are
     /// resolved by `super::remote_transport`'s three-tier chain:
     /// `OMMX_BASIC_AUTH_*` env vars (explicit override) →

--- a/rust/ommx/src/artifact/save.rs
+++ b/rust/ommx/src/artifact/save.rs
@@ -38,7 +38,7 @@ use tar::{EntryType, Header};
 /// pins this string at `1.0.0`; importers reject anything else.
 const OCI_LAYOUT_VERSION: &str = "1.0.0";
 
-impl LocalArtifact {
+impl LocalArtifact<'_> {
     /// Pack this artifact into a `.ommx` OCI archive at `output`.
     ///
     /// Identity-preserving: the manifest bytes the SQLite Local

--- a/rust/ommx/src/dataset/miplib2017.rs
+++ b/rust/ommx/src/dataset/miplib2017.rs
@@ -11,7 +11,6 @@ use anyhow::{ensure, Context, Result};
 use prost::Message;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 /// CSV downloaded from [MIPLIB website](https://miplib.zib.de/tag_collection.html)
 pub const MIPLIB2017_CSV: &str = include_str!("miplib2017.csv");
@@ -257,8 +256,8 @@ pub fn load(name: &str) -> Result<(Instance, InstanceAnnotations)> {
     check_unsupported(name)?;
 
     let image_name = ghcr("Jij-Inc", "ommx", "miplib2017", name)?;
-    let registry = Arc::new(LocalRegistry::open_default()?);
-    pull_image(&registry, &image_name)?;
+    let registry = LocalRegistry::shared_default()?;
+    pull_image(registry, &image_name)?;
     let artifact = LocalArtifact::open_in_registry(registry, image_name)?;
     let layers = artifact.layers()?;
     let mut instance_layers = layers

--- a/rust/ommx/src/dataset/qplib.rs
+++ b/rust/ommx/src/dataset/qplib.rs
@@ -11,7 +11,6 @@ use anyhow::{ensure, Context, Result};
 use prost::Message;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 /// CSV downloaded from [QPLIB website](http://qplib.zib.de/) on 2025-10-02
 pub const QPLIB_CSV: &str = include_str!("qplib.csv");
@@ -293,8 +292,8 @@ pub fn load(tag: &str) -> Result<(Instance, InstanceAnnotations)> {
     );
 
     let image_name = ghcr("Jij-Inc", "ommx", "qplib", tag)?;
-    let registry = Arc::new(LocalRegistry::open_default()?);
-    pull_image(&registry, &image_name)?;
+    let registry = LocalRegistry::shared_default()?;
+    pull_image(registry, &image_name)?;
     let artifact = LocalArtifact::open_in_registry(registry, image_name)?;
     let layers = artifact.layers()?;
     let mut instance_layers = layers

--- a/rust/ommx/src/experiment/commit.rs
+++ b/rust/ommx/src/experiment/commit.rs
@@ -16,13 +16,12 @@ use oci_spec::image::{DescriptorBuilder, Digest, MediaType};
 use serde_json::json;
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 
 /// Commit an unsealed experiment state as one immutable artifact.
-pub(super) fn commit_experiment_state(
-    registry: &Arc<LocalRegistry>,
+pub(super) fn commit_experiment_state<'reg>(
+    registry: &'reg LocalRegistry,
     state: &UnsealedExperimentState,
-) -> Result<LocalArtifact> {
+) -> Result<LocalArtifact<'reg>> {
     let mut layers = Vec::new();
 
     // Record layers: experiment space first, then each run's space.
@@ -95,7 +94,7 @@ pub(super) fn commit_experiment_state(
     }
 
     Ok(LocalArtifact::from_parts(
-        Arc::clone(registry),
+        registry,
         image_name,
         sealed_artifact.digest().clone(),
     ))

--- a/rust/ommx/src/experiment/commit.rs
+++ b/rust/ommx/src/experiment/commit.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 /// Commit an unsealed experiment state as one immutable artifact.
 pub(super) fn commit_experiment_state<'reg>(
     registry: &'reg LocalRegistry,
-    state: &UnsealedExperimentState,
+    state: &UnsealedExperimentState<'reg>,
 ) -> Result<LocalArtifact<'reg>> {
     let mut layers = Vec::new();
 
@@ -102,12 +102,12 @@ pub(super) fn commit_experiment_state<'reg>(
 
 /// Store a commit-time aggregate JSON layer and return its
 /// descriptor (with the `org.ommx.experiment.layer` annotation).
-fn store_aggregate_layer(
-    registry: &LocalRegistry,
+fn store_aggregate_layer<'reg>(
+    registry: &'reg LocalRegistry,
     media_type: &str,
     layer_kind: &str,
     bytes: &[u8],
-) -> Result<StoredDescriptor> {
+) -> Result<StoredDescriptor<'reg>> {
     let digest = Digest::from_str(&sha256_digest(bytes))
         .map_err(|e| crate::error!("Failed to parse aggregate layer digest: {e}"))?;
     let mut annotations = HashMap::new();
@@ -121,7 +121,7 @@ fn store_aggregate_layer(
     registry.store_blob(descriptor, bytes)
 }
 
-fn manifest_annotations(state: &UnsealedExperimentState) -> HashMap<String, String> {
+fn manifest_annotations(state: &UnsealedExperimentState<'_>) -> HashMap<String, String> {
     HashMap::from([
         (
             ANN_ARTIFACT_KIND.to_string(),
@@ -139,7 +139,7 @@ fn manifest_annotations(state: &UnsealedExperimentState) -> HashMap<String, Stri
     ])
 }
 
-fn run_attributes_json(state: &UnsealedExperimentState) -> serde_json::Value {
+fn run_attributes_json(state: &UnsealedExperimentState<'_>) -> serde_json::Value {
     json!({
         "runs": state
             .runs
@@ -153,7 +153,7 @@ fn run_attributes_json(state: &UnsealedExperimentState) -> serde_json::Value {
     })
 }
 
-fn experiment_index_json(state: &UnsealedExperimentState) -> serde_json::Value {
+fn experiment_index_json(state: &UnsealedExperimentState<'_>) -> serde_json::Value {
     json!({
         "schema": EXPERIMENT_SCHEMA_V1,
         "name": state.name,
@@ -173,7 +173,7 @@ fn experiment_index_json(state: &UnsealedExperimentState) -> serde_json::Value {
     })
 }
 
-fn record_index_entry(record: &RecordRef) -> serde_json::Value {
+fn record_index_entry(record: &RecordRef<'_>) -> serde_json::Value {
     json!({
         "name": record.name,
         "media_type": record.descriptor.media_type().to_string(),

--- a/rust/ommx/src/experiment/model.rs
+++ b/rust/ommx/src/experiment/model.rs
@@ -48,19 +48,19 @@ impl RunStatus {
 /// A named reference to a payload that has already been written to the
 /// BlobStore.
 #[derive(Debug, Clone)]
-pub(super) struct RecordRef {
+pub(super) struct RecordRef<'reg> {
     pub(super) name: String,
     /// OCI layer descriptor whose payload bytes are present in the
     /// Local Registry BlobStore. Carries the payload media type and
     /// the experiment / record annotations.
-    pub(super) descriptor: StoredDescriptor,
+    pub(super) descriptor: StoredDescriptor<'reg>,
 }
 
 /// In-memory state of a single run.
 #[derive(Debug)]
-pub(super) struct RunState {
+pub(super) struct RunState<'reg> {
     pub(super) run_id: u64,
-    pub(super) records: Vec<RecordRef>,
+    pub(super) records: Vec<RecordRef<'reg>>,
     pub(super) status: RunStatus,
     pub(super) started_at: Instant,
     pub(super) elapsed_secs: Option<f64>,
@@ -70,13 +70,13 @@ pub(super) struct RunState {
 /// [`super::Run`] mutably borrows the parent experiment while it adds
 /// run-scoped records or closes the run lifecycle.
 #[derive(Debug)]
-pub(super) struct UnsealedExperimentState {
+pub(super) struct UnsealedExperimentState<'reg> {
     pub(super) name: String,
     /// Image name the committed artifact is published under. `None`
     /// means an anonymous name is synthesised at commit time.
     pub(super) requested_ref: Option<ImageRef>,
     /// Experiment-space records.
-    pub(super) records: Vec<RecordRef>,
-    pub(super) runs: Vec<RunState>,
+    pub(super) records: Vec<RecordRef<'reg>>,
+    pub(super) runs: Vec<RunState<'reg>>,
     pub(super) next_run_id: u64,
 }

--- a/rust/ommx/src/experiment/session.rs
+++ b/rust/ommx/src/experiment/session.rs
@@ -8,24 +8,24 @@ use crate::{Instance, SampleSet, Solution};
 use anyhow::Result;
 use oci_spec::image::MediaType;
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::time::Instant;
-use std::{str::FromStr, sync::Arc};
 
 /// OCI layer media type for JSON record payloads.
 const JSON_MEDIA_TYPE: &str = "application/json";
 
 /// A mutable, unsealed experiment session. See the [module documentation](super).
 #[derive(Debug)]
-pub struct Experiment {
-    pub(super) registry: Arc<LocalRegistry>,
+pub struct Experiment<'reg> {
+    pub(super) registry: &'reg LocalRegistry,
     pub(super) state: UnsealedExperimentState,
 }
 
 /// A sealed experiment session whose root artifact manifest has been
 /// written and published.
 #[derive(Debug, Clone)]
-pub struct SealedExperiment {
-    artifact: LocalArtifact,
+pub struct SealedExperiment<'reg> {
+    artifact: LocalArtifact<'reg>,
 }
 
 /// A handle to a single run within an [`Experiment`].
@@ -36,27 +36,29 @@ pub struct SealedExperiment {
 /// state machine later, but the Rust core keeps the lifecycle explicit
 /// in the type system.
 #[derive(Debug)]
-pub struct Run<'exp> {
-    pub(super) experiment: &'exp mut Experiment,
+pub struct Run<'exp, 'reg> {
+    pub(super) experiment: &'exp mut Experiment<'reg>,
     pub(super) run_id: u64,
 }
 
-impl Experiment {
+impl Experiment<'static> {
     /// Start a new experiment session backed by the user's default
     /// Local Registry. The committed artifact is published under an
     /// auto-generated anonymous image name.
     pub fn new(name: impl Into<String>) -> Result<Self> {
-        let registry = Arc::new(LocalRegistry::open_default()?);
+        let registry = LocalRegistry::shared_default()?;
         Ok(Self::with_registry(name, registry, None))
     }
+}
 
+impl<'reg> Experiment<'reg> {
     /// Start a new experiment session against an explicit Local
     /// Registry. When `requested_ref` is set the committed artifact is
     /// published under that image name; otherwise an anonymous image
     /// name is synthesised at commit time.
     pub fn with_registry(
         name: impl Into<String>,
-        registry: Arc<LocalRegistry>,
+        registry: &'reg LocalRegistry,
         requested_ref: Option<ImageRef>,
     ) -> Self {
         Experiment {
@@ -72,7 +74,7 @@ impl Experiment {
     }
 
     /// Start a new [`Run`]. Each run gets a fresh 0-based `run_id`.
-    pub fn run(&mut self) -> Result<Run<'_>> {
+    pub fn run(&mut self) -> Result<Run<'_, 'reg>> {
         let run_id = self.state.next_run_id;
         self.state.next_run_id += 1;
         self.state.runs.push(RunState {
@@ -136,26 +138,26 @@ impl Experiment {
     /// Seal the session into an immutable OMMX Artifact and publish it
     /// to the Local Registry. Consumes the unsealed session, so further
     /// mutation is impossible in Rust.
-    pub fn commit(self) -> Result<SealedExperiment> {
+    pub fn commit(self) -> Result<SealedExperiment<'reg>> {
         ensure_no_running_runs(&self.state)?;
-        let artifact = commit::commit_experiment_state(&self.registry, &self.state)?;
+        let artifact = commit::commit_experiment_state(self.registry, &self.state)?;
         Ok(SealedExperiment { artifact })
     }
 }
 
-impl SealedExperiment {
+impl<'reg> SealedExperiment<'reg> {
     /// The committed artifact handle.
-    pub fn artifact(&self) -> LocalArtifact {
+    pub fn artifact(&self) -> LocalArtifact<'reg> {
         self.artifact.clone()
     }
 
     /// Consume the sealed experiment and return its artifact handle.
-    pub fn into_artifact(self) -> LocalArtifact {
+    pub fn into_artifact(self) -> LocalArtifact<'reg> {
         self.artifact
     }
 }
 
-impl Run<'_> {
+impl Run<'_, '_> {
     /// This run's 0-based id within the experiment.
     pub fn run_id(&self) -> u64 {
         self.run_id

--- a/rust/ommx/src/experiment/session.rs
+++ b/rust/ommx/src/experiment/session.rs
@@ -18,7 +18,7 @@ const JSON_MEDIA_TYPE: &str = "application/json";
 #[derive(Debug)]
 pub struct Experiment<'reg> {
     pub(super) registry: &'reg LocalRegistry,
-    pub(super) state: UnsealedExperimentState,
+    pub(super) state: UnsealedExperimentState<'reg>,
 }
 
 /// A sealed experiment session whose root artifact manifest has been
@@ -233,7 +233,7 @@ impl Run<'_, '_> {
     }
 }
 
-fn ensure_no_running_runs(state: &UnsealedExperimentState) -> Result<()> {
+fn ensure_no_running_runs(state: &UnsealedExperimentState<'_>) -> Result<()> {
     if let Some(run) = state
         .runs
         .iter()
@@ -247,7 +247,10 @@ fn ensure_no_running_runs(state: &UnsealedExperimentState) -> Result<()> {
     Ok(())
 }
 
-fn find_run_mut(state: &mut UnsealedExperimentState, run_id: u64) -> Result<&mut RunState> {
+fn find_run_mut<'state, 'reg>(
+    state: &'state mut UnsealedExperimentState<'reg>,
+    run_id: u64,
+) -> Result<&'state mut RunState<'reg>> {
     state
         .runs
         .iter_mut()
@@ -259,7 +262,7 @@ fn find_run_mut(state: &mut UnsealedExperimentState, run_id: u64) -> Result<&mut
 /// within a space replaces the previous one. Within one `Vec` the space
 /// and `run_id` are already fixed, so `(media_type, name)` is the
 /// remaining key.
-fn upsert_record_ref(records: &mut Vec<RecordRef>, record_ref: RecordRef) {
+fn upsert_record_ref<'reg>(records: &mut Vec<RecordRef<'reg>>, record_ref: RecordRef<'reg>) {
     if let Some(existing) = records.iter_mut().find(|r| {
         r.descriptor.media_type() == record_ref.descriptor.media_type() && r.name == record_ref.name
     }) {
@@ -282,14 +285,14 @@ fn encode_json(name: &str, value: impl serde::Serialize) -> Result<Vec<u8>> {
 /// [`RecordRef`]: an OCI layer descriptor carrying the experiment /
 /// record annotations, plus the matching descriptor for commit-time
 /// publication.
-fn store_record_ref(
-    registry: &LocalRegistry,
+fn store_record_ref<'reg>(
+    registry: &'reg LocalRegistry,
     space: Space,
     run_id: Option<u64>,
     name: &str,
     media_type: MediaType,
     bytes: &[u8],
-) -> Result<RecordRef> {
+) -> Result<RecordRef<'reg>> {
     let digest = sha256_digest(bytes);
     let digest = oci_spec::image::Digest::from_str(&digest)
         .map_err(|e| crate::error!("Failed to parse record blob digest: {e}"))?;

--- a/rust/ommx/src/experiment/session.rs
+++ b/rust/ommx/src/experiment/session.rs
@@ -58,7 +58,7 @@ impl<'reg> Experiment<'reg> {
     /// This is intended for Rust SDK tests that need an isolated
     /// registry while still exercising the same Local Registry-backed
     /// artifact path as production code.
-    pub fn on_temp_local_registry<T>(
+    pub fn with_temp_local_registry<T>(
         name: impl Into<String>,
         f: impl FnOnce(Experiment<'_>) -> anyhow::Result<T>,
     ) -> Result<T> {

--- a/rust/ommx/src/experiment/session.rs
+++ b/rust/ommx/src/experiment/session.rs
@@ -49,7 +49,9 @@ impl Experiment<'static> {
         let registry = LocalRegistry::shared_default()?;
         Ok(Self::with_registry(name, registry, None))
     }
+}
 
+impl<'reg> Experiment<'reg> {
     /// Create a temporary Local Registry, run an experiment callback
     /// against it, and delete the registry when the callback returns.
     ///
@@ -64,9 +66,6 @@ impl Experiment<'static> {
         let experiment = Experiment::with_registry(name, &temp.registry, None);
         f(experiment)
     }
-}
-
-impl<'reg> Experiment<'reg> {
     /// Start a new experiment session against an explicit Local
     /// Registry. When `requested_ref` is set the committed artifact is
     /// published under that image name; otherwise an anonymous image

--- a/rust/ommx/src/experiment/session.rs
+++ b/rust/ommx/src/experiment/session.rs
@@ -2,7 +2,7 @@
 
 use super::model::{RecordRef, RunState, RunStatus, Space, UnsealedExperimentState};
 use super::{build_descriptor, commit, ANN_RECORD_NAME, ANN_RUN_ID, ANN_SPACE};
-use crate::artifact::local_registry::LocalRegistry;
+use crate::artifact::local_registry::{LocalRegistry, TempLocalRegistry};
 use crate::artifact::{media_types, sha256_digest, ImageRef, LocalArtifact};
 use crate::{Instance, SampleSet, Solution};
 use anyhow::Result;
@@ -48,6 +48,21 @@ impl Experiment<'static> {
     pub fn new(name: impl Into<String>) -> Result<Self> {
         let registry = LocalRegistry::shared_default()?;
         Ok(Self::with_registry(name, registry, None))
+    }
+
+    /// Create a temporary Local Registry, run an experiment callback
+    /// against it, and delete the registry when the callback returns.
+    ///
+    /// This is intended for Rust SDK tests that need an isolated
+    /// registry while still exercising the same Local Registry-backed
+    /// artifact path as production code.
+    pub fn on_temp_local_registry<T>(
+        name: impl Into<String>,
+        f: impl FnOnce(Experiment<'_>) -> anyhow::Result<T>,
+    ) -> Result<T> {
+        let temp = TempLocalRegistry::new()?;
+        let experiment = Experiment::with_registry(name, &temp.registry, None);
+        f(experiment)
     }
 }
 

--- a/rust/ommx/src/experiment/session.rs
+++ b/rust/ommx/src/experiment/session.rs
@@ -63,7 +63,7 @@ impl<'reg> Experiment<'reg> {
         f: impl FnOnce(Experiment<'_>) -> anyhow::Result<T>,
     ) -> Result<T> {
         let temp = TempLocalRegistry::new()?;
-        let experiment = Experiment::with_registry(name, &temp.registry, None);
+        let experiment = Experiment::with_registry(name, temp.registry(), None);
         f(experiment)
     }
     /// Start a new experiment session against an explicit Local

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -12,19 +12,20 @@ use crate::artifact::media_types;
 use crate::Instance;
 use oci_spec::image::{Descriptor, MediaType};
 use serde_json::json;
-use std::sync::Arc;
 use tempfile::TempDir;
 
 /// A fresh experiment backed by a throwaway temp Local Registry. The
 /// returned `TempDir` must outlive the experiment.
-fn temp_experiment(name: &str) -> (TempDir, Experiment) {
+fn temp_experiment(name: &str) -> (TempDir, Experiment<'static>) {
     let dir = tempfile::tempdir().expect("create temp dir");
-    let registry = Arc::new(LocalRegistry::open(dir.path()).expect("open temp registry"));
+    let registry = Box::leak(Box::new(
+        LocalRegistry::open(dir.path()).expect("open temp registry"),
+    ));
     let experiment = Experiment::with_registry(name, registry, None);
     (dir, experiment)
 }
 
-fn unsealed_state(experiment: &Experiment) -> &UnsealedExperimentState {
+fn unsealed_state<'exp, 'reg>(experiment: &'exp Experiment<'reg>) -> &'exp UnsealedExperimentState {
     &experiment.state
 }
 

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -25,7 +25,9 @@ fn temp_experiment(name: &str) -> (TempDir, Experiment<'static>) {
     (dir, experiment)
 }
 
-fn unsealed_state<'exp, 'reg>(experiment: &'exp Experiment<'reg>) -> &'exp UnsealedExperimentState {
+fn unsealed_state<'exp, 'reg>(
+    experiment: &'exp Experiment<'reg>,
+) -> &'exp UnsealedExperimentState<'reg> {
     &experiment.state
 }
 

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -7,20 +7,10 @@ use super::{
     ARTIFACT_KIND_EXPERIMENT, EXPERIMENT_SCHEMA_V1, EXPERIMENT_STATUS_FINISHED, LAYER_KIND_INDEX,
     LAYER_KIND_RUN_ATTRIBUTES,
 };
-use crate::artifact::local_registry::TempLocalRegistry;
 use crate::artifact::media_types;
 use crate::Instance;
 use oci_spec::image::{Descriptor, MediaType};
 use serde_json::json;
-
-/// A fresh experiment backed by a throwaway temp Local Registry. The
-/// registry lives for the duration of the callback, matching the
-/// lifetime carried by `Experiment`.
-fn with_temp_experiment<T>(name: &str, f: impl FnOnce(Experiment<'_>) -> T) -> T {
-    let temp = TempLocalRegistry::new().expect("open temp registry");
-    let experiment = Experiment::with_registry(name, &temp.registry, None);
-    f(experiment)
-}
 
 fn unsealed_state<'exp, 'reg>(
     experiment: &'exp Experiment<'reg>,
@@ -53,7 +43,7 @@ fn find_layer<'a>(layers: &'a [Descriptor], key: &str, value: &str) -> &'a Descr
 /// run handle, record the final status, and set elapsed time.
 #[test]
 fn run_lifecycle_assigns_ids_and_records_status() {
-    with_temp_experiment("lifecycle", |mut experiment| {
+    Experiment::on_temp_local_registry("lifecycle", |mut experiment| {
         {
             let run0 = experiment.run().unwrap();
             assert_eq!(run0.run_id(), 0);
@@ -70,14 +60,16 @@ fn run_lifecycle_assigns_ids_and_records_status() {
         assert!(state.runs[0].elapsed_secs.is_some());
         assert_eq!(state.runs[1].status, RunStatus::Failed);
         assert!(state.runs[1].elapsed_secs.is_some());
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// `log_*` writes the payload to the BlobStore immediately, before any
 /// commit advances a public ref.
 #[test]
 fn log_writes_blob_to_blobstore_immediately() {
-    with_temp_experiment("eager-write", |mut experiment| {
+    Experiment::on_temp_local_registry("eager-write", |mut experiment| {
         {
             let mut run = experiment.run().unwrap();
             run.log_json("solver", json!("scip")).unwrap();
@@ -90,14 +82,16 @@ fn log_writes_blob_to_blobstore_immediately() {
             digest
         };
         assert!(experiment.registry.blobs().exists(&digest).unwrap());
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// Logging the same `(space, media type, name)` again replaces the
 /// record.
 #[test]
 fn log_upserts_same_space_media_type_name() {
-    with_temp_experiment("upsert", |mut experiment| {
+    Experiment::on_temp_local_registry("upsert", |mut experiment| {
         experiment.log_json("dataset", json!("miplib2017")).unwrap();
         experiment.log_json("dataset", json!("qplib")).unwrap();
 
@@ -120,14 +114,16 @@ fn log_upserts_same_space_media_type_name() {
             .read_bytes(json_record.descriptor.digest())
             .unwrap();
         assert_eq!(bytes, serde_json::to_vec(&json!("qplib")).unwrap());
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// `commit()` seals the session into an OMMX Artifact whose manifest and
 /// layer annotations describe the experiment / run records.
 #[test]
 fn commit_produces_experiment_artifact() {
-    with_temp_experiment("commit", |mut experiment| {
+    Experiment::on_temp_local_registry("commit", |mut experiment| {
         experiment.log_json("dataset", json!("miplib2017")).unwrap();
 
         let instance: Instance =
@@ -201,7 +197,9 @@ fn commit_produces_experiment_artifact() {
             artifact.get_manifest().unwrap().config().media_type(),
             &MediaType::EmptyJSON
         );
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// `commit()` consumes the unsealed session and returns a sealed handle.
@@ -209,7 +207,7 @@ fn commit_produces_experiment_artifact() {
 /// in Rust because the original `Experiment` value has moved.
 #[test]
 fn commit_returns_sealed_experiment() {
-    with_temp_experiment("sealed", |mut experiment| {
+    Experiment::on_temp_local_registry("sealed", |mut experiment| {
         {
             let mut run = experiment.run().unwrap();
             run.log_json("seed", json!(0)).unwrap();
@@ -226,7 +224,9 @@ fn commit_returns_sealed_experiment() {
                 .map(String::as_str),
             Some("sealed")
         );
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// Dropping a run handle without closing it does not implicitly mark
@@ -234,21 +234,23 @@ fn commit_returns_sealed_experiment() {
 /// manifest while a run is still `running`.
 #[test]
 fn commit_rejects_unclosed_run() {
-    with_temp_experiment("unclosed-run", |mut experiment| {
+    Experiment::on_temp_local_registry("unclosed-run", |mut experiment| {
         {
             let mut run = experiment.run().unwrap();
             run.log_json("seed", json!(0)).unwrap();
         }
 
         assert!(experiment.commit().is_err());
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// A byte-identical record logged by two runs yields two annotation-
 /// distinct layer descriptors backed by one shared CAS blob.
 #[test]
 fn byte_identical_record_across_runs_shares_one_blob() {
-    with_temp_experiment("shared-blob", |mut experiment| {
+    Experiment::on_temp_local_registry("shared-blob", |mut experiment| {
         let payload = json!({ "formulation": "relaxed" });
 
         {
@@ -284,14 +286,16 @@ fn byte_identical_record_across_runs_shares_one_blob() {
             candidates[0].digest().to_string(),
             candidates[1].digest().to_string()
         );
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// Caller-defined payload types are represented directly by OCI media
 /// type, without an additional OMMX record-kind axis.
 #[test]
 fn log_record_accepts_caller_defined_media_type() {
-    with_temp_experiment("custom-media-type", |mut experiment| {
+    Experiment::on_temp_local_registry("custom-media-type", |mut experiment| {
         let media_type = MediaType::Other("application/vnd.jijmodeling.model+json".to_string());
         experiment
             .log_record("source-model", media_type.clone(), br#"{"variables": []}"#)
@@ -305,5 +309,7 @@ fn log_record_accepts_caller_defined_media_type() {
             artifact.get_blob(source_model.digest()).unwrap(),
             br#"{"variables": []}"#
         );
-    });
+        Ok(())
+    })
+    .unwrap();
 }

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -43,7 +43,7 @@ fn find_layer<'a>(layers: &'a [Descriptor], key: &str, value: &str) -> &'a Descr
 /// run handle, record the final status, and set elapsed time.
 #[test]
 fn run_lifecycle_assigns_ids_and_records_status() {
-    Experiment::on_temp_local_registry("lifecycle", |mut experiment| {
+    Experiment::with_temp_local_registry("lifecycle", |mut experiment| {
         {
             let run0 = experiment.run().unwrap();
             assert_eq!(run0.run_id(), 0);
@@ -69,7 +69,7 @@ fn run_lifecycle_assigns_ids_and_records_status() {
 /// commit advances a public ref.
 #[test]
 fn log_writes_blob_to_blobstore_immediately() {
-    Experiment::on_temp_local_registry("eager-write", |mut experiment| {
+    Experiment::with_temp_local_registry("eager-write", |mut experiment| {
         {
             let mut run = experiment.run().unwrap();
             run.log_json("solver", json!("scip")).unwrap();
@@ -91,7 +91,7 @@ fn log_writes_blob_to_blobstore_immediately() {
 /// record.
 #[test]
 fn log_upserts_same_space_media_type_name() {
-    Experiment::on_temp_local_registry("upsert", |mut experiment| {
+    Experiment::with_temp_local_registry("upsert", |mut experiment| {
         experiment.log_json("dataset", json!("miplib2017")).unwrap();
         experiment.log_json("dataset", json!("qplib")).unwrap();
 
@@ -123,7 +123,7 @@ fn log_upserts_same_space_media_type_name() {
 /// layer annotations describe the experiment / run records.
 #[test]
 fn commit_produces_experiment_artifact() {
-    Experiment::on_temp_local_registry("commit", |mut experiment| {
+    Experiment::with_temp_local_registry("commit", |mut experiment| {
         experiment.log_json("dataset", json!("miplib2017")).unwrap();
 
         let instance: Instance =
@@ -207,7 +207,7 @@ fn commit_produces_experiment_artifact() {
 /// in Rust because the original `Experiment` value has moved.
 #[test]
 fn commit_returns_sealed_experiment() {
-    Experiment::on_temp_local_registry("sealed", |mut experiment| {
+    Experiment::with_temp_local_registry("sealed", |mut experiment| {
         {
             let mut run = experiment.run().unwrap();
             run.log_json("seed", json!(0)).unwrap();
@@ -234,7 +234,7 @@ fn commit_returns_sealed_experiment() {
 /// manifest while a run is still `running`.
 #[test]
 fn commit_rejects_unclosed_run() {
-    Experiment::on_temp_local_registry("unclosed-run", |mut experiment| {
+    Experiment::with_temp_local_registry("unclosed-run", |mut experiment| {
         {
             let mut run = experiment.run().unwrap();
             run.log_json("seed", json!(0)).unwrap();
@@ -250,7 +250,7 @@ fn commit_rejects_unclosed_run() {
 /// distinct layer descriptors backed by one shared CAS blob.
 #[test]
 fn byte_identical_record_across_runs_shares_one_blob() {
-    Experiment::on_temp_local_registry("shared-blob", |mut experiment| {
+    Experiment::with_temp_local_registry("shared-blob", |mut experiment| {
         let payload = json!({ "formulation": "relaxed" });
 
         {
@@ -295,7 +295,7 @@ fn byte_identical_record_across_runs_shares_one_blob() {
 /// type, without an additional OMMX record-kind axis.
 #[test]
 fn log_record_accepts_caller_defined_media_type() {
-    Experiment::on_temp_local_registry("custom-media-type", |mut experiment| {
+    Experiment::with_temp_local_registry("custom-media-type", |mut experiment| {
         let media_type = MediaType::Other("application/vnd.jijmodeling.model+json".to_string());
         experiment
             .log_record("source-model", media_type.clone(), br#"{"variables": []}"#)

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -7,22 +7,19 @@ use super::{
     ARTIFACT_KIND_EXPERIMENT, EXPERIMENT_SCHEMA_V1, EXPERIMENT_STATUS_FINISHED, LAYER_KIND_INDEX,
     LAYER_KIND_RUN_ATTRIBUTES,
 };
-use crate::artifact::local_registry::LocalRegistry;
+use crate::artifact::local_registry::TempLocalRegistry;
 use crate::artifact::media_types;
 use crate::Instance;
 use oci_spec::image::{Descriptor, MediaType};
 use serde_json::json;
-use tempfile::TempDir;
 
 /// A fresh experiment backed by a throwaway temp Local Registry. The
-/// returned `TempDir` must outlive the experiment.
-fn temp_experiment(name: &str) -> (TempDir, Experiment<'static>) {
-    let dir = tempfile::tempdir().expect("create temp dir");
-    let registry = Box::leak(Box::new(
-        LocalRegistry::open(dir.path()).expect("open temp registry"),
-    ));
-    let experiment = Experiment::with_registry(name, registry, None);
-    (dir, experiment)
+/// registry lives for the duration of the callback, matching the
+/// lifetime carried by `Experiment`.
+fn with_temp_experiment<T>(name: &str, f: impl FnOnce(Experiment<'_>) -> T) -> T {
+    let temp = TempLocalRegistry::new().expect("open temp registry");
+    let experiment = Experiment::with_registry(name, &temp.registry, None);
+    f(experiment)
 }
 
 fn unsealed_state<'exp, 'reg>(
@@ -56,151 +53,155 @@ fn find_layer<'a>(layers: &'a [Descriptor], key: &str, value: &str) -> &'a Descr
 /// run handle, record the final status, and set elapsed time.
 #[test]
 fn run_lifecycle_assigns_ids_and_records_status() {
-    let (_dir, mut experiment) = temp_experiment("lifecycle");
-    {
-        let run0 = experiment.run().unwrap();
-        assert_eq!(run0.run_id(), 0);
-        run0.finish().unwrap();
-    }
-    {
-        let run1 = experiment.run().unwrap();
-        assert_eq!(run1.run_id(), 1);
-        run1.fail().unwrap();
-    }
+    with_temp_experiment("lifecycle", |mut experiment| {
+        {
+            let run0 = experiment.run().unwrap();
+            assert_eq!(run0.run_id(), 0);
+            run0.finish().unwrap();
+        }
+        {
+            let run1 = experiment.run().unwrap();
+            assert_eq!(run1.run_id(), 1);
+            run1.fail().unwrap();
+        }
 
-    let state = unsealed_state(&experiment);
-    assert_eq!(state.runs[0].status, RunStatus::Finished);
-    assert!(state.runs[0].elapsed_secs.is_some());
-    assert_eq!(state.runs[1].status, RunStatus::Failed);
-    assert!(state.runs[1].elapsed_secs.is_some());
+        let state = unsealed_state(&experiment);
+        assert_eq!(state.runs[0].status, RunStatus::Finished);
+        assert!(state.runs[0].elapsed_secs.is_some());
+        assert_eq!(state.runs[1].status, RunStatus::Failed);
+        assert!(state.runs[1].elapsed_secs.is_some());
+    });
 }
 
 /// `log_*` writes the payload to the BlobStore immediately, before any
 /// commit advances a public ref.
 #[test]
 fn log_writes_blob_to_blobstore_immediately() {
-    let (_dir, mut experiment) = temp_experiment("eager-write");
-    {
-        let mut run = experiment.run().unwrap();
-        run.log_json("solver", json!("scip")).unwrap();
-    }
+    with_temp_experiment("eager-write", |mut experiment| {
+        {
+            let mut run = experiment.run().unwrap();
+            run.log_json("solver", json!("scip")).unwrap();
+        }
 
-    let digest = {
-        let state = unsealed_state(&experiment);
-        assert_eq!(state.runs[0].records.len(), 1);
-        let digest = state.runs[0].records[0].descriptor.digest().clone();
-        digest
-    };
-    assert!(experiment.registry.blobs().exists(&digest).unwrap());
+        let digest = {
+            let state = unsealed_state(&experiment);
+            assert_eq!(state.runs[0].records.len(), 1);
+            let digest = state.runs[0].records[0].descriptor.digest().clone();
+            digest
+        };
+        assert!(experiment.registry.blobs().exists(&digest).unwrap());
+    });
 }
 
 /// Logging the same `(space, media type, name)` again replaces the
 /// record.
 #[test]
 fn log_upserts_same_space_media_type_name() {
-    let (_dir, mut experiment) = temp_experiment("upsert");
-    experiment.log_json("dataset", json!("miplib2017")).unwrap();
-    experiment.log_json("dataset", json!("qplib")).unwrap();
+    with_temp_experiment("upsert", |mut experiment| {
+        experiment.log_json("dataset", json!("miplib2017")).unwrap();
+        experiment.log_json("dataset", json!("qplib")).unwrap();
 
-    let instance: Instance =
-        crate::random::random_deterministic(crate::InstanceParameters::default_lp());
-    experiment.log_instance("dataset", &instance).unwrap();
+        let instance: Instance =
+            crate::random::random_deterministic(crate::InstanceParameters::default_lp());
+        experiment.log_instance("dataset", &instance).unwrap();
 
-    let state = unsealed_state(&experiment);
-    assert_eq!(state.records.len(), 2);
-    let json_record = state
-        .records
-        .iter()
-        .find(|record| {
-            record.descriptor.media_type() == &MediaType::Other("application/json".into())
-        })
-        .unwrap();
-    let bytes = experiment
-        .registry
-        .blobs()
-        .read_bytes(json_record.descriptor.digest())
-        .unwrap();
-    assert_eq!(bytes, serde_json::to_vec(&json!("qplib")).unwrap());
+        let state = unsealed_state(&experiment);
+        assert_eq!(state.records.len(), 2);
+        let json_record = state
+            .records
+            .iter()
+            .find(|record| {
+                record.descriptor.media_type() == &MediaType::Other("application/json".into())
+            })
+            .unwrap();
+        let bytes = experiment
+            .registry
+            .blobs()
+            .read_bytes(json_record.descriptor.digest())
+            .unwrap();
+        assert_eq!(bytes, serde_json::to_vec(&json!("qplib")).unwrap());
+    });
 }
 
 /// `commit()` seals the session into an OMMX Artifact whose manifest and
 /// layer annotations describe the experiment / run records.
 #[test]
 fn commit_produces_experiment_artifact() {
-    let (_dir, mut experiment) = temp_experiment("commit");
-    experiment.log_json("dataset", json!("miplib2017")).unwrap();
+    with_temp_experiment("commit", |mut experiment| {
+        experiment.log_json("dataset", json!("miplib2017")).unwrap();
 
-    let instance: Instance =
-        crate::random::random_deterministic(crate::InstanceParameters::default_lp());
-    {
-        let mut run = experiment.run().unwrap();
-        run.log_instance("candidate", &instance).unwrap();
-        run.log_json("config", json!({ "relaxed": true })).unwrap();
-        run.finish().unwrap();
-    }
+        let instance: Instance =
+            crate::random::random_deterministic(crate::InstanceParameters::default_lp());
+        {
+            let mut run = experiment.run().unwrap();
+            run.log_instance("candidate", &instance).unwrap();
+            run.log_json("config", json!({ "relaxed": true })).unwrap();
+            run.finish().unwrap();
+        }
 
-    let sealed = experiment.commit().unwrap();
-    let artifact = sealed.artifact();
+        let sealed = experiment.commit().unwrap();
+        let artifact = sealed.artifact();
 
-    let annotations = artifact.annotations().unwrap();
-    assert_eq!(
-        annotations.get(ANN_ARTIFACT_KIND).map(String::as_str),
-        Some(ARTIFACT_KIND_EXPERIMENT)
-    );
-    assert_eq!(
-        annotations.get(ANN_EXPERIMENT_SCHEMA).map(String::as_str),
-        Some(EXPERIMENT_SCHEMA_V1)
-    );
-    assert_eq!(
-        annotations.get(ANN_EXPERIMENT_NAME).map(String::as_str),
-        Some("commit")
-    );
-    assert_eq!(
-        annotations.get(ANN_EXPERIMENT_STATUS).map(String::as_str),
-        Some(EXPERIMENT_STATUS_FINISHED)
-    );
+        let annotations = artifact.annotations().unwrap();
+        assert_eq!(
+            annotations.get(ANN_ARTIFACT_KIND).map(String::as_str),
+            Some(ARTIFACT_KIND_EXPERIMENT)
+        );
+        assert_eq!(
+            annotations.get(ANN_EXPERIMENT_SCHEMA).map(String::as_str),
+            Some(EXPERIMENT_SCHEMA_V1)
+        );
+        assert_eq!(
+            annotations.get(ANN_EXPERIMENT_NAME).map(String::as_str),
+            Some("commit")
+        );
+        assert_eq!(
+            annotations.get(ANN_EXPERIMENT_STATUS).map(String::as_str),
+            Some(EXPERIMENT_STATUS_FINISHED)
+        );
 
-    // 3 records (1 experiment-space + 2 run-space) + run-attributes + index.
-    let layers = artifact.layers().unwrap();
-    assert_eq!(layers.len(), 5);
+        // 3 records (1 experiment-space + 2 run-space) + run-attributes + index.
+        let layers = artifact.layers().unwrap();
+        assert_eq!(layers.len(), 5);
 
-    let dataset = find_layer(&layers, ANN_RECORD_NAME, "dataset");
-    assert_eq!(
-        layer_annotation(dataset, ANN_SPACE).as_deref(),
-        Some("experiment")
-    );
-    assert_eq!(
-        dataset.media_type(),
-        &MediaType::Other("application/json".into())
-    );
-    assert!(layer_annotation(dataset, ANN_RUN_ID).is_none());
+        let dataset = find_layer(&layers, ANN_RECORD_NAME, "dataset");
+        assert_eq!(
+            layer_annotation(dataset, ANN_SPACE).as_deref(),
+            Some("experiment")
+        );
+        assert_eq!(
+            dataset.media_type(),
+            &MediaType::Other("application/json".into())
+        );
+        assert!(layer_annotation(dataset, ANN_RUN_ID).is_none());
 
-    let candidate = find_layer(&layers, ANN_RECORD_NAME, "candidate");
-    assert_eq!(
-        layer_annotation(candidate, ANN_SPACE).as_deref(),
-        Some("run")
-    );
-    assert_eq!(
-        layer_annotation(candidate, ANN_RUN_ID).as_deref(),
-        Some("0")
-    );
-    assert_eq!(candidate.media_type(), &media_types::v1_instance());
-    assert_eq!(
-        artifact.get_blob(candidate.digest()).unwrap(),
-        instance.to_bytes()
-    );
+        let candidate = find_layer(&layers, ANN_RECORD_NAME, "candidate");
+        assert_eq!(
+            layer_annotation(candidate, ANN_SPACE).as_deref(),
+            Some("run")
+        );
+        assert_eq!(
+            layer_annotation(candidate, ANN_RUN_ID).as_deref(),
+            Some("0")
+        );
+        assert_eq!(candidate.media_type(), &media_types::v1_instance());
+        assert_eq!(
+            artifact.get_blob(candidate.digest()).unwrap(),
+            instance.to_bytes()
+        );
 
-    // Aggregate layers are not tagged as records.
-    let run_attrs = find_layer(&layers, ANN_LAYER, LAYER_KIND_RUN_ATTRIBUTES);
-    assert!(layer_annotation(run_attrs, ANN_SPACE).is_none());
-    let index = find_layer(&layers, ANN_LAYER, LAYER_KIND_INDEX);
-    assert!(layer_annotation(index, ANN_SPACE).is_none());
+        // Aggregate layers are not tagged as records.
+        let run_attrs = find_layer(&layers, ANN_LAYER, LAYER_KIND_RUN_ATTRIBUTES);
+        assert!(layer_annotation(run_attrs, ANN_SPACE).is_none());
+        let index = find_layer(&layers, ANN_LAYER, LAYER_KIND_INDEX);
+        assert!(layer_annotation(index, ANN_SPACE).is_none());
 
-    // Config is the OCI 1.1 empty config.
-    assert_eq!(
-        artifact.get_manifest().unwrap().config().media_type(),
-        &MediaType::EmptyJSON
-    );
+        // Config is the OCI 1.1 empty config.
+        assert_eq!(
+            artifact.get_manifest().unwrap().config().media_type(),
+            &MediaType::EmptyJSON
+        );
+    });
 }
 
 /// `commit()` consumes the unsealed session and returns a sealed handle.
@@ -208,23 +209,24 @@ fn commit_produces_experiment_artifact() {
 /// in Rust because the original `Experiment` value has moved.
 #[test]
 fn commit_returns_sealed_experiment() {
-    let (_dir, mut experiment) = temp_experiment("sealed");
-    {
-        let mut run = experiment.run().unwrap();
-        run.log_json("seed", json!(0)).unwrap();
-        run.finish().unwrap();
-    }
+    with_temp_experiment("sealed", |mut experiment| {
+        {
+            let mut run = experiment.run().unwrap();
+            run.log_json("seed", json!(0)).unwrap();
+            run.finish().unwrap();
+        }
 
-    let sealed = experiment.commit().unwrap();
-    let artifact = sealed.artifact();
-    assert_eq!(
-        artifact
-            .annotations()
-            .unwrap()
-            .get(ANN_EXPERIMENT_NAME)
-            .map(String::as_str),
-        Some("sealed")
-    );
+        let sealed = experiment.commit().unwrap();
+        let artifact = sealed.artifact();
+        assert_eq!(
+            artifact
+                .annotations()
+                .unwrap()
+                .get(ANN_EXPERIMENT_NAME)
+                .map(String::as_str),
+            Some("sealed")
+        );
+    });
 }
 
 /// Dropping a run handle without closing it does not implicitly mark
@@ -232,71 +234,76 @@ fn commit_returns_sealed_experiment() {
 /// manifest while a run is still `running`.
 #[test]
 fn commit_rejects_unclosed_run() {
-    let (_dir, mut experiment) = temp_experiment("unclosed-run");
-    {
-        let mut run = experiment.run().unwrap();
-        run.log_json("seed", json!(0)).unwrap();
-    }
+    with_temp_experiment("unclosed-run", |mut experiment| {
+        {
+            let mut run = experiment.run().unwrap();
+            run.log_json("seed", json!(0)).unwrap();
+        }
 
-    assert!(experiment.commit().is_err());
+        assert!(experiment.commit().is_err());
+    });
 }
 
 /// A byte-identical record logged by two runs yields two annotation-
 /// distinct layer descriptors backed by one shared CAS blob.
 #[test]
 fn byte_identical_record_across_runs_shares_one_blob() {
-    let (_dir, mut experiment) = temp_experiment("shared-blob");
-    let payload = json!({ "formulation": "relaxed" });
+    with_temp_experiment("shared-blob", |mut experiment| {
+        let payload = json!({ "formulation": "relaxed" });
 
-    {
-        let mut run0 = experiment.run().unwrap();
-        run0.log_json("candidate", payload.clone()).unwrap();
-        run0.finish().unwrap();
-    }
+        {
+            let mut run0 = experiment.run().unwrap();
+            run0.log_json("candidate", payload.clone()).unwrap();
+            run0.finish().unwrap();
+        }
 
-    {
-        let mut run1 = experiment.run().unwrap();
-        run1.log_json("candidate", payload.clone()).unwrap();
-        run1.finish().unwrap();
-    }
+        {
+            let mut run1 = experiment.run().unwrap();
+            run1.log_json("candidate", payload.clone()).unwrap();
+            run1.finish().unwrap();
+        }
 
-    let artifact = experiment.commit().unwrap().into_artifact();
-    let layers = artifact.layers().unwrap();
+        let artifact = experiment.commit().unwrap().into_artifact();
+        let layers = artifact.layers().unwrap();
 
-    let candidates: Vec<&Descriptor> = layers
-        .iter()
-        .filter(|layer| layer_annotation(layer, ANN_RECORD_NAME).as_deref() == Some("candidate"))
-        .collect();
-    assert_eq!(candidates.len(), 2);
-    let mut run_ids: Vec<Option<String>> = candidates
-        .iter()
-        .map(|layer| layer_annotation(layer, ANN_RUN_ID))
-        .collect();
-    run_ids.sort();
-    assert_eq!(run_ids, vec![Some("0".to_string()), Some("1".to_string())]);
-    // Same content -> same digest -> one physical blob.
-    assert_eq!(
-        candidates[0].digest().to_string(),
-        candidates[1].digest().to_string()
-    );
+        let candidates: Vec<&Descriptor> = layers
+            .iter()
+            .filter(|layer| {
+                layer_annotation(layer, ANN_RECORD_NAME).as_deref() == Some("candidate")
+            })
+            .collect();
+        assert_eq!(candidates.len(), 2);
+        let mut run_ids: Vec<Option<String>> = candidates
+            .iter()
+            .map(|layer| layer_annotation(layer, ANN_RUN_ID))
+            .collect();
+        run_ids.sort();
+        assert_eq!(run_ids, vec![Some("0".to_string()), Some("1".to_string())]);
+        // Same content -> same digest -> one physical blob.
+        assert_eq!(
+            candidates[0].digest().to_string(),
+            candidates[1].digest().to_string()
+        );
+    });
 }
 
 /// Caller-defined payload types are represented directly by OCI media
 /// type, without an additional OMMX record-kind axis.
 #[test]
 fn log_record_accepts_caller_defined_media_type() {
-    let (_dir, mut experiment) = temp_experiment("custom-media-type");
-    let media_type = MediaType::Other("application/vnd.jijmodeling.model+json".to_string());
-    experiment
-        .log_record("source-model", media_type.clone(), br#"{"variables": []}"#)
-        .unwrap();
+    with_temp_experiment("custom-media-type", |mut experiment| {
+        let media_type = MediaType::Other("application/vnd.jijmodeling.model+json".to_string());
+        experiment
+            .log_record("source-model", media_type.clone(), br#"{"variables": []}"#)
+            .unwrap();
 
-    let artifact = experiment.commit().unwrap().into_artifact();
-    let layers = artifact.layers().unwrap();
-    let source_model = find_layer(&layers, ANN_RECORD_NAME, "source-model");
-    assert_eq!(source_model.media_type(), &media_type);
-    assert_eq!(
-        artifact.get_blob(source_model.digest()).unwrap(),
-        br#"{"variables": []}"#
-    );
+        let artifact = experiment.commit().unwrap().into_artifact();
+        let layers = artifact.layers().unwrap();
+        let source_model = find_layer(&layers, ANN_RECORD_NAME, "source-model");
+        assert_eq!(source_model.media_type(), &media_type);
+        assert_eq!(
+            artifact.get_blob(source_model.digest()).unwrap(),
+            br#"{"variables": []}"#
+        );
+    });
 }

--- a/rust/ommx/tests/auth_e2e.rs
+++ b/rust/ommx/tests/auth_e2e.rs
@@ -83,10 +83,12 @@ fn start_htpasswd_registry() -> Container<GenericImage> {
 /// Build a tiny LocalArtifact in a fresh tempdir-backed SQLite Local
 /// Registry. Returns the artifact (containing one INSTANCE layer) plus
 /// the registry's tempdir handle so it stays alive for the caller.
-fn build_test_artifact(image_name: ImageRef) -> Result<(LocalArtifact, tempfile::TempDir)> {
+fn build_test_artifact(
+    image_name: ImageRef,
+) -> Result<(LocalArtifact<'static>, tempfile::TempDir)> {
     let dir = tempfile::tempdir()?;
-    let registry = Arc::new(LocalRegistry::open(dir.path())?);
-    let mut builder = ArtifactDraft::with_registry(registry.clone(), image_name);
+    let registry = Box::leak(Box::new(LocalRegistry::open(dir.path())?));
+    let mut builder = ArtifactDraft::with_registry(registry, image_name);
     builder.add_layer_bytes(
         oci_spec::image::MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         b"auth-e2e-test".to_vec(),
@@ -317,7 +319,7 @@ fn cli_push_routes_through_native_path() -> Result<()> {
     {
         let local = Arc::new(LocalRegistry::open(dir.path())?);
         let mut builder =
-            ArtifactDraft::with_registry(local.clone(), ImageRef::parse(&image_name)?);
+            ArtifactDraft::with_registry(local.as_ref(), ImageRef::parse(&image_name)?);
         builder.add_layer_bytes(
             oci_spec::image::MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"cli-dispatch".to_vec(),
@@ -379,7 +381,7 @@ fn push_oci_archive_via_load_then_push() -> Result<()> {
     let receiver_dir = tempfile::tempdir()?;
     let receiver = Arc::new(LocalRegistry::open(receiver_dir.path())?);
     import_oci_archive(&receiver, &archive_path)?;
-    let receiver_local = LocalArtifact::open_in_registry(receiver, image_name)?;
+    let receiver_local = LocalArtifact::open_in_registry(receiver.as_ref(), image_name)?;
     receiver_local.push()
 }
 
@@ -423,7 +425,7 @@ fn pull_image_round_trips_through_anonymous_registry() -> Result<()> {
     // digest, same single layer, same layer bytes. Failure on any of
     // these assertions means the native pull lost data on the way
     // through `RemoteTransport` + `publish_artifact_atomic`.
-    let pulled = LocalArtifact::open_in_registry(receiver, image_name)?;
+    let pulled = LocalArtifact::open_in_registry(receiver.as_ref(), image_name)?;
     assert_eq!(pulled.manifest_digest(), &outcome.manifest_digest);
     let layers = pulled.layers()?;
     assert_eq!(layers.len(), 1);

--- a/rust/ommx/tests/auth_e2e.rs
+++ b/rust/ommx/tests/auth_e2e.rs
@@ -27,7 +27,7 @@
 
 use anyhow::Result;
 use ommx::artifact::{
-    local_registry::{import_oci_archive, pull_image, LocalRegistry},
+    local_registry::{import_oci_archive, pull_image, LocalRegistry, TempLocalRegistry},
     media_types, ArtifactDraft, ImageRef, LocalArtifact,
 };
 use serial_test::serial;
@@ -81,14 +81,13 @@ fn start_htpasswd_registry() -> Container<GenericImage> {
 }
 
 /// Build a tiny LocalArtifact in a fresh tempdir-backed SQLite Local
-/// Registry. Returns the artifact (containing one INSTANCE layer) plus
-/// the registry's tempdir handle so it stays alive for the caller.
-fn build_test_artifact(
+/// Registry and run `f` while that registry is still alive.
+fn with_test_artifact<T>(
     image_name: ImageRef,
-) -> Result<(LocalArtifact<'static>, tempfile::TempDir)> {
-    let dir = tempfile::tempdir()?;
-    let registry = Box::leak(Box::new(LocalRegistry::open(dir.path())?));
-    let mut builder = ArtifactDraft::with_registry(registry, image_name);
+    f: impl FnOnce(LocalArtifact<'_>) -> Result<T>,
+) -> Result<T> {
+    let temp = TempLocalRegistry::new()?;
+    let mut builder = ArtifactDraft::with_registry(&temp.registry, image_name);
     builder.add_layer_bytes(
         oci_spec::image::MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
         b"auth-e2e-test".to_vec(),
@@ -98,7 +97,7 @@ fn build_test_artifact(
         )]),
     )?;
     let artifact = builder.commit()?;
-    Ok((artifact, dir))
+    f(artifact)
 }
 
 /// Materialise a fake `~/.docker/config.json` in a tempdir and point
@@ -174,8 +173,7 @@ fn push_anonymous_against_open_registry() -> Result<()> {
     let registry = start_anonymous_registry();
     let port = registry.get_host_port_ipv4(5000)?;
     let image_name = ImageRef::parse(&format!("localhost:{port}/ommx-test/anon:tag1"))?;
-    let (artifact, _dir) = build_test_artifact(image_name)?;
-    artifact.push()
+    with_test_artifact(image_name, |artifact| artifact.push())
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -196,8 +194,7 @@ fn push_with_docker_config_only() -> Result<()> {
     let _docker_dir = write_docker_config(&host, ALICE_USER, ALICE_PASSWORD)?;
 
     let image_name = ImageRef::parse(&format!("{host}/ommx-test/docker-only:tag1"))?;
-    let (artifact, _dir) = build_test_artifact(image_name)?;
-    artifact.push()
+    with_test_artifact(image_name, |artifact| artifact.push())
 }
 
 /// Sanity check: the htpasswd registry actually enforces auth. If
@@ -211,16 +208,17 @@ fn push_anonymous_against_htpasswd_registry_fails() -> Result<()> {
     let registry = start_htpasswd_registry();
     let port = registry.get_host_port_ipv4(5000)?;
     let image_name = ImageRef::parse(&format!("localhost:{port}/ommx-test/anon-fail:tag1"))?;
-    let (artifact, _dir) = build_test_artifact(image_name)?;
-    let err = artifact
-        .push()
-        .expect_err("anonymous push must be rejected");
-    let msg = format!("{err:#}");
-    assert!(
-        msg.contains("auth") || msg.contains("401") || msg.contains("unauthorized"),
-        "expected an auth-related error, got: {msg}"
-    );
-    Ok(())
+    with_test_artifact(image_name, |artifact| {
+        let err = artifact
+            .push()
+            .expect_err("anonymous push must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("auth") || msg.contains("401") || msg.contains("unauthorized"),
+            "expected an auth-related error, got: {msg}"
+        );
+        Ok(())
+    })
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -244,8 +242,7 @@ fn push_with_env_basic_auth() -> Result<()> {
     set_env("OMMX_BASIC_AUTH_PASSWORD", ALICE_PASSWORD);
 
     let image_name = ImageRef::parse(&format!("{host}/ommx-test/env-auth:tag1"))?;
-    let (artifact, _dir) = build_test_artifact(image_name)?;
-    artifact.push()
+    with_test_artifact(image_name, |artifact| artifact.push())
 }
 
 /// Env override with wrong password must fail against the registry —
@@ -265,9 +262,10 @@ fn push_with_wrong_env_password_fails() -> Result<()> {
     set_env("OMMX_BASIC_AUTH_PASSWORD", "wrong-password");
 
     let image_name = ImageRef::parse(&format!("{host}/ommx-test/wrong-pw:tag1"))?;
-    let (artifact, _dir) = build_test_artifact(image_name)?;
-    assert!(artifact.push().is_err());
-    Ok(())
+    with_test_artifact(image_name, |artifact| {
+        assert!(artifact.push().is_err());
+        Ok(())
+    })
 }
 
 /// Env override beats docker config when both are present: the env
@@ -289,8 +287,7 @@ fn env_override_beats_docker_config() -> Result<()> {
     set_env("OMMX_BASIC_AUTH_PASSWORD", ALICE_PASSWORD);
 
     let image_name = ImageRef::parse(&format!("{host}/ommx-test/env-wins:tag1"))?;
-    let (artifact, _dir) = build_test_artifact(image_name)?;
-    artifact.push()
+    with_test_artifact(image_name, |artifact| artifact.push())
 }
 
 /// The `ommx` CLI's push subcommand must route through
@@ -369,11 +366,11 @@ fn push_oci_archive_via_load_then_push() -> Result<()> {
     let image_name = ImageRef::parse(&format!("localhost:{port}/ommx-test/archive-push:tag1"))?;
 
     // Sender side: build in SQLite, save to archive on disk.
-    let (sender_local, _sender_dir) = build_test_artifact(image_name.clone())?;
     let archive_dir = tempfile::tempdir()?;
     let archive_path = archive_dir.path().join("artifact.ommx");
-    sender_local.save(&archive_path)?;
-    drop(sender_local);
+    with_test_artifact(image_name.clone(), |sender_local| {
+        sender_local.save(&archive_path)
+    })?;
 
     // Receiver side: import the archive into a fresh SQLite registry,
     // then push from that registry. Matches the v3 "archive is
@@ -407,13 +404,13 @@ fn pull_image_round_trips_through_anonymous_registry() -> Result<()> {
     let image_name = ImageRef::parse(&format!("localhost:{port}/ommx-test/pull-rt:tag1"))?;
 
     // Push from a sender-side SQLite registry.
-    let (sender_local, _sender_dir) = build_test_artifact(image_name.clone())?;
-    let expected_layer_bytes = {
+    let expected_layer_bytes = with_test_artifact(image_name.clone(), |sender_local| {
         let layers = sender_local.layers()?;
         assert_eq!(layers.len(), 1);
-        sender_local.get_blob(layers[0].digest())?
-    };
-    sender_local.push()?;
+        let expected_layer_bytes = sender_local.get_blob(layers[0].digest())?;
+        sender_local.push()?;
+        Ok(expected_layer_bytes)
+    })?;
 
     // Pull into a fresh receiver-side SQLite registry tempdir.
     let receiver_dir = tempfile::tempdir()?;
@@ -452,14 +449,15 @@ fn partial_env_override_bails_before_registry_call() -> Result<()> {
     // PASSWORD deliberately unset.
 
     let image_name = ImageRef::parse(&format!("{host}/ommx-test/partial:tag1"))?;
-    let (artifact, _dir) = build_test_artifact(image_name)?;
-    let err = artifact
-        .push()
-        .expect_err("partial OMMX_BASIC_AUTH_* must bail");
-    let msg = format!("{err:#}");
-    assert!(
-        msg.contains("OMMX_BASIC_AUTH_PASSWORD") && msg.contains("unset"),
-        "error should name the missing var: {msg}"
-    );
-    Ok(())
+    with_test_artifact(image_name, |artifact| {
+        let err = artifact
+            .push()
+            .expect_err("partial OMMX_BASIC_AUTH_* must bail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("OMMX_BASIC_AUTH_PASSWORD") && msg.contains("unset"),
+            "error should name the missing var: {msg}"
+        );
+        Ok(())
+    })
 }

--- a/rust/ommx/tests/auth_e2e.rs
+++ b/rust/ommx/tests/auth_e2e.rs
@@ -86,7 +86,7 @@ fn with_test_artifact<T>(
     image_name: ImageRef,
     f: impl FnOnce(LocalArtifact<'_>) -> Result<T>,
 ) -> Result<T> {
-    ArtifactDraft::on_temp_local_registry(image_name, |mut draft| {
+    ArtifactDraft::with_temp_local_registry(image_name, |mut draft| {
         draft.add_layer_bytes(
             oci_spec::image::MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
             b"auth-e2e-test".to_vec(),

--- a/rust/ommx/tests/auth_e2e.rs
+++ b/rust/ommx/tests/auth_e2e.rs
@@ -27,7 +27,7 @@
 
 use anyhow::Result;
 use ommx::artifact::{
-    local_registry::{import_oci_archive, pull_image, LocalRegistry, TempLocalRegistry},
+    local_registry::{import_oci_archive, pull_image, LocalRegistry},
     media_types, ArtifactDraft, ImageRef, LocalArtifact,
 };
 use serial_test::serial;
@@ -86,18 +86,18 @@ fn with_test_artifact<T>(
     image_name: ImageRef,
     f: impl FnOnce(LocalArtifact<'_>) -> Result<T>,
 ) -> Result<T> {
-    let temp = TempLocalRegistry::new()?;
-    let mut builder = ArtifactDraft::with_registry(&temp.registry, image_name);
-    builder.add_layer_bytes(
-        oci_spec::image::MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
-        b"auth-e2e-test".to_vec(),
-        HashMap::from([(
-            "org.ommx.v1.instance.title".to_string(),
-            "auth-e2e".to_string(),
-        )]),
-    )?;
-    let artifact = builder.commit()?;
-    f(artifact)
+    ArtifactDraft::on_temp_local_registry(image_name, |mut draft| {
+        draft.add_layer_bytes(
+            oci_spec::image::MediaType::Other(media_types::V1_INSTANCE_MEDIA_TYPE.to_string()),
+            b"auth-e2e-test".to_vec(),
+            HashMap::from([(
+                "org.ommx.v1.instance.title".to_string(),
+                "auth-e2e".to_string(),
+            )]),
+        )?;
+        let artifact = draft.commit()?;
+        f(artifact)
+    })
 }
 
 /// Materialise a fake `~/.docker/config.json` in a tempdir and point


### PR DESCRIPTION
## Summary

- Add a process-wide shared default `LocalRegistry` accessor that returns `&'static LocalRegistry`.
- Change `LocalArtifact`, `ArtifactDraft`, and Experiment session types to borrow `LocalRegistry` instead of storing `Arc<LocalRegistry>`.
- Bind `StoredDescriptor` to the `LocalRegistry` reference that created or verified it, and propagate the lifetime through unsealed/sealed artifact state and experiment records.
- Validate registry identity when sealing an artifact and when publishing/replacing a sealed manifest ref.
- Add `TempLocalRegistry`, `ArtifactDraft::with_temp_local_registry(...)`, and `Experiment::with_temp_local_registry(...)` for Rust SDK tests that need an isolated temporary Local Registry without leaking registry handles.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `RUSTC_WRAPPER= cargo check -p ommx --all-targets --features remote-artifact,cli,built`
- `RUSTC_WRAPPER= cargo check -p _ommx_rust --all-targets --features remote-artifact`
- `RUSTC_WRAPPER= cargo check -p ommx --test auth_e2e --features remote-artifact,cli,built`
- `RUSTC_WRAPPER= cargo test -p ommx artifact::local_registry::tests --features remote-artifact,cli,built`
- `RUSTC_WRAPPER= cargo test -p ommx experiment::tests --features remote-artifact,cli,built`
