### PR TITLE
Expose Instance.substitute in the Python SDK

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -12412,6 +12412,48 @@
               "deprecated": null
             },
             {
+              "name": "substitute",
+              "doc": "Substitute decision variables with function expressions (in-place).\n\nReplaces each given decision variable with the provided function in the\nobjective and all active constraints. This is the general substitution\nmechanism behind {meth}`~ommx.v1.Instance.log_encode`, exposed so that\nusers can implement their own integer encodings (e.g. unary, one-hot).\n\n**Args:**\n- `assignments`: A dict mapping decision variable IDs to the function\n  expressions that should replace them.\n\nRaises ``ValueError`` on cyclic or recursive assignments, or when\nsubstituting a variable that is a member of an indicator, one-hot, or\nSOS1 constraint.\n\n# Examples\n\nEncode an integer variable x0 in range $[0, 3]$ into two binary\nvariables by hand, instead of using {meth}`~ommx.v1.Instance.log_encode`:\n\n```python\n>>> from ommx.v1 import Instance, DecisionVariable\n>>> x = DecisionVariable.integer(0, lower=0, upper=3, name=\"x\")\n>>> b = [DecisionVariable.binary(i, name=\"b\", subscripts=[i]) for i in (1, 2)]\n>>> instance = Instance.from_components(\n...     decision_variables=[x, *b],\n...     objective=x,\n...     constraints=[],\n...     sense=Instance.MAXIMIZE,\n... )\n>>> instance.substitute({0: b[0] + 2 * b[1]})\n>>> instance.objective\nFunction(x1 + 2*x2)\n```",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "assignments",
+                      "type_": {
+                        "display": "Mapping[int, _ommx_rust.ToFunction]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "int",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "ToFunction",
+                            "link_target": {
+                              "fqn": "ommx._ommx_rust.ToFunction",
+                              "doc_module": "ommx._ommx_rust",
+                              "kind": "Class",
+                              "attribute": null
+                            },
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "None",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
               "name": "to_bytes",
               "doc": "",
               "signatures": [

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -394,3 +394,78 @@ def test_multiple_log_encodes():
     instance.log_encode()
     second_encode = instance.decision_variables
     assert first_encode == second_encode
+
+
+def test_substitute_unary_encode():
+    """Custom unary (thermometer) encoding of an integer variable via `substitute`.
+
+    An integer x in [0, 4] is replaced by the linear expression x = sum(b_i).
+    Validity (a "thermometer" pattern) is enforced by ordering constraints
+    b_{i+1} <= b_i, which the user adds separately with `add_constraint`.
+    """
+    x = DecisionVariable.integer(0, lower=0, upper=4, name="x")
+    b = [DecisionVariable.binary(i + 1, name="b", subscripts=[i]) for i in range(4)]
+    instance = Instance.from_components(
+        decision_variables=[x, *b],
+        objective=x,
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+
+    instance.substitute({0: b[0] + b[1] + b[2] + b[3]})  # x = sum(b_i)
+    for i in range(3):
+        instance.add_constraint(b[i + 1] - b[i] <= 0)  # b_{i+1} <= b_i
+
+    # Thermometer assignments are feasible and decode to the original integer.
+    for k in range(5):  # number of bits set to 1
+        state = {i + 1: (1 if i < k else 0) for i in range(4)}
+        solution = instance.evaluate(state)
+        assert solution.feasible
+        assert solution.objective == pytest.approx(k)
+
+    # A non-thermometer assignment violates the ordering constraints.
+    assert not instance.evaluate({1: 0, 2: 1, 3: 0, 4: 0}).feasible
+
+
+def test_substitute_one_hot_encode():
+    """Custom one-hot encoding of an integer variable via `substitute`.
+
+    An integer x in [0, 3] is replaced by x = sum(v * b_v), with a one-hot
+    constraint sum(b_v) == 1 added separately by the user. Unlike unary, the
+    decode is still linear but the structural constraint is an equality.
+    """
+    x = DecisionVariable.integer(0, lower=0, upper=3, name="x")
+    b = [DecisionVariable.binary(i + 1, name="b", subscripts=[i]) for i in range(4)]
+    instance = Instance.from_components(
+        decision_variables=[x, *b],
+        objective=x,
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+
+    instance.substitute({0: b[1] + 2 * b[2] + 3 * b[3]})  # x = sum(v * b_v)
+    instance.add_constraint((b[0] + b[1] + b[2] + b[3]) == 1)  # one-hot constraint
+
+    # One-hot assignments are feasible and decode to the selected domain value.
+    for v in range(4):
+        state = {i + 1: (1 if i == v else 0) for i in range(4)}
+        solution = instance.evaluate(state)
+        assert solution.feasible
+        assert solution.objective == pytest.approx(v)
+
+    # Multiple bits set or all bits unset violate the one-hot constraint.
+    assert not instance.evaluate({1: 1, 2: 1, 3: 0, 4: 0}).feasible
+    assert not instance.evaluate({1: 0, 2: 0, 3: 0, 4: 0}).feasible
+
+
+def test_substitute_recursive_assignment_raises():
+    """`substitute` rejects an assignment that depends on the variable itself."""
+    x = [DecisionVariable.integer(i, lower=0, upper=3, name="x") for i in range(2)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=x[0] + x[1],
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+    with pytest.raises(ValueError):
+        instance.substitute({0: x[0] + x[1]})

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -467,5 +467,11 @@ def test_substitute_recursive_assignment_raises():
         constraints={},
         sense=Instance.MAXIMIZE,
     )
+    objective_before = Function(instance.objective)
+    decision_variable_ids_before = {v.id for v in instance.decision_variables}
+
     with pytest.raises(ValueError):
         instance.substitute({0: x[0] + x[1]})
+
+    assert {v.id for v in instance.decision_variables} == decision_variable_ids_before
+    assert instance.objective.almost_equal(objective_before)

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -3077,6 +3077,43 @@ class Instance:
         Function(x1 + x3 + 2*x4 + x5 + 2*x6)
         ```
         """
+    def substitute(self, assignments: typing.Mapping[builtins.int, ToFunction]) -> None:
+        r"""
+        Substitute decision variables with function expressions (in-place).
+
+        Replaces each given decision variable with the provided function in the
+        objective and all active constraints. This is the general substitution
+        mechanism behind {meth}`~ommx.v1.Instance.log_encode`, exposed so that
+        users can implement their own integer encodings (e.g. unary, one-hot).
+
+        **Args:**
+        - `assignments`: A dict mapping decision variable IDs to the function
+          expressions that should replace them.
+
+        Raises ``ValueError`` on cyclic or recursive assignments, or when
+        substituting a variable that is a member of an indicator, one-hot, or
+        SOS1 constraint.
+
+        # Examples
+
+        Encode an integer variable x0 in range $[0, 3]$ into two binary
+        variables by hand, instead of using {meth}`~ommx.v1.Instance.log_encode`:
+
+        ```python
+        >>> from ommx.v1 import Instance, DecisionVariable
+        >>> x = DecisionVariable.integer(0, lower=0, upper=3, name="x")
+        >>> b = [DecisionVariable.binary(i, name="b", subscripts=[i]) for i in (1, 2)]
+        >>> instance = Instance.from_components(
+        ...     decision_variables=[x, *b],
+        ...     objective=x,
+        ...     constraints=[],
+        ...     sense=Instance.MAXIMIZE,
+        ... )
+        >>> instance.substitute({0: b[0] + 2 * b[1]})
+        >>> instance.objective
+        Function(x1 + 2*x2)
+        ```
+        """
     def convert_inequality_to_equality_with_integer_slack(
         self, constraint_id: builtins.int, max_integer_range: builtins.int
     ) -> None:

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -1723,6 +1723,55 @@ impl Instance {
         Ok(())
     }
 
+    /// Substitute decision variables with function expressions (in-place).
+    ///
+    /// Replaces each given decision variable with the provided function in the
+    /// objective and all active constraints. This is the general substitution
+    /// mechanism behind {meth}`~ommx.v1.Instance.log_encode`, exposed so that
+    /// users can implement their own integer encodings (e.g. unary, one-hot).
+    ///
+    /// **Args:**
+    /// - `assignments`: A dict mapping decision variable IDs to the function
+    ///   expressions that should replace them.
+    ///
+    /// Raises ``ValueError`` on cyclic or recursive assignments, or when
+    /// substituting a variable that is a member of an indicator, one-hot, or
+    /// SOS1 constraint.
+    ///
+    /// # Examples
+    ///
+    /// Encode an integer variable x0 in range $[0, 3]$ into two binary
+    /// variables by hand, instead of using {meth}`~ommx.v1.Instance.log_encode`:
+    ///
+    /// ```python
+    /// >>> from ommx.v1 import Instance, DecisionVariable
+    /// >>> x = DecisionVariable.integer(0, lower=0, upper=3, name="x")
+    /// >>> b = [DecisionVariable.binary(i, name="b", subscripts=[i]) for i in (1, 2)]
+    /// >>> instance = Instance.from_components(
+    /// ...     decision_variables=[x, *b],
+    /// ...     objective=x,
+    /// ...     constraints=[],
+    /// ...     sense=Instance.MAXIMIZE,
+    /// ... )
+    /// >>> instance.substitute({0: b[0] + 2 * b[1]})
+    /// >>> instance.objective
+    /// Function(x1 + 2*x2)
+    /// ```
+    #[pyo3(signature = (assignments))]
+    pub fn substitute(
+        &mut self,
+        py: Python<'_>,
+        assignments: HashMap<u64, Function>,
+    ) -> PyResult<()> {
+        let _guard = crate::TRACING.attach_parent_context(py);
+        let iter = assignments
+            .into_iter()
+            .map(|(id, f)| (VariableID::from(id), f.0));
+        ommx::substitute(&mut self.inner, iter)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
     /// Convert an inequality constraint $f(x) \leq 0$ to an equality constraint $f(x) + s/a = 0$ with an integer slack variable $s$.
     ///
     /// - Since $a$ is determined as the minimal multiplier to make every coefficient of $a f(x)$ integer,

--- a/rust/ommx/src/substitute.rs
+++ b/rust/ommx/src/substitute.rs
@@ -232,42 +232,57 @@ pub(crate) fn check_self_assignment(
 }
 
 /// In-place version of [`Substitute::substitute`].
+///
+/// This clones the current value, runs the consuming substitution API on the
+/// clone, and commits the result back only on success. If substitution fails,
+/// `substituted` is left unchanged. Use [`Substitute::substitute`] directly
+/// when you want explicit control over cloning or ownership.
 pub fn substitute<T>(
     substituted: &mut T,
     assignments: impl IntoIterator<Item = (VariableID, Function)>,
 ) -> Result<(), SubstitutionError>
 where
-    T: Substitute<Output = T> + Default,
+    T: Substitute<Output = T> + Clone,
 {
-    let inner = std::mem::take(substituted);
-    *substituted = inner.substitute(assignments)?;
+    let updated = substituted.clone().substitute(assignments)?;
+    *substituted = updated;
     Ok(())
 }
 
 /// In-place version of [`Substitute::substitute_one`].
+///
+/// This clones the current value and commits the substituted value back only on
+/// success. If substitution fails, `substituted` is left unchanged. Use
+/// [`Substitute::substitute_one`] directly when you want explicit control over
+/// cloning or ownership.
 pub fn substitute_one<T>(
     substituted: &mut T,
     assigned: VariableID,
     linear: &Function,
 ) -> Result<(), SubstitutionError>
 where
-    T: Substitute<Output = T> + Default,
+    T: Substitute<Output = T> + Clone,
 {
-    let inner = std::mem::take(substituted);
-    *substituted = inner.substitute_one(assigned, linear)?;
+    let updated = substituted.clone().substitute_one(assigned, linear)?;
+    *substituted = updated;
     Ok(())
 }
 
 /// In-place version of [`Substitute::substitute_acyclic`].
+///
+/// This clones the current value and commits the substituted value back only on
+/// success. If substitution fails, `substituted` is left unchanged. Use
+/// [`Substitute::substitute_acyclic`] directly when you want explicit control
+/// over cloning or ownership.
 pub fn substitute_acyclic<T>(
     substituted: &mut T,
     acyclic: &AcyclicAssignments,
 ) -> Result<(), SubstitutionError>
 where
-    T: Substitute<Output = T> + Default,
+    T: Substitute<Output = T> + Clone,
 {
-    let inner = std::mem::take(substituted);
-    *substituted = inner.substitute_acyclic(acyclic)?;
+    let updated = substituted.clone().substitute_acyclic(acyclic)?;
+    *substituted = updated;
     Ok(())
 }
 
@@ -294,4 +309,52 @@ pub(crate) fn substitute_one_via_acyclic<T: Substitute>(
 ) -> Result<<T as Substitute>::Output, SubstitutionError> {
     let acyclic = AcyclicAssignments::new([(assigned, f.clone())])?;
     substituted.substitute_acyclic(&acyclic)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coeff, linear};
+
+    #[test]
+    fn in_place_substitute_preserves_value_on_error() {
+        let mut function = Function::from(linear!(1) + coeff!(2.0));
+        let original = function.clone();
+
+        let err = substitute(
+            &mut function,
+            [(
+                VariableID::from(1),
+                Function::from(linear!(1) + coeff!(1.0)),
+            )],
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SubstitutionError::RecursiveAssignment { var_id }
+                if var_id == VariableID::from(1)
+        ));
+        assert!(function == original);
+    }
+
+    #[test]
+    fn in_place_substitute_one_preserves_value_on_error() {
+        let mut function = Function::from(linear!(1) + coeff!(2.0));
+        let original = function.clone();
+
+        let err = substitute_one(
+            &mut function,
+            VariableID::from(1),
+            &Function::from(linear!(1) + coeff!(1.0)),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SubstitutionError::RecursiveAssignment { var_id }
+                if var_id == VariableID::from(1)
+        ));
+        assert!(function == original);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `substitute` method to the Python `Instance` class, exposing the Rust `Substitute` capability through the PyO3 bindings.

Until now the Python SDK only offered `partial_evaluate` (substitute a variable with a **constant value**). There was no way to substitute a variable with an **arbitrary function expression** — which is exactly the mechanism that the built-in `log_encode` uses internally (create binary variables → build a linear expression → substitute the integer variable).

By exposing `substitute`, users can now implement their own integer-to-binary encodings (unary, one-hot, etc.) entirely from the Python SDK, instead of being limited to the default log encoding.

- New in-place method `Instance.substitute(assignments: dict[int, ToFunction])` — replaces each given decision variable with the provided function in the objective and all active constraints.
- Raises `ValueError` on cyclic / recursive assignments, or when substituting a member of an indicator / one-hot / SOS1 constraint.
- Tests demonstrating custom **unary (thermometer)** and **one-hot** encodings, plus a recursive-assignment rejection case.

## Usage examples

### Basic: substitute a variable with an expression

```python
from ommx.v1 import Instance, DecisionVariable

x = DecisionVariable.integer(0, lower=0, upper=3, name="x")
b = [DecisionVariable.binary(i, name="b", subscripts=[i]) for i in (1, 2)]
instance = Instance.from_components(
    decision_variables=[x, *b],
    objective=x,
    constraints=[],
    sense=Instance.MAXIMIZE,
)

# Manually log-encode x0 into two binary variables, instead of calling log_encode()
instance.substitute({0: b[0] + 2 * b[1]})
instance.objective  # Function(x1 + 2*x2)
```

### Custom unary (thermometer) encoding

The decode expression is linear; validity is enforced by ordering constraints the user adds separately.

```python
x = DecisionVariable.integer(0, lower=0, upper=4, name="x")
b = [DecisionVariable.binary(i + 1, name="b", subscripts=[i]) for i in range(4)]
instance = Instance.from_components(
    decision_variables=[x, *b], objective=x, constraints={}, sense=Instance.MAXIMIZE,
)

instance.substitute({0: b[0] + b[1] + b[2] + b[3]})   # x = sum(b_i)
for i in range(3):
    instance.add_constraint(b[i + 1] - b[i] <= 0)      # b_{i+1} <= b_i
```

### Custom one-hot encoding

```python
x = DecisionVariable.integer(0, lower=0, upper=3, name="x")
b = [DecisionVariable.binary(i + 1, name="b", subscripts=[i]) for i in range(4)]
instance = Instance.from_components(
    decision_variables=[x, *b], objective=x, constraints={}, sense=Instance.MAXIMIZE,
)

instance.substitute({0: b[1] + 2 * b[2] + 3 * b[3]})   # x = sum(v * b_v)
instance.add_constraint((b[0] + b[1] + b[2] + b[3]) == 1)  # one-hot constraint
```

> Note: practical integer encodings (log / unary / one-hot) all have a **linear** decode expression and push non-linearity into constraints. `substitute` itself accepts any `Function` (including polynomials), but high-degree encodings such as Gray code expand to O(2ⁿ) terms and are not suitable as substitution targets.

## Test plan

- [x] `task python:ommx:pytest-unit` — 394 passed (incl. new `test_substitute_unary_encode`, `test_substitute_one_hot_encode`, `test_substitute_recursive_assignment_raises`)
- [x] `task python:ommx:pytest-doctest` — passed (incl. the `substitute` docstring example)
- [x] pyright / ruff lint pass; `task format` clean
- [x] Rust extension module builds; stubs regenerated via `task python:stubgen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)