### PR TITLE
Refactor experiment attachment logging into a trait

### DIFF
--- a/python/ommx/src/experiment.rs
+++ b/python/ommx/src/experiment.rs
@@ -12,6 +12,7 @@ use std::{
 use crate::pandas::{raw_entries_to_dataframe, PyDataFrame};
 use crate::{PyArtifact, PyDescriptor};
 use ommx::artifact::AsArtifact;
+use ommx::experiment::AttachmentLogger;
 
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
@@ -346,7 +347,8 @@ impl PyExperiment {
         media_type: &str,
         bytes: &Bound<pyo3::types::PyBytes>,
     ) -> Result<()> {
-        self.inner.log_attachment(
+        AttachmentLogger::log_attachment(
+            &self.inner,
             name,
             MediaType::Other(media_type.to_string()),
             bytes.as_bytes(),
@@ -360,13 +362,17 @@ impl PyExperiment {
     pub fn log_json(&mut self, py: Python<'_>, name: &str, value: &Bound<PyAny>) -> Result<()> {
         let json = py.import("json")?;
         let blob: String = json.call_method1("dumps", (value,))?.extract()?;
-        self.inner
-            .log_attachment(name, MediaType::Other("application/json".to_string()), blob)
+        AttachmentLogger::log_attachment(
+            &self.inner,
+            name,
+            MediaType::Other("application/json".to_string()),
+            blob,
+        )
     }
 
     /// Attach an Instance in the experiment space.
     pub fn log_instance(&mut self, name: &str, instance: &crate::Instance) -> Result<()> {
-        self.inner.log_instance(name, &instance.inner)
+        AttachmentLogger::log_instance(&self.inner, name, &instance.inner)
     }
 
     /// Attach an ParametricInstance in the experiment space.
@@ -375,17 +381,17 @@ impl PyExperiment {
         name: &str,
         pi: &crate::ParametricInstance,
     ) -> Result<()> {
-        self.inner.log_parametric_instance(name, &pi.inner)
+        AttachmentLogger::log_parametric_instance(&self.inner, name, &pi.inner)
     }
 
     /// Attach a Solution in the experiment space.
     pub fn log_solution(&mut self, name: &str, solution: &crate::Solution) -> Result<()> {
-        self.inner.log_solution(name, &solution.inner)
+        AttachmentLogger::log_solution(&self.inner, name, &solution.inner)
     }
 
     /// Attach a SampleSet in the experiment space.
     pub fn log_sample_set(&mut self, name: &str, sample_set: &crate::SampleSet) -> Result<()> {
-        self.inner.log_sample_set(name, &sample_set.inner)
+        AttachmentLogger::log_sample_set(&self.inner, name, &sample_set.inner)
     }
 
     /// Commit this unsealed Experiment into the local registry.
@@ -682,7 +688,8 @@ impl PyRun {
         media_type: &str,
         bytes: &Bound<pyo3::types::PyBytes>,
     ) -> Result<()> {
-        self.as_open_mut()?.log_attachment(
+        AttachmentLogger::log_attachment(
+            self.as_open_mut()?,
             name,
             MediaType::Other(media_type.to_string()),
             bytes.as_bytes(),
@@ -696,7 +703,8 @@ impl PyRun {
     pub fn log_json(&mut self, py: Python<'_>, name: &str, value: &Bound<PyAny>) -> Result<()> {
         let json = py.import("json")?;
         let blob: String = json.call_method1("dumps", (value,))?.extract()?;
-        self.as_open_mut()?.log_attachment(
+        AttachmentLogger::log_attachment(
+            self.as_open_mut()?,
             name,
             MediaType::Other("application/json".to_string()),
             blob,
@@ -709,7 +717,7 @@ impl PyRun {
     /// when the instance is the input of a solver call and should be paired
     /// with the returned solution.
     pub fn log_instance(&mut self, name: &str, instance: &crate::Instance) -> Result<()> {
-        self.as_open_mut()?.log_instance(name, &instance.inner)
+        AttachmentLogger::log_instance(self.as_open_mut()?, name, &instance.inner)
     }
 
     /// Attach a ParametricInstance in this run.
@@ -718,7 +726,7 @@ impl PyRun {
         name: &str,
         pi: &crate::ParametricInstance,
     ) -> Result<()> {
-        self.as_open_mut()?.log_parametric_instance(name, &pi.inner)
+        AttachmentLogger::log_parametric_instance(self.as_open_mut()?, name, &pi.inner)
     }
 
     /// Attach a Solution in this run.
@@ -727,12 +735,12 @@ impl PyRun {
     /// when the solution is produced by a solver call and should be paired
     /// with the input instance.
     pub fn log_solution(&mut self, name: &str, solution: &crate::Solution) -> Result<()> {
-        self.as_open_mut()?.log_solution(name, &solution.inner)
+        AttachmentLogger::log_solution(self.as_open_mut()?, name, &solution.inner)
     }
 
     /// Attach a SampleSet in this run.
     pub fn log_sample_set(&mut self, name: &str, sample_set: &crate::SampleSet) -> Result<()> {
-        self.as_open_mut()?.log_sample_set(name, &sample_set.inner)
+        AttachmentLogger::log_sample_set(self.as_open_mut()?, name, &sample_set.inner)
     }
 
     /// Solve an Instance with an OMMX SolverAdapter and log a Solve entry.

--- a/rust/ommx/src/experiment.rs
+++ b/rust/ommx/src/experiment.rs
@@ -24,7 +24,7 @@
 //!
 //! ```ignore
 //! use ommx::artifact::ImageRef;
-//! use ommx::experiment::{Experiment, Name};
+//! use ommx::experiment::{AttachmentLogger, Experiment, Name};
 //!
 //! let image_name = ImageRef::parse("ghcr.io/jij-inc/ommx/scip_reblock115:latest")?;
 //! let exp = Experiment::new(image_name)?;
@@ -51,6 +51,7 @@ mod artifact;
 mod attachment;
 pub mod config;
 mod dynamic;
+mod logging;
 mod parameter;
 mod run;
 mod sealed;
@@ -59,15 +60,14 @@ mod sealed;
 mod tests;
 
 pub use dynamic::{ExperimentDyn, RunDyn, SealedRunDyn, SolveDyn};
+pub use logging::AttachmentLogger;
 pub use parameter::{ParameterValue, RunParameterCell};
 pub use sealed::{SealedRun, Solve};
 
 use crate::artifact::local_registry::{LocalRegistry, StoredDescriptor, TempLocalRegistry};
-use crate::artifact::{media_types, ImageRef, LocalArtifact};
-use crate::{Instance, SampleSet, Solution};
+use crate::artifact::{ImageRef, LocalArtifact};
 use anyhow::Result;
-use attachment::{encode_json, json_media_type, store_attachment_descriptor, AttachmentSpace};
-use oci_spec::image::MediaType;
+use attachment::{store_attachment_descriptor, AttachmentSpace};
 use parameter::ParameterSet;
 use std::collections::BTreeMap;
 use std::sync::{Mutex, MutexGuard};
@@ -256,39 +256,12 @@ impl<'reg> Experiment<'reg> {
         })
     }
 
-    /// Attach arbitrary bytes with an explicit OCI media type in the
-    /// experiment space.
-    pub fn log_attachment(
+    fn add_attachment(
         &self,
         name: &str,
-        media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
+        media_type: oci_spec::image::MediaType,
+        bytes: &[u8],
     ) -> Result<()> {
-        self.add_attachment(name, media_type, bytes.as_ref())
-    }
-
-    /// Attach a JSON-serialisable value in the experiment space.
-    pub fn log_json(&self, name: &str, value: impl serde::Serialize) -> Result<()> {
-        let bytes = encode_json(name, &value)?;
-        self.log_attachment(name, json_media_type(), bytes)
-    }
-
-    /// Attach an [`Instance`] in the experiment space.
-    pub fn log_instance(&self, name: &str, instance: &Instance) -> Result<()> {
-        self.log_attachment(name, media_types::v1_instance(), instance.to_bytes())
-    }
-
-    /// Attach a [`Solution`] in the experiment space.
-    pub fn log_solution(&self, name: &str, solution: &Solution) -> Result<()> {
-        self.log_attachment(name, media_types::v1_solution(), solution.to_bytes())
-    }
-
-    /// Attach a [`SampleSet`] in the experiment space.
-    pub fn log_sample_set(&self, name: &str, sample_set: &SampleSet) -> Result<()> {
-        self.log_attachment(name, media_types::v1_sample_set(), sample_set.to_bytes())
-    }
-
-    fn add_attachment(&self, name: &str, media_type: MediaType, bytes: &[u8]) -> Result<()> {
         let descriptor = store_attachment_descriptor(
             self.registry,
             AttachmentSpace::Experiment,

--- a/rust/ommx/src/experiment.rs
+++ b/rust/ommx/src/experiment.rs
@@ -68,6 +68,7 @@ use crate::artifact::local_registry::{LocalRegistry, StoredDescriptor, TempLocal
 use crate::artifact::{ImageRef, LocalArtifact};
 use anyhow::Result;
 use attachment::{store_attachment_descriptor, AttachmentSpace};
+use oci_spec::image::MediaType;
 use parameter::ParameterSet;
 use std::collections::BTreeMap;
 use std::sync::{Mutex, MutexGuard};
@@ -256,24 +257,6 @@ impl<'reg> Experiment<'reg> {
         })
     }
 
-    fn add_attachment(
-        &self,
-        name: &str,
-        media_type: oci_spec::image::MediaType,
-        bytes: &[u8],
-    ) -> Result<()> {
-        let descriptor = store_attachment_descriptor(
-            self.registry,
-            AttachmentSpace::Experiment,
-            name,
-            media_type,
-            bytes,
-        )?;
-        let mut state = self.lock_state();
-        state.attachments.push(descriptor);
-        Ok(())
-    }
-
     fn push_closed_run(&self, run: RunEntry<'reg>) -> Result<()> {
         let mut state = self.lock_state();
         if state.runs.contains_key(&run.run_id) {
@@ -308,6 +291,26 @@ impl<'reg> Experiment<'reg> {
         };
         let artifact = state.commit(self.registry)?;
         SealedExperiment::from_artifact(artifact)
+    }
+}
+
+impl<'reg> AttachmentLogger for &Experiment<'reg> {
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        let descriptor = store_attachment_descriptor(
+            self.registry,
+            AttachmentSpace::Experiment,
+            name,
+            media_type,
+            bytes.as_ref(),
+        )?;
+        let mut state = self.lock_state();
+        state.attachments.push(descriptor);
+        Ok(())
     }
 }
 

--- a/rust/ommx/src/experiment/attachment.rs
+++ b/rust/ommx/src/experiment/attachment.rs
@@ -58,7 +58,7 @@ pub fn json_media_type() -> MediaType {
 }
 
 pub fn encode_json(name: &str, value: impl serde::Serialize) -> Result<Vec<u8>> {
-    serde_json::to_vec(&value)
+    crate::artifact::stable_json_bytes(&value)
         .map_err(|e| crate::error!("Failed to encode JSON attachment `{name}`: {e}"))
 }
 

--- a/rust/ommx/src/experiment/dynamic/mod.rs
+++ b/rust/ommx/src/experiment/dynamic/mod.rs
@@ -17,8 +17,8 @@
 
 use super::attachment::{store_attachment_descriptor, AttachmentSpace};
 use super::{
-    allocate_next_run_id, next_run_id, Name, RunEntry, RunParameterCell, SealedExperiment,
-    UnsealedExperimentState,
+    allocate_next_run_id, next_run_id, AttachmentLogger, Name, RunEntry, RunParameterCell,
+    SealedExperiment, UnsealedExperimentState,
 };
 use crate::artifact::local_registry::{LocalRegistry, StoredDescriptor};
 use crate::artifact::{
@@ -349,16 +349,18 @@ impl ExperimentDyn {
             ExperimentDynLifecycle::Sealed(_) | ExperimentDynLifecycle::Failed { .. } => 0,
         }
     }
+}
 
-    pub(super) fn add_attachment(
-        &self,
+impl AttachmentLogger for &ExperimentDyn {
+    fn log_attachment(
+        self,
         name: &str,
         media_type: MediaType,
-        bytes: &[u8],
+        bytes: impl AsRef<[u8]>,
     ) -> Result<()> {
         let mut dyn_state = lock_experiment_state(&self.state);
         let descriptor =
-            store_experiment_attachment_descriptor(&dyn_state, name, media_type, bytes)?;
+            store_experiment_attachment_descriptor(&dyn_state, name, media_type, bytes.as_ref())?;
         let ExperimentDynLifecycle::Unsealed { state, .. } = &mut dyn_state.lifecycle else {
             return bail_non_unsealed(&dyn_state.lifecycle);
         };
@@ -368,7 +370,9 @@ impl ExperimentDyn {
         state.attachments.push(descriptor);
         Ok(())
     }
+}
 
+impl ExperimentDyn {
     pub fn commit(&self) -> Result<LocalArtifactDyn> {
         let mut dyn_state = lock_experiment_state(&self.state);
         let (state, open_runs) = match &mut dyn_state.lifecycle {

--- a/rust/ommx/src/experiment/dynamic/mod.rs
+++ b/rust/ommx/src/experiment/dynamic/mod.rs
@@ -15,9 +15,7 @@
 //! `LocalRegistry::stored_descriptor` before returning them, restoring
 //! the Local Registry storage invariant at the API boundary.
 
-use super::attachment::{
-    encode_json, json_media_type, store_attachment_descriptor, AttachmentSpace,
-};
+use super::attachment::{store_attachment_descriptor, AttachmentSpace};
 use super::{
     allocate_next_run_id, next_run_id, Name, RunEntry, RunParameterCell, SealedExperiment,
     UnsealedExperimentState,
@@ -26,7 +24,7 @@ use crate::artifact::local_registry::{LocalRegistry, StoredDescriptor};
 use crate::artifact::{
     media_types, AsArtifact, ImageRef, LocalArtifact, LocalArtifactDyn, LocalRegistryHandle,
 };
-use crate::{Instance, ParametricInstance, SampleSet, Solution};
+use crate::{Instance, Solution};
 use anyhow::{ensure, Result};
 use oci_spec::image::{Descriptor, MediaType};
 use std::collections::BTreeMap;
@@ -352,15 +350,15 @@ impl ExperimentDyn {
         }
     }
 
-    pub fn log_attachment(
+    pub(super) fn add_attachment(
         &self,
         name: &str,
         media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
+        bytes: &[u8],
     ) -> Result<()> {
         let mut dyn_state = lock_experiment_state(&self.state);
         let descriptor =
-            store_experiment_attachment_descriptor(&dyn_state, name, media_type, bytes.as_ref())?;
+            store_experiment_attachment_descriptor(&dyn_state, name, media_type, bytes)?;
         let ExperimentDynLifecycle::Unsealed { state, .. } = &mut dyn_state.lifecycle else {
             return bail_non_unsealed(&dyn_state.lifecycle);
         };
@@ -369,43 +367,6 @@ impl ExperimentDyn {
             .ok_or_else(|| anyhow::anyhow!("Experiment has already been committed"))?;
         state.attachments.push(descriptor);
         Ok(())
-    }
-
-    pub fn log_json(&self, name: &str, value: impl serde::Serialize) -> Result<()> {
-        let bytes = encode_json(name, value)?;
-        self.log_attachment(name, json_media_type(), bytes)
-    }
-
-    pub fn log_instance(&self, name: &str, instance: &Instance) -> Result<()> {
-        self.log_attachment(
-            name,
-            crate::artifact::media_types::v1_instance(),
-            instance.to_bytes(),
-        )
-    }
-
-    pub fn log_parametric_instance(&self, name: &str, pi: &ParametricInstance) -> Result<()> {
-        self.log_attachment(
-            name,
-            crate::artifact::media_types::v1_parametric_instance(),
-            pi.to_bytes(),
-        )
-    }
-
-    pub fn log_solution(&self, name: &str, solution: &Solution) -> Result<()> {
-        self.log_attachment(
-            name,
-            crate::artifact::media_types::v1_solution(),
-            solution.to_bytes(),
-        )
-    }
-
-    pub fn log_sample_set(&self, name: &str, sample_set: &SampleSet) -> Result<()> {
-        self.log_attachment(
-            name,
-            crate::artifact::media_types::v1_sample_set(),
-            sample_set.to_bytes(),
-        )
     }
 
     pub fn commit(&self) -> Result<LocalArtifactDyn> {

--- a/rust/ommx/src/experiment/dynamic/run.rs
+++ b/rust/ommx/src/experiment/dynamic/run.rs
@@ -1,7 +1,7 @@
 //! Dynamic-lifetime Run handle.
 
 use super::super::parameter::ParameterSet;
-use super::super::ParameterValue;
+use super::super::{AttachmentLogger, ParameterValue};
 use super::{
     bail_non_unsealed, lock_experiment_state, store_run_attachment_descriptor,
     store_solve_payload_descriptor, ExperimentDyn, ExperimentDynLifecycle, ExperimentDynState,
@@ -90,21 +90,6 @@ impl RunDyn {
         self.open_mut()?.parameters.insert(name, value)
     }
 
-    pub(in crate::experiment) fn add_attachment(
-        &mut self,
-        name: &str,
-        media_type: MediaType,
-        bytes: &[u8],
-    ) -> Result<()> {
-        let run_id = self.open()?.run_id;
-        let descriptor = {
-            let dyn_state = lock_experiment_state(&self.experiment_state);
-            store_run_attachment_descriptor(&dyn_state, run_id, name, media_type, bytes)?
-        };
-        self.open_mut()?.attachments.push(descriptor);
-        Ok(())
-    }
-
     pub fn log_finished_solve_result(
         &mut self,
         input: &Instance,
@@ -185,6 +170,23 @@ impl RunDyn {
         self.run_state
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("Run has already been finished"))
+    }
+}
+
+impl AttachmentLogger for &mut RunDyn {
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        let run_id = self.open()?.run_id;
+        let descriptor = {
+            let dyn_state = lock_experiment_state(&self.experiment_state);
+            store_run_attachment_descriptor(&dyn_state, run_id, name, media_type, bytes.as_ref())?
+        };
+        self.open_mut()?.attachments.push(descriptor);
+        Ok(())
     }
 }
 

--- a/rust/ommx/src/experiment/dynamic/run.rs
+++ b/rust/ommx/src/experiment/dynamic/run.rs
@@ -1,6 +1,5 @@
 //! Dynamic-lifetime Run handle.
 
-use super::super::attachment::{encode_json, json_media_type};
 use super::super::parameter::ParameterSet;
 use super::super::ParameterValue;
 use super::{
@@ -9,7 +8,7 @@ use super::{
     RunEntryDyn, SolveEntryDyn,
 };
 use crate::artifact::media_types;
-use crate::{Instance, ParametricInstance, SampleSet, Solution};
+use crate::{Instance, Solution};
 use anyhow::Result;
 use oci_spec::image::{Descriptor, MediaType};
 use std::sync::{Arc, Mutex};
@@ -91,40 +90,19 @@ impl RunDyn {
         self.open_mut()?.parameters.insert(name, value)
     }
 
-    pub fn log_attachment(
+    pub(in crate::experiment) fn add_attachment(
         &mut self,
         name: &str,
         media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
+        bytes: &[u8],
     ) -> Result<()> {
         let run_id = self.open()?.run_id;
         let descriptor = {
             let dyn_state = lock_experiment_state(&self.experiment_state);
-            store_run_attachment_descriptor(&dyn_state, run_id, name, media_type, bytes.as_ref())?
+            store_run_attachment_descriptor(&dyn_state, run_id, name, media_type, bytes)?
         };
         self.open_mut()?.attachments.push(descriptor);
         Ok(())
-    }
-
-    pub fn log_json(&mut self, name: &str, value: impl serde::Serialize) -> Result<()> {
-        let bytes = encode_json(name, value)?;
-        self.log_attachment(name, json_media_type(), bytes)
-    }
-
-    pub fn log_instance(&mut self, name: &str, instance: &Instance) -> Result<()> {
-        self.log_attachment(name, media_types::v1_instance(), instance.to_bytes())
-    }
-
-    pub fn log_parametric_instance(&mut self, name: &str, pi: &ParametricInstance) -> Result<()> {
-        self.log_attachment(name, media_types::v1_parametric_instance(), pi.to_bytes())
-    }
-
-    pub fn log_solution(&mut self, name: &str, solution: &Solution) -> Result<()> {
-        self.log_attachment(name, media_types::v1_solution(), solution.to_bytes())
-    }
-
-    pub fn log_sample_set(&mut self, name: &str, sample_set: &SampleSet) -> Result<()> {
-        self.log_attachment(name, media_types::v1_sample_set(), sample_set.to_bytes())
     }
 
     pub fn log_finished_solve_result(

--- a/rust/ommx/src/experiment/logging.rs
+++ b/rust/ommx/src/experiment/logging.rs
@@ -1,6 +1,5 @@
 //! Shared attachment logging APIs for experiment and run handles.
 
-use super::{Experiment, ExperimentDyn, Run, RunDyn};
 use crate::artifact::media_types;
 use crate::{Instance, ParametricInstance, SampleSet, Solution};
 use anyhow::Result;
@@ -62,49 +61,5 @@ pub trait AttachmentLogger {
         Self: Sized,
     {
         self.log_attachment(name, media_types::v1_sample_set(), sample_set.to_bytes())
-    }
-}
-
-impl<'a, 'reg> AttachmentLogger for &'a Experiment<'reg> {
-    fn log_attachment(
-        self,
-        name: &str,
-        media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
-    ) -> Result<()> {
-        self.add_attachment(name, media_type, bytes.as_ref())
-    }
-}
-
-impl<'a, 'exp, 'reg> AttachmentLogger for &'a mut Run<'exp, 'reg> {
-    fn log_attachment(
-        self,
-        name: &str,
-        media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
-    ) -> Result<()> {
-        self.add_attachment(name, media_type, bytes.as_ref())
-    }
-}
-
-impl<'a> AttachmentLogger for &'a ExperimentDyn {
-    fn log_attachment(
-        self,
-        name: &str,
-        media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
-    ) -> Result<()> {
-        self.add_attachment(name, media_type, bytes.as_ref())
-    }
-}
-
-impl<'a> AttachmentLogger for &'a mut RunDyn {
-    fn log_attachment(
-        self,
-        name: &str,
-        media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
-    ) -> Result<()> {
-        self.add_attachment(name, media_type, bytes.as_ref())
     }
 }

--- a/rust/ommx/src/experiment/logging.rs
+++ b/rust/ommx/src/experiment/logging.rs
@@ -10,10 +10,11 @@ use super::attachment::{encode_json, json_media_type};
 /// A handle that can log attachment payloads into an Experiment space.
 ///
 /// The concrete attachment space depends on the implementor: an
-/// [`Experiment`] logs into the experiment-wide space, while a [`Run`]
-/// logs into that run's space. The typed `log_*` helpers share the same
-/// media-type mapping across both static and dynamic handles.
-pub trait AttachmentLogger {
+/// [`Experiment`](crate::experiment::Experiment) logs into the experiment-wide
+/// space, while a [`Run`](crate::experiment::Run) logs into that run's space.
+/// The typed `log_*` helpers share the same media-type mapping across both
+/// static and dynamic handles.
+pub trait AttachmentLogger: Sized {
     /// Attach arbitrary bytes with an explicit OCI media type.
     fn log_attachment(
         self,
@@ -23,43 +24,28 @@ pub trait AttachmentLogger {
     ) -> Result<()>;
 
     /// Attach a JSON-serialisable value.
-    fn log_json(self, name: &str, value: impl serde::Serialize) -> Result<()>
-    where
-        Self: Sized,
-    {
+    fn log_json(self, name: &str, value: impl serde::Serialize) -> Result<()> {
         let bytes = encode_json(name, value)?;
         self.log_attachment(name, json_media_type(), bytes)
     }
 
     /// Attach an [`Instance`].
-    fn log_instance(self, name: &str, instance: &Instance) -> Result<()>
-    where
-        Self: Sized,
-    {
+    fn log_instance(self, name: &str, instance: &Instance) -> Result<()> {
         self.log_attachment(name, media_types::v1_instance(), instance.to_bytes())
     }
 
     /// Attach a [`ParametricInstance`].
-    fn log_parametric_instance(self, name: &str, pi: &ParametricInstance) -> Result<()>
-    where
-        Self: Sized,
-    {
+    fn log_parametric_instance(self, name: &str, pi: &ParametricInstance) -> Result<()> {
         self.log_attachment(name, media_types::v1_parametric_instance(), pi.to_bytes())
     }
 
     /// Attach a [`Solution`].
-    fn log_solution(self, name: &str, solution: &Solution) -> Result<()>
-    where
-        Self: Sized,
-    {
+    fn log_solution(self, name: &str, solution: &Solution) -> Result<()> {
         self.log_attachment(name, media_types::v1_solution(), solution.to_bytes())
     }
 
     /// Attach a [`SampleSet`].
-    fn log_sample_set(self, name: &str, sample_set: &SampleSet) -> Result<()>
-    where
-        Self: Sized,
-    {
+    fn log_sample_set(self, name: &str, sample_set: &SampleSet) -> Result<()> {
         self.log_attachment(name, media_types::v1_sample_set(), sample_set.to_bytes())
     }
 }

--- a/rust/ommx/src/experiment/logging.rs
+++ b/rust/ommx/src/experiment/logging.rs
@@ -1,0 +1,110 @@
+//! Shared attachment logging APIs for experiment and run handles.
+
+use super::{Experiment, ExperimentDyn, Run, RunDyn};
+use crate::artifact::media_types;
+use crate::{Instance, ParametricInstance, SampleSet, Solution};
+use anyhow::Result;
+use oci_spec::image::MediaType;
+
+use super::attachment::{encode_json, json_media_type};
+
+/// A handle that can log attachment payloads into an Experiment space.
+///
+/// The concrete attachment space depends on the implementor: an
+/// [`Experiment`] logs into the experiment-wide space, while a [`Run`]
+/// logs into that run's space. The typed `log_*` helpers share the same
+/// media-type mapping across both static and dynamic handles.
+pub trait AttachmentLogger {
+    /// Attach arbitrary bytes with an explicit OCI media type.
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()>;
+
+    /// Attach a JSON-serialisable value.
+    fn log_json(self, name: &str, value: impl serde::Serialize) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let bytes = encode_json(name, value)?;
+        self.log_attachment(name, json_media_type(), bytes)
+    }
+
+    /// Attach an [`Instance`].
+    fn log_instance(self, name: &str, instance: &Instance) -> Result<()>
+    where
+        Self: Sized,
+    {
+        self.log_attachment(name, media_types::v1_instance(), instance.to_bytes())
+    }
+
+    /// Attach a [`ParametricInstance`].
+    fn log_parametric_instance(self, name: &str, pi: &ParametricInstance) -> Result<()>
+    where
+        Self: Sized,
+    {
+        self.log_attachment(name, media_types::v1_parametric_instance(), pi.to_bytes())
+    }
+
+    /// Attach a [`Solution`].
+    fn log_solution(self, name: &str, solution: &Solution) -> Result<()>
+    where
+        Self: Sized,
+    {
+        self.log_attachment(name, media_types::v1_solution(), solution.to_bytes())
+    }
+
+    /// Attach a [`SampleSet`].
+    fn log_sample_set(self, name: &str, sample_set: &SampleSet) -> Result<()>
+    where
+        Self: Sized,
+    {
+        self.log_attachment(name, media_types::v1_sample_set(), sample_set.to_bytes())
+    }
+}
+
+impl<'a, 'reg> AttachmentLogger for &'a Experiment<'reg> {
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        self.add_attachment(name, media_type, bytes.as_ref())
+    }
+}
+
+impl<'a, 'exp, 'reg> AttachmentLogger for &'a mut Run<'exp, 'reg> {
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        self.add_attachment(name, media_type, bytes.as_ref())
+    }
+}
+
+impl<'a> AttachmentLogger for &'a ExperimentDyn {
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        self.add_attachment(name, media_type, bytes.as_ref())
+    }
+}
+
+impl<'a> AttachmentLogger for &'a mut RunDyn {
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        self.add_attachment(name, media_type, bytes.as_ref())
+    }
+}

--- a/rust/ommx/src/experiment/run.rs
+++ b/rust/ommx/src/experiment/run.rs
@@ -1,7 +1,7 @@
 //! Experiment / Run handles and run lifecycle.
 
 use super::attachment::{store_attachment_descriptor, AttachmentSpace};
-use super::{ParameterValue, Run, RunEntry, SolveEntry};
+use super::{AttachmentLogger, ParameterValue, Run, RunEntry, SolveEntry};
 use crate::artifact::media_types;
 use crate::{Instance, Solution};
 use anyhow::Result;
@@ -68,23 +68,6 @@ impl<'exp, 'reg> Run<'exp, 'reg> {
         self.close()
     }
 
-    pub(super) fn add_attachment(
-        &mut self,
-        name: &str,
-        media_type: MediaType,
-        bytes: &[u8],
-    ) -> Result<()> {
-        let descriptor = store_attachment_descriptor(
-            self.experiment.registry,
-            AttachmentSpace::Run(self.run_id),
-            name,
-            media_type,
-            bytes,
-        )?;
-        self.attachments.push(descriptor);
-        Ok(())
-    }
-
     fn close(self) -> Result<()> {
         let Run {
             experiment,
@@ -101,6 +84,25 @@ impl<'exp, 'reg> Run<'exp, 'reg> {
             parameters,
         };
         experiment.push_closed_run(run)?;
+        Ok(())
+    }
+}
+
+impl<'exp, 'reg> AttachmentLogger for &mut Run<'exp, 'reg> {
+    fn log_attachment(
+        self,
+        name: &str,
+        media_type: MediaType,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        let descriptor = store_attachment_descriptor(
+            self.experiment.registry,
+            AttachmentSpace::Run(self.run_id),
+            name,
+            media_type,
+            bytes.as_ref(),
+        )?;
+        self.attachments.push(descriptor);
         Ok(())
     }
 }

--- a/rust/ommx/src/experiment/run.rs
+++ b/rust/ommx/src/experiment/run.rs
@@ -1,11 +1,9 @@
 //! Experiment / Run handles and run lifecycle.
 
-use super::attachment::{
-    encode_json, json_media_type, store_attachment_descriptor, AttachmentSpace,
-};
+use super::attachment::{store_attachment_descriptor, AttachmentSpace};
 use super::{ParameterValue, Run, RunEntry, SolveEntry};
 use crate::artifact::media_types;
-use crate::{Instance, ParametricInstance, SampleSet, Solution};
+use crate::{Instance, Solution};
 use anyhow::Result;
 use oci_spec::image::MediaType;
 
@@ -26,43 +24,6 @@ impl<'exp, 'reg> Run<'exp, 'reg> {
         let name = name.into();
         let value = value.into();
         self.parameters.insert(name, value)
-    }
-
-    /// Attach arbitrary bytes with an explicit OCI media type in this
-    /// run's space.
-    pub fn log_attachment(
-        &mut self,
-        name: &str,
-        media_type: MediaType,
-        bytes: impl AsRef<[u8]>,
-    ) -> Result<()> {
-        self.add_attachment(name, media_type, bytes.as_ref())
-    }
-
-    /// Attach a JSON-serialisable value in this run's space.
-    pub fn log_json(&mut self, name: &str, value: impl serde::Serialize) -> Result<()> {
-        let bytes = encode_json(name, &value)?;
-        self.log_attachment(name, json_media_type(), bytes)
-    }
-
-    /// Attach an [`Instance`] in this run's space.
-    pub fn log_instance(&mut self, name: &str, instance: &Instance) -> Result<()> {
-        self.log_attachment(name, media_types::v1_instance(), instance.to_bytes())
-    }
-
-    /// Attach an [`ParametricInstance`] in this run's space.
-    pub fn log_parametric_instance(&mut self, name: &str, pi: &ParametricInstance) -> Result<()> {
-        self.log_attachment(name, media_types::v1_parametric_instance(), pi.to_bytes())
-    }
-
-    /// Attach a [`Solution`] in this run's space.
-    pub fn log_solution(&mut self, name: &str, solution: &Solution) -> Result<()> {
-        self.log_attachment(name, media_types::v1_solution(), solution.to_bytes())
-    }
-
-    /// Attach a [`SampleSet`] in this run's space.
-    pub fn log_sample_set(&mut self, name: &str, sample_set: &SampleSet) -> Result<()> {
-        self.log_attachment(name, media_types::v1_sample_set(), sample_set.to_bytes())
     }
 
     /// Log one already-finished solver result under this run.
@@ -107,7 +68,12 @@ impl<'exp, 'reg> Run<'exp, 'reg> {
         self.close()
     }
 
-    fn add_attachment(&mut self, name: &str, media_type: MediaType, bytes: &[u8]) -> Result<()> {
+    pub(super) fn add_attachment(
+        &mut self,
+        name: &str,
+        media_type: MediaType,
+        bytes: &[u8],
+    ) -> Result<()> {
         let descriptor = store_attachment_descriptor(
             self.experiment.registry,
             AttachmentSpace::Run(self.run_id),

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::artifact::local_registry::{StoredDescriptor, UnsealedArtifact};
 use crate::artifact::{media_types, AsArtifact, ImageRef, LocalArtifact, LocalRegistryHandle};
-use crate::{Evaluate, Function, Instance, Sense};
+use crate::{Evaluate, Function, Instance, ParametricInstance, SampleSet, Sense, Solution};
 use oci_spec::image::{Descriptor, MediaType};
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap};
@@ -53,6 +53,49 @@ fn find_layer<'a, 'reg>(
 
 fn blob_bytes(artifact: &LocalArtifact<'_>, descriptor: &StoredDescriptor<'_>) -> Vec<u8> {
     artifact.get_blob(descriptor).unwrap()
+}
+
+fn empty_instance() -> Instance {
+    Instance::new(
+        Sense::Minimize,
+        Function::Zero,
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .unwrap()
+}
+
+fn empty_parametric_instance() -> ParametricInstance {
+    ParametricInstance::builder()
+        .sense(Sense::Minimize)
+        .objective(Function::Zero)
+        .decision_variables(BTreeMap::new())
+        .parameters(BTreeMap::new())
+        .constraints(BTreeMap::new())
+        .build()
+        .unwrap()
+}
+
+fn empty_solution(instance: &Instance) -> Solution {
+    instance
+        .evaluate(
+            &crate::v1::State {
+                entries: HashMap::new(),
+            },
+            crate::ATol::default(),
+        )
+        .unwrap()
+}
+
+fn empty_sample_set(instance: &Instance) -> SampleSet {
+    instance
+        .evaluate_samples(
+            &crate::Sampled::from(crate::v1::State {
+                entries: HashMap::new(),
+            }),
+            crate::ATol::default(),
+        )
+        .unwrap()
 }
 
 /// `run()` hands out fresh 0-based ids; `finish()` consumes the run
@@ -168,12 +211,11 @@ fn log_preserves_attachment_descriptor_log_order() {
     with_temp_experiment(|experiment| {
         experiment.log_json("dataset", json!("miplib2017")).unwrap();
         experiment.log_json("dataset", json!("qplib")).unwrap();
+        experiment
+            .log_json("dataset", json!("set-covering"))
+            .unwrap();
 
-        let instance: Instance =
-            crate::random::random_deterministic(crate::InstanceParameters::default_lp());
-        experiment.log_instance("dataset", &instance).unwrap();
-
-        let json_digests = with_unsealed_state(&experiment, |state| {
+        with_unsealed_state(&experiment, |state| {
             assert_eq!(state.attachments.len(), 3);
             assert_eq!(
                 state
@@ -187,61 +229,85 @@ fn log_preserves_attachment_descriptor_log_order() {
                     "dataset".to_string()
                 ]
             );
-            assert_eq!(
-                state
-                    .attachments
-                    .iter()
-                    .map(|attachment| attachment.media_type().clone())
-                    .collect::<Vec<_>>(),
-                vec![
-                    MediaType::Other("application/json".into()),
-                    MediaType::Other("application/json".into()),
-                    media_types::v1_instance(),
-                ]
-            );
-            state
-                .attachments
-                .iter()
-                .take(2)
-                .map(|attachment| attachment.digest().clone())
-                .collect::<Vec<_>>()
         });
-        let first_bytes = experiment
-            .registry
-            .blobs()
-            .read_bytes(&json_digests[0])
-            .unwrap();
-        let second_bytes = experiment
-            .registry
-            .blobs()
-            .read_bytes(&json_digests[1])
-            .unwrap();
-        assert_eq!(
-            first_bytes,
-            serde_json::to_vec(&json!("miplib2017")).unwrap()
-        );
-        assert_eq!(second_bytes, serde_json::to_vec(&json!("qplib")).unwrap());
         Ok(())
     });
 }
 
 #[test]
-fn attachment_logger_trait_logs_static_handles() {
+fn attachment_logger_typed_methods_use_expected_media_types_and_bytes() {
     with_temp_experiment(|experiment| {
-        let instance: Instance =
-            crate::random::random_deterministic(crate::InstanceParameters::default_lp());
+        let instance = empty_instance();
+        let parametric_instance = empty_parametric_instance();
+        let solution = empty_solution(&instance);
+        let sample_set = empty_sample_set(&instance);
 
-        super::AttachmentLogger::log_json(&experiment, "dataset", json!("miplib2017")).unwrap();
-        {
-            let mut run = experiment.run().unwrap();
-            super::AttachmentLogger::log_instance(&mut run, "candidate", &instance).unwrap();
-            run.finish().unwrap();
-        }
+        experiment
+            .log_json("json", json!({ "dataset": "miplib2017" }))
+            .unwrap();
+        experiment.log_instance("instance", &instance).unwrap();
+        experiment
+            .log_parametric_instance("parametric-instance", &parametric_instance)
+            .unwrap();
+        experiment.log_solution("solution", &solution).unwrap();
+        experiment
+            .log_sample_set("sample-set", &sample_set)
+            .unwrap();
 
-        with_unsealed_state(&experiment, |state| {
-            assert_eq!(state.attachments.len(), 1);
-            assert_eq!(state.runs.get(&0).unwrap().attachments.len(), 1);
+        let (names, media_types, blobs) = with_unsealed_state(&experiment, |state| {
+            (
+                state
+                    .attachments
+                    .iter()
+                    .map(|attachment| layer_annotation(attachment, ANN_ATTACHMENT_NAME).unwrap())
+                    .collect::<Vec<_>>(),
+                state
+                    .attachments
+                    .iter()
+                    .map(|attachment| attachment.media_type().clone())
+                    .collect::<Vec<_>>(),
+                state
+                    .attachments
+                    .iter()
+                    .map(|descriptor| {
+                        experiment
+                            .registry
+                            .blobs()
+                            .read_bytes(descriptor.digest())
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>(),
+            )
         });
+        assert_eq!(
+            names,
+            vec![
+                "json".to_string(),
+                "instance".to_string(),
+                "parametric-instance".to_string(),
+                "solution".to_string(),
+                "sample-set".to_string(),
+            ]
+        );
+        assert_eq!(
+            media_types,
+            vec![
+                MediaType::Other("application/json".to_string()),
+                media_types::v1_instance(),
+                media_types::v1_parametric_instance(),
+                media_types::v1_solution(),
+                media_types::v1_sample_set(),
+            ]
+        );
+
+        assert_eq!(
+            blobs[0],
+            serde_json::to_vec(&json!({ "dataset": "miplib2017" })).unwrap()
+        );
+        assert_eq!(blobs[1], instance.to_bytes());
+        assert_eq!(blobs[2], parametric_instance.to_bytes());
+        assert_eq!(blobs[3], solution.to_bytes());
+        assert_eq!(blobs[4], sample_set.to_bytes());
         Ok(())
     });
 }

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -160,6 +160,48 @@ fn log_writes_blob_to_blobstore_immediately() {
     });
 }
 
+#[test]
+fn log_json_encodes_hash_maps_stably() {
+    fn map(entries: impl IntoIterator<Item = (&'static str, i32)>) -> HashMap<&'static str, i32> {
+        entries.into_iter().collect()
+    }
+
+    let first = HashMap::from([
+        ("outer_b", map([("d", 4), ("c", 3)])),
+        ("outer_a", map([("b", 2), ("a", 1)])),
+    ]);
+    let second = HashMap::from([
+        ("outer_a", map([("a", 1), ("b", 2)])),
+        ("outer_b", map([("c", 3), ("d", 4)])),
+    ]);
+
+    with_temp_experiment(|experiment| {
+        experiment.log_json("first", first).unwrap();
+        experiment.log_json("second", second).unwrap();
+
+        let bytes = with_unsealed_state(&experiment, |state| {
+            state
+                .attachments
+                .iter()
+                .map(|descriptor| {
+                    experiment
+                        .registry
+                        .blobs()
+                        .read_bytes(descriptor.digest())
+                        .unwrap()
+                })
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(bytes.len(), 2);
+        assert_eq!(bytes[0], bytes[1]);
+        assert_eq!(
+            bytes[0],
+            br#"{"outer_a":{"a":1,"b":2},"outer_b":{"c":3,"d":4}}"#
+        );
+        Ok(())
+    });
+}
+
 /// `commit()` seals the session into an OMMX Artifact whose manifest and
 /// layer annotations describe the experiment / run attachments.
 #[test]

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -3,9 +3,9 @@
 use super::config::{ExperimentConfig, ExperimentConfigRun, LayerRef};
 use super::UnsealedExperimentState;
 use super::{
-    Experiment, ExperimentDyn, Name, ParameterValue, SealedExperiment, ANN_ATTACHMENT_NAME,
-    ANN_LAYER, ANN_RUN_ID, ANN_SPACE, EXPERIMENT_CONFIG_MEDIA_TYPE, EXPERIMENT_STATUS_FINISHED,
-    LAYER_KIND_RUN_PARAMETERS, RUN_PARAMETERS_MEDIA_TYPE,
+    AttachmentLogger, Experiment, ExperimentDyn, Name, ParameterValue, SealedExperiment,
+    ANN_ATTACHMENT_NAME, ANN_LAYER, ANN_RUN_ID, ANN_SPACE, EXPERIMENT_CONFIG_MEDIA_TYPE,
+    EXPERIMENT_STATUS_FINISHED, LAYER_KIND_RUN_PARAMETERS, RUN_PARAMETERS_MEDIA_TYPE,
 };
 use crate::artifact::local_registry::{StoredDescriptor, UnsealedArtifact};
 use crate::artifact::{media_types, AsArtifact, ImageRef, LocalArtifact, LocalRegistryHandle};
@@ -221,6 +221,27 @@ fn log_preserves_attachment_descriptor_log_order() {
             serde_json::to_vec(&json!("miplib2017")).unwrap()
         );
         assert_eq!(second_bytes, serde_json::to_vec(&json!("qplib")).unwrap());
+        Ok(())
+    });
+}
+
+#[test]
+fn attachment_logger_trait_logs_static_handles() {
+    with_temp_experiment(|experiment| {
+        let instance: Instance =
+            crate::random::random_deterministic(crate::InstanceParameters::default_lp());
+
+        super::AttachmentLogger::log_json(&experiment, "dataset", json!("miplib2017")).unwrap();
+        {
+            let mut run = experiment.run().unwrap();
+            super::AttachmentLogger::log_instance(&mut run, "candidate", &instance).unwrap();
+            run.finish().unwrap();
+        }
+
+        with_unsealed_state(&experiment, |state| {
+            assert_eq!(state.attachments.len(), 1);
+            assert_eq!(state.runs.get(&0).unwrap().attachments.len(), 1);
+        });
         Ok(())
     });
 }

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -935,25 +935,6 @@ fn dropping_unclosed_run_does_not_write_back() {
     });
 }
 
-/// Caller-defined payload types are represented directly by OCI media
-/// type, without an additional OMMX attachment-kind axis.
-#[test]
-fn log_attachment_accepts_caller_defined_media_type() {
-    with_temp_experiment(|experiment| {
-        let media_type = MediaType::Other("application/vnd.jijmodeling.model+json".to_string());
-        experiment
-            .log_attachment("source-model", media_type.clone(), br#"{"variables": []}"#)
-            .unwrap();
-
-        let artifact = experiment.commit().unwrap().into_artifact();
-        let layers = artifact.layers().unwrap();
-        let source_model = find_layer(&layers, ANN_ATTACHMENT_NAME, "source-model");
-        assert_eq!(source_model.media_type(), &media_type);
-        assert_eq!(blob_bytes(&artifact, source_model), br#"{"variables": []}"#);
-        Ok(())
-    });
-}
-
 #[test]
 fn experiment_dyn_keeps_temp_registry_alive_for_derived_artifacts() {
     let experiment = ExperimentDyn::with_temp_local_registry(Name::Anonymous).unwrap();

--- a/rust/ommx/src/experiment/tests.rs
+++ b/rust/ommx/src/experiment/tests.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::artifact::local_registry::{StoredDescriptor, UnsealedArtifact};
 use crate::artifact::{media_types, AsArtifact, ImageRef, LocalArtifact, LocalRegistryHandle};
-use crate::{Evaluate, Function, Instance, ParametricInstance, SampleSet, Sense, Solution};
+use crate::{Evaluate, Function, Instance, Sense};
 use oci_spec::image::{Descriptor, MediaType};
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap};
@@ -53,49 +53,6 @@ fn find_layer<'a, 'reg>(
 
 fn blob_bytes(artifact: &LocalArtifact<'_>, descriptor: &StoredDescriptor<'_>) -> Vec<u8> {
     artifact.get_blob(descriptor).unwrap()
-}
-
-fn empty_instance() -> Instance {
-    Instance::new(
-        Sense::Minimize,
-        Function::Zero,
-        BTreeMap::new(),
-        BTreeMap::new(),
-    )
-    .unwrap()
-}
-
-fn empty_parametric_instance() -> ParametricInstance {
-    ParametricInstance::builder()
-        .sense(Sense::Minimize)
-        .objective(Function::Zero)
-        .decision_variables(BTreeMap::new())
-        .parameters(BTreeMap::new())
-        .constraints(BTreeMap::new())
-        .build()
-        .unwrap()
-}
-
-fn empty_solution(instance: &Instance) -> Solution {
-    instance
-        .evaluate(
-            &crate::v1::State {
-                entries: HashMap::new(),
-            },
-            crate::ATol::default(),
-        )
-        .unwrap()
-}
-
-fn empty_sample_set(instance: &Instance) -> SampleSet {
-    instance
-        .evaluate_samples(
-            &crate::Sampled::from(crate::v1::State {
-                entries: HashMap::new(),
-            }),
-            crate::ATol::default(),
-        )
-        .unwrap()
 }
 
 /// `run()` hands out fresh 0-based ids; `finish()` consumes the run
@@ -199,115 +156,6 @@ fn log_writes_blob_to_blobstore_immediately() {
             run.attachments[0].digest().clone()
         });
         assert!(experiment.registry.blobs().exists(&digest).unwrap());
-        Ok(())
-    });
-}
-
-/// Attachment descriptors are append-only within the Experiment/Run state.
-/// BlobStore still deduplicates byte-identical payloads by digest, but
-/// the Experiment model preserves each log call as a descriptor entry.
-#[test]
-fn log_preserves_attachment_descriptor_log_order() {
-    with_temp_experiment(|experiment| {
-        experiment.log_json("dataset", json!("miplib2017")).unwrap();
-        experiment.log_json("dataset", json!("qplib")).unwrap();
-        experiment
-            .log_json("dataset", json!("set-covering"))
-            .unwrap();
-
-        with_unsealed_state(&experiment, |state| {
-            assert_eq!(state.attachments.len(), 3);
-            assert_eq!(
-                state
-                    .attachments
-                    .iter()
-                    .map(|attachment| layer_annotation(attachment, ANN_ATTACHMENT_NAME).unwrap())
-                    .collect::<Vec<_>>(),
-                vec![
-                    "dataset".to_string(),
-                    "dataset".to_string(),
-                    "dataset".to_string()
-                ]
-            );
-        });
-        Ok(())
-    });
-}
-
-#[test]
-fn attachment_logger_typed_methods_use_expected_media_types_and_bytes() {
-    with_temp_experiment(|experiment| {
-        let instance = empty_instance();
-        let parametric_instance = empty_parametric_instance();
-        let solution = empty_solution(&instance);
-        let sample_set = empty_sample_set(&instance);
-
-        experiment
-            .log_json("json", json!({ "dataset": "miplib2017" }))
-            .unwrap();
-        experiment.log_instance("instance", &instance).unwrap();
-        experiment
-            .log_parametric_instance("parametric-instance", &parametric_instance)
-            .unwrap();
-        experiment.log_solution("solution", &solution).unwrap();
-        experiment
-            .log_sample_set("sample-set", &sample_set)
-            .unwrap();
-
-        let (names, media_types, blobs) = with_unsealed_state(&experiment, |state| {
-            (
-                state
-                    .attachments
-                    .iter()
-                    .map(|attachment| layer_annotation(attachment, ANN_ATTACHMENT_NAME).unwrap())
-                    .collect::<Vec<_>>(),
-                state
-                    .attachments
-                    .iter()
-                    .map(|attachment| attachment.media_type().clone())
-                    .collect::<Vec<_>>(),
-                state
-                    .attachments
-                    .iter()
-                    .map(|descriptor| {
-                        experiment
-                            .registry
-                            .blobs()
-                            .read_bytes(descriptor.digest())
-                            .unwrap()
-                    })
-                    .collect::<Vec<_>>(),
-            )
-        });
-        assert_eq!(
-            names,
-            vec![
-                "json".to_string(),
-                "instance".to_string(),
-                "parametric-instance".to_string(),
-                "solution".to_string(),
-                "sample-set".to_string(),
-            ]
-        );
-        assert_eq!(
-            media_types,
-            vec![
-                MediaType::Other("application/json".to_string()),
-                media_types::v1_instance(),
-                media_types::v1_parametric_instance(),
-                media_types::v1_solution(),
-                media_types::v1_sample_set(),
-            ]
-        );
-
-        assert_eq!(
-            blobs[0],
-            serde_json::to_vec(&json!({ "dataset": "miplib2017" })).unwrap()
-        );
-        assert_eq!(blobs[1], instance.to_bytes());
-        assert_eq!(blobs[2], parametric_instance.to_bytes());
-        assert_eq!(blobs[3], solution.to_bytes());
-        assert_eq!(blobs[4], sample_set.to_bytes());
         Ok(())
     });
 }
@@ -1083,50 +931,6 @@ fn dropping_unclosed_run_does_not_write_back() {
         assert!(layers
             .iter()
             .all(|layer| layer_annotation(layer, ANN_ATTACHMENT_NAME).as_deref() != Some("seed")));
-        Ok(())
-    });
-}
-
-/// A byte-identical attachment logged by two runs yields two annotation-
-/// distinct layer descriptors backed by one shared CAS blob.
-#[test]
-fn byte_identical_attachment_across_runs_shares_one_blob() {
-    with_temp_experiment(|experiment| {
-        let payload = json!({ "formulation": "relaxed" });
-
-        {
-            let mut run0 = experiment.run().unwrap();
-            run0.log_json("candidate", payload.clone()).unwrap();
-            run0.finish().unwrap();
-        }
-
-        {
-            let mut run1 = experiment.run().unwrap();
-            run1.log_json("candidate", payload.clone()).unwrap();
-            run1.finish().unwrap();
-        }
-
-        let artifact = experiment.commit().unwrap().into_artifact();
-        let layers = artifact.layers().unwrap();
-
-        let candidates: Vec<&StoredDescriptor<'_>> = layers
-            .iter()
-            .filter(|layer| {
-                layer_annotation(layer, ANN_ATTACHMENT_NAME).as_deref() == Some("candidate")
-            })
-            .collect();
-        assert_eq!(candidates.len(), 2);
-        let mut run_ids: Vec<Option<String>> = candidates
-            .iter()
-            .map(|layer| layer_annotation(layer, ANN_RUN_ID))
-            .collect();
-        run_ids.sort();
-        assert_eq!(run_ids, vec![Some("0".to_string()), Some("1".to_string())]);
-        // Same content -> same digest -> one physical blob.
-        assert_eq!(
-            candidates[0].digest().to_string(),
-            candidates[1].digest().to_string()
-        );
         Ok(())
     });
 }


### PR DESCRIPTION
## Summary
- Introduce `AttachmentLogger` as the shared Rust trait for experiment and run attachment logging.
- Move `log_attachment` storage behavior into each static and dynamic handle implementation, and remove duplicate inherent `log_*` methods from Rust handles.
- Keep the Python `Experiment` / `Run` logging API delegating through the Rust trait.
- Encode JSON attachments with stable object-key ordering, so `HashMap` inputs produce deterministic payload bytes.
- Remove redundant attachment tests that duplicated API signatures, CAS behavior, or type-level lifecycle guarantees.
