### PR TITLE
Expose ParametricInstance substitute

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -18713,6 +18713,48 @@
               "deprecated": null
             },
             {
+              "name": "substitute",
+              "doc": "Substitute decision variables with function expressions (in-place).\n\nReplaces each given decision variable with the provided function in the\nobjective and all active constraints. Replacement functions may still\nreference parameters; those parameter references remain in this\nparametric instance and are evaluated later by {meth}`with_parameters`.\nAssignment targets must be existing decision variable IDs. Replacement\nexpressions may only reference existing decision variable or parameter\nIDs; parameter IDs cannot be assignment targets.\n\n**Args:**\n- `assignments`: A dict mapping decision variable IDs to the function\n  expressions that should replace them.\n\n**Important:**\nThis method performs an algebraic rewrite. It does not automatically\ntranslate the substituted variable's bound or kind into constraints on\nthe replacement expression. If the substitution must preserve the\noptimization problem, the caller must provide a domain-preserving\nencoding or add the required linking and bound constraints explicitly.\n\nRaises ``ValueError`` on cyclic or recursive assignments, undefined\nIDs, when a parameter ID is used as an assignment target, or when\nsubstituting a variable that is a member of an indicator, one-hot, or\nSOS1 constraint.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "assignments",
+                      "type_": {
+                        "display": "Mapping[int, _ommx_rust.ToFunction]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "int",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "ToFunction",
+                            "link_target": {
+                              "fqn": "ommx._ommx_rust.ToFunction",
+                              "doc_module": "ommx._ommx_rust",
+                              "kind": "Class",
+                              "attribute": null
+                            },
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "None",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
               "name": "to_bytes",
               "doc": "",
               "signatures": [

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -546,7 +546,9 @@ def test_parametric_instance_substitute_undefined_rhs_id_raises():
     )
     objective_before = Function(parametric.objective)
 
-    with pytest.raises(ValueError, match="Undefined variable ID is used in substitution"):
+    with pytest.raises(
+        ValueError, match="Undefined variable ID is used in substitution"
+    ):
         parametric.substitute({0: DecisionVariable.binary(999)})
 
     assert parametric.objective.almost_equal(objective_before)

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -1,4 +1,4 @@
-from ommx.v1 import Instance, DecisionVariable, Function
+from ommx.v1 import Instance, DecisionVariable, Function, Parameter, ParametricInstance
 import math
 import pytest
 
@@ -475,3 +475,78 @@ def test_substitute_recursive_assignment_raises():
 
     assert {v.id for v in instance.decision_variables} == decision_variable_ids_before
     assert instance.objective.almost_equal(objective_before)
+
+
+def test_parametric_instance_substitute_with_parameterized_rhs():
+    """ParametricInstance.substitute keeps parameters symbolic until materialization."""
+    x = DecisionVariable.integer(0, lower=0, upper=10, name="x")
+    y = DecisionVariable.binary(1, name="y")
+    p = Parameter(100, name="p")
+    parametric = ParametricInstance.from_components(
+        decision_variables=[x, y],
+        parameters=[p],
+        objective=x + p * y,
+        constraints={0: x <= p + 1},
+        sense=Instance.MAXIMIZE,
+    )
+
+    parametric.substitute({0: p * y + 1})
+
+    instance = parametric.with_parameters({100: 2.0})
+    assert instance.objective.almost_equal(Function(4 * y + 1))
+    solution = instance.evaluate({1: 1})
+    assert solution.feasible
+    assert solution.objective == pytest.approx(5.0)
+
+
+def test_parametric_instance_substitute_recursive_assignment_raises():
+    x = [DecisionVariable.integer(i, lower=0, upper=3, name="x") for i in range(2)]
+    p = Parameter(100, name="p")
+    parametric = ParametricInstance.from_components(
+        decision_variables=x,
+        parameters=[p],
+        objective=x[0] + p * x[1],
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+    objective_before = Function(parametric.objective)
+
+    with pytest.raises(ValueError):
+        parametric.substitute({0: x[0] + p})
+
+    assert parametric.objective.almost_equal(objective_before)
+
+
+def test_parametric_instance_substitute_parameter_id_raises():
+    x = DecisionVariable.binary(0, name="x")
+    p = Parameter(100, name="p")
+    parametric = ParametricInstance.from_components(
+        decision_variables=[x],
+        parameters=[p],
+        objective=x + p,
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+    objective_before = Function(parametric.objective)
+
+    with pytest.raises(ValueError, match="Cannot substitute parameter"):
+        parametric.substitute({100: x})
+
+    assert parametric.objective.almost_equal(objective_before)
+
+
+def test_parametric_instance_substitute_undefined_rhs_id_raises():
+    x = DecisionVariable.binary(0, name="x")
+    parametric = ParametricInstance.from_components(
+        decision_variables=[x],
+        parameters=[],
+        objective=x,
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+    objective_before = Function(parametric.objective)
+
+    with pytest.raises(ValueError, match="Undefined variable ID is used in substitution"):
+        parametric.substitute({0: DecisionVariable.binary(999)})
+
+    assert parametric.objective.almost_equal(objective_before)

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -4350,6 +4350,34 @@ class ParametricInstance:
 
         Parameters can be provided as a dict mapping parameter IDs to their values.
         """
+    def substitute(self, assignments: typing.Mapping[builtins.int, ToFunction]) -> None:
+        r"""
+        Substitute decision variables with function expressions (in-place).
+
+        Replaces each given decision variable with the provided function in the
+        objective and all active constraints. Replacement functions may still
+        reference parameters; those parameter references remain in this
+        parametric instance and are evaluated later by {meth}`with_parameters`.
+        Assignment targets must be existing decision variable IDs. Replacement
+        expressions may only reference existing decision variable or parameter
+        IDs; parameter IDs cannot be assignment targets.
+
+        **Args:**
+        - `assignments`: A dict mapping decision variable IDs to the function
+          expressions that should replace them.
+
+        **Important:**
+        This method performs an algebraic rewrite. It does not automatically
+        translate the substituted variable's bound or kind into constraints on
+        the replacement expression. If the substitution must preserve the
+        optimization problem, the caller must provide a domain-preserving
+        encoding or add the required linking and bound constraints explicitly.
+
+        Raises ``ValueError`` on cyclic or recursive assignments, undefined
+        IDs, when a parameter ID is used as an assignment target, or when
+        substituting a variable that is a member of an indicator, one-hot, or
+        SOS1 constraint.
+        """
     def add_decision_variable(
         self, variable: DecisionVariable
     ) -> AttachedDecisionVariable:

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -227,6 +227,46 @@ impl ParametricInstance {
         })
     }
 
+    /// Substitute decision variables with function expressions (in-place).
+    ///
+    /// Replaces each given decision variable with the provided function in the
+    /// objective and all active constraints. Replacement functions may still
+    /// reference parameters; those parameter references remain in this
+    /// parametric instance and are evaluated later by {meth}`with_parameters`.
+    /// Assignment targets must be existing decision variable IDs. Replacement
+    /// expressions may only reference existing decision variable or parameter
+    /// IDs; parameter IDs cannot be assignment targets.
+    ///
+    /// **Args:**
+    /// - `assignments`: A dict mapping decision variable IDs to the function
+    ///   expressions that should replace them.
+    ///
+    /// **Important:**
+    /// This method performs an algebraic rewrite. It does not automatically
+    /// translate the substituted variable's bound or kind into constraints on
+    /// the replacement expression. If the substitution must preserve the
+    /// optimization problem, the caller must provide a domain-preserving
+    /// encoding or add the required linking and bound constraints explicitly.
+    ///
+    /// Raises ``ValueError`` on cyclic or recursive assignments, undefined
+    /// IDs, when a parameter ID is used as an assignment target, or when
+    /// substituting a variable that is a member of an indicator, one-hot, or
+    /// SOS1 constraint.
+    #[pyo3(signature = (assignments))]
+    pub fn substitute(
+        &mut self,
+        py: Python<'_>,
+        assignments: HashMap<u64, Function>,
+    ) -> PyResult<()> {
+        let _guard = crate::TRACING.attach_parent_context(py);
+        let iter = assignments
+            .into_iter()
+            .map(|(id, f)| (VariableID::from(id), f.0));
+        ommx::substitute(&mut self.inner, iter)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
     #[getter]
     pub fn sense(&self) -> Sense {
         (*self.inner.sense()).into()

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -447,6 +447,10 @@ impl Instance {
 /// - The keys of [`Self::constraints`] and [`Self::removed_constraints`] are disjoint sets.
 /// - The keys of [`Self::decision_variable_dependency`] must be in [`Self::decision_variables`],
 ///   but must NOT be used in the objective function or constraints.
+///   The RHS expressions of [`Self::decision_variable_dependency`] may
+///   reference IDs from [`Self::decision_variables`] or [`Self::parameters`],
+///   and may not reference undefined IDs. Parameter IDs in RHS expressions are
+///   evaluated by [`Self::with_parameters`].
 ///   See also the document of [`DecisionVariableAnalysis`].
 /// - The following three sets must be pairwise disjoint (from [`DecisionVariableAnalysis`]):
 ///   - **used**: Variable IDs appearing in the objective function or constraints

--- a/rust/ommx/src/instance/convert.rs
+++ b/rust/ommx/src/instance/convert.rs
@@ -140,9 +140,7 @@ impl ParametricInstance {
         // Decision-variable dependency RHS expressions can also reference
         // parameter IDs. Without substitution, dependent-variable
         // expressions in the resulting `Instance` would carry dangling
-        // parameter references (the parametric builder doesn't restrict
-        // `decision_variable_dependency` RHS bodies to decision-variable
-        // IDs only).
+        // parameter references.
         let mut decision_variable_dependency = self.decision_variable_dependency;
         decision_variable_dependency.partial_evaluate(&state, atol)?;
 
@@ -185,9 +183,9 @@ mod with_parameters_tests {
 
     /// Parameter substitution must apply to the right-hand-side of
     /// `decision_variable_dependency` entries. The RHS is a `Function`
-    /// over arbitrary IDs; the parametric builder doesn't restrict it to
-    /// decision-variable IDs only, so a parameter reference there would
-    /// dangle in the resulting `Instance` without explicit substitution.
+    /// over defined decision-variable or parameter IDs, so a parameter
+    /// reference there would dangle in the resulting `Instance` without
+    /// explicit substitution.
     #[test]
     fn decision_variable_dependency_rhs_is_substituted() {
         use crate::AcyclicAssignments;

--- a/rust/ommx/src/instance/parametric_builder.rs
+++ b/rust/ommx/src/instance/parametric_builder.rs
@@ -157,6 +157,8 @@ impl ParametricInstanceBuilder {
     /// - The objective function or constraints reference undefined variable IDs
     /// - The keys of `constraints` and `removed_constraints` are not disjoint
     /// - The keys of `decision_variable_dependency` are not in `decision_variables`
+    /// - The RHS expressions of `decision_variable_dependency` reference IDs
+    ///   outside `decision_variables` or `parameters`
     /// - `used`, `fixed`, and `dependent` are not pairwise disjoint (see [`DecisionVariableAnalysis`])
     pub fn build(self) -> crate::Result<ParametricInstance> {
         let sense = self
@@ -371,6 +373,14 @@ impl ParametricInstanceBuilder {
                 crate::bail!(
                     { ?id },
                     "Variable ID {id:?} in decision_variable_dependency is not in decision_variables",
+                );
+            }
+        }
+        for id in self.decision_variable_dependency.required_ids() {
+            if !all_variable_ids.contains(&id) {
+                crate::bail!(
+                    { ?id },
+                    "Undefined variable ID is used in decision_variable_dependency: {id:?}",
                 );
             }
         }
@@ -617,6 +627,68 @@ mod tests {
         assert!(instance
             .indicator_constraints()
             .contains_key(&crate::IndicatorConstraintID::from(7)));
+    }
+
+    #[test]
+    fn test_parametric_builder_dependency_rhs_allows_parameter() {
+        use crate::{linear, AcyclicAssignments};
+        use maplit::btreemap;
+
+        let dep = VariableID::from(1);
+        let x = VariableID::from(2);
+        let p = VariableID::from(100);
+        let dependency = AcyclicAssignments::new(btreemap! {
+            dep => Function::from(linear!(2) + linear!(100)),
+        })
+        .unwrap();
+
+        let instance = ParametricInstance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(btreemap! {
+                dep => DecisionVariable::binary(dep),
+                x => DecisionVariable::binary(x),
+            })
+            .parameters(btreemap! {
+                p => v1::Parameter { id: 100, ..Default::default() },
+            })
+            .constraints(BTreeMap::new())
+            .decision_variable_dependency(dependency)
+            .build();
+
+        assert!(instance.is_ok());
+    }
+
+    #[test]
+    fn test_parametric_builder_dependency_rhs_rejects_undefined_id() {
+        use crate::{linear, AcyclicAssignments};
+        use maplit::btreemap;
+
+        let dep = VariableID::from(1);
+        let undefined = VariableID::from(999);
+        let dependency = AcyclicAssignments::new(btreemap! {
+            dep => Function::from(linear!(999)),
+        })
+        .unwrap();
+
+        let err = ParametricInstance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(btreemap! {
+                dep => DecisionVariable::binary(dep),
+            })
+            .parameters(BTreeMap::new())
+            .constraints(BTreeMap::new())
+            .decision_variable_dependency(dependency)
+            .build()
+            .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Undefined variable ID is used in decision_variable_dependency")
+                && msg.contains(&format!("{undefined:?}")),
+            "unexpected error: {msg}",
+        );
     }
 
     #[test]

--- a/rust/ommx/src/instance/substitute.rs
+++ b/rust/ommx/src/instance/substitute.rs
@@ -108,6 +108,108 @@ impl Substitute for Instance {
     }
 }
 
+impl Substitute for ParametricInstance {
+    type Output = Self;
+
+    fn substitute_acyclic(
+        mut self,
+        acyclic: &crate::AcyclicAssignments,
+    ) -> Result<Self::Output, crate::SubstitutionError> {
+        let substituted_variables: std::collections::BTreeSet<VariableID> =
+            acyclic.iter().map(|(var_id, _)| *var_id).collect();
+
+        for (var_id, function) in acyclic.iter() {
+            if self.parameters.contains_key(var_id) {
+                return Err(SubstitutionError::ParameterSubstitution { parameter: *var_id });
+            }
+            if !self.decision_variables.contains_key(var_id) {
+                return Err(SubstitutionError::UndefinedSubstitutionVariable { variable: *var_id });
+            }
+            for required_id in function.required_ids() {
+                if !self.decision_variables.contains_key(&required_id)
+                    && !self.parameters.contains_key(&required_id)
+                {
+                    return Err(SubstitutionError::UndefinedSubstitutionVariable {
+                        variable: required_id,
+                    });
+                }
+            }
+        }
+
+        let mut affected_constraint_ids = std::collections::BTreeSet::new();
+        for (constraint_id, constraint) in self.constraint_collection.active() {
+            let required_ids = constraint.required_ids();
+            if !required_ids.is_disjoint(&substituted_variables) {
+                affected_constraint_ids.insert(*constraint_id);
+            }
+        }
+
+        substitute_acyclic(&mut self.objective, acyclic)?;
+
+        for constraint_id in &affected_constraint_ids {
+            if let Some(constraint) = self
+                .constraint_collection
+                .active_mut()
+                .get_mut(constraint_id)
+            {
+                substitute_acyclic(&mut constraint.stage.function, acyclic)?;
+            }
+        }
+
+        for (&cid, ic) in self.indicator_constraint_collection.active().iter() {
+            if substituted_variables.contains(&ic.indicator_variable) {
+                return Err(SubstitutionError::IndicatorVariableSubstitution {
+                    indicator_variable: ic.indicator_variable,
+                    constraint_id: cid,
+                });
+            }
+        }
+        for ic in self
+            .indicator_constraint_collection
+            .active_mut()
+            .values_mut()
+        {
+            let required_ids = ic.stage.function.required_ids();
+            if !required_ids.is_disjoint(&substituted_variables) {
+                substitute_acyclic(&mut ic.stage.function, acyclic)?;
+            }
+        }
+
+        for (&cid, oh) in self.one_hot_constraint_collection.active().iter() {
+            for var_id in &oh.variables {
+                if substituted_variables.contains(var_id) {
+                    return Err(SubstitutionError::OneHotVariableSubstitution {
+                        variable: *var_id,
+                        constraint_id: cid,
+                    });
+                }
+            }
+        }
+        for (&cid, sos1) in self.sos1_constraint_collection.active().iter() {
+            for var_id in &sos1.variables {
+                if substituted_variables.contains(var_id) {
+                    return Err(SubstitutionError::Sos1VariableSubstitution {
+                        variable: *var_id,
+                        constraint_id: cid,
+                    });
+                }
+            }
+        }
+
+        substitute_acyclic(&mut self.decision_variable_dependency, acyclic)?;
+
+        Ok(self)
+    }
+
+    fn substitute_one(
+        self,
+        assigned: VariableID,
+        f: &Function,
+    ) -> Result<Self::Output, SubstitutionError> {
+        substitute_one_via_acyclic(self, assigned, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,6 +257,124 @@ mod tests {
             .decision_variable_dependency
             .get(&VariableID::from(1))
             .is_some());
+    }
+
+    #[test]
+    fn test_parametric_instance_substitute_parameterized_rhs() {
+        let mut decision_variables = BTreeMap::new();
+        decision_variables.insert(
+            VariableID::from(0),
+            DecisionVariable::continuous(VariableID::from(0)),
+        );
+        decision_variables.insert(
+            VariableID::from(1),
+            DecisionVariable::continuous(VariableID::from(1)),
+        );
+
+        let mut parameters = BTreeMap::new();
+        parameters.insert(
+            VariableID::from(100),
+            crate::v1::Parameter {
+                id: 100,
+                ..Default::default()
+            },
+        );
+
+        let objective = Function::from(linear!(0) + linear!(100));
+        let parametric = ParametricInstance::new(
+            Sense::Minimize,
+            objective,
+            decision_variables,
+            parameters,
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let substituted = parametric
+            .substitute_one(
+                VariableID::from(0),
+                &Function::from(linear!(1) + linear!(100)),
+            )
+            .unwrap();
+
+        assert_eq!(substituted.decision_variable_dependency.len(), 1);
+        assert!(substituted
+            .decision_variable_dependency
+            .get(&VariableID::from(0))
+            .is_some());
+
+        let mut parameter_values = crate::v1::Parameters::default();
+        parameter_values.entries.insert(100, 2.0);
+        let instance = substituted.with_parameters(parameter_values).unwrap();
+        let state = crate::v1::State::from_iter([(1, 3.0)]);
+        let value = instance
+            .objective()
+            .evaluate(&state, crate::ATol::default())
+            .unwrap();
+        assert_eq!(value, 7.0);
+    }
+
+    #[test]
+    fn test_parametric_instance_substitute_parameter_target_fails() {
+        let mut decision_variables = BTreeMap::new();
+        decision_variables.insert(
+            VariableID::from(0),
+            DecisionVariable::continuous(VariableID::from(0)),
+        );
+
+        let mut parameters = BTreeMap::new();
+        parameters.insert(
+            VariableID::from(100),
+            crate::v1::Parameter {
+                id: 100,
+                ..Default::default()
+            },
+        );
+
+        let parametric = ParametricInstance::new(
+            Sense::Minimize,
+            Function::from(linear!(0) + linear!(100)),
+            decision_variables,
+            parameters,
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let err = parametric
+            .substitute_one(VariableID::from(100), &Function::from(linear!(0)))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SubstitutionError::ParameterSubstitution { parameter }
+                if parameter == VariableID::from(100)
+        ));
+    }
+
+    #[test]
+    fn test_parametric_instance_substitute_undefined_rhs_fails() {
+        let mut decision_variables = BTreeMap::new();
+        decision_variables.insert(
+            VariableID::from(0),
+            DecisionVariable::continuous(VariableID::from(0)),
+        );
+
+        let parametric = ParametricInstance::new(
+            Sense::Minimize,
+            Function::from(linear!(0)),
+            decision_variables,
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let err = parametric
+            .substitute_one(VariableID::from(0), &Function::from(linear!(999)))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SubstitutionError::UndefinedSubstitutionVariable { variable }
+                if variable == VariableID::from(999)
+        ));
     }
 
     #[test]

--- a/rust/ommx/src/instance/substitute.rs
+++ b/rust/ommx/src/instance/substitute.rs
@@ -11,6 +11,10 @@ impl Substitute for Instance {
         mut self,
         acyclic: &crate::AcyclicAssignments,
     ) -> Result<Self::Output, crate::SubstitutionError> {
+        if acyclic.is_empty() {
+            return Ok(self);
+        }
+
         // Get the set of variables being substituted
         let substituted_variables: std::collections::BTreeSet<VariableID> =
             acyclic.iter().map(|(var_id, _)| *var_id).collect();
@@ -115,6 +119,10 @@ impl Substitute for ParametricInstance {
         mut self,
         acyclic: &crate::AcyclicAssignments,
     ) -> Result<Self::Output, crate::SubstitutionError> {
+        if acyclic.is_empty() {
+            return Ok(self);
+        }
+
         let substituted_variables: std::collections::BTreeSet<VariableID> =
             acyclic.iter().map(|(var_id, _)| *var_id).collect();
 

--- a/rust/ommx/src/substitute/error.rs
+++ b/rust/ommx/src/substitute/error.rs
@@ -20,6 +20,16 @@ pub enum SubstitutionError {
         constraint_id: crate::indicator_constraint::IndicatorConstraintID,
     },
 
+    /// `ParametricInstance::substitute` only substitutes decision variables.
+    #[error(
+        "Cannot substitute parameter {parameter:?}; use with_parameters to assign parameter values"
+    )]
+    ParameterSubstitution { parameter: VariableID },
+
+    /// Substitution assignments may only reference IDs defined by the host.
+    #[error("Undefined variable ID is used in substitution: {variable:?}")]
+    UndefinedSubstitutionVariable { variable: VariableID },
+
     /// Substituting a one-hot variable would change the constraint type.
     #[error("Cannot substitute variable {variable:?} of one-hot constraint {constraint_id:?}")]
     OneHotVariableSubstitution {


### PR DESCRIPTION
## Summary

- Add `Substitute` support for `ParametricInstance` in the Rust core.
- Expose `ParametricInstance.substitute` in the Python SDK with generated stubs and API docs.
- Clarify and validate `decision_variable_dependency` invariants for parametric instances: keys must be decision variables, while RHS expressions may reference defined decision variables or parameters.

## Why

`Instance.substitute` was exposed to Python in #891, but `ParametricInstance` did not provide the same API. Parametric substitutions need one additional rule: parameter IDs can appear in replacement expressions, but they cannot be assignment targets. Parameter references in dependency RHS expressions are then evaluated by `with_parameters`.