### PR TITLE
Add experimental instance diff mapping utilities

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -19,6 +19,7 @@ Utilities
 
    ../autoapi/ommx/adapter/index
    ../autoapi/ommx/dataset/index
+   ../autoapi/ommx/diff/index
    ../autoapi/ommx/testing/index
    ../autoapi/ommx/mps/index
    ../autoapi/ommx/qplib/index

--- a/python/ommx-tests/tests/test_diff_instance_mapping.py
+++ b/python/ommx-tests/tests/test_diff_instance_mapping.py
@@ -7,6 +7,7 @@ from ommx.v1 import (
     OneHotConstraint,
     Sos1Constraint,
 )
+import pytest
 
 
 def test_match_instance_ids_recovers_relabelled_regular_constraints():
@@ -117,3 +118,40 @@ def test_match_instance_ids_reports_unverified_for_nonmatching_objective():
     assert not mapping.verified
     assert not mapping.objective_matches
     assert mapping.score < 1.0 or mapping.diagnostics
+
+
+def test_match_instance_ids_uses_coarser_buckets_than_final_verification():
+    x = [DecisionVariable.binary(i) for i in range(2)]
+    source = Instance.from_components(
+        decision_variables=x,
+        objective=1.004 * x[0] + 2 * x[1],
+        constraints={1: x[0] + 3 * x[1] <= 1},
+        sense=Instance.MINIMIZE,
+    )
+
+    y = [DecisionVariable.binary(10), DecisionVariable.binary(11)]
+    target = Instance.from_components(
+        decision_variables=y,
+        objective=1.006 * y[0] + 2 * y[1],
+        constraints={100: y[0] + 3 * y[1] <= 1},
+        sense=Instance.MINIMIZE,
+    )
+
+    mapping = match_instance_ids(source, target, atol=1e-2)
+
+    assert mapping.verified
+    assert mapping.decision_variables == {0: 10, 1: 11}
+
+
+def test_match_instance_ids_rejects_color_atol_stricter_than_atol():
+    x = [DecisionVariable.binary(0)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=x[0],
+        constraints={},
+        sense=Instance.MINIMIZE,
+    )
+
+    with pytest.raises(ValueError) as e:
+        match_instance_ids(instance, instance, atol=1e-2, color_atol=1e-3)
+    assert str(e.value) == "color_atol must be greater than or equal to atol"

--- a/python/ommx-tests/tests/test_diff_instance_mapping.py
+++ b/python/ommx-tests/tests/test_diff_instance_mapping.py
@@ -1,0 +1,119 @@
+from ommx.diff import match_instance_ids
+from ommx.v1 import (
+    Constraint,
+    DecisionVariable,
+    IndicatorConstraint,
+    Instance,
+    OneHotConstraint,
+    Sos1Constraint,
+)
+
+
+def test_match_instance_ids_recovers_relabelled_regular_constraints():
+    x = [DecisionVariable.binary(i) for i in range(3)]
+    source = Instance.from_components(
+        decision_variables=x,
+        objective=5 * x[0] + 7 * x[1] + 11 * x[2],
+        constraints={
+            10: x[0] + x[1] + x[2] <= 1,
+            20: 2 * x[1] - x[2] == 0,
+            30: x[0] + 3 * x[2] <= 2,
+        },
+        sense=Instance.MINIMIZE,
+    )
+
+    y = {
+        0: DecisionVariable.binary(102),
+        1: DecisionVariable.binary(101),
+        2: DecisionVariable.binary(103),
+    }
+    target = Instance.from_components(
+        decision_variables=[y[0], y[1], y[2]],
+        objective=5 * y[0] + 7 * y[1] + 11 * y[2],
+        constraints={
+            200: y[0] + y[1] + y[2] <= 1,
+            100: 2 * y[1] - y[2] == 0,
+            300: y[0] + 3 * y[2] <= 2,
+        },
+        sense=Instance.MINIMIZE,
+    )
+
+    mapping = match_instance_ids(source, target)
+
+    assert mapping.verified
+    assert mapping.objective_matches
+    assert mapping.decision_variables == {0: 102, 1: 101, 2: 103}
+    assert mapping.constraints == {10: 200, 20: 100, 30: 300}
+    assert mapping.score == 1.0
+
+
+def test_match_instance_ids_handles_structural_constraints():
+    x0 = DecisionVariable.binary(0)
+    x1 = DecisionVariable.binary(1)
+    x2 = DecisionVariable.binary(2)
+    source = Instance.from_components(
+        decision_variables=[x0, x1, x2],
+        objective=x1 + 2 * x2,
+        constraints={},
+        indicator_constraints={
+            7: IndicatorConstraint(
+                indicator_variable=x0,
+                function=x1 + x2 - 1,
+                equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+            )
+        },
+        one_hot_constraints={8: OneHotConstraint(variables=[0, 2])},
+        sos1_constraints={9: Sos1Constraint(variables=[1, 2])},
+        sense=Instance.MINIMIZE,
+    )
+
+    y0 = DecisionVariable.binary(100)
+    y1 = DecisionVariable.binary(200)
+    y2 = DecisionVariable.binary(300)
+    target = Instance.from_components(
+        decision_variables=[y0, y1, y2],
+        objective=y1 + 2 * y2,
+        constraints={},
+        indicator_constraints={
+            70: IndicatorConstraint(
+                indicator_variable=y0,
+                function=y1 + y2 - 1,
+                equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+            )
+        },
+        one_hot_constraints={80: OneHotConstraint(variables=[100, 300])},
+        sos1_constraints={90: Sos1Constraint(variables=[200, 300])},
+        sense=Instance.MINIMIZE,
+    )
+
+    mapping = match_instance_ids(source, target)
+
+    assert mapping.verified
+    assert mapping.decision_variables == {0: 100, 1: 200, 2: 300}
+    assert mapping.indicator_constraints == {7: 70}
+    assert mapping.one_hot_constraints == {8: 80}
+    assert mapping.sos1_constraints == {9: 90}
+
+
+def test_match_instance_ids_reports_unverified_for_nonmatching_objective():
+    x = [DecisionVariable.binary(i) for i in range(2)]
+    source = Instance.from_components(
+        decision_variables=x,
+        objective=x[0] + x[1],
+        constraints={1: x[0] + x[1] <= 1},
+        sense=Instance.MINIMIZE,
+    )
+
+    y = [DecisionVariable.binary(10), DecisionVariable.binary(11)]
+    target = Instance.from_components(
+        decision_variables=y,
+        objective=y[0] + 2 * y[1],
+        constraints={100: y[0] + y[1] <= 1},
+        sense=Instance.MINIMIZE,
+    )
+
+    mapping = match_instance_ids(source, target)
+
+    assert not mapping.verified
+    assert not mapping.objective_matches
+    assert mapping.score < 1.0 or mapping.diagnostics

--- a/python/ommx/ommx/diff/__init__.py
+++ b/python/ommx/ommx/diff/__init__.py
@@ -1,0 +1,9 @@
+"""Instance diffing utilities for OMMX.
+
+The current API exposes the ID-mapping heuristic used as the first step toward
+semantic instance diffs.
+"""
+
+from .instance_mapping import InstanceMapping, match_instance_ids
+
+__all__ = ["InstanceMapping", "match_instance_ids"]

--- a/python/ommx/ommx/diff/graph.py
+++ b/python/ommx/ommx/diff/graph.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from collections import Counter
+import math
+from typing import Any
+
+from ommx.v1 import Function, Instance
+
+from .types import FactorKey, FactorNode, InstanceGraph, Monomial, Terms
+
+
+def build_graph(
+    instance: Instance, *, atol: float, color_atol: float, include_metadata: bool
+) -> InstanceGraph:
+    variables: dict[int, tuple[Any, ...]] = {}
+    for attached in instance.decision_variables:
+        var = attached.detach()
+        variables[var.id] = _variable_attrs(
+            var, atol=color_atol, include_metadata=include_metadata
+        )
+
+    factors: dict[FactorKey, FactorNode] = {}
+    objective_terms = function_terms(instance.objective, atol=atol)
+    factors[("objective", -1)] = _function_factor(
+        key=("objective", -1),
+        kind="objective",
+        function_terms=objective_terms,
+        equality=None,
+        metadata=(),
+        atol=color_atol,
+        sense=str(instance.sense),
+    )
+
+    for constraint_id, attached in instance.constraints.items():
+        metadata = _constraint_metadata(attached, include_metadata)
+        factors[("constraint", int(constraint_id))] = _function_factor(
+            key=("constraint", int(constraint_id)),
+            kind="constraint",
+            function_terms=function_terms(attached.function, atol=atol),
+            equality=str(attached.equality),
+            metadata=metadata,
+            atol=color_atol,
+        )
+
+    for constraint_id, attached in instance.indicator_constraints.items():
+        metadata = _constraint_metadata(attached, include_metadata)
+        terms = function_terms(attached.function, atol=atol)
+        neighbors = dict(function_neighbors(terms, atol=color_atol))
+        indicator_id = int(attached.indicator_variable_id)
+        labels = list(neighbors.get(indicator_id, ()))
+        labels.append(("indicator",))
+        neighbors[indicator_id] = tuple(sorted(labels, key=repr))
+        attrs = (
+            "indicator",
+            str(attached.equality),
+            function_shape_signature(terms, color_atol),
+            metadata,
+        )
+        factors[("indicator", int(constraint_id))] = FactorNode(
+            key=("indicator", int(constraint_id)),
+            attrs=attrs,
+            terms=terms,
+            neighbors=neighbors,
+            indicator_variable=indicator_id,
+        )
+
+    for constraint_id, attached in instance.one_hot_constraints.items():
+        factors[("one_hot", int(constraint_id))] = _membership_factor(
+            key=("one_hot", int(constraint_id)),
+            kind="one_hot",
+            variables=tuple(int(v) for v in attached.variables),
+            metadata=_constraint_metadata(attached, include_metadata),
+        )
+
+    for constraint_id, attached in instance.sos1_constraints.items():
+        factors[("sos1", int(constraint_id))] = _membership_factor(
+            key=("sos1", int(constraint_id)),
+            kind="sos1",
+            variables=tuple(int(v) for v in attached.variables),
+            metadata=_constraint_metadata(attached, include_metadata),
+        )
+
+    var_to_factors: dict[int, dict[FactorKey, tuple[Any, ...]]] = {
+        variable_id: {} for variable_id in variables
+    }
+    for key, factor in factors.items():
+        for variable_id, edge_label in factor.neighbors.items():
+            var_to_factors.setdefault(variable_id, {})[key] = edge_label
+
+    return InstanceGraph(
+        variables=variables,
+        factors=factors,
+        var_to_factors=var_to_factors,
+        sense=str(instance.sense),
+    )
+
+
+def resolve_color_atol(atol: float, color_atol: float | None) -> float:
+    if atol < 0:
+        raise ValueError("atol must be non-negative")
+    if color_atol is None:
+        return 10 * atol
+    if color_atol < 0:
+        raise ValueError("color_atol must be non-negative")
+    if color_atol < atol:
+        raise ValueError("color_atol must be greater than or equal to atol")
+    return color_atol
+
+
+def function_terms(function: Function, *, atol: float) -> Terms:
+    terms: dict[Monomial, float] = {}
+    for raw_monomial, raw_coefficient in function.terms.items():
+        coefficient = float(raw_coefficient)
+        if abs(coefficient) <= atol:
+            continue
+        monomial = tuple(sorted(int(v) for v in raw_monomial))
+        terms[monomial] = terms.get(monomial, 0.0) + coefficient
+    return {
+        monomial: coefficient
+        for monomial, coefficient in terms.items()
+        if abs(coefficient) > atol
+    }
+
+
+def function_neighbors(terms: Terms, *, atol: float) -> dict[int, tuple[Any, ...]]:
+    labels: dict[int, list[tuple[Any, ...]]] = {}
+    for monomial, coefficient in terms.items():
+        powers = Counter(monomial)
+        power_shape = tuple(sorted(powers.values()))
+        for variable_id, power in powers.items():
+            labels.setdefault(variable_id, []).append(
+                (
+                    "term",
+                    len(monomial),
+                    int(power),
+                    power_shape,
+                    quantize_float(coefficient, atol),
+                )
+            )
+    return {
+        variable_id: tuple(sorted(edge_labels, key=repr))
+        for variable_id, edge_labels in labels.items()
+    }
+
+
+def function_shape_signature(terms: Terms, atol: float) -> tuple[Any, ...]:
+    items = []
+    for monomial, coefficient in terms.items():
+        power_shape = tuple(sorted(Counter(monomial).values()))
+        items.append((len(monomial), power_shape, quantize_float(coefficient, atol)))
+    return tuple(sorted(items, key=repr))
+
+
+def quantize_float(value: float, atol: float) -> tuple[str, int]:
+    if math.isnan(value):
+        return ("nan", 0)
+    if math.isinf(value):
+        return ("inf", 1 if value > 0 else -1)
+    if atol <= 0:
+        return ("exact", hash(repr(value)))
+    return ("q", int(round(value / atol)))
+
+
+def _variable_attrs(
+    var: Any, *, atol: float, include_metadata: bool
+) -> tuple[Any, ...]:
+    attrs: tuple[Any, ...] = (
+        "variable",
+        int(var.kind),
+        quantize_float(float(var.bound.lower), atol),
+        quantize_float(float(var.bound.upper), atol),
+        _quantize_optional_float(var.substituted_value, atol),
+    )
+    if include_metadata:
+        attrs += (
+            str(var.name),
+            tuple(int(s) for s in var.subscripts),
+            tuple(sorted((str(k), str(v)) for k, v in var.parameters.items())),
+            str(var.description),
+        )
+    return attrs
+
+
+def _constraint_metadata(attached: Any, include_metadata: bool) -> tuple[Any, ...]:
+    if not include_metadata:
+        return ()
+    return (
+        str(getattr(attached, "name", None)),
+        tuple(int(s) for s in getattr(attached, "subscripts", ())),
+        tuple(
+            sorted(
+                (str(k), str(v)) for k, v in getattr(attached, "parameters", {}).items()
+            )
+        ),
+        str(getattr(attached, "description", None)),
+    )
+
+
+def _function_factor(
+    *,
+    key: FactorKey,
+    kind: str,
+    function_terms: Terms,
+    equality: str | None,
+    metadata: tuple[Any, ...],
+    atol: float,
+    sense: str | None = None,
+) -> FactorNode:
+    attrs = (
+        kind,
+        sense,
+        equality,
+        function_shape_signature(function_terms, atol),
+        metadata,
+    )
+    return FactorNode(
+        key=key,
+        attrs=attrs,
+        terms=function_terms,
+        neighbors=function_neighbors(function_terms, atol=atol),
+    )
+
+
+def _membership_factor(
+    *,
+    key: FactorKey,
+    kind: str,
+    variables: tuple[int, ...],
+    metadata: tuple[Any, ...],
+) -> FactorNode:
+    neighbors = {variable_id: (("member",),) for variable_id in variables}
+    attrs = (kind, len(variables), metadata)
+    return FactorNode(
+        key=key,
+        attrs=attrs,
+        terms={},
+        neighbors=neighbors,
+        variables=tuple(sorted(variables)),
+    )
+
+
+def _quantize_optional_float(
+    value: float | None, atol: float
+) -> tuple[str, int] | None:
+    if value is None:
+        return None
+    return quantize_float(float(value), atol)

--- a/python/ommx/ommx/diff/instance_mapping.py
+++ b/python/ommx/ommx/diff/instance_mapping.py
@@ -1,0 +1,980 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+import math
+from typing import Any
+
+from ommx.v1 import Function, Instance
+
+_FactorKey = tuple[str, int]
+_Monomial = tuple[int, ...]
+_Terms = dict[_Monomial, float]
+
+
+@dataclass(frozen=True)
+class InstanceMapping:
+    """Heuristic ID mapping between two structurally similar instances.
+
+    ``decision_variables`` maps source decision variable IDs to target IDs.
+    Constraint mappings are split by OMMX constraint collection.
+    """
+
+    decision_variables: Mapping[int, int]
+    constraints: Mapping[int, int]
+    indicator_constraints: Mapping[int, int]
+    one_hot_constraints: Mapping[int, int]
+    sos1_constraints: Mapping[int, int]
+    objective_matches: bool
+    verified: bool
+    score: float
+    backtracking_steps: int
+    ambiguous_decision_variables: Mapping[int, tuple[int, ...]]
+    ambiguous_constraints: Mapping[int, tuple[int, ...]]
+    diagnostics: tuple[str, ...] = ()
+
+    @property
+    def is_complete(self) -> bool:
+        return self.verified
+
+
+@dataclass(frozen=True)
+class _FactorNode:
+    key: _FactorKey
+    attrs: tuple[Any, ...]
+    terms: _Terms
+    neighbors: Mapping[int, tuple[Any, ...]]
+    variables: tuple[int, ...] = ()
+    indicator_variable: int | None = None
+
+
+@dataclass(frozen=True)
+class _Graph:
+    variables: Mapping[int, tuple[Any, ...]]
+    factors: Mapping[_FactorKey, _FactorNode]
+    var_to_factors: Mapping[int, Mapping[_FactorKey, tuple[Any, ...]]]
+    sense: str
+
+
+@dataclass
+class _Colors:
+    source_variables: dict[int, int]
+    target_variables: dict[int, int]
+    source_factors: dict[_FactorKey, int]
+    target_factors: dict[_FactorKey, int]
+
+
+@dataclass
+class _SearchState:
+    variable_map: dict[int, int]
+    inverse_variable_map: dict[int, int]
+    factor_map: dict[_FactorKey, _FactorKey]
+    inverse_factor_map: dict[_FactorKey, _FactorKey]
+
+    def copy(self) -> "_SearchState":
+        return _SearchState(
+            variable_map=dict(self.variable_map),
+            inverse_variable_map=dict(self.inverse_variable_map),
+            factor_map=dict(self.factor_map),
+            inverse_factor_map=dict(self.inverse_factor_map),
+        )
+
+
+def match_instance_ids(
+    source: Instance,
+    target: Instance,
+    *,
+    atol: float = 1e-12,
+    max_refinement_iterations: int = 12,
+    max_backtracking_steps: int = 100_000,
+    include_metadata: bool = False,
+) -> InstanceMapping:
+    """Infer a source-to-target ID mapping between two OMMX instances.
+
+    This is an experimental heuristic. It builds a factor graph whose nodes are
+    decision variables and objective/constraint factors, refines node colors by
+    neighborhood signatures, then runs a bounded backtracking search over the
+    remaining candidates. The returned mapping is marked ``verified`` only when
+    all active factors and the objective match after applying the inferred
+    decision-variable mapping.
+
+    Args:
+        source: Instance whose IDs are mapped from.
+        target: Instance whose IDs are mapped to.
+        atol: Absolute tolerance used when grouping coefficients and bounds.
+        max_refinement_iterations: Maximum color-refinement rounds.
+        max_backtracking_steps: Search budget for ambiguous color classes.
+        include_metadata: Include names, subscripts, and parameters in
+            fingerprints. The default ignores metadata and matches math shape.
+    """
+
+    source_graph = _build_graph(source, atol=atol, include_metadata=include_metadata)
+    target_graph = _build_graph(target, atol=atol, include_metadata=include_metadata)
+    colors = _refine_colors(
+        source_graph,
+        target_graph,
+        atol=atol,
+        max_iterations=max_refinement_iterations,
+    )
+    result, steps = _search_mapping(
+        source_graph,
+        target_graph,
+        colors,
+        max_steps=max_backtracking_steps,
+        atol=atol,
+    )
+    verified = _verify_mapping(source_graph, target_graph, result, atol=atol)
+    objective_matches = _objective_matches(
+        source_graph, target_graph, result, atol=atol
+    )
+    diagnostics = _diagnostics(source_graph, target_graph, result, verified, steps)
+
+    return InstanceMapping(
+        decision_variables=dict(sorted(result.variable_map.items())),
+        constraints=_extract_factor_mapping(result, "constraint"),
+        indicator_constraints=_extract_factor_mapping(result, "indicator"),
+        one_hot_constraints=_extract_factor_mapping(result, "one_hot"),
+        sos1_constraints=_extract_factor_mapping(result, "sos1"),
+        objective_matches=objective_matches,
+        verified=verified,
+        score=_score(source_graph, result),
+        backtracking_steps=steps,
+        ambiguous_decision_variables=_ambiguous_variables(
+            source_graph, target_graph, colors, result
+        ),
+        ambiguous_constraints=_ambiguous_factors(
+            source_graph, target_graph, colors, result, "constraint"
+        ),
+        diagnostics=diagnostics,
+    )
+
+
+def _build_graph(instance: Instance, *, atol: float, include_metadata: bool) -> _Graph:
+    variables: dict[int, tuple[Any, ...]] = {}
+    for attached in instance.decision_variables:
+        var = attached.detach()
+        variables[var.id] = _variable_attrs(
+            var, atol=atol, include_metadata=include_metadata
+        )
+
+    factors: dict[_FactorKey, _FactorNode] = {}
+    objective_terms = _function_terms(instance.objective, atol=atol)
+    factors[("objective", -1)] = _function_factor(
+        key=("objective", -1),
+        kind="objective",
+        function_terms=objective_terms,
+        equality=None,
+        metadata=(),
+        atol=atol,
+        sense=str(instance.sense),
+    )
+
+    for constraint_id, attached in instance.constraints.items():
+        metadata = _constraint_metadata(attached, include_metadata)
+        factors[("constraint", int(constraint_id))] = _function_factor(
+            key=("constraint", int(constraint_id)),
+            kind="constraint",
+            function_terms=_function_terms(attached.function, atol=atol),
+            equality=str(attached.equality),
+            metadata=metadata,
+            atol=atol,
+        )
+
+    for constraint_id, attached in instance.indicator_constraints.items():
+        metadata = _constraint_metadata(attached, include_metadata)
+        terms = _function_terms(attached.function, atol=atol)
+        neighbors = dict(_function_neighbors(terms, atol=atol))
+        indicator_id = int(attached.indicator_variable_id)
+        labels = list(neighbors.get(indicator_id, ()))
+        labels.append(("indicator",))
+        neighbors[indicator_id] = tuple(sorted(labels, key=repr))
+        attrs = (
+            "indicator",
+            str(attached.equality),
+            _function_shape_signature(terms, atol),
+            metadata,
+        )
+        factors[("indicator", int(constraint_id))] = _FactorNode(
+            key=("indicator", int(constraint_id)),
+            attrs=attrs,
+            terms=terms,
+            neighbors=neighbors,
+            indicator_variable=indicator_id,
+        )
+
+    for constraint_id, attached in instance.one_hot_constraints.items():
+        factors[("one_hot", int(constraint_id))] = _membership_factor(
+            key=("one_hot", int(constraint_id)),
+            kind="one_hot",
+            variables=tuple(int(v) for v in attached.variables),
+            metadata=_constraint_metadata(attached, include_metadata),
+        )
+
+    for constraint_id, attached in instance.sos1_constraints.items():
+        factors[("sos1", int(constraint_id))] = _membership_factor(
+            key=("sos1", int(constraint_id)),
+            kind="sos1",
+            variables=tuple(int(v) for v in attached.variables),
+            metadata=_constraint_metadata(attached, include_metadata),
+        )
+
+    var_to_factors: dict[int, dict[_FactorKey, tuple[Any, ...]]] = {
+        variable_id: {} for variable_id in variables
+    }
+    for key, factor in factors.items():
+        for variable_id, edge_label in factor.neighbors.items():
+            var_to_factors.setdefault(variable_id, {})[key] = edge_label
+
+    return _Graph(
+        variables=variables,
+        factors=factors,
+        var_to_factors=var_to_factors,
+        sense=str(instance.sense),
+    )
+
+
+def _variable_attrs(
+    var: Any, *, atol: float, include_metadata: bool
+) -> tuple[Any, ...]:
+    attrs: tuple[Any, ...] = (
+        "variable",
+        int(var.kind),
+        _quantize_float(float(var.bound.lower), atol),
+        _quantize_float(float(var.bound.upper), atol),
+        _quantize_optional_float(var.substituted_value, atol),
+    )
+    if include_metadata:
+        attrs += (
+            str(var.name),
+            tuple(int(s) for s in var.subscripts),
+            tuple(sorted((str(k), str(v)) for k, v in var.parameters.items())),
+            str(var.description),
+        )
+    return attrs
+
+
+def _constraint_metadata(attached: Any, include_metadata: bool) -> tuple[Any, ...]:
+    if not include_metadata:
+        return ()
+    return (
+        str(getattr(attached, "name", None)),
+        tuple(int(s) for s in getattr(attached, "subscripts", ())),
+        tuple(
+            sorted(
+                (str(k), str(v)) for k, v in getattr(attached, "parameters", {}).items()
+            )
+        ),
+        str(getattr(attached, "description", None)),
+    )
+
+
+def _function_factor(
+    *,
+    key: _FactorKey,
+    kind: str,
+    function_terms: _Terms,
+    equality: str | None,
+    metadata: tuple[Any, ...],
+    atol: float,
+    sense: str | None = None,
+) -> _FactorNode:
+    attrs = (
+        kind,
+        sense,
+        equality,
+        _function_shape_signature(function_terms, atol),
+        metadata,
+    )
+    return _FactorNode(
+        key=key,
+        attrs=attrs,
+        terms=function_terms,
+        neighbors=_function_neighbors(function_terms, atol=atol),
+    )
+
+
+def _membership_factor(
+    *,
+    key: _FactorKey,
+    kind: str,
+    variables: tuple[int, ...],
+    metadata: tuple[Any, ...],
+) -> _FactorNode:
+    neighbors = {variable_id: (("member",),) for variable_id in variables}
+    attrs = (kind, len(variables), metadata)
+    return _FactorNode(
+        key=key,
+        attrs=attrs,
+        terms={},
+        neighbors=neighbors,
+        variables=tuple(sorted(variables)),
+    )
+
+
+def _function_terms(function: Function, *, atol: float) -> _Terms:
+    terms: dict[_Monomial, float] = {}
+    for raw_monomial, raw_coefficient in function.terms.items():
+        coefficient = float(raw_coefficient)
+        if abs(coefficient) <= atol:
+            continue
+        monomial = tuple(sorted(int(v) for v in raw_monomial))
+        terms[monomial] = terms.get(monomial, 0.0) + coefficient
+    return {
+        monomial: coefficient
+        for monomial, coefficient in terms.items()
+        if abs(coefficient) > atol
+    }
+
+
+def _function_neighbors(terms: _Terms, *, atol: float) -> dict[int, tuple[Any, ...]]:
+    labels: dict[int, list[tuple[Any, ...]]] = {}
+    for monomial, coefficient in terms.items():
+        powers = Counter(monomial)
+        power_shape = tuple(sorted(powers.values()))
+        for variable_id, power in powers.items():
+            labels.setdefault(variable_id, []).append(
+                (
+                    "term",
+                    len(monomial),
+                    int(power),
+                    power_shape,
+                    _quantize_float(coefficient, atol),
+                )
+            )
+    return {
+        variable_id: tuple(sorted(edge_labels, key=repr))
+        for variable_id, edge_labels in labels.items()
+    }
+
+
+def _function_shape_signature(terms: _Terms, atol: float) -> tuple[Any, ...]:
+    items = []
+    for monomial, coefficient in terms.items():
+        power_shape = tuple(sorted(Counter(monomial).values()))
+        items.append((len(monomial), power_shape, _quantize_float(coefficient, atol)))
+    return tuple(sorted(items, key=repr))
+
+
+def _colored_terms(
+    terms: _Terms,
+    variable_colors: Mapping[int, int],
+    atol: float,
+) -> tuple[Any, ...]:
+    items = []
+    for monomial, coefficient in terms.items():
+        color_counts = tuple(
+            sorted(Counter(variable_colors[v] for v in monomial).items())
+        )
+        items.append((color_counts, _quantize_float(coefficient, atol)))
+    return tuple(sorted(items, key=repr))
+
+
+def _refine_colors(
+    source: _Graph,
+    target: _Graph,
+    *,
+    atol: float,
+    max_iterations: int,
+) -> _Colors:
+    source_variable_colors, target_variable_colors = _intern_pair(
+        source.variables, target.variables
+    )
+    source_factor_colors, target_factor_colors = _intern_pair(
+        {k: f.attrs for k, f in source.factors.items()},
+        {k: f.attrs for k, f in target.factors.items()},
+    )
+
+    for _ in range(max_iterations):
+        next_source_factor_raw = _factor_color_inputs(
+            source, source_variable_colors, atol=atol
+        )
+        next_target_factor_raw = _factor_color_inputs(
+            target, target_variable_colors, atol=atol
+        )
+        next_source_factor_colors, next_target_factor_colors = _intern_pair(
+            next_source_factor_raw, next_target_factor_raw
+        )
+
+        next_source_variable_raw = _variable_color_inputs(
+            source, next_source_factor_colors
+        )
+        next_target_variable_raw = _variable_color_inputs(
+            target, next_target_factor_colors
+        )
+        next_source_variable_colors, next_target_variable_colors = _intern_pair(
+            next_source_variable_raw, next_target_variable_raw
+        )
+
+        if (
+            next_source_variable_colors == source_variable_colors
+            and next_target_variable_colors == target_variable_colors
+            and next_source_factor_colors == source_factor_colors
+            and next_target_factor_colors == target_factor_colors
+        ):
+            break
+
+        source_variable_colors = next_source_variable_colors
+        target_variable_colors = next_target_variable_colors
+        source_factor_colors = next_source_factor_colors
+        target_factor_colors = next_target_factor_colors
+
+    return _Colors(
+        source_variables=source_variable_colors,
+        target_variables=target_variable_colors,
+        source_factors=source_factor_colors,
+        target_factors=target_factor_colors,
+    )
+
+
+def _factor_color_inputs(
+    graph: _Graph,
+    variable_colors: Mapping[int, int],
+    *,
+    atol: float,
+) -> dict[_FactorKey, tuple[Any, ...]]:
+    out = {}
+    for key, factor in graph.factors.items():
+        neighborhood = tuple(
+            sorted(
+                (
+                    factor.neighbors[variable_id],
+                    variable_colors.get(variable_id),
+                )
+                for variable_id in factor.neighbors
+            )
+        )
+        out[key] = (
+            factor.attrs,
+            _colored_terms(factor.terms, variable_colors, atol),
+            neighborhood,
+        )
+    return out
+
+
+def _variable_color_inputs(
+    graph: _Graph,
+    factor_colors: Mapping[_FactorKey, int],
+) -> dict[int, tuple[Any, ...]]:
+    out = {}
+    for variable_id, attrs in graph.variables.items():
+        neighborhood = tuple(
+            sorted(
+                (edge_label, factor_colors[factor_key])
+                for factor_key, edge_label in graph.var_to_factors.get(
+                    variable_id, {}
+                ).items()
+            )
+        )
+        out[variable_id] = (attrs, neighborhood)
+    return out
+
+
+def _intern_pair(
+    source_values: Mapping[Any, Any],
+    target_values: Mapping[Any, Any],
+) -> tuple[dict[Any, int], dict[Any, int]]:
+    unique_values = {_freeze(value) for value in source_values.values()} | {
+        _freeze(value) for value in target_values.values()
+    }
+    interned = {
+        value: index for index, value in enumerate(sorted(unique_values, key=repr))
+    }
+    return (
+        {key: interned[_freeze(value)] for key, value in source_values.items()},
+        {key: interned[_freeze(value)] for key, value in target_values.items()},
+    )
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple(sorted((_freeze(k), _freeze(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(v) for v in value)
+    if isinstance(value, set):
+        return tuple(sorted((_freeze(v) for v in value), key=repr))
+    return value
+
+
+def _search_mapping(
+    source: _Graph,
+    target: _Graph,
+    colors: _Colors,
+    *,
+    max_steps: int,
+    atol: float,
+) -> tuple[_SearchState, int]:
+    state = _SearchState(
+        variable_map={},
+        inverse_variable_map={},
+        factor_map={("objective", -1): ("objective", -1)},
+        inverse_factor_map={("objective", -1): ("objective", -1)},
+    )
+    best = state.copy()
+    steps = 0
+
+    variable_candidates = _variable_candidates_by_color(source, target, colors)
+    factor_candidates = _factor_candidates_by_color(source, target, colors)
+
+    def remember(candidate: _SearchState) -> None:
+        nonlocal best
+        if _mapped_size(candidate) > _mapped_size(best):
+            best = candidate.copy()
+
+    def recurse(current: _SearchState) -> _SearchState | None:
+        nonlocal steps
+        steps += 1
+        remember(current)
+        if steps > max_steps:
+            return None
+        if _source_is_fully_mapped(source, current):
+            if _verify_mapping(source, target, current, atol=atol):
+                return current
+            return None
+
+        item = _choose_next_item(
+            source,
+            target,
+            current,
+            variable_candidates,
+            factor_candidates,
+            atol=atol,
+        )
+        if item is None:
+            return None
+        item_kind, source_key, candidates = item
+        if not candidates:
+            return None
+
+        for target_key in candidates:
+            next_state = current.copy()
+            if item_kind == "variable":
+                source_variable = int(source_key)
+                target_variable = int(target_key)
+                next_state.variable_map[source_variable] = target_variable
+                next_state.inverse_variable_map[target_variable] = source_variable
+            else:
+                source_factor = source_key
+                target_factor = target_key
+                next_state.factor_map[source_factor] = target_factor
+                next_state.inverse_factor_map[target_factor] = source_factor
+            result = recurse(next_state)
+            if result is not None:
+                return result
+        return None
+
+    result = recurse(state)
+    return (result or best, min(steps, max_steps))
+
+
+def _variable_candidates_by_color(
+    source: _Graph, target: _Graph, colors: _Colors
+) -> dict[int, tuple[int, ...]]:
+    by_color: dict[int, list[int]] = {}
+    for target_variable, color in colors.target_variables.items():
+        by_color.setdefault(color, []).append(target_variable)
+    return {
+        source_variable: tuple(sorted(by_color.get(color, ())))
+        for source_variable, color in colors.source_variables.items()
+    }
+
+
+def _factor_candidates_by_color(
+    source: _Graph, target: _Graph, colors: _Colors
+) -> dict[_FactorKey, tuple[_FactorKey, ...]]:
+    by_color: dict[tuple[str, int], list[_FactorKey]] = {}
+    for target_key, color in colors.target_factors.items():
+        by_color.setdefault((target_key[0], color), []).append(target_key)
+    return {
+        source_key: tuple(sorted(by_color.get((source_key[0], color), ())))
+        for source_key, color in colors.source_factors.items()
+        if source_key[0] != "objective"
+    }
+
+
+def _choose_next_item(
+    source: _Graph,
+    target: _Graph,
+    state: _SearchState,
+    variable_candidates: Mapping[int, tuple[int, ...]],
+    factor_candidates: Mapping[_FactorKey, tuple[_FactorKey, ...]],
+    *,
+    atol: float,
+) -> tuple[str, Any, tuple[Any, ...]] | None:
+    choices: list[tuple[tuple[int, int, int], str, Any, tuple[Any, ...]]] = []
+
+    for source_variable in source.variables:
+        if source_variable in state.variable_map:
+            continue
+        candidates = tuple(
+            target_variable
+            for target_variable in variable_candidates.get(source_variable, ())
+            if target_variable not in state.inverse_variable_map
+            and _variable_pair_consistent(
+                source, target, state, source_variable, target_variable, atol=atol
+            )
+        )
+        degree = len(source.var_to_factors.get(source_variable, {}))
+        choices.append(
+            (
+                (len(candidates), -degree, source_variable),
+                "variable",
+                source_variable,
+                candidates,
+            )
+        )
+
+    for source_factor in _output_factor_keys(source):
+        if source_factor in state.factor_map:
+            continue
+        candidates = tuple(
+            target_factor
+            for target_factor in factor_candidates.get(source_factor, ())
+            if target_factor not in state.inverse_factor_map
+            and _factor_pair_consistent(
+                source, target, state, source_factor, target_factor, atol=atol
+            )
+        )
+        edge_count = len(source.factors[source_factor].neighbors)
+        choices.append(
+            (
+                (len(candidates), -edge_count, source_factor[1]),
+                "factor",
+                source_factor,
+                candidates,
+            )
+        )
+
+    if not choices:
+        return None
+    _, kind, source_key, candidates = min(choices, key=lambda item: item[0])
+    return kind, source_key, candidates
+
+
+def _variable_pair_consistent(
+    source: _Graph,
+    target: _Graph,
+    state: _SearchState,
+    source_variable: int,
+    target_variable: int,
+    *,
+    atol: float,
+) -> bool:
+    if source.variables[source_variable] != target.variables[target_variable]:
+        return False
+    trial = state.copy()
+    trial.variable_map[source_variable] = target_variable
+    trial.inverse_variable_map[target_variable] = source_variable
+    for source_factor, target_factor in trial.factor_map.items():
+        if not _mapped_factor_edges_match(
+            source, target, trial, source_factor, target_factor, atol=atol
+        ):
+            return False
+    return True
+
+
+def _factor_pair_consistent(
+    source: _Graph,
+    target: _Graph,
+    state: _SearchState,
+    source_factor: _FactorKey,
+    target_factor: _FactorKey,
+    *,
+    atol: float,
+) -> bool:
+    if (
+        source.factors[source_factor].attrs[:3]
+        != target.factors[target_factor].attrs[:3]
+    ):
+        return False
+    trial = state.copy()
+    trial.factor_map[source_factor] = target_factor
+    trial.inverse_factor_map[target_factor] = source_factor
+    return _mapped_factor_edges_match(
+        source, target, trial, source_factor, target_factor, atol=atol
+    )
+
+
+def _mapped_factor_edges_match(
+    source: _Graph,
+    target: _Graph,
+    state: _SearchState,
+    source_factor: _FactorKey,
+    target_factor: _FactorKey,
+    *,
+    atol: float,
+) -> bool:
+    source_node = source.factors[source_factor]
+    target_node = target.factors[target_factor]
+    for source_variable, target_variable in state.variable_map.items():
+        source_edge = source_node.neighbors.get(source_variable)
+        target_edge = target_node.neighbors.get(target_variable)
+        if source_edge != target_edge:
+            return False
+
+    if source_node.indicator_variable is not None:
+        mapped_indicator = state.variable_map.get(source_node.indicator_variable)
+        if (
+            mapped_indicator is not None
+            and mapped_indicator != target_node.indicator_variable
+        ):
+            return False
+
+    return _partial_terms_match(
+        source_node.terms,
+        target_node.terms,
+        state.variable_map,
+        state.inverse_variable_map,
+        atol=atol,
+    )
+
+
+def _partial_terms_match(
+    source_terms: _Terms,
+    target_terms: _Terms,
+    variable_map: Mapping[int, int],
+    inverse_variable_map: Mapping[int, int],
+    *,
+    atol: float,
+) -> bool:
+    source_known = {
+        _map_monomial(monomial, variable_map): coefficient
+        for monomial, coefficient in source_terms.items()
+        if all(variable_id in variable_map for variable_id in monomial)
+    }
+    target_known = {
+        monomial: coefficient
+        for monomial, coefficient in target_terms.items()
+        if all(variable_id in inverse_variable_map for variable_id in monomial)
+    }
+    return _terms_close(source_known, target_known, atol=atol)
+
+
+def _verify_mapping(
+    source: _Graph,
+    target: _Graph,
+    state: _SearchState,
+    *,
+    atol: float,
+) -> bool:
+    if len(source.variables) != len(target.variables):
+        return False
+    if len(state.variable_map) != len(source.variables):
+        return False
+    if source.sense != target.sense:
+        return False
+    if len(_output_factor_keys(source)) != len(_output_factor_keys(target)):
+        return False
+    if len(state.factor_map) != len(source.factors):
+        return False
+    if not _objective_matches(source, target, state, atol=atol):
+        return False
+
+    for source_factor, target_factor in state.factor_map.items():
+        if source_factor[0] == "objective":
+            continue
+        if source_factor[0] != target_factor[0]:
+            return False
+        if not _factor_matches(
+            source.factors[source_factor],
+            target.factors[target_factor],
+            state.variable_map,
+            atol=atol,
+        ):
+            return False
+    return True
+
+
+def _objective_matches(
+    source: _Graph,
+    target: _Graph,
+    state: _SearchState,
+    *,
+    atol: float,
+) -> bool:
+    if len(state.variable_map) != len(source.variables):
+        return False
+    if source.sense != target.sense:
+        return False
+    return _function_matches(
+        source.factors[("objective", -1)].terms,
+        target.factors[("objective", -1)].terms,
+        state.variable_map,
+        atol=atol,
+    )
+
+
+def _factor_matches(
+    source: _FactorNode,
+    target: _FactorNode,
+    variable_map: Mapping[int, int],
+    *,
+    atol: float,
+) -> bool:
+    if source.attrs[:3] != target.attrs[:3]:
+        return False
+    if source.indicator_variable is not None:
+        if variable_map.get(source.indicator_variable) != target.indicator_variable:
+            return False
+    if source.variables:
+        return (
+            tuple(sorted(variable_map[v] for v in source.variables)) == target.variables
+        )
+    return _function_matches(source.terms, target.terms, variable_map, atol=atol)
+
+
+def _function_matches(
+    source_terms: _Terms,
+    target_terms: _Terms,
+    variable_map: Mapping[int, int],
+    *,
+    atol: float,
+) -> bool:
+    if any(
+        variable_id not in variable_map
+        for monomial in source_terms
+        for variable_id in monomial
+    ):
+        return False
+    mapped_terms: dict[_Monomial, float] = {}
+    for monomial, coefficient in source_terms.items():
+        mapped_monomial = _map_monomial(monomial, variable_map)
+        mapped_terms[mapped_monomial] = (
+            mapped_terms.get(mapped_monomial, 0.0) + coefficient
+        )
+    return _terms_close(mapped_terms, target_terms, atol=atol)
+
+
+def _map_monomial(monomial: _Monomial, variable_map: Mapping[int, int]) -> _Monomial:
+    return tuple(sorted(variable_map[variable_id] for variable_id in monomial))
+
+
+def _terms_close(source_terms: _Terms, target_terms: _Terms, *, atol: float) -> bool:
+    keys = set(source_terms) | set(target_terms)
+    for key in keys:
+        if abs(source_terms.get(key, 0.0) - target_terms.get(key, 0.0)) > atol:
+            return False
+    return True
+
+
+def _source_is_fully_mapped(source: _Graph, state: _SearchState) -> bool:
+    return len(state.variable_map) == len(source.variables) and len(
+        state.factor_map
+    ) == len(source.factors)
+
+
+def _output_factor_keys(graph: _Graph) -> tuple[_FactorKey, ...]:
+    return tuple(
+        sorted((key for key in graph.factors if key[0] != "objective"), key=repr)
+    )
+
+
+def _extract_factor_mapping(state: _SearchState, kind: str) -> dict[int, int]:
+    out = {}
+    for source_factor, target_factor in state.factor_map.items():
+        if source_factor[0] == kind:
+            out[source_factor[1]] = target_factor[1]
+    return dict(sorted(out.items()))
+
+
+def _score(source: _Graph, state: _SearchState) -> float:
+    total = len(source.variables) + len(_output_factor_keys(source))
+    if total == 0:
+        return 1.0
+    mapped = len(state.variable_map) + sum(
+        1 for factor_key in state.factor_map if factor_key[0] != "objective"
+    )
+    return mapped / total
+
+
+def _mapped_size(state: _SearchState) -> int:
+    return len(state.variable_map) + sum(
+        1 for factor_key in state.factor_map if factor_key[0] != "objective"
+    )
+
+
+def _ambiguous_variables(
+    source: _Graph,
+    target: _Graph,
+    colors: _Colors,
+    state: _SearchState,
+) -> dict[int, tuple[int, ...]]:
+    by_color: dict[int, list[int]] = {}
+    for target_variable, color in colors.target_variables.items():
+        by_color.setdefault(color, []).append(target_variable)
+    out = {}
+    for source_variable, color in colors.source_variables.items():
+        if source_variable in state.variable_map:
+            continue
+        candidates = tuple(sorted(by_color.get(color, ())))
+        if len(candidates) != 1:
+            out[source_variable] = candidates
+    return out
+
+
+def _ambiguous_factors(
+    source: _Graph,
+    target: _Graph,
+    colors: _Colors,
+    state: _SearchState,
+    kind: str,
+) -> dict[int, tuple[int, ...]]:
+    by_color: dict[int, list[int]] = {}
+    for target_key, color in colors.target_factors.items():
+        if target_key[0] == kind:
+            by_color.setdefault(color, []).append(target_key[1])
+    out = {}
+    for source_key, color in colors.source_factors.items():
+        if source_key[0] != kind or source_key in state.factor_map:
+            continue
+        candidates = tuple(sorted(by_color.get(color, ())))
+        if len(candidates) != 1:
+            out[source_key[1]] = candidates
+    return out
+
+
+def _diagnostics(
+    source: _Graph,
+    target: _Graph,
+    state: _SearchState,
+    verified: bool,
+    steps: int,
+) -> tuple[str, ...]:
+    messages = []
+    if verified:
+        return ()
+    if len(source.variables) != len(target.variables):
+        messages.append(
+            f"decision variable count differs: {len(source.variables)} != {len(target.variables)}"
+        )
+    for kind in ("constraint", "indicator", "one_hot", "sos1"):
+        source_count = sum(1 for key in source.factors if key[0] == kind)
+        target_count = sum(1 for key in target.factors if key[0] == kind)
+        if source_count != target_count:
+            messages.append(f"{kind} count differs: {source_count} != {target_count}")
+    if source.sense != target.sense:
+        messages.append(f"sense differs: {source.sense} != {target.sense}")
+    if len(state.variable_map) < len(source.variables):
+        messages.append("some source decision variables remain unmapped")
+    if len(state.factor_map) < len(source.factors):
+        messages.append("some source constraints remain unmapped")
+    messages.append(f"search stopped after {steps} steps")
+    return tuple(messages)
+
+
+def _quantize_optional_float(
+    value: float | None, atol: float
+) -> tuple[str, int] | None:
+    if value is None:
+        return None
+    return _quantize_float(float(value), atol)
+
+
+def _quantize_float(value: float, atol: float) -> tuple[str, int]:
+    if math.isnan(value):
+        return ("nan", 0)
+    if math.isinf(value):
+        return ("inf", 1 if value > 0 else -1)
+    if atol <= 0:
+        return ("exact", hash(repr(value)))
+    return ("q", int(round(value / atol)))

--- a/python/ommx/ommx/diff/instance_mapping.py
+++ b/python/ommx/ommx/diff/instance_mapping.py
@@ -86,6 +86,7 @@ def match_instance_ids(
     target: Instance,
     *,
     atol: float = 1e-12,
+    color_atol: float | None = None,
     max_refinement_iterations: int = 12,
     max_backtracking_steps: int = 100_000,
     include_metadata: bool = False,
@@ -103,18 +104,31 @@ def match_instance_ids(
         source: Instance whose IDs are mapped from.
         target: Instance whose IDs are mapped to.
         atol: Absolute tolerance used when grouping coefficients and bounds.
+        color_atol: Coarser absolute tolerance used only for color/fingerprint
+            bucketing. The final verification still uses ``atol``.
         max_refinement_iterations: Maximum color-refinement rounds.
         max_backtracking_steps: Search budget for ambiguous color classes.
         include_metadata: Include names, subscripts, and parameters in
             fingerprints. The default ignores metadata and matches math shape.
     """
 
-    source_graph = _build_graph(source, atol=atol, include_metadata=include_metadata)
-    target_graph = _build_graph(target, atol=atol, include_metadata=include_metadata)
+    effective_color_atol = _resolve_color_atol(atol, color_atol)
+    source_graph = _build_graph(
+        source,
+        atol=atol,
+        color_atol=effective_color_atol,
+        include_metadata=include_metadata,
+    )
+    target_graph = _build_graph(
+        target,
+        atol=atol,
+        color_atol=effective_color_atol,
+        include_metadata=include_metadata,
+    )
     colors = _refine_colors(
         source_graph,
         target_graph,
-        atol=atol,
+        atol=effective_color_atol,
         max_iterations=max_refinement_iterations,
     )
     result, steps = _search_mapping(
@@ -150,12 +164,14 @@ def match_instance_ids(
     )
 
 
-def _build_graph(instance: Instance, *, atol: float, include_metadata: bool) -> _Graph:
+def _build_graph(
+    instance: Instance, *, atol: float, color_atol: float, include_metadata: bool
+) -> _Graph:
     variables: dict[int, tuple[Any, ...]] = {}
     for attached in instance.decision_variables:
         var = attached.detach()
         variables[var.id] = _variable_attrs(
-            var, atol=atol, include_metadata=include_metadata
+            var, atol=color_atol, include_metadata=include_metadata
         )
 
     factors: dict[_FactorKey, _FactorNode] = {}
@@ -166,7 +182,7 @@ def _build_graph(instance: Instance, *, atol: float, include_metadata: bool) -> 
         function_terms=objective_terms,
         equality=None,
         metadata=(),
-        atol=atol,
+        atol=color_atol,
         sense=str(instance.sense),
     )
 
@@ -178,13 +194,13 @@ def _build_graph(instance: Instance, *, atol: float, include_metadata: bool) -> 
             function_terms=_function_terms(attached.function, atol=atol),
             equality=str(attached.equality),
             metadata=metadata,
-            atol=atol,
+            atol=color_atol,
         )
 
     for constraint_id, attached in instance.indicator_constraints.items():
         metadata = _constraint_metadata(attached, include_metadata)
         terms = _function_terms(attached.function, atol=atol)
-        neighbors = dict(_function_neighbors(terms, atol=atol))
+        neighbors = dict(_function_neighbors(terms, atol=color_atol))
         indicator_id = int(attached.indicator_variable_id)
         labels = list(neighbors.get(indicator_id, ()))
         labels.append(("indicator",))
@@ -192,7 +208,7 @@ def _build_graph(instance: Instance, *, atol: float, include_metadata: bool) -> 
         attrs = (
             "indicator",
             str(attached.equality),
-            _function_shape_signature(terms, atol),
+            _function_shape_signature(terms, color_atol),
             metadata,
         )
         factors[("indicator", int(constraint_id))] = _FactorNode(
@@ -232,6 +248,18 @@ def _build_graph(instance: Instance, *, atol: float, include_metadata: bool) -> 
         var_to_factors=var_to_factors,
         sense=str(instance.sense),
     )
+
+
+def _resolve_color_atol(atol: float, color_atol: float | None) -> float:
+    if atol < 0:
+        raise ValueError("atol must be non-negative")
+    if color_atol is None:
+        return 10 * atol
+    if color_atol < 0:
+        raise ValueError("color_atol must be non-negative")
+    if color_atol < atol:
+        raise ValueError("color_atol must be greater than or equal to atol")
+    return color_atol
 
 
 def _variable_attrs(

--- a/python/ommx/ommx/diff/instance_mapping.py
+++ b/python/ommx/ommx/diff/instance_mapping.py
@@ -61,16 +61,16 @@ def match_instance_ids(
     all active factors and the objective match after applying the inferred
     decision-variable mapping.
 
-    Args:
-        source: Instance whose IDs are mapped from.
-        target: Instance whose IDs are mapped to.
-        atol: Absolute tolerance used when grouping coefficients and bounds.
-        color_atol: Coarser absolute tolerance used only for color/fingerprint
-            bucketing. The final verification still uses ``atol``.
-        max_refinement_iterations: Maximum color-refinement rounds.
-        max_backtracking_steps: Search budget for ambiguous color classes.
-        include_metadata: Include names, subscripts, and parameters in
-            fingerprints. The default ignores metadata and matches math shape.
+    :param source: Instance whose IDs are mapped from.
+    :param target: Instance whose IDs are mapped to.
+    :param atol: Absolute tolerance used when grouping coefficients and bounds.
+    :param color_atol: Coarser absolute tolerance used only for
+        color/fingerprint bucketing. The final verification still uses
+        ``atol``.
+    :param max_refinement_iterations: Maximum color-refinement rounds.
+    :param max_backtracking_steps: Search budget for ambiguous color classes.
+    :param include_metadata: Include names, subscripts, and parameters in
+        fingerprints. The default ignores metadata and matches math shape.
     """
 
     effective_color_atol = resolve_color_atol(atol, color_atol)

--- a/python/ommx/ommx/diff/instance_mapping.py
+++ b/python/ommx/ommx/diff/instance_mapping.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
-from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass
-import math
-from typing import Any
 
-from ommx.v1 import Function, Instance
+from ommx.v1 import Instance
 
-_FactorKey = tuple[str, int]
-_Monomial = tuple[int, ...]
-_Terms = dict[_Monomial, float]
+from .graph import build_graph, resolve_color_atol
+from .isomorphism import (
+    ambiguous_factors,
+    ambiguous_variables,
+    refine_colors,
+    search_mapping,
+)
+from .types import InstanceGraph, SearchState
+from .verify import objective_matches, output_factor_keys, verify_mapping
 
 
 @dataclass(frozen=True)
@@ -37,48 +40,6 @@ class InstanceMapping:
     @property
     def is_complete(self) -> bool:
         return self.verified
-
-
-@dataclass(frozen=True)
-class _FactorNode:
-    key: _FactorKey
-    attrs: tuple[Any, ...]
-    terms: _Terms
-    neighbors: Mapping[int, tuple[Any, ...]]
-    variables: tuple[int, ...] = ()
-    indicator_variable: int | None = None
-
-
-@dataclass(frozen=True)
-class _Graph:
-    variables: Mapping[int, tuple[Any, ...]]
-    factors: Mapping[_FactorKey, _FactorNode]
-    var_to_factors: Mapping[int, Mapping[_FactorKey, tuple[Any, ...]]]
-    sense: str
-
-
-@dataclass
-class _Colors:
-    source_variables: dict[int, int]
-    target_variables: dict[int, int]
-    source_factors: dict[_FactorKey, int]
-    target_factors: dict[_FactorKey, int]
-
-
-@dataclass
-class _SearchState:
-    variable_map: dict[int, int]
-    inverse_variable_map: dict[int, int]
-    factor_map: dict[_FactorKey, _FactorKey]
-    inverse_factor_map: dict[_FactorKey, _FactorKey]
-
-    def copy(self) -> "_SearchState":
-        return _SearchState(
-            variable_map=dict(self.variable_map),
-            inverse_variable_map=dict(self.inverse_variable_map),
-            factor_map=dict(self.factor_map),
-            inverse_factor_map=dict(self.inverse_factor_map),
-        )
 
 
 def match_instance_ids(
@@ -112,36 +73,34 @@ def match_instance_ids(
             fingerprints. The default ignores metadata and matches math shape.
     """
 
-    effective_color_atol = _resolve_color_atol(atol, color_atol)
-    source_graph = _build_graph(
+    effective_color_atol = resolve_color_atol(atol, color_atol)
+    source_graph = build_graph(
         source,
         atol=atol,
         color_atol=effective_color_atol,
         include_metadata=include_metadata,
     )
-    target_graph = _build_graph(
+    target_graph = build_graph(
         target,
         atol=atol,
         color_atol=effective_color_atol,
         include_metadata=include_metadata,
     )
-    colors = _refine_colors(
+    colors = refine_colors(
         source_graph,
         target_graph,
         atol=effective_color_atol,
         max_iterations=max_refinement_iterations,
     )
-    result, steps = _search_mapping(
+    result, steps = search_mapping(
         source_graph,
         target_graph,
         colors,
         max_steps=max_backtracking_steps,
         atol=atol,
     )
-    verified = _verify_mapping(source_graph, target_graph, result, atol=atol)
-    objective_matches = _objective_matches(
-        source_graph, target_graph, result, atol=atol
-    )
+    verified = verify_mapping(source_graph, target_graph, result, atol=atol)
+    matches_objective = objective_matches(source_graph, target_graph, result, atol=atol)
     diagnostics = _diagnostics(source_graph, target_graph, result, verified, steps)
 
     return InstanceMapping(
@@ -150,754 +109,21 @@ def match_instance_ids(
         indicator_constraints=_extract_factor_mapping(result, "indicator"),
         one_hot_constraints=_extract_factor_mapping(result, "one_hot"),
         sos1_constraints=_extract_factor_mapping(result, "sos1"),
-        objective_matches=objective_matches,
+        objective_matches=matches_objective,
         verified=verified,
         score=_score(source_graph, result),
         backtracking_steps=steps,
-        ambiguous_decision_variables=_ambiguous_variables(
+        ambiguous_decision_variables=ambiguous_variables(
             source_graph, target_graph, colors, result
         ),
-        ambiguous_constraints=_ambiguous_factors(
+        ambiguous_constraints=ambiguous_factors(
             source_graph, target_graph, colors, result, "constraint"
         ),
         diagnostics=diagnostics,
     )
 
 
-def _build_graph(
-    instance: Instance, *, atol: float, color_atol: float, include_metadata: bool
-) -> _Graph:
-    variables: dict[int, tuple[Any, ...]] = {}
-    for attached in instance.decision_variables:
-        var = attached.detach()
-        variables[var.id] = _variable_attrs(
-            var, atol=color_atol, include_metadata=include_metadata
-        )
-
-    factors: dict[_FactorKey, _FactorNode] = {}
-    objective_terms = _function_terms(instance.objective, atol=atol)
-    factors[("objective", -1)] = _function_factor(
-        key=("objective", -1),
-        kind="objective",
-        function_terms=objective_terms,
-        equality=None,
-        metadata=(),
-        atol=color_atol,
-        sense=str(instance.sense),
-    )
-
-    for constraint_id, attached in instance.constraints.items():
-        metadata = _constraint_metadata(attached, include_metadata)
-        factors[("constraint", int(constraint_id))] = _function_factor(
-            key=("constraint", int(constraint_id)),
-            kind="constraint",
-            function_terms=_function_terms(attached.function, atol=atol),
-            equality=str(attached.equality),
-            metadata=metadata,
-            atol=color_atol,
-        )
-
-    for constraint_id, attached in instance.indicator_constraints.items():
-        metadata = _constraint_metadata(attached, include_metadata)
-        terms = _function_terms(attached.function, atol=atol)
-        neighbors = dict(_function_neighbors(terms, atol=color_atol))
-        indicator_id = int(attached.indicator_variable_id)
-        labels = list(neighbors.get(indicator_id, ()))
-        labels.append(("indicator",))
-        neighbors[indicator_id] = tuple(sorted(labels, key=repr))
-        attrs = (
-            "indicator",
-            str(attached.equality),
-            _function_shape_signature(terms, color_atol),
-            metadata,
-        )
-        factors[("indicator", int(constraint_id))] = _FactorNode(
-            key=("indicator", int(constraint_id)),
-            attrs=attrs,
-            terms=terms,
-            neighbors=neighbors,
-            indicator_variable=indicator_id,
-        )
-
-    for constraint_id, attached in instance.one_hot_constraints.items():
-        factors[("one_hot", int(constraint_id))] = _membership_factor(
-            key=("one_hot", int(constraint_id)),
-            kind="one_hot",
-            variables=tuple(int(v) for v in attached.variables),
-            metadata=_constraint_metadata(attached, include_metadata),
-        )
-
-    for constraint_id, attached in instance.sos1_constraints.items():
-        factors[("sos1", int(constraint_id))] = _membership_factor(
-            key=("sos1", int(constraint_id)),
-            kind="sos1",
-            variables=tuple(int(v) for v in attached.variables),
-            metadata=_constraint_metadata(attached, include_metadata),
-        )
-
-    var_to_factors: dict[int, dict[_FactorKey, tuple[Any, ...]]] = {
-        variable_id: {} for variable_id in variables
-    }
-    for key, factor in factors.items():
-        for variable_id, edge_label in factor.neighbors.items():
-            var_to_factors.setdefault(variable_id, {})[key] = edge_label
-
-    return _Graph(
-        variables=variables,
-        factors=factors,
-        var_to_factors=var_to_factors,
-        sense=str(instance.sense),
-    )
-
-
-def _resolve_color_atol(atol: float, color_atol: float | None) -> float:
-    if atol < 0:
-        raise ValueError("atol must be non-negative")
-    if color_atol is None:
-        return 10 * atol
-    if color_atol < 0:
-        raise ValueError("color_atol must be non-negative")
-    if color_atol < atol:
-        raise ValueError("color_atol must be greater than or equal to atol")
-    return color_atol
-
-
-def _variable_attrs(
-    var: Any, *, atol: float, include_metadata: bool
-) -> tuple[Any, ...]:
-    attrs: tuple[Any, ...] = (
-        "variable",
-        int(var.kind),
-        _quantize_float(float(var.bound.lower), atol),
-        _quantize_float(float(var.bound.upper), atol),
-        _quantize_optional_float(var.substituted_value, atol),
-    )
-    if include_metadata:
-        attrs += (
-            str(var.name),
-            tuple(int(s) for s in var.subscripts),
-            tuple(sorted((str(k), str(v)) for k, v in var.parameters.items())),
-            str(var.description),
-        )
-    return attrs
-
-
-def _constraint_metadata(attached: Any, include_metadata: bool) -> tuple[Any, ...]:
-    if not include_metadata:
-        return ()
-    return (
-        str(getattr(attached, "name", None)),
-        tuple(int(s) for s in getattr(attached, "subscripts", ())),
-        tuple(
-            sorted(
-                (str(k), str(v)) for k, v in getattr(attached, "parameters", {}).items()
-            )
-        ),
-        str(getattr(attached, "description", None)),
-    )
-
-
-def _function_factor(
-    *,
-    key: _FactorKey,
-    kind: str,
-    function_terms: _Terms,
-    equality: str | None,
-    metadata: tuple[Any, ...],
-    atol: float,
-    sense: str | None = None,
-) -> _FactorNode:
-    attrs = (
-        kind,
-        sense,
-        equality,
-        _function_shape_signature(function_terms, atol),
-        metadata,
-    )
-    return _FactorNode(
-        key=key,
-        attrs=attrs,
-        terms=function_terms,
-        neighbors=_function_neighbors(function_terms, atol=atol),
-    )
-
-
-def _membership_factor(
-    *,
-    key: _FactorKey,
-    kind: str,
-    variables: tuple[int, ...],
-    metadata: tuple[Any, ...],
-) -> _FactorNode:
-    neighbors = {variable_id: (("member",),) for variable_id in variables}
-    attrs = (kind, len(variables), metadata)
-    return _FactorNode(
-        key=key,
-        attrs=attrs,
-        terms={},
-        neighbors=neighbors,
-        variables=tuple(sorted(variables)),
-    )
-
-
-def _function_terms(function: Function, *, atol: float) -> _Terms:
-    terms: dict[_Monomial, float] = {}
-    for raw_monomial, raw_coefficient in function.terms.items():
-        coefficient = float(raw_coefficient)
-        if abs(coefficient) <= atol:
-            continue
-        monomial = tuple(sorted(int(v) for v in raw_monomial))
-        terms[monomial] = terms.get(monomial, 0.0) + coefficient
-    return {
-        monomial: coefficient
-        for monomial, coefficient in terms.items()
-        if abs(coefficient) > atol
-    }
-
-
-def _function_neighbors(terms: _Terms, *, atol: float) -> dict[int, tuple[Any, ...]]:
-    labels: dict[int, list[tuple[Any, ...]]] = {}
-    for monomial, coefficient in terms.items():
-        powers = Counter(monomial)
-        power_shape = tuple(sorted(powers.values()))
-        for variable_id, power in powers.items():
-            labels.setdefault(variable_id, []).append(
-                (
-                    "term",
-                    len(monomial),
-                    int(power),
-                    power_shape,
-                    _quantize_float(coefficient, atol),
-                )
-            )
-    return {
-        variable_id: tuple(sorted(edge_labels, key=repr))
-        for variable_id, edge_labels in labels.items()
-    }
-
-
-def _function_shape_signature(terms: _Terms, atol: float) -> tuple[Any, ...]:
-    items = []
-    for monomial, coefficient in terms.items():
-        power_shape = tuple(sorted(Counter(monomial).values()))
-        items.append((len(monomial), power_shape, _quantize_float(coefficient, atol)))
-    return tuple(sorted(items, key=repr))
-
-
-def _colored_terms(
-    terms: _Terms,
-    variable_colors: Mapping[int, int],
-    atol: float,
-) -> tuple[Any, ...]:
-    items = []
-    for monomial, coefficient in terms.items():
-        color_counts = tuple(
-            sorted(Counter(variable_colors[v] for v in monomial).items())
-        )
-        items.append((color_counts, _quantize_float(coefficient, atol)))
-    return tuple(sorted(items, key=repr))
-
-
-def _refine_colors(
-    source: _Graph,
-    target: _Graph,
-    *,
-    atol: float,
-    max_iterations: int,
-) -> _Colors:
-    source_variable_colors, target_variable_colors = _intern_pair(
-        source.variables, target.variables
-    )
-    source_factor_colors, target_factor_colors = _intern_pair(
-        {k: f.attrs for k, f in source.factors.items()},
-        {k: f.attrs for k, f in target.factors.items()},
-    )
-
-    for _ in range(max_iterations):
-        next_source_factor_raw = _factor_color_inputs(
-            source, source_variable_colors, atol=atol
-        )
-        next_target_factor_raw = _factor_color_inputs(
-            target, target_variable_colors, atol=atol
-        )
-        next_source_factor_colors, next_target_factor_colors = _intern_pair(
-            next_source_factor_raw, next_target_factor_raw
-        )
-
-        next_source_variable_raw = _variable_color_inputs(
-            source, next_source_factor_colors
-        )
-        next_target_variable_raw = _variable_color_inputs(
-            target, next_target_factor_colors
-        )
-        next_source_variable_colors, next_target_variable_colors = _intern_pair(
-            next_source_variable_raw, next_target_variable_raw
-        )
-
-        if (
-            next_source_variable_colors == source_variable_colors
-            and next_target_variable_colors == target_variable_colors
-            and next_source_factor_colors == source_factor_colors
-            and next_target_factor_colors == target_factor_colors
-        ):
-            break
-
-        source_variable_colors = next_source_variable_colors
-        target_variable_colors = next_target_variable_colors
-        source_factor_colors = next_source_factor_colors
-        target_factor_colors = next_target_factor_colors
-
-    return _Colors(
-        source_variables=source_variable_colors,
-        target_variables=target_variable_colors,
-        source_factors=source_factor_colors,
-        target_factors=target_factor_colors,
-    )
-
-
-def _factor_color_inputs(
-    graph: _Graph,
-    variable_colors: Mapping[int, int],
-    *,
-    atol: float,
-) -> dict[_FactorKey, tuple[Any, ...]]:
-    out = {}
-    for key, factor in graph.factors.items():
-        neighborhood = tuple(
-            sorted(
-                (
-                    factor.neighbors[variable_id],
-                    variable_colors.get(variable_id),
-                )
-                for variable_id in factor.neighbors
-            )
-        )
-        out[key] = (
-            factor.attrs,
-            _colored_terms(factor.terms, variable_colors, atol),
-            neighborhood,
-        )
-    return out
-
-
-def _variable_color_inputs(
-    graph: _Graph,
-    factor_colors: Mapping[_FactorKey, int],
-) -> dict[int, tuple[Any, ...]]:
-    out = {}
-    for variable_id, attrs in graph.variables.items():
-        neighborhood = tuple(
-            sorted(
-                (edge_label, factor_colors[factor_key])
-                for factor_key, edge_label in graph.var_to_factors.get(
-                    variable_id, {}
-                ).items()
-            )
-        )
-        out[variable_id] = (attrs, neighborhood)
-    return out
-
-
-def _intern_pair(
-    source_values: Mapping[Any, Any],
-    target_values: Mapping[Any, Any],
-) -> tuple[dict[Any, int], dict[Any, int]]:
-    unique_values = {_freeze(value) for value in source_values.values()} | {
-        _freeze(value) for value in target_values.values()
-    }
-    interned = {
-        value: index for index, value in enumerate(sorted(unique_values, key=repr))
-    }
-    return (
-        {key: interned[_freeze(value)] for key, value in source_values.items()},
-        {key: interned[_freeze(value)] for key, value in target_values.items()},
-    )
-
-
-def _freeze(value: Any) -> Any:
-    if isinstance(value, dict):
-        return tuple(sorted((_freeze(k), _freeze(v)) for k, v in value.items()))
-    if isinstance(value, (list, tuple)):
-        return tuple(_freeze(v) for v in value)
-    if isinstance(value, set):
-        return tuple(sorted((_freeze(v) for v in value), key=repr))
-    return value
-
-
-def _search_mapping(
-    source: _Graph,
-    target: _Graph,
-    colors: _Colors,
-    *,
-    max_steps: int,
-    atol: float,
-) -> tuple[_SearchState, int]:
-    state = _SearchState(
-        variable_map={},
-        inverse_variable_map={},
-        factor_map={("objective", -1): ("objective", -1)},
-        inverse_factor_map={("objective", -1): ("objective", -1)},
-    )
-    best = state.copy()
-    steps = 0
-
-    variable_candidates = _variable_candidates_by_color(source, target, colors)
-    factor_candidates = _factor_candidates_by_color(source, target, colors)
-
-    def remember(candidate: _SearchState) -> None:
-        nonlocal best
-        if _mapped_size(candidate) > _mapped_size(best):
-            best = candidate.copy()
-
-    def recurse(current: _SearchState) -> _SearchState | None:
-        nonlocal steps
-        steps += 1
-        remember(current)
-        if steps > max_steps:
-            return None
-        if _source_is_fully_mapped(source, current):
-            if _verify_mapping(source, target, current, atol=atol):
-                return current
-            return None
-
-        item = _choose_next_item(
-            source,
-            target,
-            current,
-            variable_candidates,
-            factor_candidates,
-            atol=atol,
-        )
-        if item is None:
-            return None
-        item_kind, source_key, candidates = item
-        if not candidates:
-            return None
-
-        for target_key in candidates:
-            next_state = current.copy()
-            if item_kind == "variable":
-                source_variable = int(source_key)
-                target_variable = int(target_key)
-                next_state.variable_map[source_variable] = target_variable
-                next_state.inverse_variable_map[target_variable] = source_variable
-            else:
-                source_factor = source_key
-                target_factor = target_key
-                next_state.factor_map[source_factor] = target_factor
-                next_state.inverse_factor_map[target_factor] = source_factor
-            result = recurse(next_state)
-            if result is not None:
-                return result
-        return None
-
-    result = recurse(state)
-    return (result or best, min(steps, max_steps))
-
-
-def _variable_candidates_by_color(
-    source: _Graph, target: _Graph, colors: _Colors
-) -> dict[int, tuple[int, ...]]:
-    by_color: dict[int, list[int]] = {}
-    for target_variable, color in colors.target_variables.items():
-        by_color.setdefault(color, []).append(target_variable)
-    return {
-        source_variable: tuple(sorted(by_color.get(color, ())))
-        for source_variable, color in colors.source_variables.items()
-    }
-
-
-def _factor_candidates_by_color(
-    source: _Graph, target: _Graph, colors: _Colors
-) -> dict[_FactorKey, tuple[_FactorKey, ...]]:
-    by_color: dict[tuple[str, int], list[_FactorKey]] = {}
-    for target_key, color in colors.target_factors.items():
-        by_color.setdefault((target_key[0], color), []).append(target_key)
-    return {
-        source_key: tuple(sorted(by_color.get((source_key[0], color), ())))
-        for source_key, color in colors.source_factors.items()
-        if source_key[0] != "objective"
-    }
-
-
-def _choose_next_item(
-    source: _Graph,
-    target: _Graph,
-    state: _SearchState,
-    variable_candidates: Mapping[int, tuple[int, ...]],
-    factor_candidates: Mapping[_FactorKey, tuple[_FactorKey, ...]],
-    *,
-    atol: float,
-) -> tuple[str, Any, tuple[Any, ...]] | None:
-    choices: list[tuple[tuple[int, int, int], str, Any, tuple[Any, ...]]] = []
-
-    for source_variable in source.variables:
-        if source_variable in state.variable_map:
-            continue
-        candidates = tuple(
-            target_variable
-            for target_variable in variable_candidates.get(source_variable, ())
-            if target_variable not in state.inverse_variable_map
-            and _variable_pair_consistent(
-                source, target, state, source_variable, target_variable, atol=atol
-            )
-        )
-        degree = len(source.var_to_factors.get(source_variable, {}))
-        choices.append(
-            (
-                (len(candidates), -degree, source_variable),
-                "variable",
-                source_variable,
-                candidates,
-            )
-        )
-
-    for source_factor in _output_factor_keys(source):
-        if source_factor in state.factor_map:
-            continue
-        candidates = tuple(
-            target_factor
-            for target_factor in factor_candidates.get(source_factor, ())
-            if target_factor not in state.inverse_factor_map
-            and _factor_pair_consistent(
-                source, target, state, source_factor, target_factor, atol=atol
-            )
-        )
-        edge_count = len(source.factors[source_factor].neighbors)
-        choices.append(
-            (
-                (len(candidates), -edge_count, source_factor[1]),
-                "factor",
-                source_factor,
-                candidates,
-            )
-        )
-
-    if not choices:
-        return None
-    _, kind, source_key, candidates = min(choices, key=lambda item: item[0])
-    return kind, source_key, candidates
-
-
-def _variable_pair_consistent(
-    source: _Graph,
-    target: _Graph,
-    state: _SearchState,
-    source_variable: int,
-    target_variable: int,
-    *,
-    atol: float,
-) -> bool:
-    if source.variables[source_variable] != target.variables[target_variable]:
-        return False
-    trial = state.copy()
-    trial.variable_map[source_variable] = target_variable
-    trial.inverse_variable_map[target_variable] = source_variable
-    for source_factor, target_factor in trial.factor_map.items():
-        if not _mapped_factor_edges_match(
-            source, target, trial, source_factor, target_factor, atol=atol
-        ):
-            return False
-    return True
-
-
-def _factor_pair_consistent(
-    source: _Graph,
-    target: _Graph,
-    state: _SearchState,
-    source_factor: _FactorKey,
-    target_factor: _FactorKey,
-    *,
-    atol: float,
-) -> bool:
-    if (
-        source.factors[source_factor].attrs[:3]
-        != target.factors[target_factor].attrs[:3]
-    ):
-        return False
-    trial = state.copy()
-    trial.factor_map[source_factor] = target_factor
-    trial.inverse_factor_map[target_factor] = source_factor
-    return _mapped_factor_edges_match(
-        source, target, trial, source_factor, target_factor, atol=atol
-    )
-
-
-def _mapped_factor_edges_match(
-    source: _Graph,
-    target: _Graph,
-    state: _SearchState,
-    source_factor: _FactorKey,
-    target_factor: _FactorKey,
-    *,
-    atol: float,
-) -> bool:
-    source_node = source.factors[source_factor]
-    target_node = target.factors[target_factor]
-    for source_variable, target_variable in state.variable_map.items():
-        source_edge = source_node.neighbors.get(source_variable)
-        target_edge = target_node.neighbors.get(target_variable)
-        if source_edge != target_edge:
-            return False
-
-    if source_node.indicator_variable is not None:
-        mapped_indicator = state.variable_map.get(source_node.indicator_variable)
-        if (
-            mapped_indicator is not None
-            and mapped_indicator != target_node.indicator_variable
-        ):
-            return False
-
-    return _partial_terms_match(
-        source_node.terms,
-        target_node.terms,
-        state.variable_map,
-        state.inverse_variable_map,
-        atol=atol,
-    )
-
-
-def _partial_terms_match(
-    source_terms: _Terms,
-    target_terms: _Terms,
-    variable_map: Mapping[int, int],
-    inverse_variable_map: Mapping[int, int],
-    *,
-    atol: float,
-) -> bool:
-    source_known = {
-        _map_monomial(monomial, variable_map): coefficient
-        for monomial, coefficient in source_terms.items()
-        if all(variable_id in variable_map for variable_id in monomial)
-    }
-    target_known = {
-        monomial: coefficient
-        for monomial, coefficient in target_terms.items()
-        if all(variable_id in inverse_variable_map for variable_id in monomial)
-    }
-    return _terms_close(source_known, target_known, atol=atol)
-
-
-def _verify_mapping(
-    source: _Graph,
-    target: _Graph,
-    state: _SearchState,
-    *,
-    atol: float,
-) -> bool:
-    if len(source.variables) != len(target.variables):
-        return False
-    if len(state.variable_map) != len(source.variables):
-        return False
-    if source.sense != target.sense:
-        return False
-    if len(_output_factor_keys(source)) != len(_output_factor_keys(target)):
-        return False
-    if len(state.factor_map) != len(source.factors):
-        return False
-    if not _objective_matches(source, target, state, atol=atol):
-        return False
-
-    for source_factor, target_factor in state.factor_map.items():
-        if source_factor[0] == "objective":
-            continue
-        if source_factor[0] != target_factor[0]:
-            return False
-        if not _factor_matches(
-            source.factors[source_factor],
-            target.factors[target_factor],
-            state.variable_map,
-            atol=atol,
-        ):
-            return False
-    return True
-
-
-def _objective_matches(
-    source: _Graph,
-    target: _Graph,
-    state: _SearchState,
-    *,
-    atol: float,
-) -> bool:
-    if len(state.variable_map) != len(source.variables):
-        return False
-    if source.sense != target.sense:
-        return False
-    return _function_matches(
-        source.factors[("objective", -1)].terms,
-        target.factors[("objective", -1)].terms,
-        state.variable_map,
-        atol=atol,
-    )
-
-
-def _factor_matches(
-    source: _FactorNode,
-    target: _FactorNode,
-    variable_map: Mapping[int, int],
-    *,
-    atol: float,
-) -> bool:
-    if source.attrs[:3] != target.attrs[:3]:
-        return False
-    if source.indicator_variable is not None:
-        if variable_map.get(source.indicator_variable) != target.indicator_variable:
-            return False
-    if source.variables:
-        return (
-            tuple(sorted(variable_map[v] for v in source.variables)) == target.variables
-        )
-    return _function_matches(source.terms, target.terms, variable_map, atol=atol)
-
-
-def _function_matches(
-    source_terms: _Terms,
-    target_terms: _Terms,
-    variable_map: Mapping[int, int],
-    *,
-    atol: float,
-) -> bool:
-    if any(
-        variable_id not in variable_map
-        for monomial in source_terms
-        for variable_id in monomial
-    ):
-        return False
-    mapped_terms: dict[_Monomial, float] = {}
-    for monomial, coefficient in source_terms.items():
-        mapped_monomial = _map_monomial(monomial, variable_map)
-        mapped_terms[mapped_monomial] = (
-            mapped_terms.get(mapped_monomial, 0.0) + coefficient
-        )
-    return _terms_close(mapped_terms, target_terms, atol=atol)
-
-
-def _map_monomial(monomial: _Monomial, variable_map: Mapping[int, int]) -> _Monomial:
-    return tuple(sorted(variable_map[variable_id] for variable_id in monomial))
-
-
-def _terms_close(source_terms: _Terms, target_terms: _Terms, *, atol: float) -> bool:
-    keys = set(source_terms) | set(target_terms)
-    for key in keys:
-        if abs(source_terms.get(key, 0.0) - target_terms.get(key, 0.0)) > atol:
-            return False
-    return True
-
-
-def _source_is_fully_mapped(source: _Graph, state: _SearchState) -> bool:
-    return len(state.variable_map) == len(source.variables) and len(
-        state.factor_map
-    ) == len(source.factors)
-
-
-def _output_factor_keys(graph: _Graph) -> tuple[_FactorKey, ...]:
-    return tuple(
-        sorted((key for key in graph.factors if key[0] != "objective"), key=repr)
-    )
-
-
-def _extract_factor_mapping(state: _SearchState, kind: str) -> dict[int, int]:
+def _extract_factor_mapping(state: SearchState, kind: str) -> dict[int, int]:
     out = {}
     for source_factor, target_factor in state.factor_map.items():
         if source_factor[0] == kind:
@@ -905,8 +131,8 @@ def _extract_factor_mapping(state: _SearchState, kind: str) -> dict[int, int]:
     return dict(sorted(out.items()))
 
 
-def _score(source: _Graph, state: _SearchState) -> float:
-    total = len(source.variables) + len(_output_factor_keys(source))
+def _score(source: InstanceGraph, state: SearchState) -> float:
+    total = len(source.variables) + len(output_factor_keys(source))
     if total == 0:
         return 1.0
     mapped = len(state.variable_map) + sum(
@@ -915,56 +141,10 @@ def _score(source: _Graph, state: _SearchState) -> float:
     return mapped / total
 
 
-def _mapped_size(state: _SearchState) -> int:
-    return len(state.variable_map) + sum(
-        1 for factor_key in state.factor_map if factor_key[0] != "objective"
-    )
-
-
-def _ambiguous_variables(
-    source: _Graph,
-    target: _Graph,
-    colors: _Colors,
-    state: _SearchState,
-) -> dict[int, tuple[int, ...]]:
-    by_color: dict[int, list[int]] = {}
-    for target_variable, color in colors.target_variables.items():
-        by_color.setdefault(color, []).append(target_variable)
-    out = {}
-    for source_variable, color in colors.source_variables.items():
-        if source_variable in state.variable_map:
-            continue
-        candidates = tuple(sorted(by_color.get(color, ())))
-        if len(candidates) != 1:
-            out[source_variable] = candidates
-    return out
-
-
-def _ambiguous_factors(
-    source: _Graph,
-    target: _Graph,
-    colors: _Colors,
-    state: _SearchState,
-    kind: str,
-) -> dict[int, tuple[int, ...]]:
-    by_color: dict[int, list[int]] = {}
-    for target_key, color in colors.target_factors.items():
-        if target_key[0] == kind:
-            by_color.setdefault(color, []).append(target_key[1])
-    out = {}
-    for source_key, color in colors.source_factors.items():
-        if source_key[0] != kind or source_key in state.factor_map:
-            continue
-        candidates = tuple(sorted(by_color.get(color, ())))
-        if len(candidates) != 1:
-            out[source_key[1]] = candidates
-    return out
-
-
 def _diagnostics(
-    source: _Graph,
-    target: _Graph,
-    state: _SearchState,
+    source: InstanceGraph,
+    target: InstanceGraph,
+    state: SearchState,
     verified: bool,
     steps: int,
 ) -> tuple[str, ...]:
@@ -988,21 +168,3 @@ def _diagnostics(
         messages.append("some source constraints remain unmapped")
     messages.append(f"search stopped after {steps} steps")
     return tuple(messages)
-
-
-def _quantize_optional_float(
-    value: float | None, atol: float
-) -> tuple[str, int] | None:
-    if value is None:
-        return None
-    return _quantize_float(float(value), atol)
-
-
-def _quantize_float(value: float, atol: float) -> tuple[str, int]:
-    if math.isnan(value):
-        return ("nan", 0)
-    if math.isinf(value):
-        return ("inf", 1 if value > 0 else -1)
-    if atol <= 0:
-        return ("exact", hash(repr(value)))
-    return ("q", int(round(value / atol)))

--- a/python/ommx/ommx/diff/isomorphism.py
+++ b/python/ommx/ommx/diff/isomorphism.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+from .graph import quantize_float
+from .types import Colors, FactorKey, InstanceGraph, SearchState, Terms
+from .verify import (
+    map_monomial,
+    output_factor_keys,
+    source_is_fully_mapped,
+    terms_close,
+    verify_mapping,
+)
+
+
+def refine_colors(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    *,
+    atol: float,
+    max_iterations: int,
+) -> Colors:
+    source_variable_colors, target_variable_colors = _intern_pair(
+        source.variables, target.variables
+    )
+    source_factor_colors, target_factor_colors = _intern_pair(
+        {k: f.attrs for k, f in source.factors.items()},
+        {k: f.attrs for k, f in target.factors.items()},
+    )
+
+    for _ in range(max_iterations):
+        next_source_factor_raw = _factor_color_inputs(
+            source, source_variable_colors, atol=atol
+        )
+        next_target_factor_raw = _factor_color_inputs(
+            target, target_variable_colors, atol=atol
+        )
+        next_source_factor_colors, next_target_factor_colors = _intern_pair(
+            next_source_factor_raw, next_target_factor_raw
+        )
+
+        next_source_variable_raw = _variable_color_inputs(
+            source, next_source_factor_colors
+        )
+        next_target_variable_raw = _variable_color_inputs(
+            target, next_target_factor_colors
+        )
+        next_source_variable_colors, next_target_variable_colors = _intern_pair(
+            next_source_variable_raw, next_target_variable_raw
+        )
+
+        if (
+            next_source_variable_colors == source_variable_colors
+            and next_target_variable_colors == target_variable_colors
+            and next_source_factor_colors == source_factor_colors
+            and next_target_factor_colors == target_factor_colors
+        ):
+            break
+
+        source_variable_colors = next_source_variable_colors
+        target_variable_colors = next_target_variable_colors
+        source_factor_colors = next_source_factor_colors
+        target_factor_colors = next_target_factor_colors
+
+    return Colors(
+        source_variables=source_variable_colors,
+        target_variables=target_variable_colors,
+        source_factors=source_factor_colors,
+        target_factors=target_factor_colors,
+    )
+
+
+def search_mapping(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    colors: Colors,
+    *,
+    max_steps: int,
+    atol: float,
+) -> tuple[SearchState, int]:
+    state = SearchState(
+        variable_map={},
+        inverse_variable_map={},
+        factor_map={("objective", -1): ("objective", -1)},
+        inverse_factor_map={("objective", -1): ("objective", -1)},
+    )
+    best = state.copy()
+    steps = 0
+
+    variable_candidates = _variable_candidates_by_color(source, target, colors)
+    factor_candidates = _factor_candidates_by_color(source, target, colors)
+
+    def remember(candidate: SearchState) -> None:
+        nonlocal best
+        if mapped_size(candidate) > mapped_size(best):
+            best = candidate.copy()
+
+    def recurse(current: SearchState) -> SearchState | None:
+        nonlocal steps
+        steps += 1
+        remember(current)
+        if steps > max_steps:
+            return None
+        if source_is_fully_mapped(source, current):
+            if verify_mapping(source, target, current, atol=atol):
+                return current
+            return None
+
+        item = _choose_next_item(
+            source,
+            target,
+            current,
+            variable_candidates,
+            factor_candidates,
+            atol=atol,
+        )
+        if item is None:
+            return None
+        item_kind, source_key, candidates = item
+        if not candidates:
+            return None
+
+        for target_key in candidates:
+            next_state = current.copy()
+            if item_kind == "variable":
+                source_variable = int(source_key)
+                target_variable = int(target_key)
+                next_state.variable_map[source_variable] = target_variable
+                next_state.inverse_variable_map[target_variable] = source_variable
+            else:
+                source_factor = source_key
+                target_factor = target_key
+                next_state.factor_map[source_factor] = target_factor
+                next_state.inverse_factor_map[target_factor] = source_factor
+            result = recurse(next_state)
+            if result is not None:
+                return result
+        return None
+
+    result = recurse(state)
+    return (result or best, min(steps, max_steps))
+
+
+def ambiguous_variables(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    colors: Colors,
+    state: SearchState,
+) -> dict[int, tuple[int, ...]]:
+    by_color: dict[int, list[int]] = {}
+    for target_variable, color in colors.target_variables.items():
+        by_color.setdefault(color, []).append(target_variable)
+    out = {}
+    for source_variable, color in colors.source_variables.items():
+        if source_variable in state.variable_map:
+            continue
+        candidates = tuple(sorted(by_color.get(color, ())))
+        if len(candidates) != 1:
+            out[source_variable] = candidates
+    return out
+
+
+def ambiguous_factors(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    colors: Colors,
+    state: SearchState,
+    kind: str,
+) -> dict[int, tuple[int, ...]]:
+    by_color: dict[int, list[int]] = {}
+    for target_key, color in colors.target_factors.items():
+        if target_key[0] == kind:
+            by_color.setdefault(color, []).append(target_key[1])
+    out = {}
+    for source_key, color in colors.source_factors.items():
+        if source_key[0] != kind or source_key in state.factor_map:
+            continue
+        candidates = tuple(sorted(by_color.get(color, ())))
+        if len(candidates) != 1:
+            out[source_key[1]] = candidates
+    return out
+
+
+def mapped_size(state: SearchState) -> int:
+    return len(state.variable_map) + sum(
+        1 for factor_key in state.factor_map if factor_key[0] != "objective"
+    )
+
+
+def _colored_terms(
+    terms: Terms,
+    variable_colors: Mapping[int, int],
+    atol: float,
+) -> tuple[Any, ...]:
+    items = []
+    for monomial, coefficient in terms.items():
+        color_counts = tuple(
+            sorted(Counter(variable_colors[v] for v in monomial).items())
+        )
+        items.append((color_counts, quantize_float(coefficient, atol)))
+    return tuple(sorted(items, key=repr))
+
+
+def _factor_color_inputs(
+    graph: InstanceGraph,
+    variable_colors: Mapping[int, int],
+    *,
+    atol: float,
+) -> dict[FactorKey, tuple[Any, ...]]:
+    out = {}
+    for key, factor in graph.factors.items():
+        neighborhood = tuple(
+            sorted(
+                (
+                    factor.neighbors[variable_id],
+                    variable_colors.get(variable_id),
+                )
+                for variable_id in factor.neighbors
+            )
+        )
+        out[key] = (
+            factor.attrs,
+            _colored_terms(factor.terms, variable_colors, atol),
+            neighborhood,
+        )
+    return out
+
+
+def _variable_color_inputs(
+    graph: InstanceGraph,
+    factor_colors: Mapping[FactorKey, int],
+) -> dict[int, tuple[Any, ...]]:
+    out = {}
+    for variable_id, attrs in graph.variables.items():
+        neighborhood = tuple(
+            sorted(
+                (edge_label, factor_colors[factor_key])
+                for factor_key, edge_label in graph.var_to_factors.get(
+                    variable_id, {}
+                ).items()
+            )
+        )
+        out[variable_id] = (attrs, neighborhood)
+    return out
+
+
+def _intern_pair(
+    source_values: Mapping[Any, Any],
+    target_values: Mapping[Any, Any],
+) -> tuple[dict[Any, int], dict[Any, int]]:
+    unique_values = {_freeze(value) for value in source_values.values()} | {
+        _freeze(value) for value in target_values.values()
+    }
+    interned = {
+        value: index for index, value in enumerate(sorted(unique_values, key=repr))
+    }
+    return (
+        {key: interned[_freeze(value)] for key, value in source_values.items()},
+        {key: interned[_freeze(value)] for key, value in target_values.items()},
+    )
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple(sorted((_freeze(k), _freeze(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(v) for v in value)
+    if isinstance(value, set):
+        return tuple(sorted((_freeze(v) for v in value), key=repr))
+    return value
+
+
+def _variable_candidates_by_color(
+    source: InstanceGraph, target: InstanceGraph, colors: Colors
+) -> dict[int, tuple[int, ...]]:
+    by_color: dict[int, list[int]] = {}
+    for target_variable, color in colors.target_variables.items():
+        by_color.setdefault(color, []).append(target_variable)
+    return {
+        source_variable: tuple(sorted(by_color.get(color, ())))
+        for source_variable, color in colors.source_variables.items()
+    }
+
+
+def _factor_candidates_by_color(
+    source: InstanceGraph, target: InstanceGraph, colors: Colors
+) -> dict[FactorKey, tuple[FactorKey, ...]]:
+    by_color: dict[tuple[str, int], list[FactorKey]] = {}
+    for target_key, color in colors.target_factors.items():
+        by_color.setdefault((target_key[0], color), []).append(target_key)
+    return {
+        source_key: tuple(sorted(by_color.get((source_key[0], color), ())))
+        for source_key, color in colors.source_factors.items()
+        if source_key[0] != "objective"
+    }
+
+
+def _choose_next_item(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    state: SearchState,
+    variable_candidates: Mapping[int, tuple[int, ...]],
+    factor_candidates: Mapping[FactorKey, tuple[FactorKey, ...]],
+    *,
+    atol: float,
+) -> tuple[str, Any, tuple[Any, ...]] | None:
+    choices: list[tuple[tuple[int, int, int], str, Any, tuple[Any, ...]]] = []
+
+    for source_variable in source.variables:
+        if source_variable in state.variable_map:
+            continue
+        candidates = tuple(
+            target_variable
+            for target_variable in variable_candidates.get(source_variable, ())
+            if target_variable not in state.inverse_variable_map
+            and _variable_pair_consistent(
+                source, target, state, source_variable, target_variable, atol=atol
+            )
+        )
+        degree = len(source.var_to_factors.get(source_variable, {}))
+        choices.append(
+            (
+                (len(candidates), -degree, source_variable),
+                "variable",
+                source_variable,
+                candidates,
+            )
+        )
+
+    for source_factor in output_factor_keys(source):
+        if source_factor in state.factor_map:
+            continue
+        candidates = tuple(
+            target_factor
+            for target_factor in factor_candidates.get(source_factor, ())
+            if target_factor not in state.inverse_factor_map
+            and _factor_pair_consistent(
+                source, target, state, source_factor, target_factor, atol=atol
+            )
+        )
+        edge_count = len(source.factors[source_factor].neighbors)
+        choices.append(
+            (
+                (len(candidates), -edge_count, source_factor[1]),
+                "factor",
+                source_factor,
+                candidates,
+            )
+        )
+
+    if not choices:
+        return None
+    _, kind, source_key, candidates = min(choices, key=lambda item: item[0])
+    return kind, source_key, candidates
+
+
+def _variable_pair_consistent(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    state: SearchState,
+    source_variable: int,
+    target_variable: int,
+    *,
+    atol: float,
+) -> bool:
+    if source.variables[source_variable] != target.variables[target_variable]:
+        return False
+    trial = state.copy()
+    trial.variable_map[source_variable] = target_variable
+    trial.inverse_variable_map[target_variable] = source_variable
+    for source_factor, target_factor in trial.factor_map.items():
+        if not _mapped_factor_edges_match(
+            source, target, trial, source_factor, target_factor, atol=atol
+        ):
+            return False
+    return True
+
+
+def _factor_pair_consistent(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    state: SearchState,
+    source_factor: FactorKey,
+    target_factor: FactorKey,
+    *,
+    atol: float,
+) -> bool:
+    if (
+        source.factors[source_factor].attrs[:3]
+        != target.factors[target_factor].attrs[:3]
+    ):
+        return False
+    trial = state.copy()
+    trial.factor_map[source_factor] = target_factor
+    trial.inverse_factor_map[target_factor] = source_factor
+    return _mapped_factor_edges_match(
+        source, target, trial, source_factor, target_factor, atol=atol
+    )
+
+
+def _mapped_factor_edges_match(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    state: SearchState,
+    source_factor: FactorKey,
+    target_factor: FactorKey,
+    *,
+    atol: float,
+) -> bool:
+    source_node = source.factors[source_factor]
+    target_node = target.factors[target_factor]
+    for source_variable, target_variable in state.variable_map.items():
+        source_edge = source_node.neighbors.get(source_variable)
+        target_edge = target_node.neighbors.get(target_variable)
+        if source_edge != target_edge:
+            return False
+
+    if source_node.indicator_variable is not None:
+        mapped_indicator = state.variable_map.get(source_node.indicator_variable)
+        if (
+            mapped_indicator is not None
+            and mapped_indicator != target_node.indicator_variable
+        ):
+            return False
+
+    return _partial_terms_match(
+        source_node.terms,
+        target_node.terms,
+        state.variable_map,
+        state.inverse_variable_map,
+        atol=atol,
+    )
+
+
+def _partial_terms_match(
+    source_terms: Terms,
+    target_terms: Terms,
+    variable_map: Mapping[int, int],
+    inverse_variable_map: Mapping[int, int],
+    *,
+    atol: float,
+) -> bool:
+    source_known = {
+        map_monomial(monomial, variable_map): coefficient
+        for monomial, coefficient in source_terms.items()
+        if all(variable_id in variable_map for variable_id in monomial)
+    }
+    target_known = {
+        monomial: coefficient
+        for monomial, coefficient in target_terms.items()
+        if all(variable_id in inverse_variable_map for variable_id in monomial)
+    }
+    return terms_close(source_known, target_known, atol=atol)

--- a/python/ommx/ommx/diff/types.py
+++ b/python/ommx/ommx/diff/types.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+FactorKey = tuple[str, int]
+Monomial = tuple[int, ...]
+Terms = dict[Monomial, float]
+
+
+@dataclass(frozen=True)
+class FactorNode:
+    key: FactorKey
+    attrs: tuple[Any, ...]
+    terms: Terms
+    neighbors: Mapping[int, tuple[Any, ...]]
+    variables: tuple[int, ...] = ()
+    indicator_variable: int | None = None
+
+
+@dataclass(frozen=True)
+class InstanceGraph:
+    variables: Mapping[int, tuple[Any, ...]]
+    factors: Mapping[FactorKey, FactorNode]
+    var_to_factors: Mapping[int, Mapping[FactorKey, tuple[Any, ...]]]
+    sense: str
+
+
+@dataclass
+class Colors:
+    source_variables: dict[int, int]
+    target_variables: dict[int, int]
+    source_factors: dict[FactorKey, int]
+    target_factors: dict[FactorKey, int]
+
+
+@dataclass
+class SearchState:
+    variable_map: dict[int, int]
+    inverse_variable_map: dict[int, int]
+    factor_map: dict[FactorKey, FactorKey]
+    inverse_factor_map: dict[FactorKey, FactorKey]
+
+    def copy(self) -> "SearchState":
+        return SearchState(
+            variable_map=dict(self.variable_map),
+            inverse_variable_map=dict(self.inverse_variable_map),
+            factor_map=dict(self.factor_map),
+            inverse_factor_map=dict(self.inverse_factor_map),
+        )

--- a/python/ommx/ommx/diff/verify.py
+++ b/python/ommx/ommx/diff/verify.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .types import FactorKey, FactorNode, InstanceGraph, Monomial, SearchState, Terms
+
+
+def verify_mapping(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    state: SearchState,
+    *,
+    atol: float,
+) -> bool:
+    if len(source.variables) != len(target.variables):
+        return False
+    if len(state.variable_map) != len(source.variables):
+        return False
+    if source.sense != target.sense:
+        return False
+    if len(output_factor_keys(source)) != len(output_factor_keys(target)):
+        return False
+    if len(state.factor_map) != len(source.factors):
+        return False
+    if not objective_matches(source, target, state, atol=atol):
+        return False
+
+    for source_factor, target_factor in state.factor_map.items():
+        if source_factor[0] == "objective":
+            continue
+        if source_factor[0] != target_factor[0]:
+            return False
+        if not factor_matches(
+            source.factors[source_factor],
+            target.factors[target_factor],
+            state.variable_map,
+            atol=atol,
+        ):
+            return False
+    return True
+
+
+def objective_matches(
+    source: InstanceGraph,
+    target: InstanceGraph,
+    state: SearchState,
+    *,
+    atol: float,
+) -> bool:
+    if len(state.variable_map) != len(source.variables):
+        return False
+    if source.sense != target.sense:
+        return False
+    return function_matches(
+        source.factors[("objective", -1)].terms,
+        target.factors[("objective", -1)].terms,
+        state.variable_map,
+        atol=atol,
+    )
+
+
+def factor_matches(
+    source: FactorNode,
+    target: FactorNode,
+    variable_map: Mapping[int, int],
+    *,
+    atol: float,
+) -> bool:
+    if source.attrs[:3] != target.attrs[:3]:
+        return False
+    if source.indicator_variable is not None:
+        if variable_map.get(source.indicator_variable) != target.indicator_variable:
+            return False
+    if source.variables:
+        return (
+            tuple(sorted(variable_map[v] for v in source.variables)) == target.variables
+        )
+    return function_matches(source.terms, target.terms, variable_map, atol=atol)
+
+
+def function_matches(
+    source_terms: Terms,
+    target_terms: Terms,
+    variable_map: Mapping[int, int],
+    *,
+    atol: float,
+) -> bool:
+    if any(
+        variable_id not in variable_map
+        for monomial in source_terms
+        for variable_id in monomial
+    ):
+        return False
+    mapped_terms: dict[Monomial, float] = {}
+    for monomial, coefficient in source_terms.items():
+        mapped_monomial = map_monomial(monomial, variable_map)
+        mapped_terms[mapped_monomial] = (
+            mapped_terms.get(mapped_monomial, 0.0) + coefficient
+        )
+    return terms_close(mapped_terms, target_terms, atol=atol)
+
+
+def map_monomial(monomial: Monomial, variable_map: Mapping[int, int]) -> Monomial:
+    return tuple(sorted(variable_map[variable_id] for variable_id in monomial))
+
+
+def terms_close(source_terms: Terms, target_terms: Terms, *, atol: float) -> bool:
+    keys = set(source_terms) | set(target_terms)
+    for key in keys:
+        if abs(source_terms.get(key, 0.0) - target_terms.get(key, 0.0)) > atol:
+            return False
+    return True
+
+
+def source_is_fully_mapped(source: InstanceGraph, state: SearchState) -> bool:
+    return len(state.variable_map) == len(source.variables) and len(
+        state.factor_map
+    ) == len(source.factors)
+
+
+def output_factor_keys(graph: InstanceGraph) -> tuple[FactorKey, ...]:
+    return tuple(
+        sorted((key for key in graph.factors if key[0] != "objective"), key=repr)
+    )


### PR DESCRIPTION
## Summary
- Add a new `ommx.diff` module that exposes the instance ID-mapping heuristic as the first step toward semantic diffs
- Match decision variables and constraint collections across two `Instance` objects using structural fingerprints, refinement, and bounded backtracking
- Add focused tests covering regular constraints, structural constraints, and an unverified mismatch case

## Testing
- `uv run pytest python/ommx-tests/tests/test_diff_instance_mapping.py`
- `uv run ruff check python/ommx/ommx/diff python/ommx-tests/tests/test_diff_instance_mapping.py`
- `uv run ruff format --check python/ommx/ommx/diff python/ommx-tests/tests/test_diff_instance_mapping.py`
- `task python:test`