### PR TITLE
Strip Python wheels in CI builds

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           command: build
           args: >
+            --strip
             --out wheels
             -m python/ommx/Cargo.toml
       - name: Upload wheel

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -25,7 +25,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --strip --out dist --interpreter 3.10 3.13t 3.14t
+          args: --release --strip --out dist --interpreter 3.10 3.14t
           target: ${{ matrix.target }}
           working-directory: ./python/ommx
           manylinux: manylinux_2_28
@@ -47,7 +47,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --strip --out dist --interpreter 3.10 3.13t 3.14t
+          args: --release --strip --out dist --interpreter 3.10 3.14t
           working-directory: ./python/ommx
 
       - name: Upload wheels
@@ -66,13 +66,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.13t
+          python-version: "3.10"
           cache: "pip"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --strip --out dist --interpreter 3.10 3.13t
+          args: --release --strip --out dist --interpreter 3.10
           working-directory: ./python/ommx
 
       - name: Upload wheels

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -25,7 +25,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.10 3.13t 3.14t
+          args: --release --strip --out dist --interpreter 3.10 3.13t 3.14t
           target: ${{ matrix.target }}
           working-directory: ./python/ommx
           manylinux: manylinux_2_28
@@ -47,7 +47,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.10 3.13t 3.14t
+          args: --release --strip --out dist --interpreter 3.10 3.13t 3.14t
           working-directory: ./python/ommx
 
       - name: Upload wheels
@@ -72,7 +72,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.10 3.13t
+          args: --release --strip --out dist --interpreter 3.10 3.13t
           working-directory: ./python/ommx
 
       - name: Upload wheels

--- a/python/ommx-highs-adapter/pyproject.toml
+++ b/python/ommx-highs-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_highs_adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 description = "An adapter between OMMX and HiGHS"
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
 readme = "README.md"
@@ -19,7 +19,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
 ]
 
-dependencies = ["ommx >= 3.0.0a6, < 4.0.0","highspy>=1.9.0", "numpy>=1.17.3"]
+dependencies = ["ommx >= 3.0.0a7, < 4.0.0","highspy>=1.9.0", "numpy>=1.17.3"]
 
 [project.urls]
 Repository = "https://github.com/Jij-Inc/ommx"

--- a/python/ommx-openjij-adapter/pyproject.toml
+++ b/python/ommx-openjij-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_openjij_adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 
 description = "OMMX Adapter for OpenJij."
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
@@ -21,7 +21,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["ommx >= 3.0.0a6, < 4.0.0","openjij >= 0.9.2, < 1.0.0"]
+dependencies = ["ommx >= 3.0.0a7, < 4.0.0","openjij >= 0.9.2, < 1.0.0"]
 
 [project.urls]
 Repository = "https://github.com/Jij-Inc/ommx"

--- a/python/ommx-pyscipopt-adapter/pyproject.toml
+++ b/python/ommx-pyscipopt-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_pyscipopt_adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 description = "An adapter for the SCIP from OMMX."
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
 readme = "README.md"
@@ -18,7 +18,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["ommx >= 3.0.0a6, < 4.0.0","PySCIPOpt >= 6.0.0, < 7.0.0"]
+dependencies = ["ommx >= 3.0.0a7, < 4.0.0","PySCIPOpt >= 6.0.0, < 7.0.0"]
 
 [project.urls]
 Repository = "https://github.com/Jij-Inc/ommx"

--- a/python/ommx-python-mip-adapter/pyproject.toml
+++ b/python/ommx-python-mip-adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_python_mip_adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 
 description = "An adapter for the Python-MIP from/to OMMX."
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "ommx >= 3.0.0a6, < 4.0.0",
+  "ommx >= 3.0.0a7, < 4.0.0",
   "mip >= 1.17.0, < 2.0.0",
   "cffi >= 1.15.0, < 2.0.0",
 ]

--- a/python/ommx-tests/pyproject.toml
+++ b/python/ommx-tests/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ommx_tests"
-version = "3.0.0a6"
+version = "3.0.0a7"
 
 description = "Test suite for OMMX Python SDK"
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
@@ -23,7 +23,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
 ]
 
-dependencies = ["ommx >= 3.0.0a6, < 4.0.0","pluggy"]
+dependencies = ["ommx >= 3.0.0a7, < 4.0.0","pluggy"]
 
 [project.urls]
 Repository = "https://github.com/Jij-Inc/ommx"

--- a/python/ommx/pyproject.toml
+++ b/python/ommx/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "ommx"
 
-version = "3.0.0a6"
+version = "3.0.0a7"
 description = "Open Mathematical prograMming eXchange (OMMX)"
 authors = [{ name = "Jij Inc.", email = "info@j-ij.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2233,7 +2233,7 @@ wheels = [
 
 [[package]]
 name = "ommx"
-version = "3.0.0a6"
+version = "3.0.0a7"
 source = { editable = "python/ommx" }
 dependencies = [
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2266,7 +2266,7 @@ requires-dist = [
 
 [[package]]
 name = "ommx-highs-adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 source = { editable = "python/ommx-highs-adapter" }
 dependencies = [
     { name = "highspy" },
@@ -2284,7 +2284,7 @@ requires-dist = [
 
 [[package]]
 name = "ommx-openjij-adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 source = { editable = "python/ommx-openjij-adapter" }
 dependencies = [
     { name = "ommx" },
@@ -2299,7 +2299,7 @@ requires-dist = [
 
 [[package]]
 name = "ommx-pyscipopt-adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 source = { editable = "python/ommx-pyscipopt-adapter" }
 dependencies = [
     { name = "ommx" },
@@ -2314,7 +2314,7 @@ requires-dist = [
 
 [[package]]
 name = "ommx-python-mip-adapter"
-version = "3.0.0a6"
+version = "3.0.0a7"
 source = { editable = "python/ommx-python-mip-adapter" }
 dependencies = [
     { name = "cffi" },
@@ -2331,7 +2331,7 @@ requires-dist = [
 
 [[package]]
 name = "ommx-tests"
-version = "3.0.0a6"
+version = "3.0.0a7"
 source = { editable = "python/ommx-tests" }
 dependencies = [
     { name = "ommx" },


### PR DESCRIPTION
## Summary
- Add `--strip` to maturin wheel builds in the Python CI workflow.
- Apply the same stripped build setting to release wheel jobs for Linux, macOS, and Windows targets.
- Reduce shipped wheel size by omitting unneeded debug symbols from release artifacts.

## CI
- CI is the source of truth for the updated wheel build behavior.