### PR TITLE
Add typed codecs for Experiment attachments

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -3152,6 +3152,47 @@
               "deprecated": null
             },
             {
+              "name": "get_with_codec",
+              "doc": "Read an experiment-level attachment by name and deserialize it with a codec.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. This method validates the stored media\ntype against the codec before deserializing.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": null
+                    },
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "AttachmentCodec[T]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "T",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "T",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
               "name": "import_archive",
               "doc": "Import an Experiment Artifact from a `.ommx` OCI archive file (or an OCI\nImage Layout directory).\n\nThe archive is imported into the default Local Registry, matching\n{meth}`Artifact.import_archive`, and then interpreted as an\nExperiment. The imported artifact must contain an Experiment config.",
               "signatures": [
@@ -3434,6 +3475,56 @@
                         "display": "Solution",
                         "link_target": null,
                         "children": []
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "None",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
+              "name": "log_with_codec",
+              "doc": "Serialize a Python object with an attachment codec and attach it in the experiment space.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. OMMX owns only this protocol; concrete\ncodecs should live in the package that owns the payload type.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": null
+                    },
+                    {
+                      "name": "value",
+                      "type_": {
+                        "display": "T",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": null
+                    },
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "AttachmentCodec[T]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "T",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
                       },
                       "default": null
                     }
@@ -4216,6 +4307,56 @@
               ],
               "is_async": false,
               "deprecated": null
+            },
+            {
+              "name": "log_with_codec",
+              "doc": "Serialize a Python object with an attachment codec and attach it in this run.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. OMMX owns only this protocol; concrete\ncodecs should live in the package that owns the payload type.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": null
+                    },
+                    {
+                      "name": "value",
+                      "type_": {
+                        "display": "T",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": null
+                    },
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "AttachmentCodec[T]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "T",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "None",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
             }
           ],
           "attributes": [
@@ -4429,6 +4570,47 @@
                   ],
                   "return_type": {
                     "display": "Solution",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
+              "name": "get_with_codec",
+              "doc": "Read a run-level attachment by name and deserialize it with a codec.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. This method validates the stored media\ntype against the codec before deserializing.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "str",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": null
+                    },
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "AttachmentCodec[T]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "T",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "T",
                     "link_target": null,
                     "children": []
                   }

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -3153,31 +3153,37 @@
             },
             {
               "name": "get_with_codec",
-              "doc": "Read an experiment-level attachment by name and deserialize it with a codec.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. This method validates the stored media\ntype against the codec before deserializing.",
+              "doc": "Read an experiment-level attachment by name and decode it with a codec.\n\nThe codec class must provide `media_type`, `encode(value) -> bytes`,\nand `decode(bytes) -> object`. This method validates the stored media\ntype against the codec before decoding.",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "type[AttachmentCodec[T]]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "AttachmentCodec[T]",
+                            "link_target": null,
+                            "children": [
+                              {
+                                "display": "T",
+                                "link_target": null,
+                                "children": []
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "default": null
+                    },
                     {
                       "name": "name",
                       "type_": {
                         "display": "str",
                         "link_target": null,
                         "children": []
-                      },
-                      "default": null
-                    },
-                    {
-                      "name": "codec",
-                      "type_": {
-                        "display": "AttachmentCodec[T]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "T",
-                            "link_target": null,
-                            "children": []
-                          }
-                        ]
                       },
                       "default": null
                     }
@@ -3491,10 +3497,31 @@
             },
             {
               "name": "log_with_codec",
-              "doc": "Serialize a Python object with an attachment codec and attach it in the experiment space.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. OMMX owns only this protocol; concrete\ncodecs should live in the package that owns the payload type.",
+              "doc": "Encode a Python object with an attachment codec and attach it in the experiment space.\n\nThe codec class must provide `media_type`, `encode(value) -> bytes`,\nand `decode(bytes) -> object`. OMMX owns only this protocol; concrete\ncodecs should live in the package that owns the payload type.",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "type[AttachmentCodec[T]]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "AttachmentCodec[T]",
+                            "link_target": null,
+                            "children": [
+                              {
+                                "display": "T",
+                                "link_target": null,
+                                "children": []
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "default": null
+                    },
                     {
                       "name": "name",
                       "type_": {
@@ -3510,21 +3537,6 @@
                         "display": "T",
                         "link_target": null,
                         "children": []
-                      },
-                      "default": null
-                    },
-                    {
-                      "name": "codec",
-                      "type_": {
-                        "display": "AttachmentCodec[T]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "T",
-                            "link_target": null,
-                            "children": []
-                          }
-                        ]
                       },
                       "default": null
                     }
@@ -4310,10 +4322,31 @@
             },
             {
               "name": "log_with_codec",
-              "doc": "Serialize a Python object with an attachment codec and attach it in this run.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. OMMX owns only this protocol; concrete\ncodecs should live in the package that owns the payload type.",
+              "doc": "Encode a Python object with an attachment codec and attach it in this run.\n\nThe codec class must provide `media_type`, `encode(value) -> bytes`,\nand `decode(bytes) -> object`. OMMX owns only this protocol; concrete\ncodecs should live in the package that owns the payload type.",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "type[AttachmentCodec[T]]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "AttachmentCodec[T]",
+                            "link_target": null,
+                            "children": [
+                              {
+                                "display": "T",
+                                "link_target": null,
+                                "children": []
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "default": null
+                    },
                     {
                       "name": "name",
                       "type_": {
@@ -4329,21 +4362,6 @@
                         "display": "T",
                         "link_target": null,
                         "children": []
-                      },
-                      "default": null
-                    },
-                    {
-                      "name": "codec",
-                      "type_": {
-                        "display": "AttachmentCodec[T]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "T",
-                            "link_target": null,
-                            "children": []
-                          }
-                        ]
                       },
                       "default": null
                     }
@@ -4580,31 +4598,37 @@
             },
             {
               "name": "get_with_codec",
-              "doc": "Read a run-level attachment by name and deserialize it with a codec.\n\nThe codec must provide `media_type`, `serialize(value) -> bytes`, and\n`deserialize(bytes) -> object`. This method validates the stored media\ntype against the codec before deserializing.",
+              "doc": "Read a run-level attachment by name and decode it with a codec.\n\nThe codec class must provide `media_type`, `encode(value) -> bytes`,\nand `decode(bytes) -> object`. This method validates the stored media\ntype against the codec before decoding.",
               "signatures": [
                 {
                   "parameters": [
+                    {
+                      "name": "codec",
+                      "type_": {
+                        "display": "type[AttachmentCodec[T]]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "AttachmentCodec[T]",
+                            "link_target": null,
+                            "children": [
+                              {
+                                "display": "T",
+                                "link_target": null,
+                                "children": []
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "default": null
+                    },
                     {
                       "name": "name",
                       "type_": {
                         "display": "str",
                         "link_target": null,
                         "children": []
-                      },
-                      "default": null
-                    },
-                    {
-                      "name": "codec",
-                      "type_": {
-                        "display": "AttachmentCodec[T]",
-                        "link_target": null,
-                        "children": [
-                          {
-                            "display": "T",
-                            "link_target": null,
-                            "children": []
-                          }
-                        ]
                       },
                       "default": null
                     }

--- a/docs/en/tutorial/experiment_management.md
+++ b/docs/en/tutorial/experiment_management.md
@@ -69,10 +69,11 @@ pi = ParametricInstance.from_components(
 )
 ```
 
-If the original model was written in a modeling package, keep that source model as an Attachment as well. OMMX does not decode external modeler-specific payloads; it stores their bytes with the Media Type you provide. For a JijModeling `Problem`, serialize the problem with JijModeling and attach the protobuf bytes.
+If the original model was written in a modeling package, keep that source model as an Attachment as well. For external payload types, OMMX defines only the attachment codec protocol and the `log_with_codec` / `get_with_codec` methods that invoke it. The concrete codec should live in the package that owns the object type. JijModeling is expected to provide a codec for `Problem`, so the same source model can be saved and restored without OMMX depending on JijModeling. Excel or spreadsheet payloads can follow the same pattern in the package that owns that file format.
 
 ```{code-cell} ipython3
 import jijmodeling as jm
+from jijmodeling.experimental.ommx import problem_attachment_codec
 
 @jm.Problem.define("Knapsack Problem", sense=jm.ProblemSense.MAXIMIZE)
 def jij_problem(problem: jm.DecoratedProblem):
@@ -90,8 +91,6 @@ def jij_problem(problem: jm.DecoratedProblem):
     "weight limit",
     jm.sum(w[i] * x[i] for i in N) <= W,
   )
-
-JIJMODELING_PROBLEM_MEDIA_TYPE = "application/vnd.jijmodeling.problem+protobuf"
 ```
 
 ## Run the Experiment
@@ -108,11 +107,11 @@ with Experiment() as experiment:
   # Store the model as experiment-level information.
   experiment.log_parametric_instance("instance", pi)
 
-  # Store the original JijModeling Problem as an opaque attachment.
-  experiment.log_attachment(
+  # Store the original JijModeling Problem through the codec provided by JijModeling.
+  experiment.log_with_codec(
     "jijmodeling-problem",
-    JIJMODELING_PROBLEM_MEDIA_TYPE,
-    jij_problem.to_protobuf(),
+    jij_problem,
+    problem_attachment_codec,
   )
 
   # This example does not need it, but model metadata can also be stored as JSON.
@@ -257,9 +256,11 @@ assert source_data == {
 pi = loaded_experiment.get_attachment("instance")
 assert isinstance(pi, ParametricInstance)
 
-# Unknown Media Types are returned as bytes, so decode them with the owner package.
-payload = loaded_experiment.get_attachment("jijmodeling-problem")
-restored_jij_problem = jm.Problem.from_protobuf(payload)
+# The codec validates the Media Type and deserializes the original payload.
+restored_jij_problem = loaded_experiment.get_with_codec(
+    "jijmodeling-problem",
+    problem_attachment_codec,
+)
 assert restored_jij_problem.name == jij_problem.name
 ```
 

--- a/docs/en/tutorial/experiment_management.md
+++ b/docs/en/tutorial/experiment_management.md
@@ -119,7 +119,7 @@ with Experiment() as experiment:
   # Store the model as experiment-level information.
   experiment.log_parametric_instance("instance", pi)
 
-  # Store the original JijModeling Problem through the codec provided by JijModeling.
+  # Store the original JijModeling Problem through the temporary codec defined above.
   experiment.log_with_codec(
     ProblemCodec,
     "jijmodeling-problem",

--- a/docs/en/tutorial/experiment_management.md
+++ b/docs/en/tutorial/experiment_management.md
@@ -69,11 +69,23 @@ pi = ParametricInstance.from_components(
 )
 ```
 
-If the original model was written in a modeling package, keep that source model as an Attachment as well. For external payload types, OMMX defines only the attachment codec protocol and the `log_with_codec` / `get_with_codec` methods that invoke it. The concrete codec should live in the package that owns the object type. JijModeling is expected to provide a codec for `Problem`, so the same source model can be saved and restored without OMMX depending on JijModeling. Excel or spreadsheet payloads can follow the same pattern in the package that owns that file format.
+If the original model was written in a modeling package, keep that source model as an Attachment as well. For external payload types, OMMX defines only the attachment codec protocol and the `log_with_codec` / `get_with_codec` methods that invoke it. The concrete codec should live in the package that owns the object type. This tutorial defines a temporary `ProblemCodec` for JijModeling `Problem`; JijModeling is expected to provide an equivalent codec in the future. Excel or spreadsheet payloads can follow the same pattern in the package that owns that file format.
 
 ```{code-cell} ipython3
 import jijmodeling as jm
-from jijmodeling.experimental.ommx import problem_attachment_codec
+
+
+class ProblemCodec:
+  media_type = "application/vnd.jijmodeling.problem+protobuf"
+
+  @staticmethod
+  def encode(problem: jm.Problem) -> bytes:
+    return problem.to_protobuf()
+
+  @staticmethod
+  def decode(data: bytes) -> jm.Problem:
+    return jm.Problem.from_protobuf(data)
+
 
 @jm.Problem.define("Knapsack Problem", sense=jm.ProblemSense.MAXIMIZE)
 def jij_problem(problem: jm.DecoratedProblem):
@@ -109,9 +121,9 @@ with Experiment() as experiment:
 
   # Store the original JijModeling Problem through the codec provided by JijModeling.
   experiment.log_with_codec(
+    ProblemCodec,
     "jijmodeling-problem",
     jij_problem,
-    problem_attachment_codec,
   )
 
   # This example does not need it, but model metadata can also be stored as JSON.
@@ -256,10 +268,10 @@ assert source_data == {
 pi = loaded_experiment.get_attachment("instance")
 assert isinstance(pi, ParametricInstance)
 
-# The codec validates the Media Type and deserializes the original payload.
+# The codec validates the Media Type and decodes the original payload.
 restored_jij_problem = loaded_experiment.get_with_codec(
+    ProblemCodec,
     "jijmodeling-problem",
-    problem_attachment_codec,
 )
 assert restored_jij_problem.name == jij_problem.name
 ```

--- a/docs/ja/tutorial/experiment_management.md
+++ b/docs/ja/tutorial/experiment_management.md
@@ -119,7 +119,7 @@ with Experiment() as experiment:
   # 上で作ったモデルをExperimentの情報として保存する。
   experiment.log_parametric_instance("instance", pi)
 
-  # 元のJijModeling ProblemをJijModelingが提供するCodec経由で保存する。
+  # 元のJijModeling Problemを上で定義した一時的なCodec経由で保存する。
   experiment.log_with_codec(
     ProblemCodec,
     "jijmodeling-problem",

--- a/docs/ja/tutorial/experiment_management.md
+++ b/docs/ja/tutorial/experiment_management.md
@@ -69,10 +69,11 @@ pi = ParametricInstance.from_components(
 )
 ```
 
-元のモデルをモデリング用パッケージで記述している場合は、そのソースモデルもAttachmentとして保存しておくと後から参照できます。OMMXは外部モデラー固有のペイロードを解釈せず、渡されたbytesとMedia Typeをそのまま保存します。JijModelingの `Problem` の場合は、JijModelingでProblemをシリアライズして、そのprotobuf bytesを添付します。
+元のモデルをモデリング用パッケージで記述している場合は、そのソースモデルもAttachmentとして保存しておくと後から参照できます。外部パッケージが所有する型について、OMMXはAttachment CodecのProtocolと、それを呼び出す `log_with_codec` / `get_with_codec` メソッドだけを定義します。具体的なCodecはその型を所有するパッケージ側で提供します。JijModelingは `Problem` 用のCodecを提供してくれる予定なので、OMMXがJijModelingに依存することなく、同じソースモデルを保存して読み戻せます。Excelやspreadsheetのpayloadも同じように、そのファイル形式を扱うパッケージ側でCodecを提供できます。
 
 ```{code-cell} ipython3
 import jijmodeling as jm
+from jijmodeling.experimental.ommx import problem_attachment_codec
 
 @jm.Problem.define("Knapsack Problem", sense=jm.ProblemSense.MAXIMIZE)
 def jij_problem(problem: jm.DecoratedProblem):
@@ -90,8 +91,6 @@ def jij_problem(problem: jm.DecoratedProblem):
     "重量制限",
     jm.sum(w[i] * x[i] for i in N) <= W,
   )
-
-JIJMODELING_PROBLEM_MEDIA_TYPE = "application/vnd.jijmodeling.problem+protobuf"
 ```
 
 ## 実験する
@@ -108,11 +107,11 @@ with Experiment() as experiment:
   # 上で作ったモデルをExperimentの情報として保存する。
   experiment.log_parametric_instance("instance", pi)
 
-  # 元のJijModeling ProblemをopaqueなAttachmentとして保存する。
-  experiment.log_attachment(
+  # 元のJijModeling ProblemをJijModelingが提供するCodec経由で保存する。
+  experiment.log_with_codec(
     "jijmodeling-problem",
-    JIJMODELING_PROBLEM_MEDIA_TYPE,
-    jij_problem.to_protobuf(),
+    jij_problem,
+    problem_attachment_codec,
   )
 
   # 今回は必要ないが、モデルの情報をJSONで保存することもできる。
@@ -257,9 +256,11 @@ assert source_data == {
 pi = loaded_experiment.get_attachment("instance")
 assert isinstance(pi, ParametricInstance)
 
-# OMMXが知らないMedia Typeはbytesとして返るので、所有元のパッケージでdecodeする
-payload = loaded_experiment.get_attachment("jijmodeling-problem")
-restored_jij_problem = jm.Problem.from_protobuf(payload)
+# CodecがMedia Typeを検証し、元のpayloadへdeserializeして返す
+restored_jij_problem = loaded_experiment.get_with_codec(
+    "jijmodeling-problem",
+    problem_attachment_codec,
+)
 assert restored_jij_problem.name == jij_problem.name
 ```
 

--- a/docs/ja/tutorial/experiment_management.md
+++ b/docs/ja/tutorial/experiment_management.md
@@ -69,11 +69,23 @@ pi = ParametricInstance.from_components(
 )
 ```
 
-元のモデルをモデリング用パッケージで記述している場合は、そのソースモデルもAttachmentとして保存しておくと後から参照できます。外部パッケージが所有する型について、OMMXはAttachment CodecのProtocolと、それを呼び出す `log_with_codec` / `get_with_codec` メソッドだけを定義します。具体的なCodecはその型を所有するパッケージ側で提供します。JijModelingは `Problem` 用のCodecを提供してくれる予定なので、OMMXがJijModelingに依存することなく、同じソースモデルを保存して読み戻せます。Excelやspreadsheetのpayloadも同じように、そのファイル形式を扱うパッケージ側でCodecを提供できます。
+元のモデルをモデリング用パッケージで記述している場合は、そのソースモデルもAttachmentとして保存しておくと後から参照できます。外部パッケージが所有する型について、OMMXはAttachment CodecのProtocolと、それを呼び出す `log_with_codec` / `get_with_codec` メソッドだけを定義します。具体的なCodecはその型を所有するパッケージ側で提供します。このチュートリアルではJijModeling `Problem` 用の一時的な `ProblemCodec` を定義して使います。同等のCodecは将来的にJijModeling本体で提供される予定です。Excelやspreadsheetのpayloadも同じように、そのファイル形式を扱うパッケージ側でCodecを提供できます。
 
 ```{code-cell} ipython3
 import jijmodeling as jm
-from jijmodeling.experimental.ommx import problem_attachment_codec
+
+
+class ProblemCodec:
+  media_type = "application/vnd.jijmodeling.problem+protobuf"
+
+  @staticmethod
+  def encode(problem: jm.Problem) -> bytes:
+    return problem.to_protobuf()
+
+  @staticmethod
+  def decode(data: bytes) -> jm.Problem:
+    return jm.Problem.from_protobuf(data)
+
 
 @jm.Problem.define("Knapsack Problem", sense=jm.ProblemSense.MAXIMIZE)
 def jij_problem(problem: jm.DecoratedProblem):
@@ -109,9 +121,9 @@ with Experiment() as experiment:
 
   # 元のJijModeling ProblemをJijModelingが提供するCodec経由で保存する。
   experiment.log_with_codec(
+    ProblemCodec,
     "jijmodeling-problem",
     jij_problem,
-    problem_attachment_codec,
   )
 
   # 今回は必要ないが、モデルの情報をJSONで保存することもできる。
@@ -256,10 +268,10 @@ assert source_data == {
 pi = loaded_experiment.get_attachment("instance")
 assert isinstance(pi, ParametricInstance)
 
-# CodecがMedia Typeを検証し、元のpayloadへdeserializeして返す
+# CodecがMedia Typeを検証し、元のpayloadへdecodeして返す
 restored_jij_problem = loaded_experiment.get_with_codec(
+    ProblemCodec,
     "jijmodeling-problem",
-    problem_attachment_codec,
 )
 assert restored_jij_problem.name == jij_problem.name
 ```

--- a/python/ommx-tests/tests/test_experiment_attachments.py
+++ b/python/ommx-tests/tests/test_experiment_attachments.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 
 from ommx.artifact import Descriptor
 from ommx.experiment import Experiment
-from ommx.experiment.attachments import AttachmentCodec
 
 _ATTACHMENT_NAME = "org.ommx.attachment.name"
 
@@ -28,9 +27,6 @@ class ToyPayloadCodec:
         return ToyPayload(label=payload["label"], value=payload["value"])
 
 
-_TOY_CODEC: type[AttachmentCodec[ToyPayload]] = ToyPayloadCodec
-
-
 def _attachment_by_name(attachments: list[Descriptor], name: str) -> Descriptor:
     for attachment in attachments:
         if attachment.annotations[_ATTACHMENT_NAME] == name:
@@ -42,14 +38,14 @@ def test_experiment_attachment_codec_round_trip():
     expected = ToyPayload(label="experiment", value=7)
 
     with Experiment.with_temp_local_registry() as experiment:
-        experiment.log_with_codec(_TOY_CODEC, "typed-payload", expected)
+        experiment.log_with_codec(ToyPayloadCodec, "typed-payload", expected)
 
     loaded = Experiment.from_artifact(experiment.artifact)
-    assert loaded.get_with_codec(_TOY_CODEC, "typed-payload") == expected
+    assert loaded.get_with_codec(ToyPayloadCodec, "typed-payload") == expected
 
     descriptor = _attachment_by_name(loaded.experiment_attachments, "typed-payload")
-    assert descriptor.media_type == _TOY_CODEC.media_type
-    assert loaded.get_blob("typed-payload") == _TOY_CODEC.encode(expected)
+    assert descriptor.media_type == ToyPayloadCodec.media_type
+    assert loaded.get_blob("typed-payload") == ToyPayloadCodec.encode(expected)
 
 
 def test_run_attachment_codec_round_trip():
@@ -57,12 +53,12 @@ def test_run_attachment_codec_round_trip():
 
     with Experiment.with_temp_local_registry() as experiment:
         with experiment.run() as run:
-            run.log_with_codec(_TOY_CODEC, "typed-payload", expected)
+            run.log_with_codec(ToyPayloadCodec, "typed-payload", expected)
 
     loaded = Experiment.from_artifact(experiment.artifact)
     run = loaded.runs[0]
-    assert run.get_with_codec(_TOY_CODEC, "typed-payload") == expected
+    assert run.get_with_codec(ToyPayloadCodec, "typed-payload") == expected
 
     descriptor = _attachment_by_name(run.attachments, "typed-payload")
-    assert descriptor.media_type == _TOY_CODEC.media_type
-    assert run.get_blob("typed-payload") == _TOY_CODEC.encode(expected)
+    assert descriptor.media_type == ToyPayloadCodec.media_type
+    assert run.get_blob("typed-payload") == ToyPayloadCodec.encode(expected)

--- a/python/ommx-tests/tests/test_experiment_attachments.py
+++ b/python/ommx-tests/tests/test_experiment_attachments.py
@@ -17,16 +17,18 @@ class ToyPayload:
 class ToyPayloadCodec:
     media_type = "application/vnd.ommx-tests.toy-payload+json"
 
-    def serialize(self, value: ToyPayload) -> bytes:
+    @staticmethod
+    def encode(value: ToyPayload) -> bytes:
         payload = {"label": value.label, "value": value.value}
         return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
 
-    def deserialize(self, data: bytes) -> ToyPayload:
+    @staticmethod
+    def decode(data: bytes) -> ToyPayload:
         payload = json.loads(data.decode())
         return ToyPayload(label=payload["label"], value=payload["value"])
 
 
-_TOY_CODEC: AttachmentCodec[ToyPayload] = ToyPayloadCodec()
+_TOY_CODEC: type[AttachmentCodec[ToyPayload]] = ToyPayloadCodec
 
 
 def _attachment_by_name(attachments: list[Descriptor], name: str) -> Descriptor:
@@ -40,14 +42,14 @@ def test_experiment_attachment_codec_round_trip():
     expected = ToyPayload(label="experiment", value=7)
 
     with Experiment.with_temp_local_registry() as experiment:
-        experiment.log_with_codec("typed-payload", expected, _TOY_CODEC)
+        experiment.log_with_codec(_TOY_CODEC, "typed-payload", expected)
 
     loaded = Experiment.from_artifact(experiment.artifact)
-    assert loaded.get_with_codec("typed-payload", _TOY_CODEC) == expected
+    assert loaded.get_with_codec(_TOY_CODEC, "typed-payload") == expected
 
     descriptor = _attachment_by_name(loaded.experiment_attachments, "typed-payload")
     assert descriptor.media_type == _TOY_CODEC.media_type
-    assert loaded.get_blob("typed-payload") == _TOY_CODEC.serialize(expected)
+    assert loaded.get_blob("typed-payload") == _TOY_CODEC.encode(expected)
 
 
 def test_run_attachment_codec_round_trip():
@@ -55,12 +57,12 @@ def test_run_attachment_codec_round_trip():
 
     with Experiment.with_temp_local_registry() as experiment:
         with experiment.run() as run:
-            run.log_with_codec("typed-payload", expected, _TOY_CODEC)
+            run.log_with_codec(_TOY_CODEC, "typed-payload", expected)
 
     loaded = Experiment.from_artifact(experiment.artifact)
     run = loaded.runs[0]
-    assert run.get_with_codec("typed-payload", _TOY_CODEC) == expected
+    assert run.get_with_codec(_TOY_CODEC, "typed-payload") == expected
 
     descriptor = _attachment_by_name(run.attachments, "typed-payload")
     assert descriptor.media_type == _TOY_CODEC.media_type
-    assert run.get_blob("typed-payload") == _TOY_CODEC.serialize(expected)
+    assert run.get_blob("typed-payload") == _TOY_CODEC.encode(expected)

--- a/python/ommx-tests/tests/test_experiment_attachments.py
+++ b/python/ommx-tests/tests/test_experiment_attachments.py
@@ -1,0 +1,66 @@
+import json
+from dataclasses import dataclass
+
+from ommx.artifact import Descriptor
+from ommx.experiment import Experiment
+from ommx.experiment.attachments import AttachmentCodec
+
+_ATTACHMENT_NAME = "org.ommx.attachment.name"
+
+
+@dataclass(frozen=True)
+class ToyPayload:
+    label: str
+    value: int
+
+
+class ToyPayloadCodec:
+    media_type = "application/vnd.ommx-tests.toy-payload+json"
+
+    def serialize(self, value: ToyPayload) -> bytes:
+        payload = {"label": value.label, "value": value.value}
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+    def deserialize(self, data: bytes) -> ToyPayload:
+        payload = json.loads(data.decode())
+        return ToyPayload(label=payload["label"], value=payload["value"])
+
+
+_TOY_CODEC: AttachmentCodec[ToyPayload] = ToyPayloadCodec()
+
+
+def _attachment_by_name(attachments: list[Descriptor], name: str) -> Descriptor:
+    for attachment in attachments:
+        if attachment.annotations[_ATTACHMENT_NAME] == name:
+            return attachment
+    raise AssertionError(f"attachment {name!r} not found")
+
+
+def test_experiment_attachment_codec_round_trip():
+    expected = ToyPayload(label="experiment", value=7)
+
+    with Experiment.with_temp_local_registry() as experiment:
+        experiment.log_with_codec("typed-payload", expected, _TOY_CODEC)
+
+    loaded = Experiment.from_artifact(experiment.artifact)
+    assert loaded.get_with_codec("typed-payload", _TOY_CODEC) == expected
+
+    descriptor = _attachment_by_name(loaded.experiment_attachments, "typed-payload")
+    assert descriptor.media_type == _TOY_CODEC.media_type
+    assert loaded.get_blob("typed-payload") == _TOY_CODEC.serialize(expected)
+
+
+def test_run_attachment_codec_round_trip():
+    expected = ToyPayload(label="run", value=11)
+
+    with Experiment.with_temp_local_registry() as experiment:
+        with experiment.run() as run:
+            run.log_with_codec("typed-payload", expected, _TOY_CODEC)
+
+    loaded = Experiment.from_artifact(experiment.artifact)
+    run = loaded.runs[0]
+    assert run.get_with_codec("typed-payload", _TOY_CODEC) == expected
+
+    descriptor = _attachment_by_name(run.attachments, "typed-payload")
+    assert descriptor.media_type == _TOY_CODEC.media_type
+    assert run.get_blob("typed-payload") == _TOY_CODEC.serialize(expected)

--- a/python/ommx-tests/tests/test_experiment_attachments.py
+++ b/python/ommx-tests/tests/test_experiment_attachments.py
@@ -1,6 +1,8 @@
 import json
 from dataclasses import dataclass
 
+import pytest
+
 from ommx.artifact import Descriptor
 from ommx.experiment import Experiment
 
@@ -25,6 +27,18 @@ class ToyPayloadCodec:
     def decode(data: bytes) -> ToyPayload:
         payload = json.loads(data.decode())
         return ToyPayload(label=payload["label"], value=payload["value"])
+
+
+class WrongMediaTypeCodec:
+    media_type = "application/vnd.ommx-tests.other-payload+json"
+
+    @staticmethod
+    def encode(value: ToyPayload) -> bytes:
+        return ToyPayloadCodec.encode(value)
+
+    @staticmethod
+    def decode(data: bytes) -> ToyPayload:
+        return ToyPayloadCodec.decode(data)
 
 
 def _attachment_by_name(attachments: list[Descriptor], name: str) -> Descriptor:
@@ -62,3 +76,26 @@ def test_run_attachment_codec_round_trip():
     descriptor = _attachment_by_name(run.attachments, "typed-payload")
     assert descriptor.media_type == ToyPayloadCodec.media_type
     assert run.get_blob("typed-payload") == ToyPayloadCodec.encode(expected)
+
+
+def test_experiment_attachment_codec_rejects_media_type_mismatch():
+    with Experiment.with_temp_local_registry() as experiment:
+        experiment.log_with_codec(
+            ToyPayloadCodec, "typed-payload", ToyPayload(label="experiment", value=7)
+        )
+
+    loaded = Experiment.from_artifact(experiment.artifact)
+    with pytest.raises(Exception, match="Expected media type"):
+        loaded.get_with_codec(WrongMediaTypeCodec, "typed-payload")
+
+
+def test_run_attachment_codec_rejects_media_type_mismatch():
+    with Experiment.with_temp_local_registry() as experiment:
+        with experiment.run() as run:
+            run.log_with_codec(
+                ToyPayloadCodec, "typed-payload", ToyPayload(label="run", value=11)
+            )
+
+    loaded = Experiment.from_artifact(experiment.artifact)
+    with pytest.raises(Exception, match="Expected media type"):
+        loaded.runs[0].get_with_codec(WrongMediaTypeCodec, "typed-payload")

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -1999,14 +1999,16 @@ class Experiment:
         Read raw bytes of an experiment-level attachment by name.
         """
     def get_with_codec(
-        self, name: builtins.str, codec: attachments.AttachmentCodec[attachments.T]
+        self,
+        codec: type[attachments.AttachmentCodec[attachments.T]],
+        name: builtins.str,
     ) -> attachments.T:
         r"""
-        Read an experiment-level attachment by name and deserialize it with a codec.
+        Read an experiment-level attachment by name and decode it with a codec.
 
-        The codec must provide `media_type`, `serialize(value) -> bytes`, and
-        `deserialize(bytes) -> object`. This method validates the stored media
-        type against the codec before deserializing.
+        The codec class must provide `media_type`, `encode(value) -> bytes`,
+        and `decode(bytes) -> object`. This method validates the stored media
+        type against the codec before decoding.
         """
     def run(self) -> Run:
         r"""
@@ -2037,15 +2039,15 @@ class Experiment:
         """
     def log_with_codec(
         self,
+        codec: type[attachments.AttachmentCodec[attachments.T]],
         name: builtins.str,
         value: attachments.T,
-        codec: attachments.AttachmentCodec[attachments.T],
     ) -> None:
         r"""
-        Serialize a Python object with an attachment codec and attach it in the experiment space.
+        Encode a Python object with an attachment codec and attach it in the experiment space.
 
-        The codec must provide `media_type`, `serialize(value) -> bytes`, and
-        `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+        The codec class must provide `media_type`, `encode(value) -> bytes`,
+        and `decode(bytes) -> object`. OMMX owns only this protocol; concrete
         codecs should live in the package that owns the payload type.
         """
     def log_json(self, name: builtins.str, value: typing.Any) -> None:
@@ -5505,15 +5507,15 @@ class Run:
         """
     def log_with_codec(
         self,
+        codec: type[attachments.AttachmentCodec[attachments.T]],
         name: builtins.str,
         value: attachments.T,
-        codec: attachments.AttachmentCodec[attachments.T],
     ) -> None:
         r"""
-        Serialize a Python object with an attachment codec and attach it in this run.
+        Encode a Python object with an attachment codec and attach it in this run.
 
-        The codec must provide `media_type`, `serialize(value) -> bytes`, and
-        `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+        The codec class must provide `media_type`, `encode(value) -> bytes`,
+        and `decode(bytes) -> object`. OMMX owns only this protocol; concrete
         codecs should live in the package that owns the payload type.
         """
     def log_json(self, name: builtins.str, value: typing.Any) -> None:
@@ -6201,14 +6203,16 @@ class SealedRun:
         Read raw bytes of a run-level attachment by name.
         """
     def get_with_codec(
-        self, name: builtins.str, codec: attachments.AttachmentCodec[attachments.T]
+        self,
+        codec: type[attachments.AttachmentCodec[attachments.T]],
+        name: builtins.str,
     ) -> attachments.T:
         r"""
-        Read a run-level attachment by name and deserialize it with a codec.
+        Read a run-level attachment by name and decode it with a codec.
 
-        The codec must provide `media_type`, `serialize(value) -> bytes`, and
-        `deserialize(bytes) -> object`. This method validates the stored media
-        type against the codec before deserializing.
+        The codec class must provide `media_type`, `encode(value) -> bytes`,
+        and `decode(bytes) -> object`. This method validates the stored media
+        type against the codec before decoding.
         """
     def __repr__(self) -> builtins.str: ...
 

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -7,6 +7,7 @@ import datetime
 import enum
 import numpy
 from ommx import adapter
+from ommx.experiment import attachments
 from ommx import tracing
 import os
 import pandas
@@ -1997,6 +1998,16 @@ class Experiment:
         r"""
         Read raw bytes of an experiment-level attachment by name.
         """
+    def get_with_codec(
+        self, name: builtins.str, codec: attachments.AttachmentCodec[attachments.T]
+    ) -> attachments.T:
+        r"""
+        Read an experiment-level attachment by name and deserialize it with a codec.
+
+        The codec must provide `media_type`, `serialize(value) -> bytes`, and
+        `deserialize(bytes) -> object`. This method validates the stored media
+        type against the codec before deserializing.
+        """
     def run(self) -> Run:
         r"""
         Start a new Run in this unsealed Experiment.
@@ -2023,6 +2034,19 @@ class Experiment:
 
         The `name` is stored as attachment metadata and is intended for
         humans. The bytes are stored as a layer in the committed artifact.
+        """
+    def log_with_codec(
+        self,
+        name: builtins.str,
+        value: attachments.T,
+        codec: attachments.AttachmentCodec[attachments.T],
+    ) -> None:
+        r"""
+        Serialize a Python object with an attachment codec and attach it in the experiment space.
+
+        The codec must provide `media_type`, `serialize(value) -> bytes`, and
+        `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+        codecs should live in the package that owns the payload type.
         """
     def log_json(self, name: builtins.str, value: typing.Any) -> None:
         r"""
@@ -5479,6 +5503,19 @@ class Run:
         Use this for payloads that belong to this run but are not scalar run
         parameters, for example solver logs or derived files.
         """
+    def log_with_codec(
+        self,
+        name: builtins.str,
+        value: attachments.T,
+        codec: attachments.AttachmentCodec[attachments.T],
+    ) -> None:
+        r"""
+        Serialize a Python object with an attachment codec and attach it in this run.
+
+        The codec must provide `media_type`, `serialize(value) -> bytes`, and
+        `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+        codecs should live in the package that owns the payload type.
+        """
     def log_json(self, name: builtins.str, value: typing.Any) -> None:
         r"""
         Attach a JSON-serializable value in this run.
@@ -6162,6 +6199,16 @@ class SealedRun:
     def get_blob(self, name: builtins.str) -> bytes:
         r"""
         Read raw bytes of a run-level attachment by name.
+        """
+    def get_with_codec(
+        self, name: builtins.str, codec: attachments.AttachmentCodec[attachments.T]
+    ) -> attachments.T:
+        r"""
+        Read a run-level attachment by name and deserialize it with a codec.
+
+        The codec must provide `media_type`, `serialize(value) -> bytes`, and
+        `deserialize(bytes) -> object`. This method validates the stored media
+        type against the codec before deserializing.
         """
     def __repr__(self) -> builtins.str: ...
 

--- a/python/ommx/ommx/experiment/attachments.py
+++ b/python/ommx/ommx/experiment/attachments.py
@@ -1,0 +1,40 @@
+"""Typed helpers for Experiment attachments.
+
+OMMX stores Experiment attachments as media-typed bytes. Provider packages
+that own richer Python objects can implement :class:`AttachmentCodec` to define
+how those objects are serialized into attachment bytes and deserialized back.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+
+class AttachmentCodec(Protocol[T]):
+    """Codec for one Python attachment payload type.
+
+    The codec implementation should live with the package that owns ``T``.
+    For example, a JijModeling ``Problem`` codec belongs in ``jijmodeling``,
+    not in OMMX.
+    """
+
+    @property
+    def media_type(self) -> str:
+        """OCI media type used for this attachment payload."""
+        ...
+
+    def serialize(self, value: T, /) -> bytes:
+        """Serialize a Python object to attachment bytes."""
+        ...
+
+    def deserialize(self, data: bytes, /) -> T:
+        """Deserialize attachment bytes back to a Python object."""
+        ...
+
+
+__all__ = [
+    "AttachmentCodec",
+    "T",
+]

--- a/python/ommx/ommx/experiment/attachments.py
+++ b/python/ommx/ommx/experiment/attachments.py
@@ -2,7 +2,7 @@
 
 OMMX stores Experiment attachments as media-typed bytes. Provider packages
 that own richer Python objects can implement :class:`AttachmentCodec` to define
-how those objects are serialized into attachment bytes and deserialized back.
+how those objects are encoded into attachment bytes and decoded back.
 """
 
 from __future__ import annotations
@@ -20,17 +20,17 @@ class AttachmentCodec(Protocol[T]):
     not in OMMX.
     """
 
-    @property
-    def media_type(self) -> str:
-        """OCI media type used for this attachment payload."""
+    media_type: str
+    """OCI media type used for this attachment payload."""
+
+    @staticmethod
+    def encode(value: T, /) -> bytes:
+        """Encode a Python object to attachment bytes."""
         ...
 
-    def serialize(self, value: T, /) -> bytes:
-        """Serialize a Python object to attachment bytes."""
-        ...
-
-    def deserialize(self, data: bytes, /) -> T:
-        """Deserialize attachment bytes back to a Python object."""
+    @staticmethod
+    def decode(data: bytes, /) -> T:
+        """Decode attachment bytes back to a Python object."""
         ...
 
 

--- a/python/ommx/src/experiment.rs
+++ b/python/ommx/src/experiment.rs
@@ -383,11 +383,11 @@ impl PyExperiment {
         ))
     }
 
-    /// Read an experiment-level attachment by name and deserialize it with a codec.
+    /// Read an experiment-level attachment by name and decode it with a codec.
     ///
-    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
-    /// `deserialize(bytes) -> object`. This method validates the stored media
-    /// type against the codec before deserializing.
+    /// The codec class must provide `media_type`, `encode(value) -> bytes`,
+    /// and `decode(bytes) -> object`. This method validates the stored media
+    /// type against the codec before decoding.
     #[gen_stub(override_return_type(
         type_repr = "attachments.T",
         imports = ("ommx.experiment.attachments")
@@ -395,12 +395,8 @@ impl PyExperiment {
     pub fn get_with_codec<'py>(
         &self,
         py: Python<'py>,
+        codec: AttachmentCodecInput,
         name: &str,
-        #[gen_stub(override_type(
-            type_repr = "attachments.AttachmentCodec[attachments.T]",
-            imports = ("ommx.experiment.attachments")
-        ))]
-        codec: &Bound<'py, PyAny>,
     ) -> Result<Bound<'py, PyAny>> {
         let _guard = crate::TRACING.attach_parent_context(py);
         let descriptor = self.find_attachment(name)?;
@@ -408,9 +404,9 @@ impl PyExperiment {
         let blob = attachment_blob(
             registry_handle.registry(),
             &descriptor,
-            Some(&codec_media_type(codec)?),
+            Some(&codec.media_type(py)?),
         )?;
-        codec_deserialize(py, codec, &blob)
+        codec.decode(py, &blob)
     }
 
     #[getter]
@@ -480,30 +476,21 @@ impl PyExperiment {
         )
     }
 
-    /// Serialize a Python object with an attachment codec and attach it in the experiment space.
+    /// Encode a Python object with an attachment codec and attach it in the experiment space.
     ///
-    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
-    /// `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+    /// The codec class must provide `media_type`, `encode(value) -> bytes`,
+    /// and `decode(bytes) -> object`. OMMX owns only this protocol; concrete
     /// codecs should live in the package that owns the payload type.
     pub fn log_with_codec(
         &mut self,
         py: Python<'_>,
+        codec: AttachmentCodecInput,
         name: &str,
-        #[gen_stub(override_type(
-            type_repr = "attachments.T",
-            imports = ("ommx.experiment.attachments")
-        ))]
-        value: &Bound<PyAny>,
-        #[gen_stub(override_type(
-            type_repr = "attachments.AttachmentCodec[attachments.T]",
-            imports = ("ommx.experiment.attachments")
-        ))]
-        codec: &Bound<PyAny>,
+        value: AttachmentPayloadInput,
     ) -> Result<()> {
         let _guard = crate::TRACING.attach_parent_context(py);
-        let media_type = codec_media_type(codec)?;
-        let bytes = codec_serialize(codec, value)?;
-        AttachmentLogger::log_attachment(&self.inner, name, MediaType::Other(media_type), bytes)
+        let attachment = codec.encode_attachment(py, &value)?;
+        AttachmentLogger::log_attachment(&self.inner, name, attachment.media_type, attachment.bytes)
     }
 
     /// Attach a JSON-serializable value in the experiment space.
@@ -723,30 +710,104 @@ fn attachment_blob(
     registry.get_blob(descriptor)
 }
 
-fn codec_media_type(codec: &Bound<'_, PyAny>) -> Result<String> {
-    codec
-        .getattr("media_type")
-        .context("Attachment codec must define `media_type`")?
-        .extract()
-        .context("Attachment codec `media_type` must be a string")
+pub struct AttachmentCodecInput(Py<PyType>);
+
+impl AttachmentCodecInput {
+    fn media_type(&self, py: Python<'_>) -> Result<String> {
+        self.0
+            .bind(py)
+            .getattr("media_type")
+            .context("Attachment codec class must define `media_type`")?
+            .extract()
+            .context("Attachment codec `media_type` must be a string")
+    }
+
+    fn encode(&self, py: Python<'_>, value: &Bound<'_, PyAny>) -> Result<Vec<u8>> {
+        self.0
+            .bind(py)
+            .call_method1("encode", (value,))
+            .context("Attachment codec `encode(...)` failed")?
+            .extract()
+            .context("Attachment codec `encode(...)` must return bytes")
+    }
+
+    fn decode<'py>(&self, py: Python<'py>, blob: &[u8]) -> Result<Bound<'py, PyAny>> {
+        self.0
+            .bind(py)
+            .call_method1("decode", (PyBytes::new(py, blob),))
+            .context("Attachment codec `decode(...)` failed")
+    }
+
+    fn encode_attachment(
+        &self,
+        py: Python<'_>,
+        value: &AttachmentPayloadInput,
+    ) -> Result<EncodedAttachment> {
+        let media_type = self.media_type(py)?;
+        let bytes = self.encode(py, &value.0.bind(py))?;
+        Ok(EncodedAttachment {
+            media_type: MediaType::Other(media_type),
+            bytes,
+        })
+    }
 }
 
-fn codec_serialize(codec: &Bound<'_, PyAny>, value: &Bound<'_, PyAny>) -> Result<Vec<u8>> {
-    codec
-        .call_method1("serialize", (value,))
-        .context("Attachment codec `serialize(...)` failed")?
-        .extract()
-        .context("Attachment codec `serialize(...)` must return bytes")
+pub struct AttachmentPayloadInput(Py<PyAny>);
+
+impl<'py> FromPyObject<'_, 'py> for AttachmentPayloadInput {
+    type Error = PyErr;
+
+    fn extract(ob: pyo3::Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        Ok(Self(ob.to_owned().unbind()))
+    }
 }
 
-fn codec_deserialize<'py>(
-    py: Python<'py>,
-    codec: &Bound<'py, PyAny>,
-    blob: &[u8],
-) -> Result<Bound<'py, PyAny>> {
-    codec
-        .call_method1("deserialize", (PyBytes::new(py, blob),))
-        .context("Attachment codec `deserialize(...)` failed")
+impl pyo3_stub_gen::PyStubType for AttachmentPayloadInput {
+    fn type_input() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: "attachments.T".to_string(),
+            source_module: None,
+            import: ["ommx.experiment.attachments".into()].into(),
+            type_refs: Default::default(),
+        }
+    }
+
+    fn type_output() -> pyo3_stub_gen::TypeInfo {
+        Self::type_input()
+    }
+}
+
+struct EncodedAttachment {
+    media_type: MediaType,
+    bytes: Vec<u8>,
+}
+
+impl<'py> FromPyObject<'_, 'py> for AttachmentCodecInput {
+    type Error = PyErr;
+
+    fn extract(ob: pyo3::Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        let codec = ob.extract::<Py<PyType>>().map_err(|_| {
+            pyo3::exceptions::PyTypeError::new_err(
+                "codec must be a class implementing ommx.experiment.attachments.AttachmentCodec",
+            )
+        })?;
+        Ok(Self(codec))
+    }
+}
+
+impl pyo3_stub_gen::PyStubType for AttachmentCodecInput {
+    fn type_input() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: "type[attachments.AttachmentCodec[attachments.T]]".to_string(),
+            source_module: None,
+            import: ["ommx.experiment.attachments".into()].into(),
+            type_refs: Default::default(),
+        }
+    }
+
+    fn type_output() -> pyo3_stub_gen::TypeInfo {
+        Self::type_input()
+    }
 }
 
 fn decode_attachment<'py>(
@@ -1059,35 +1120,26 @@ impl PyRun {
         )
     }
 
-    /// Serialize a Python object with an attachment codec and attach it in this run.
+    /// Encode a Python object with an attachment codec and attach it in this run.
     ///
-    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
-    /// `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+    /// The codec class must provide `media_type`, `encode(value) -> bytes`,
+    /// and `decode(bytes) -> object`. OMMX owns only this protocol; concrete
     /// codecs should live in the package that owns the payload type.
     pub fn log_with_codec(
         &mut self,
         py: Python<'_>,
+        codec: AttachmentCodecInput,
         name: &str,
-        #[gen_stub(override_type(
-            type_repr = "attachments.T",
-            imports = ("ommx.experiment.attachments")
-        ))]
-        value: &Bound<PyAny>,
-        #[gen_stub(override_type(
-            type_repr = "attachments.AttachmentCodec[attachments.T]",
-            imports = ("ommx.experiment.attachments")
-        ))]
-        codec: &Bound<PyAny>,
+        value: AttachmentPayloadInput,
     ) -> Result<()> {
         let _guard = crate::TRACING.attach_parent_context(py);
         self.ensure_store_trace_context_started()?;
-        let media_type = codec_media_type(codec)?;
-        let bytes = codec_serialize(codec, value)?;
+        let attachment = codec.encode_attachment(py, &value)?;
         AttachmentLogger::log_attachment(
             self.as_open_mut()?,
             name,
-            MediaType::Other(media_type),
-            bytes,
+            attachment.media_type,
+            attachment.bytes,
         )
     }
 
@@ -1526,11 +1578,11 @@ impl PySealedRun {
         ))
     }
 
-    /// Read a run-level attachment by name and deserialize it with a codec.
+    /// Read a run-level attachment by name and decode it with a codec.
     ///
-    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
-    /// `deserialize(bytes) -> object`. This method validates the stored media
-    /// type against the codec before deserializing.
+    /// The codec class must provide `media_type`, `encode(value) -> bytes`,
+    /// and `decode(bytes) -> object`. This method validates the stored media
+    /// type against the codec before decoding.
     #[gen_stub(override_return_type(
         type_repr = "attachments.T",
         imports = ("ommx.experiment.attachments")
@@ -1538,12 +1590,8 @@ impl PySealedRun {
     pub fn get_with_codec<'py>(
         &self,
         py: Python<'py>,
+        codec: AttachmentCodecInput,
         name: &str,
-        #[gen_stub(override_type(
-            type_repr = "attachments.AttachmentCodec[attachments.T]",
-            imports = ("ommx.experiment.attachments")
-        ))]
-        codec: &Bound<'py, PyAny>,
     ) -> Result<Bound<'py, PyAny>> {
         let _guard = crate::TRACING.attach_parent_context(py);
         let descriptor = self.find_attachment(name)?;
@@ -1551,9 +1599,9 @@ impl PySealedRun {
         let blob = attachment_blob(
             registry_handle.registry(),
             &descriptor,
-            Some(&codec_media_type(codec)?),
+            Some(&codec.media_type(py)?),
         )?;
-        codec_deserialize(py, codec, &blob)
+        codec.decode(py, &blob)
     }
 
     #[getter]

--- a/python/ommx/src/experiment.rs
+++ b/python/ommx/src/experiment.rs
@@ -388,16 +388,12 @@ impl PyExperiment {
     /// The codec class must provide `media_type`, `encode(value) -> bytes`,
     /// and `decode(bytes) -> object`. This method validates the stored media
     /// type against the codec before decoding.
-    #[gen_stub(override_return_type(
-        type_repr = "attachments.T",
-        imports = ("ommx.experiment.attachments")
-    ))]
-    pub fn get_with_codec<'py>(
+    pub fn get_with_codec(
         &self,
-        py: Python<'py>,
+        py: Python<'_>,
         codec: AttachmentCodecInput,
         name: &str,
-    ) -> Result<Bound<'py, PyAny>> {
+    ) -> Result<AttachmentPayload> {
         let _guard = crate::TRACING.attach_parent_context(py);
         let descriptor = self.find_attachment(name)?;
         let registry_handle = self.inner.registry_handle();
@@ -486,7 +482,7 @@ impl PyExperiment {
         py: Python<'_>,
         codec: AttachmentCodecInput,
         name: &str,
-        value: AttachmentPayloadInput,
+        value: AttachmentPayload,
     ) -> Result<()> {
         let _guard = crate::TRACING.attach_parent_context(py);
         let attachment = codec.encode_attachment(py, &value)?;
@@ -731,17 +727,19 @@ impl AttachmentCodecInput {
             .context("Attachment codec `encode(...)` must return bytes")
     }
 
-    fn decode<'py>(&self, py: Python<'py>, blob: &[u8]) -> Result<Bound<'py, PyAny>> {
-        self.0
+    fn decode(&self, py: Python<'_>, blob: &[u8]) -> Result<AttachmentPayload> {
+        let value = self
+            .0
             .bind(py)
             .call_method1("decode", (PyBytes::new(py, blob),))
-            .context("Attachment codec `decode(...)` failed")
+            .context("Attachment codec `decode(...)` failed")?;
+        Ok(AttachmentPayload(value.unbind()))
     }
 
     fn encode_attachment(
         &self,
         py: Python<'_>,
-        value: &AttachmentPayloadInput,
+        value: &AttachmentPayload,
     ) -> Result<EncodedAttachment> {
         let media_type = self.media_type(py)?;
         let bytes = self.encode(py, &value.0.bind(py))?;
@@ -752,9 +750,9 @@ impl AttachmentCodecInput {
     }
 }
 
-pub struct AttachmentPayloadInput(Py<PyAny>);
+pub struct AttachmentPayload(Py<PyAny>);
 
-impl<'py> FromPyObject<'_, 'py> for AttachmentPayloadInput {
+impl<'py> FromPyObject<'_, 'py> for AttachmentPayload {
     type Error = PyErr;
 
     fn extract(ob: pyo3::Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
@@ -762,7 +760,17 @@ impl<'py> FromPyObject<'_, 'py> for AttachmentPayloadInput {
     }
 }
 
-impl pyo3_stub_gen::PyStubType for AttachmentPayloadInput {
+impl<'py> pyo3::IntoPyObject<'py> for AttachmentPayload {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = std::convert::Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> std::result::Result<Self::Output, Self::Error> {
+        Ok(self.0.into_bound(py))
+    }
+}
+
+impl pyo3_stub_gen::PyStubType for AttachmentPayload {
     fn type_input() -> pyo3_stub_gen::TypeInfo {
         pyo3_stub_gen::TypeInfo {
             name: "attachments.T".to_string(),
@@ -1130,7 +1138,7 @@ impl PyRun {
         py: Python<'_>,
         codec: AttachmentCodecInput,
         name: &str,
-        value: AttachmentPayloadInput,
+        value: AttachmentPayload,
     ) -> Result<()> {
         let _guard = crate::TRACING.attach_parent_context(py);
         self.ensure_store_trace_context_started()?;
@@ -1583,16 +1591,12 @@ impl PySealedRun {
     /// The codec class must provide `media_type`, `encode(value) -> bytes`,
     /// and `decode(bytes) -> object`. This method validates the stored media
     /// type against the codec before decoding.
-    #[gen_stub(override_return_type(
-        type_repr = "attachments.T",
-        imports = ("ommx.experiment.attachments")
-    ))]
-    pub fn get_with_codec<'py>(
+    pub fn get_with_codec(
         &self,
-        py: Python<'py>,
+        py: Python<'_>,
         codec: AttachmentCodecInput,
         name: &str,
-    ) -> Result<Bound<'py, PyAny>> {
+    ) -> Result<AttachmentPayload> {
         let _guard = crate::TRACING.attach_parent_context(py);
         let descriptor = self.find_attachment(name)?;
         let registry_handle = self.run.registry_handle();

--- a/python/ommx/src/experiment.rs
+++ b/python/ommx/src/experiment.rs
@@ -383,6 +383,36 @@ impl PyExperiment {
         ))
     }
 
+    /// Read an experiment-level attachment by name and deserialize it with a codec.
+    ///
+    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
+    /// `deserialize(bytes) -> object`. This method validates the stored media
+    /// type against the codec before deserializing.
+    #[gen_stub(override_return_type(
+        type_repr = "attachments.T",
+        imports = ("ommx.experiment.attachments")
+    ))]
+    pub fn get_with_codec<'py>(
+        &self,
+        py: Python<'py>,
+        name: &str,
+        #[gen_stub(override_type(
+            type_repr = "attachments.AttachmentCodec[attachments.T]",
+            imports = ("ommx.experiment.attachments")
+        ))]
+        codec: &Bound<'py, PyAny>,
+    ) -> Result<Bound<'py, PyAny>> {
+        let _guard = crate::TRACING.attach_parent_context(py);
+        let descriptor = self.find_attachment(name)?;
+        let registry_handle = self.inner.registry_handle();
+        let blob = attachment_blob(
+            registry_handle.registry(),
+            &descriptor,
+            Some(&codec_media_type(codec)?),
+        )?;
+        codec_deserialize(py, codec, &blob)
+    }
+
     #[getter]
     /// Closed runs in insertion order.
     pub fn runs(&self) -> Result<Vec<PySealedRun>> {
@@ -448,6 +478,32 @@ impl PyExperiment {
             MediaType::Other(media_type.to_string()),
             bytes.as_bytes(),
         )
+    }
+
+    /// Serialize a Python object with an attachment codec and attach it in the experiment space.
+    ///
+    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
+    /// `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+    /// codecs should live in the package that owns the payload type.
+    pub fn log_with_codec(
+        &mut self,
+        py: Python<'_>,
+        name: &str,
+        #[gen_stub(override_type(
+            type_repr = "attachments.T",
+            imports = ("ommx.experiment.attachments")
+        ))]
+        value: &Bound<PyAny>,
+        #[gen_stub(override_type(
+            type_repr = "attachments.AttachmentCodec[attachments.T]",
+            imports = ("ommx.experiment.attachments")
+        ))]
+        codec: &Bound<PyAny>,
+    ) -> Result<()> {
+        let _guard = crate::TRACING.attach_parent_context(py);
+        let media_type = codec_media_type(codec)?;
+        let bytes = codec_serialize(codec, value)?;
+        AttachmentLogger::log_attachment(&self.inner, name, MediaType::Other(media_type), bytes)
     }
 
     /// Attach a JSON-serializable value in the experiment space.
@@ -665,6 +721,32 @@ fn attachment_blob(
         }
     }
     registry.get_blob(descriptor)
+}
+
+fn codec_media_type(codec: &Bound<'_, PyAny>) -> Result<String> {
+    codec
+        .getattr("media_type")
+        .context("Attachment codec must define `media_type`")?
+        .extract()
+        .context("Attachment codec `media_type` must be a string")
+}
+
+fn codec_serialize(codec: &Bound<'_, PyAny>, value: &Bound<'_, PyAny>) -> Result<Vec<u8>> {
+    codec
+        .call_method1("serialize", (value,))
+        .context("Attachment codec `serialize(...)` failed")?
+        .extract()
+        .context("Attachment codec `serialize(...)` must return bytes")
+}
+
+fn codec_deserialize<'py>(
+    py: Python<'py>,
+    codec: &Bound<'py, PyAny>,
+    blob: &[u8],
+) -> Result<Bound<'py, PyAny>> {
+    codec
+        .call_method1("deserialize", (PyBytes::new(py, blob),))
+        .context("Attachment codec `deserialize(...)` failed")
 }
 
 fn decode_attachment<'py>(
@@ -974,6 +1056,38 @@ impl PyRun {
             name,
             MediaType::Other(media_type.to_string()),
             bytes.as_bytes(),
+        )
+    }
+
+    /// Serialize a Python object with an attachment codec and attach it in this run.
+    ///
+    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
+    /// `deserialize(bytes) -> object`. OMMX owns only this protocol; concrete
+    /// codecs should live in the package that owns the payload type.
+    pub fn log_with_codec(
+        &mut self,
+        py: Python<'_>,
+        name: &str,
+        #[gen_stub(override_type(
+            type_repr = "attachments.T",
+            imports = ("ommx.experiment.attachments")
+        ))]
+        value: &Bound<PyAny>,
+        #[gen_stub(override_type(
+            type_repr = "attachments.AttachmentCodec[attachments.T]",
+            imports = ("ommx.experiment.attachments")
+        ))]
+        codec: &Bound<PyAny>,
+    ) -> Result<()> {
+        let _guard = crate::TRACING.attach_parent_context(py);
+        self.ensure_store_trace_context_started()?;
+        let media_type = codec_media_type(codec)?;
+        let bytes = codec_serialize(codec, value)?;
+        AttachmentLogger::log_attachment(
+            self.as_open_mut()?,
+            name,
+            MediaType::Other(media_type),
+            bytes,
         )
     }
 
@@ -1410,6 +1524,36 @@ impl PySealedRun {
             py,
             &registry_handle.registry().get_blob(&descriptor)?,
         ))
+    }
+
+    /// Read a run-level attachment by name and deserialize it with a codec.
+    ///
+    /// The codec must provide `media_type`, `serialize(value) -> bytes`, and
+    /// `deserialize(bytes) -> object`. This method validates the stored media
+    /// type against the codec before deserializing.
+    #[gen_stub(override_return_type(
+        type_repr = "attachments.T",
+        imports = ("ommx.experiment.attachments")
+    ))]
+    pub fn get_with_codec<'py>(
+        &self,
+        py: Python<'py>,
+        name: &str,
+        #[gen_stub(override_type(
+            type_repr = "attachments.AttachmentCodec[attachments.T]",
+            imports = ("ommx.experiment.attachments")
+        ))]
+        codec: &Bound<'py, PyAny>,
+    ) -> Result<Bound<'py, PyAny>> {
+        let _guard = crate::TRACING.attach_parent_context(py);
+        let descriptor = self.find_attachment(name)?;
+        let registry_handle = self.run.registry_handle();
+        let blob = attachment_blob(
+            registry_handle.registry(),
+            &descriptor,
+            Some(&codec_media_type(codec)?),
+        )?;
+        codec_deserialize(py, codec, &blob)
     }
 
     #[getter]

--- a/python/ommx/src/experiment.rs
+++ b/python/ommx/src/experiment.rs
@@ -485,7 +485,7 @@ impl PyExperiment {
         value: AttachmentPayload,
     ) -> Result<()> {
         let _guard = crate::TRACING.attach_parent_context(py);
-        let attachment = codec.encode_attachment(py, &value)?;
+        let attachment = codec.encode(py, &value)?;
         AttachmentLogger::log_attachment(&self.inner, name, attachment.media_type, attachment.bytes)
     }
 
@@ -718,13 +718,20 @@ impl AttachmentCodecInput {
             .context("Attachment codec `media_type` must be a string")
     }
 
-    fn encode(&self, py: Python<'_>, value: &Bound<'_, PyAny>) -> Result<Vec<u8>> {
-        self.0
+    fn encode(&self, py: Python<'_>, value: &AttachmentPayload) -> Result<EncodedAttachment> {
+        let media_type = self.media_type(py)?;
+        let value = value.0.bind(py);
+        let bytes = self
+            .0
             .bind(py)
             .call_method1("encode", (value,))
             .context("Attachment codec `encode(...)` failed")?
             .extract()
-            .context("Attachment codec `encode(...)` must return bytes")
+            .context("Attachment codec `encode(...)` must return bytes")?;
+        Ok(EncodedAttachment {
+            media_type: MediaType::Other(media_type),
+            bytes,
+        })
     }
 
     fn decode(&self, py: Python<'_>, blob: &[u8]) -> Result<AttachmentPayload> {
@@ -734,19 +741,6 @@ impl AttachmentCodecInput {
             .call_method1("decode", (PyBytes::new(py, blob),))
             .context("Attachment codec `decode(...)` failed")?;
         Ok(AttachmentPayload(value.unbind()))
-    }
-
-    fn encode_attachment(
-        &self,
-        py: Python<'_>,
-        value: &AttachmentPayload,
-    ) -> Result<EncodedAttachment> {
-        let media_type = self.media_type(py)?;
-        let bytes = self.encode(py, &value.0.bind(py))?;
-        Ok(EncodedAttachment {
-            media_type: MediaType::Other(media_type),
-            bytes,
-        })
     }
 }
 
@@ -1142,7 +1136,7 @@ impl PyRun {
     ) -> Result<()> {
         let _guard = crate::TRACING.attach_parent_context(py);
         self.ensure_store_trace_context_started()?;
-        let attachment = codec.encode_attachment(py, &value)?;
+        let attachment = codec.encode(py, &value)?;
         AttachmentLogger::log_attachment(
             self.as_open_mut()?,
             name,

--- a/python/ommx/src/experiment.rs
+++ b/python/ommx/src/experiment.rs
@@ -397,12 +397,7 @@ impl PyExperiment {
         let _guard = crate::TRACING.attach_parent_context(py);
         let descriptor = self.find_attachment(name)?;
         let registry_handle = self.inner.registry_handle();
-        let blob = attachment_blob(
-            registry_handle.registry(),
-            &descriptor,
-            Some(&codec.media_type(py)?),
-        )?;
-        codec.decode(py, &blob)
+        codec.decode_from_descriptor(py, registry_handle.registry(), &descriptor)
     }
 
     #[getter]
@@ -467,7 +462,7 @@ impl PyExperiment {
         AttachmentLogger::log_attachment(
             &self.inner,
             name,
-            MediaType::Other(media_type.to_string()),
+            MediaType::from(media_type),
             bytes.as_bytes(),
         )
     }
@@ -499,7 +494,7 @@ impl PyExperiment {
         AttachmentLogger::log_attachment(
             &self.inner,
             name,
-            MediaType::Other("application/json".to_string()),
+            MediaType::from("application/json"),
             blob,
         )
     }
@@ -692,30 +687,18 @@ fn attachment_annotations(descriptor: &Descriptor) -> std::collections::HashMap<
         .unwrap_or_default()
 }
 
-fn attachment_blob(
-    registry: &LocalRegistry,
-    descriptor: &StoredDescriptor<'_>,
-    expected_media_type: Option<&str>,
-) -> Result<Vec<u8>> {
-    if let Some(expected) = expected_media_type {
-        let actual = descriptor.media_type().to_string();
-        if actual != expected {
-            anyhow::bail!("Expected media type '{expected}', got '{actual}'");
-        }
-    }
-    registry.get_blob(descriptor)
-}
-
 pub struct AttachmentCodecInput(Py<PyType>);
 
 impl AttachmentCodecInput {
-    fn media_type(&self, py: Python<'_>) -> Result<String> {
-        self.0
+    fn media_type(&self, py: Python<'_>) -> Result<MediaType> {
+        let media_type: String = self
+            .0
             .bind(py)
             .getattr("media_type")
             .context("Attachment codec class must define `media_type`")?
             .extract()
-            .context("Attachment codec `media_type` must be a string")
+            .context("Attachment codec `media_type` must be a string")?;
+        Ok(MediaType::from(media_type.as_str()))
     }
 
     fn encode(&self, py: Python<'_>, value: &AttachmentPayload) -> Result<EncodedAttachment> {
@@ -728,10 +711,7 @@ impl AttachmentCodecInput {
             .context("Attachment codec `encode(...)` failed")?
             .extract()
             .context("Attachment codec `encode(...)` must return bytes")?;
-        Ok(EncodedAttachment {
-            media_type: MediaType::Other(media_type),
-            bytes,
-        })
+        Ok(EncodedAttachment { media_type, bytes })
     }
 
     fn decode(&self, py: Python<'_>, blob: &[u8]) -> Result<AttachmentPayload> {
@@ -741,6 +721,18 @@ impl AttachmentCodecInput {
             .call_method1("decode", (PyBytes::new(py, blob),))
             .context("Attachment codec `decode(...)` failed")?;
         Ok(AttachmentPayload(value.unbind()))
+    }
+
+    fn decode_from_descriptor(
+        &self,
+        py: Python<'_>,
+        registry: &LocalRegistry,
+        descriptor: &StoredDescriptor<'_>,
+    ) -> Result<AttachmentPayload> {
+        let expected = self.media_type(py)?;
+        descriptor.ensure_media_type(&expected)?;
+        let blob = registry.get_blob(descriptor)?;
+        self.decode(py, &blob)
     }
 }
 
@@ -851,7 +843,7 @@ fn decode_attachment<'py>(
                 .unbind()
                 .into_bound(py))
         }
-        _ => Ok(PyBytes::new(py, &attachment_blob(registry, descriptor, None)?).into_any()),
+        _ => Ok(PyBytes::new(py, &registry.get_blob(descriptor)?).into_any()),
     }
 }
 
@@ -860,7 +852,9 @@ fn decode_json_attachment<'py>(
     registry: &LocalRegistry,
     descriptor: &StoredDescriptor<'_>,
 ) -> Result<Bound<'py, PyAny>> {
-    let blob = attachment_blob(registry, descriptor, Some("application/json"))?;
+    let expected = MediaType::from("application/json");
+    descriptor.ensure_media_type(&expected)?;
+    let blob = registry.get_blob(descriptor)?;
     let json = py.import("json")?;
     Ok(json.call_method1("loads", (PyBytes::new(py, &blob),))?)
 }
@@ -869,11 +863,9 @@ fn decode_instance_attachment(
     registry: &LocalRegistry,
     descriptor: &StoredDescriptor<'_>,
 ) -> Result<crate::Instance> {
-    let blob = attachment_blob(
-        registry,
-        descriptor,
-        Some(ommx::artifact::media_types::V1_INSTANCE_MEDIA_TYPE),
-    )?;
+    let expected = ommx::artifact::media_types::v1_instance();
+    descriptor.ensure_media_type(&expected)?;
+    let blob = registry.get_blob(descriptor)?;
     Ok(crate::Instance {
         inner: ommx::Instance::from_bytes(&blob)?,
         annotations: attachment_annotations(descriptor),
@@ -884,11 +876,9 @@ fn decode_parametric_instance_attachment(
     registry: &LocalRegistry,
     descriptor: &StoredDescriptor<'_>,
 ) -> Result<crate::ParametricInstance> {
-    let blob = attachment_blob(
-        registry,
-        descriptor,
-        Some(ommx::artifact::media_types::V1_PARAMETRIC_INSTANCE_MEDIA_TYPE),
-    )?;
+    let expected = ommx::artifact::media_types::v1_parametric_instance();
+    descriptor.ensure_media_type(&expected)?;
+    let blob = registry.get_blob(descriptor)?;
     Ok(crate::ParametricInstance {
         inner: ommx::ParametricInstance::from_bytes(&blob)?,
         annotations: attachment_annotations(descriptor),
@@ -899,11 +889,9 @@ fn decode_solution_attachment(
     registry: &LocalRegistry,
     descriptor: &StoredDescriptor<'_>,
 ) -> Result<crate::Solution> {
-    let blob = attachment_blob(
-        registry,
-        descriptor,
-        Some(ommx::artifact::media_types::V1_SOLUTION_MEDIA_TYPE),
-    )?;
+    let expected = ommx::artifact::media_types::v1_solution();
+    descriptor.ensure_media_type(&expected)?;
+    let blob = registry.get_blob(descriptor)?;
     Ok(crate::Solution {
         inner: ommx::Solution::from_bytes(&blob)?,
         annotations: attachment_annotations(descriptor),
@@ -914,11 +902,9 @@ fn decode_sample_set_attachment(
     registry: &LocalRegistry,
     descriptor: &StoredDescriptor<'_>,
 ) -> Result<crate::SampleSet> {
-    let blob = attachment_blob(
-        registry,
-        descriptor,
-        Some(ommx::artifact::media_types::V1_SAMPLE_SET_MEDIA_TYPE),
-    )?;
+    let expected = ommx::artifact::media_types::v1_sample_set();
+    descriptor.ensure_media_type(&expected)?;
+    let blob = registry.get_blob(descriptor)?;
     Ok(crate::SampleSet {
         inner: ommx::SampleSet::from_bytes(&blob)?,
         annotations: attachment_annotations(descriptor),
@@ -1117,7 +1103,7 @@ impl PyRun {
         AttachmentLogger::log_attachment(
             self.as_open_mut()?,
             name,
-            MediaType::Other(media_type.to_string()),
+            MediaType::from(media_type),
             bytes.as_bytes(),
         )
     }
@@ -1156,7 +1142,7 @@ impl PyRun {
         AttachmentLogger::log_attachment(
             self.as_open_mut()?,
             name,
-            MediaType::Other("application/json".to_string()),
+            MediaType::from("application/json"),
             blob,
         )
     }
@@ -1594,12 +1580,7 @@ impl PySealedRun {
         let _guard = crate::TRACING.attach_parent_context(py);
         let descriptor = self.find_attachment(name)?;
         let registry_handle = self.run.registry_handle();
-        let blob = attachment_blob(
-            registry_handle.registry(),
-            &descriptor,
-            Some(&codec.media_type(py)?),
-        )?;
-        codec.decode(py, &blob)
+        codec.decode_from_descriptor(py, registry_handle.registry(), &descriptor)
     }
 
     #[getter]

--- a/rust/ommx/src/artifact/local_registry/index.rs
+++ b/rust/ommx/src/artifact/local_registry/index.rs
@@ -505,17 +505,7 @@ fn parse_annotations_json(
 }
 
 fn media_type_from_string(media_type: String) -> MediaType {
-    if media_type == MediaType::ImageManifest.to_string() {
-        MediaType::ImageManifest
-    } else if media_type == MediaType::ImageIndex.to_string() {
-        MediaType::ImageIndex
-    } else if media_type == MediaType::EmptyJSON.to_string() {
-        MediaType::EmptyJSON
-    } else if media_type == MediaType::ArtifactManifest.to_string() {
-        MediaType::ArtifactManifest
-    } else {
-        MediaType::Other(media_type)
-    }
+    MediaType::from(media_type.as_str())
 }
 
 fn read_u64(row: &rusqlite::Row<'_>, idx: usize) -> rusqlite::Result<u64> {

--- a/rust/ommx/src/artifact/local_registry/registry.rs
+++ b/rust/ommx/src/artifact/local_registry/registry.rs
@@ -45,6 +45,17 @@ pub struct StoredDescriptor<'reg> {
 }
 
 impl StoredDescriptor<'_> {
+    /// Ensure this descriptor has the expected OCI media type before a typed
+    /// decoder reads its blob.
+    pub fn ensure_media_type(&self, expected: &MediaType) -> Result<()> {
+        let actual = self.media_type();
+        ensure!(
+            actual == expected,
+            "Expected media type '{expected}', got '{actual}'"
+        );
+        Ok(())
+    }
+
     /// Check registry-instance identity for crate-internal artifact handles.
     ///
     /// This is crate-visible because `LocalArtifact` and Experiment state live

--- a/rust/ommx/src/experiment/artifact.rs
+++ b/rust/ommx/src/experiment/artifact.rs
@@ -237,9 +237,5 @@ fn store_aggregate_json_layer<'reg>(
     media_type: &str,
     value: &impl serde::Serialize,
 ) -> Result<StoredDescriptor<'reg>> {
-    registry.store_json_layer_blob(
-        MediaType::Other(media_type.to_string()),
-        value,
-        Default::default(),
-    )
+    registry.store_json_layer_blob(MediaType::from(media_type), value, Default::default())
 }

--- a/rust/ommx/src/experiment/attachment.rs
+++ b/rust/ommx/src/experiment/attachment.rs
@@ -53,7 +53,7 @@ pub fn store_attachment_descriptor<'reg>(
 }
 
 pub fn json_media_type() -> MediaType {
-    MediaType::Other(JSON_MEDIA_TYPE.to_string())
+    MediaType::from(JSON_MEDIA_TYPE)
 }
 
 pub fn encode_json(name: &str, value: impl serde::Serialize) -> Result<Vec<u8>> {


### PR DESCRIPTION
## Summary
- Add a generic `AttachmentCodec[T]` protocol in `ommx.experiment.attachments` so owner packages can define the media type plus `encode` / `decode` pair for their payload types.
- Add codec-based attachment APIs on Experiment objects: `Experiment.log_with_codec`, `Experiment.get_with_codec`, `Run.log_with_codec`, and `SealedRun.get_with_codec`.
- Preserve typed Python stubs by routing codec classes through PyO3 wrapper types, with `type[AttachmentCodec[T]]` inputs and `T` payload/return types.
- Parse attachment media type strings through `oci_spec::image::MediaType` and validate stored descriptor media types before codec or typed attachment decoding.
- Update the Experiment tutorial in English and Japanese to show a temporary JijModeling `ProblemCodec`, with the long-term codec ownership remaining in JijModeling or other payload-owner packages.
- Add round-trip and media-type mismatch tests for experiment-level and run-level codec attachments, and regenerate the Python stub/API reference data.
