### PR TITLE
Move decision variable state population to Instance

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -15904,6 +15904,60 @@
               "deprecated": null
             },
             {
+              "name": "populate_state",
+              "doc": "Populate fixed, irrelevant, and dependent decision variables in a state.\n\nThe input state must contain all decision variables that are actually used\nby this instance's objective and active constraints. The returned\n{class}`~ommx.v1.State` contains every decision variable in the instance.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "state",
+                      "type_": {
+                        "display": "ToState",
+                        "link_target": {
+                          "fqn": "ommx.v1.ToState",
+                          "doc_module": "ommx.v1",
+                          "kind": "Class",
+                          "attribute": null
+                        },
+                        "children": []
+                      },
+                      "default": null
+                    },
+                    {
+                      "name": "atol",
+                      "type_": {
+                        "display": "Optional[float]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "float",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "display": "State",
+                    "link_target": {
+                      "fqn": "ommx.v1.State",
+                      "doc_module": "ommx.v1",
+                      "kind": "Class",
+                      "attribute": null
+                    },
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
               "name": "random_samples",
               "doc": "Generate random samples for this instance.\n\nThe generated samples will contain ``num_samples`` sample entries divided into\n``num_different_samples`` groups, where each group shares the same state but has\ndifferent sample IDs.\n\n**Args:**\n- `rng`: Random number generator\n- `num_different_samples`: Number of different states to generate\n- `num_samples`: Total number of samples to generate\n- `max_sample_id`: Maximum sample ID (default: ``num_samples``)\n\n**Returns:**\nSamples object\n\n# Examples\n\nGenerate samples for a simple instance:\n\n```python\n>>> from ommx.v1 import Instance, DecisionVariable, Rng\n>>> x = [DecisionVariable.binary(i) for i in range(3)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints=[(sum(x) <= 2).set_id(0)],\n...     sense=Instance.MAXIMIZE,\n... )\n\n>>> rng = Rng()\n>>> samples = instance.random_samples(rng, num_different_samples=2, num_samples=5)\n>>> samples.num_samples()\n5\n```",
               "signatures": [

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -28,6 +28,27 @@ assert restored.get_user_annotation("owner") == "analytics"
 
 {class}`~ommx.v1.Solution` and {class}`~ommx.v1.SampleSet` also expose process metadata through `instance`, `solver`, `parameters`, `start`, and `end`; those fields round-trip through both protobuf bytes and Artifacts.
 
+### 🆕 `Instance.populate_state` for complete solver states ([#944](https://github.com/Jij-Inc/ommx/pull/944))
+
+{meth}`~ommx.v1.Instance.populate_state` is now exposed in the Python SDK. It validates a partial solver state against an Instance and returns a {class}`~ommx.v1.State` containing every decision variable by filling fixed variables, irrelevant variables, and dependent variables owned by the Instance.
+
+```python
+from ommx.v1 import DecisionVariable, Instance
+
+x = {i: DecisionVariable.continuous(i) for i in [1, 2, 5, 10, 99]}
+instance = Instance.from_components(
+    decision_variables=list(x.values()),
+    objective=x[1] + x[2],
+    constraints={},
+    sense=Instance.MINIMIZE,
+)
+instance.substitute({10: x[1] + x[2], 5: x[10] + 1})
+instance = instance.partial_evaluate({99: 4.0})
+
+state = instance.populate_state({1: 2.0, 2: 3.0})
+assert state.entries == {1: 2.0, 2: 3.0, 5: 6.0, 10: 5.0, 99: 4.0}
+```
+
 ## 3.0.0 Alpha 7
 
 [![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0a7-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0a7)

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -28,6 +28,27 @@ assert restored.get_user_annotation("owner") == "analytics"
 
 {class}`~ommx.v1.Solution` と {class}`~ommx.v1.SampleSet` では、process metadata を `instance`、`solver`、`parameters`、`start`、`end` から扱えます。これらの field も protobuf bytes と Artifact の両方で round-trip します。
 
+### 🆕 完全な solver state を作る `Instance.populate_state` ([#944](https://github.com/Jij-Inc/ommx/pull/944))
+
+{meth}`~ommx.v1.Instance.populate_state` を Python SDK から使えるようにしました。部分的な solver state を Instance に対して検証し、Instance が所有する固定変数、irrelevant な変数、dependent variable を補完して、すべての決定変数を含む {class}`~ommx.v1.State` を返します。
+
+```python
+from ommx.v1 import DecisionVariable, Instance
+
+x = {i: DecisionVariable.continuous(i) for i in [1, 2, 5, 10, 99]}
+instance = Instance.from_components(
+    decision_variables=list(x.values()),
+    objective=x[1] + x[2],
+    constraints={},
+    sense=Instance.MINIMIZE,
+)
+instance.substitute({10: x[1] + x[2], 5: x[10] + 1})
+instance = instance.partial_evaluate({99: 4.0})
+
+state = instance.populate_state({1: 2.0, 2: 3.0})
+assert state.entries == {1: 2.0, 2: 3.0, 5: 6.0, 10: 5.0, 99: 4.0}
+```
+
 ## 3.0.0 Alpha 7
 
 [![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0a7-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0a7)

--- a/python/ommx-tests/tests/__snapshots__/test_snapshot_print.ambr
+++ b/python/ommx-tests/tests/__snapshots__/test_snapshot_print.ambr
@@ -20,7 +20,7 @@
       Binary: 5, Integer: 0, Continuous: 0, Semi-Integer: 0, Semi-Continuous: 0
   
     Usage-based Partitioning:
-      Used: 3 (in objective: 2, in constraints: 3), Fixed: 1, Dependent: 0, Irrelevant: 1
+      Used: 3 (in objective: 2, in regular constraints: 3), Fixed: 1, Dependent: 0, Irrelevant: 1
   
     Binary Variables (5):
       x0: [0, 1]
@@ -32,7 +32,7 @@
     Used in Objective (2):
       x1, x2
   
-    Used in Constraints (2 constraints):
+    Used in Regular Constraints (2 constraints):
       0: x1, x2
       1: x1, x3
   

--- a/python/ommx-tests/tests/test_decision_variable_analysis.py
+++ b/python/ommx-tests/tests/test_decision_variable_analysis.py
@@ -106,3 +106,31 @@ def test_bound_wrapper_functionality():
     # Test string representations
     assert "0" in str(bound)
     assert "1" in str(bound)
+
+
+def test_instance_populate_state():
+    """Test that Instance owns state population for fixed/dependent variables."""
+    x = {i: DecisionVariable.continuous(i) for i in [1, 2, 5, 10, 99]}
+    instance = Instance.from_components(
+        decision_variables=list(x.values()),
+        objective=x[1] + x[2],
+        constraints={},
+        sense=Instance.MINIMIZE,
+    )
+    instance.substitute(
+        {
+            10: x[1] + x[2],
+            5: x[10] + 1,
+        }
+    )
+    instance = instance.partial_evaluate({99: 4.0})
+
+    populated = instance.populate_state({1: 2.0, 2: 3.0})
+
+    assert populated.entries == {
+        1: 2.0,
+        2: 3.0,
+        5: 6.0,
+        10: 5.0,
+        99: 4.0,
+    }

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -3198,6 +3198,16 @@ class Instance:
             ...
         ValueError: The state does not contain some required IDs: {VariableID(2)}
         """
+    def populate_state(
+        self, state: ToState, *, atol: typing.Optional[builtins.float] = None
+    ) -> State:
+        r"""
+        Populate fixed, irrelevant, and dependent decision variables in a state.
+
+        The input state must contain all decision variables that are actually used
+        by this instance's objective and active constraints. The returned
+        {class}`~ommx.v1.State` contains every decision variable in the instance.
+        """
     def partial_evaluate(
         self, state: ToState, *, atol: typing.Optional[builtins.float] = None
     ) -> Instance:

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -1080,6 +1080,31 @@ impl Instance {
         Ok(Solution { inner: solution })
     }
 
+    /// Populate fixed, irrelevant, and dependent decision variables in a state.
+    ///
+    /// The input state must contain all decision variables that are actually used
+    /// by this instance's objective and active constraints. The returned
+    /// {class}`~ommx.v1.State` contains every decision variable in the instance.
+    #[pyo3(signature = (state, *, atol=None))]
+    pub fn populate_state(
+        &self,
+        py: Python<'_>,
+        state: State,
+        atol: Option<f64>,
+    ) -> PyResult<State> {
+        let _guard = crate::TRACING.attach_parent_context(py);
+        let atol = match atol {
+            Some(value) => ommx::ATol::new(value)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?,
+            None => ommx::ATol::default(),
+        };
+        let state = self
+            .inner
+            .populate_state(state.0, atol)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(State(state))
+    }
+
     /// Creates a new instance with specific decision variables fixed to given values.
     ///
     /// This method substitutes the specified decision variables with their provided values,

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -147,6 +147,18 @@ impl Kind {
     }
 }
 
+fn ensure_finite_value(id: VariableID, value: f64) -> Result<(), DecisionVariableError> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(DecisionVariableError::NonFiniteValue { id, value })
+    }
+}
+
+fn values_are_consistent(left: f64, right: f64, atol: ATol) -> bool {
+    left.is_finite() && right.is_finite() && (left - right).abs() <= *atol
+}
+
 /// The decision variable's intrinsic data.
 ///
 /// Holds only `id`, `kind`, `bound`, and `substituted_value`. Auxiliary
@@ -280,6 +292,7 @@ impl DecisionVariable {
             substituted_value: value,
             atol,
         };
+        ensure_finite_value(self.id, value)?;
         if !self.bound.contains(value, atol) {
             return Err(err());
         }
@@ -341,8 +354,9 @@ impl DecisionVariable {
     }
 
     pub fn substitute(&mut self, new_value: f64, atol: ATol) -> Result<(), DecisionVariableError> {
+        ensure_finite_value(self.id, new_value)?;
         if let Some(previous_value) = self.substituted_value {
-            if (new_value - previous_value).abs() > atol {
+            if !values_are_consistent(new_value, previous_value, atol) {
                 return Err(DecisionVariableError::SubstitutedValueOverwrite {
                     id: self.id,
                     previous_value,
@@ -367,6 +381,9 @@ pub enum DecisionVariableError {
         kind: Kind,
         bound: Bound,
     },
+
+    #[error("Decision variable value for ID={id} must be finite: value={value}")]
+    NonFiniteValue { id: VariableID, value: f64 },
 
     #[error("Substituted value for ID={id} cannot be overwritten: previous={previous_value}, new={new_value}, atol={atol:?}")]
     SubstitutedValueOverwrite {
@@ -426,9 +443,11 @@ impl EvaluatedDecisionVariable {
         value: f64,
         atol: crate::ATol,
     ) -> Result<Self, DecisionVariableError> {
+        ensure_finite_value(decision_variable.id, value)?;
+
         // Check consistency with existing substituted_value if present
         if let Some(substituted_value) = decision_variable.substituted_value {
-            if (substituted_value - value).abs() > *atol {
+            if !values_are_consistent(substituted_value, value, atol) {
                 return Err(DecisionVariableError::SubstitutedValueOverwrite {
                     id: decision_variable.id,
                     previous_value: substituted_value,
@@ -451,6 +470,10 @@ impl EvaluatedDecisionVariable {
 
     /// Check if the value satisfies kind and bound constraints
     pub fn is_valid(&self, atol: crate::ATol) -> bool {
+        if !self.value.is_finite() {
+            return false;
+        }
+
         // Check bound
         if !self.bound.contains(self.value, atol) {
             return false;
@@ -491,11 +514,15 @@ impl SampledDecisionVariable {
         samples: Sampled<f64>,
         atol: crate::ATol,
     ) -> Result<Self, DecisionVariableError> {
+        for (_, &sample_value) in samples.iter() {
+            ensure_finite_value(decision_variable.id, sample_value)?;
+        }
+
         // Check consistency with existing substituted_value if present
         if let Some(substituted_value) = decision_variable.substituted_value {
             // Check that all sample values are consistent with substituted_value
             for (_, &sample_value) in samples.iter() {
-                if (substituted_value - sample_value).abs() > *atol {
+                if !values_are_consistent(substituted_value, sample_value, atol) {
                     return Err(DecisionVariableError::SubstitutedValueOverwrite {
                         id: decision_variable.id,
                         previous_value: substituted_value,
@@ -757,6 +784,43 @@ mod tests {
         assert!(matches!(
             result,
             Err(DecisionVariableError::EmptyBoundIntersection { .. })
+        ));
+    }
+
+    #[test]
+    fn test_decision_variable_rejects_non_finite_values() {
+        let id = VariableID::from(1);
+        let mut dv = DecisionVariable::continuous(id);
+
+        assert!(matches!(
+            dv.substitute(f64::NAN, ATol::default()),
+            Err(DecisionVariableError::NonFiniteValue { .. })
+        ));
+        assert!(matches!(
+            DecisionVariable::new(
+                id,
+                Kind::Continuous,
+                Bound::default(),
+                Some(f64::INFINITY),
+                ATol::default()
+            ),
+            Err(DecisionVariableError::NonFiniteValue { .. })
+        ));
+        assert!(matches!(
+            EvaluatedDecisionVariable::new(dv, f64::NEG_INFINITY, ATol::default()),
+            Err(DecisionVariableError::NonFiniteValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sampled_decision_variable_rejects_non_finite_values() {
+        let id = VariableID::from(1);
+        let dv = DecisionVariable::continuous(id);
+        let samples = Sampled::new([vec![crate::SampleID::from(0)]], [f64::NAN]).unwrap();
+
+        assert!(matches!(
+            SampledDecisionVariable::new(dv, samples, ATol::default()),
+            Err(DecisionVariableError::NonFiniteValue { .. })
         ));
     }
 

--- a/rust/ommx/src/instance/analysis.rs
+++ b/rust/ommx/src/instance/analysis.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{v1::State, ATol, AcyclicAssignments, Bound, Bounds, Evaluate, Kind, VariableIDSet};
+use crate::{Bound, Bounds, Evaluate, Kind, VariableIDSet};
 use std::collections::BTreeMap;
 
 /// The result of analyzing the decision variables in an instance.
@@ -14,22 +14,19 @@ use std::collections::BTreeMap;
 ///   variables and constraints, removed constraints or fixed variables which does not affect the
 ///   optimization problem itself.
 ///
-/// - Validating the state returned by solvers, and populating the variables which does not passed to the solvers.
-///   - The state by solvers is **valid** if:
-///     - It contains every [`Self::used`] decision variables. Other IDs are allowed as long as consistent with the population result.
-///     - The values for each decision variable are within the bounds.
-///   - [`Self::populate`] checks the state is valid, and populates the state as follows:
-///     - For [`Self::fixed`] ID, the fixed value is used.
-///     - For [`Self::irrelevant`] ID, [`Bound::nearest_to_zero`] is used as the value.
-///     - For [`Self::dependent`] ID, the value is evaluated from other IDs.
+/// This struct is only an analysis view. Validation and population of solver
+/// states is an [`Instance`] responsibility; use [`Instance::populate_state`].
 ///
 /// Invariants
 /// -----------
 /// - Every IDs are subset of [`Self::all`].
 /// - (kind-based partitioning) [`Self::binary`], [`Self::integer`], [`Self::continuous`], [`Self::semi_integer`], and [`Self::semi_continuous`]
 ///   are disjoint, and their union is equal to [`Self::all`].
-/// - (usage-based partitioning) The union of [`Self::used_in_objective`] and [`Self::used_in_constraints`] (= [`Self::used`]), [`Self::fixed`],
-///   and [`Self::dependent`] are disjoint each other. Remaining decision variables are [`Self::irrelevant`].
+/// - (usage-based partitioning) [`Self::used`], [`Self::fixed`], and
+///   [`Self::dependent`] are disjoint each other. Remaining decision variables
+///   are [`Self::irrelevant`]. [`Self::used`] includes IDs used in the objective
+///   or active constraints; [`Self::used_in_constraints`] is the regular
+///   constraint-level breakdown.
 #[derive(Debug, Clone, PartialEq, getset::Getters, serde::Serialize, serde::Deserialize)]
 pub struct DecisionVariableAnalysis {
     /// The IDs of all decision variables
@@ -56,10 +53,10 @@ pub struct DecisionVariableAnalysis {
     /// The set of decision variables that are used in the objective function.
     #[getset(get = "pub")]
     used_in_objective: VariableIDSet,
-    /// The set of decision variables that are used in the constraints.
+    /// The set of decision variables that are used in regular constraints.
     #[getset(get = "pub")]
     used_in_constraints: BTreeMap<ConstraintID, VariableIDSet>,
-    /// The set of decision variables that are used in the objective function or constraints.
+    /// The set of decision variables that are used in the objective function or active constraints.
     #[getset(get = "pub")]
     used: VariableIDSet,
     /// Fixed decision variables
@@ -118,102 +115,6 @@ impl DecisionVariableAnalysis {
             .map(|(id, bound)| (*id, *bound))
             .collect()
     }
-
-    /// Check the state is **valid**, and populate the state with the removed decision variables
-    ///
-    /// Post-condition
-    /// --------------
-    /// - The IDs of returned [`State`] are the same as [`Self::all`].
-    pub fn populate(&self, mut state: State, atol: ATol) -> crate::Result<State> {
-        let state_ids: VariableIDSet = state.entries.keys().map(|id| (*id).into()).collect();
-
-        // Check the IDs in the state are subset of all IDs
-        let unknown_ids: VariableIDSet = state_ids.difference(&self.all).cloned().collect();
-        if !unknown_ids.is_empty() {
-            crate::bail!(
-                { ?unknown_ids },
-                "state contains unknown variable IDs: {unknown_ids:?}",
-            );
-        }
-
-        // Check the state contains every used decision variables
-        let missing_ids: VariableIDSet = self.used().difference(&state_ids).cloned().collect();
-        if !missing_ids.is_empty() {
-            crate::bail!(
-                { ?missing_ids },
-                "state is missing required variable IDs: {missing_ids:?}",
-            );
-        }
-
-        // Note: Bound and kind checking is intentionally omitted here.
-        // These constraints will be validated as part of Solution::feasible() instead.
-
-        // Populate the state with fixed variables
-        for (id, value) in self.fixed() {
-            use std::collections::hash_map::Entry;
-            match state.entries.entry(id.into_inner()) {
-                Entry::Occupied(entry) => {
-                    if (entry.get() - value).abs() > atol {
-                        let state_value = *entry.get();
-                        let instance_value = *value;
-                        crate::bail!(
-                            { id = ?id, state_value, instance_value },
-                            "state value for variable {id:?} is inconsistent with instance (state={state_value}, instance={instance_value})",
-                        );
-                    }
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(*value);
-                }
-            }
-        }
-        // Populate the state with irrelevant variables
-        for (id, (kind, bound)) in self.irrelevant() {
-            use std::collections::hash_map::Entry;
-            match state.entries.entry(id.into_inner()) {
-                Entry::Occupied(_entry) => {
-                    // Value already exists, no need to check or modify
-                    // Note: Bound and kind checking is intentionally omitted here.
-                }
-                Entry::Vacant(entry) => {
-                    let value = match kind {
-                        Kind::Binary | Kind::Integer | Kind::Continuous => bound.nearest_to_zero(),
-                        Kind::SemiInteger | Kind::SemiContinuous => 0.0,
-                    };
-                    entry.insert(value);
-                }
-            }
-        }
-        // Populate the state with dependent variables in topological order.
-        // Emit the diagnostic context via tracing and propagate the original
-        // error unchanged, so callers can still
-        // `err.downcast_ref::<SubstitutionError>()` after propagation.
-        let acyclic = AcyclicAssignments::new(
-            self.dependent()
-                .iter()
-                .map(|(id, (_kind, _bound, f))| (*id, f.clone())),
-        )
-        .inspect_err(|e| {
-            tracing::error!(error = %e, "cyclic dependency among dependent variables");
-        })?;
-        for (id, f) in acyclic.evaluation_order_iter() {
-            let value = f.evaluate(&state, atol).inspect_err(|e| {
-                tracing::error!(?id, error = %e, "failed to evaluate dependent variable");
-            })?;
-            // Note: Bound and kind checking is intentionally omitted here.
-            // These constraints will be validated as part of Solution::feasible() instead.
-            if let Some(v) = state.entries.insert(id.into_inner(), value) {
-                if (v - value).abs() > atol {
-                    crate::bail!(
-                        { id = ?id, state_value = v, instance_value = value },
-                        "state value for variable {id:?} is inconsistent with instance (state={v}, instance={value})",
-                    );
-                }
-            }
-        }
-
-        Ok(state)
-    }
 }
 
 impl Instance {
@@ -232,12 +133,10 @@ impl Instance {
 
     pub fn used_decision_variable_ids(&self) -> VariableIDSet {
         let mut used = self.objective.required_ids();
-        for constraint in self.constraints().values() {
-            used.extend(constraint.function().required_ids());
-        }
-        for ic in self.indicator_constraints().values() {
-            used.extend(ic.required_ids());
-        }
+        used.extend(self.constraint_collection.required_ids());
+        used.extend(self.indicator_constraint_collection.required_ids());
+        used.extend(self.one_hot_constraint_collection.required_ids());
+        used.extend(self.sos1_constraint_collection.required_ids());
         // Note: named_functions are intentionally excluded from the "used" set.
         // They are auxiliary quantities that can reference fixed/dependent variables.
         used
@@ -291,12 +190,7 @@ impl Instance {
             used_in_constraints.insert(cid, required_ids);
         }
 
-        let mut used = used_in_objective.clone();
-        // Note: named_functions are intentionally excluded from the "used" set.
-        // They are auxiliary quantities that can reference fixed/dependent variables.
-        for ids in used_in_constraints.values() {
-            used.extend(ids);
-        }
+        let used = self.used_decision_variable_ids();
 
         let dependent: BTreeMap<VariableID, _> = self
             .decision_variable_dependency
@@ -374,7 +268,7 @@ impl std::fmt::Display for DecisionVariableAnalysis {
         // They are auxiliary quantities that can reference fixed/dependent/irrelevant variables.
         writeln!(
             f,
-            "    Used: {} (in objective: {}, in constraints: {}), Fixed: {}, Dependent: {}, Irrelevant: {}",
+            "    Used: {} (in objective: {}, in regular constraints: {}), Fixed: {}, Dependent: {}, Irrelevant: {}",
             self.used.len(),
             self.used_in_objective.len(),
             used_in_constraints_count,
@@ -445,7 +339,7 @@ impl std::fmt::Display for DecisionVariableAnalysis {
         if !self.used_in_constraints.is_empty() {
             writeln!(
                 f,
-                "\n  Used in Constraints ({} constraints):",
+                "\n  Used in Regular Constraints ({} constraints):",
                 self.used_in_constraints.len()
             )?;
             for (constraint_id, var_ids) in &self.used_in_constraints {
@@ -603,9 +497,8 @@ mod tests {
             .build()
             .unwrap();
 
-        let analysis = instance.analyze_decision_variables();
-
         // Verify x_5 and x_10 are both dependent
+        let analysis = instance.analyze_decision_variables();
         assert!(analysis.dependent().contains_key(&VariableID::from(5)));
         assert!(analysis.dependent().contains_key(&VariableID::from(10)));
 
@@ -615,7 +508,7 @@ mod tests {
         // This should succeed with topological sort:
         // 1. Evaluate x_10 = x_1 + x_2 = 2.0 + 3.0 = 5.0
         // 2. Evaluate x_5 = x_10 + 1 = 5.0 + 1.0 = 6.0
-        let populated = analysis.populate(state, ATol::default()).unwrap();
+        let populated = instance.populate_state(state, ATol::default()).unwrap();
 
         assert_eq!(populated.entries.get(&1), Some(&2.0));
         assert_eq!(populated.entries.get(&2), Some(&3.0));
@@ -674,10 +567,14 @@ mod tests {
             (instance, state) in Instance::arbitrary()
                 .prop_flat_map(move |instance| instance.arbitrary_state().prop_map(move |state| (instance.clone(), state)))
         ) {
-            let analysis = instance.analyze_decision_variables();
-            let populated = analysis.populate(state.clone(), ATol::default()).unwrap();
+            let populated = instance
+                .populate_state(state.clone(), crate::ATol::default())
+                .unwrap();
             let populated_ids: VariableIDSet = populated.entries.keys().map(|id| (*id).into()).collect();
-            prop_assert_eq!(populated_ids, analysis.all);
+            prop_assert_eq!(
+                populated_ids,
+                instance.decision_variables().keys().copied().collect()
+            );
         }
     }
 }

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -6,6 +6,30 @@ use crate::{
 };
 use std::collections::BTreeMap;
 
+fn ensure_state_value_is_finite(var_id: u64, value: f64) -> Result<()> {
+    if !value.is_finite() {
+        crate::bail!(
+            { var_id, value },
+            "state value for variable ID={var_id} must be finite (value={value})",
+        );
+    }
+    Ok(())
+}
+
+fn ensure_instance_value_is_finite(var_id: VariableID, value: f64) -> Result<()> {
+    if !value.is_finite() {
+        crate::bail!(
+            { var_id = ?var_id, value },
+            "instance value for variable {var_id:?} must be finite (value={value})",
+        );
+    }
+    Ok(())
+}
+
+fn values_are_consistent(left: f64, right: f64, atol: ATol) -> bool {
+    left.is_finite() && right.is_finite() && (left - right).abs() <= *atol
+}
+
 /// Merge additional variable fixings from propagation into `expanded` state.
 ///
 /// Returns `Err` if any fixing conflicts with an existing value in `expanded`
@@ -18,8 +42,10 @@ fn merge_state(
     changed: &mut bool,
 ) -> Result<()> {
     for (var_id, value) in additional.entries {
+        ensure_state_value_is_finite(var_id, value)?;
         if let Some(&existing) = expanded.entries.get(&var_id) {
-            if (existing - value).abs() > *atol {
+            ensure_state_value_is_finite(var_id, existing)?;
+            if !values_are_consistent(existing, value, atol) {
                 return Err(crate::error!(
                     "Conflicting variable fixings for ID={var_id}: \
                      existing={existing}, new={value}"
@@ -62,13 +88,18 @@ impl StatePopulationPlan<'_> {
             );
         }
 
+        for (&id, &value) in &state.entries {
+            ensure_state_value_is_finite(id, value)?;
+        }
+
         // Bound and kind checking is intentionally left to Solution::feasible().
         for (id, value) in &self.fixed {
+            ensure_instance_value_is_finite(*id, *value)?;
             use std::collections::hash_map::Entry;
             match state.entries.entry(id.into_inner()) {
                 Entry::Occupied(entry) => {
-                    if (entry.get() - value).abs() > atol {
-                        let state_value = *entry.get();
+                    let state_value = *entry.get();
+                    if !values_are_consistent(state_value, *value, atol) {
                         let instance_value = *value;
                         crate::bail!(
                             { id = ?id, state_value, instance_value },
@@ -100,12 +131,25 @@ impl StatePopulationPlan<'_> {
             let value = f.evaluate(&state, atol).inspect_err(|e| {
                 tracing::error!(?id, error = %e, "failed to evaluate dependent variable");
             })?;
-            if let Some(v) = state.entries.insert(id.into_inner(), value) {
-                if (v - value).abs() > atol {
-                    crate::bail!(
-                        { id = ?id, state_value = v, instance_value = value },
-                        "state value for variable {id:?} is inconsistent with instance (state={v}, instance={value})",
-                    );
+            if !value.is_finite() {
+                crate::bail!(
+                    { id = ?id, value },
+                    "dependent variable {id:?} evaluated to non-finite value: {value}",
+                );
+            }
+            use std::collections::hash_map::Entry;
+            match state.entries.entry(id.into_inner()) {
+                Entry::Occupied(entry) => {
+                    let state_value = *entry.get();
+                    if !values_are_consistent(state_value, value, atol) {
+                        crate::bail!(
+                            { id = ?id, state_value, instance_value = value },
+                            "state value for variable {id:?} is inconsistent with instance (state={state_value}, instance={value})",
+                        );
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(value);
                 }
             }
         }
@@ -470,6 +514,86 @@ mod tests {
             let s2 = instance.evaluate(&v, ATol::default()).unwrap();
             prop_assert!(s1.state().abs_diff_eq(&s2.state(), ATol::default()));
         }
+    }
+
+    #[test]
+    fn test_populate_state_rejects_non_finite_fixed_value_from_state() {
+        let mut x2 = crate::DecisionVariable::continuous(VariableID::from(2));
+        x2.substitute(3.0, ATol::default()).unwrap();
+        let decision_variables = BTreeMap::from([
+            (
+                VariableID::from(1),
+                crate::DecisionVariable::continuous(VariableID::from(1)),
+            ),
+            (VariableID::from(2), x2),
+        ]);
+        let instance = Instance::new(
+            Sense::Minimize,
+            Function::from(linear!(1)),
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let state = v1::State::from(HashMap::from([(1, 1.0), (2, f64::NAN)]));
+
+        let err = instance.populate_state(state, ATol::default()).unwrap_err();
+        assert!(err.to_string().contains("must be finite"));
+    }
+
+    #[test]
+    fn test_populate_state_rejects_non_finite_existing_dependent_value() {
+        let decision_variables = BTreeMap::from([
+            (
+                VariableID::from(1),
+                crate::DecisionVariable::continuous(VariableID::from(1)),
+            ),
+            (
+                VariableID::from(10),
+                crate::DecisionVariable::continuous(VariableID::from(10)),
+            ),
+        ]);
+        let mut instance = Instance::new(
+            Sense::Minimize,
+            Function::from(linear!(1)),
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+        instance.decision_variable_dependency = crate::assign! {
+            10 <- linear!(1)
+        };
+        let state = v1::State::from(HashMap::from([(1, 1.0), (10, f64::INFINITY)]));
+
+        let err = instance.populate_state(state, ATol::default()).unwrap_err();
+        assert!(err.to_string().contains("must be finite"));
+    }
+
+    #[test]
+    fn test_populate_state_rejects_non_finite_dependent_evaluation() {
+        let decision_variables = BTreeMap::from([
+            (
+                VariableID::from(1),
+                crate::DecisionVariable::continuous(VariableID::from(1)),
+            ),
+            (
+                VariableID::from(10),
+                crate::DecisionVariable::continuous(VariableID::from(10)),
+            ),
+        ]);
+        let mut instance = Instance::new(
+            Sense::Minimize,
+            Function::from(linear!(1)),
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+        instance.decision_variable_dependency = crate::assign! {
+            10 <- coeff!(f64::MAX) * linear!(1)
+        };
+        let state = v1::State::from(HashMap::from([(1, f64::MAX)]));
+
+        let err = instance.populate_state(state, ATol::default()).unwrap_err();
+        assert!(err.to_string().contains("evaluated to non-finite value"));
     }
 
     /// Test that named functions can reference fixed, dependent, and irrelevant variables

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::Result;
 use crate::{
-    constraint::RemovedReason, ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet,
+    constraint::RemovedReason, ATol, Bound, Evaluate, Kind, Propagate, PropagateOutcome,
+    VariableIDSet,
 };
 use std::collections::BTreeMap;
 
@@ -33,15 +34,138 @@ fn merge_state(
     Ok(())
 }
 
+struct StatePopulationPlan<'a> {
+    all: VariableIDSet,
+    used: VariableIDSet,
+    fixed: Vec<(VariableID, f64)>,
+    irrelevant: Vec<(VariableID, Kind, Bound)>,
+    dependency: &'a AcyclicAssignments,
+}
+
+impl StatePopulationPlan<'_> {
+    fn populate(&self, mut state: v1::State, atol: ATol) -> Result<v1::State> {
+        let state_ids: VariableIDSet = state.entries.keys().map(|id| (*id).into()).collect();
+
+        let unknown_ids: VariableIDSet = state_ids.difference(&self.all).cloned().collect();
+        if !unknown_ids.is_empty() {
+            crate::bail!(
+                { ?unknown_ids },
+                "state contains unknown variable IDs: {unknown_ids:?}",
+            );
+        }
+
+        let missing_ids: VariableIDSet = self.used.difference(&state_ids).cloned().collect();
+        if !missing_ids.is_empty() {
+            crate::bail!(
+                { ?missing_ids },
+                "state is missing required variable IDs: {missing_ids:?}",
+            );
+        }
+
+        // Bound and kind checking is intentionally left to Solution::feasible().
+        for (id, value) in &self.fixed {
+            use std::collections::hash_map::Entry;
+            match state.entries.entry(id.into_inner()) {
+                Entry::Occupied(entry) => {
+                    if (entry.get() - value).abs() > atol {
+                        let state_value = *entry.get();
+                        let instance_value = *value;
+                        crate::bail!(
+                            { id = ?id, state_value, instance_value },
+                            "state value for variable {id:?} is inconsistent with instance (state={state_value}, instance={instance_value})",
+                        );
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(*value);
+                }
+            }
+        }
+
+        for (id, kind, bound) in &self.irrelevant {
+            use std::collections::hash_map::Entry;
+            match state.entries.entry(id.into_inner()) {
+                Entry::Occupied(_entry) => {}
+                Entry::Vacant(entry) => {
+                    let value = match kind {
+                        Kind::Binary | Kind::Integer | Kind::Continuous => bound.nearest_to_zero(),
+                        Kind::SemiInteger | Kind::SemiContinuous => 0.0,
+                    };
+                    entry.insert(value);
+                }
+            }
+        }
+
+        for (id, f) in self.dependency.evaluation_order_iter() {
+            let value = f.evaluate(&state, atol).inspect_err(|e| {
+                tracing::error!(?id, error = %e, "failed to evaluate dependent variable");
+            })?;
+            if let Some(v) = state.entries.insert(id.into_inner(), value) {
+                if (v - value).abs() > atol {
+                    crate::bail!(
+                        { id = ?id, state_value = v, instance_value = value },
+                        "state value for variable {id:?} is inconsistent with instance (state={v}, instance={value})",
+                    );
+                }
+            }
+        }
+
+        Ok(state)
+    }
+}
+
+impl Instance {
+    fn state_population_plan(&self) -> StatePopulationPlan<'_> {
+        let all: VariableIDSet = self.decision_variables.keys().copied().collect();
+        let used = self.used_decision_variable_ids();
+
+        let fixed: Vec<_> = self
+            .decision_variables
+            .iter()
+            .filter_map(|(id, dv)| dv.substituted_value().map(|value| (*id, value)))
+            .collect();
+        let fixed_ids: VariableIDSet = fixed.iter().map(|(id, _)| *id).collect();
+        let dependent_ids: VariableIDSet = self.decision_variable_dependency.keys().collect();
+        let relevant: VariableIDSet = used
+            .iter()
+            .chain(fixed_ids.iter())
+            .chain(dependent_ids.iter())
+            .copied()
+            .collect();
+
+        let irrelevant = self
+            .decision_variables
+            .iter()
+            .filter(|(id, _)| !relevant.contains(id))
+            .map(|(id, dv)| (*id, dv.kind(), dv.bound()))
+            .collect();
+
+        StatePopulationPlan {
+            all,
+            used,
+            fixed,
+            irrelevant,
+            dependency: &self.decision_variable_dependency,
+        }
+    }
+
+    /// Check the state is valid for this instance and populate fixed,
+    /// irrelevant, and dependent decision variables.
+    ///
+    /// Post-condition: the returned state contains exactly this instance's
+    /// decision-variable IDs.
+    pub fn populate_state(&self, state: v1::State, atol: ATol) -> Result<v1::State> {
+        self.state_population_plan().populate(state, atol)
+    }
+}
+
 impl Evaluate for Instance {
     type Output = crate::Solution;
     type SampledOutput = crate::SampleSet;
 
     #[tracing::instrument(skip_all)]
     fn evaluate(&self, state: &v1::State, atol: ATol) -> Result<Self::Output> {
-        let state = self
-            .analyze_decision_variables()
-            .populate(state.clone(), atol)?;
+        let state = self.populate_state(state.clone(), atol)?;
 
         let objective = self.objective.evaluate(&state, atol)?;
         let evaluated_constraints = self.constraint_collection.evaluate(&state, atol)?;
@@ -93,11 +217,11 @@ impl Evaluate for Instance {
     ) -> Result<Self::SampledOutput> {
         // Populate the decision variables in the samples
         let samples = {
-            let analysis = self.analyze_decision_variables();
+            let population = self.state_population_plan();
             let mut samples = samples.clone();
             for state in samples.iter_mut() {
                 let taken = std::mem::take(state);
-                *state = analysis.populate(taken, atol)?;
+                *state = population.populate(taken, atol)?;
             }
             samples
         };
@@ -191,7 +315,7 @@ impl Evaluate for Instance {
     }
 
     fn required_ids(&self) -> VariableIDSet {
-        self.analyze_decision_variables().used().clone()
+        self.used_decision_variable_ids()
     }
 }
 

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -165,6 +165,7 @@ mod tests {
         Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24
         Instance.decision_variable_dependency;AcyclicAssignments.assignments;FnvHashMap[stack] 32
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
+        Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.description;Option[stack] 168
         Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[stack] 24
@@ -234,6 +235,7 @@ mod tests {
         Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24
         Instance.decision_variable_dependency;AcyclicAssignments.assignments;FnvHashMap[stack] 32
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
+        Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;BTreeMap[key] 16
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 32
@@ -321,6 +323,7 @@ mod tests {
         Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24
         Instance.decision_variable_dependency;AcyclicAssignments.assignments;FnvHashMap[stack] 32
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
+        Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;BTreeMap[key] 16
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 32
@@ -402,6 +405,7 @@ mod tests {
         Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24
         Instance.decision_variable_dependency;AcyclicAssignments.assignments;FnvHashMap[stack] 32
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
+        Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;BTreeMap[key] 24
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 48
@@ -493,6 +497,7 @@ mod tests {
         Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24
         Instance.decision_variable_dependency;AcyclicAssignments.assignments;FnvHashMap[stack] 32
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
+        Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;BTreeMap[key] 8
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 16

--- a/rust/ommx/src/instance/snapshots/ommx__instance__analysis__tests__decision_variable_analysis_display.snap
+++ b/rust/ommx/src/instance/snapshots/ommx__instance__analysis__tests__decision_variable_analysis_display.snap
@@ -9,7 +9,7 @@ DecisionVariableAnalysis {
     Binary: 5, Integer: 0, Continuous: 0, Semi-Integer: 0, Semi-Continuous: 0
 
   Usage-based Partitioning:
-    Used: 3 (in objective: 2, in constraints: 3), Fixed: 1, Dependent: 1, Irrelevant: 1
+    Used: 3 (in objective: 2, in regular constraints: 3), Fixed: 1, Dependent: 1, Irrelevant: 1
 
   Binary Variables (5):
     x0: [0, 1]
@@ -21,7 +21,7 @@ DecisionVariableAnalysis {
   Used in Objective (2):
     x1, x2
 
-  Used in Constraints (2 constraints):
+  Used in Regular Constraints (2 constraints):
     0: x1, x2
     1: x0
 

--- a/rust/ommx/src/sos1_constraint/evaluate.rs
+++ b/rust/ommx/src/sos1_constraint/evaluate.rs
@@ -1,6 +1,18 @@
 use super::*;
 use crate::{ATol, Evaluate, Propagate, PropagateOutcome, VariableIDSet};
 
+fn ensure_sos1_value_is_finite(var_id: VariableID, value: f64) -> crate::Result<()> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        crate::bail!(
+            "Variable {:?} in SOS1 constraint must be finite (value={})",
+            var_id,
+            value
+        );
+    }
+}
+
 impl Propagate for Sos1Constraint<Created> {
     type Transformed = std::convert::Infallible;
 
@@ -18,6 +30,7 @@ impl Propagate for Sos1Constraint<Created> {
                 continue;
             };
 
+            ensure_sos1_value_is_finite(var_id, value)?;
             if value.abs() < *atol {
                 // Variable is ~0, removed from set
             } else {
@@ -134,6 +147,7 @@ fn check_sos1(
             )
         })?;
 
+        ensure_sos1_value_is_finite(var_id, *value)?;
         if value.abs() >= *atol {
             // Variable is non-zero
             if active.is_some() {
@@ -187,6 +201,15 @@ mod tests {
         let result = c.evaluate(&state, ATol::default()).unwrap();
         assert!(!result.stage.feasible);
         assert_eq!(result.stage.active_variable, None);
+    }
+
+    #[test]
+    fn test_evaluate_rejects_non_finite_value() {
+        let c = make_sos1(1, &[1, 2, 3]);
+        let state = crate::v1::State::from(HashMap::from([(1, f64::NAN), (2, 0.0), (3, 0.0)]));
+
+        let err = c.evaluate(&state, ATol::default()).unwrap_err();
+        assert!(err.to_string().contains("must be finite"));
     }
 
     #[test]
@@ -309,6 +332,15 @@ mod tests {
         let state = crate::v1::State::from(HashMap::from([(1, 1.0), (2, 2.0)]));
         let result = c.propagate(&state, ATol::default());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_propagate_rejects_non_finite_value() {
+        let c = make_sos1(1, &[1, 2, 3]);
+        let state = crate::v1::State::from(HashMap::from([(1, f64::INFINITY)]));
+
+        let err = c.propagate(&state, ATol::default()).unwrap_err();
+        assert!(err.to_string().contains("must be finite"));
     }
 
     #[test]

--- a/rust/ommx/src/substitute/assignments/logical_memory.rs
+++ b/rust/ommx/src/substitute/assignments/logical_memory.rs
@@ -61,7 +61,7 @@ mod tests {
         AcyclicAssignments.assignments;FnvHashMap[stack] 32
         AcyclicAssignments.assignments;Linear;PolynomialBase.terms 160
         AcyclicAssignments.dependency 224
-        AcyclicAssignments.topological_order 32
+        AcyclicAssignments.topological_order 16
         AcyclicAssignments.topological_order;Vec[stack] 24
         "###);
     }

--- a/rust/ommx/src/substitute/assignments/logical_memory.rs
+++ b/rust/ommx/src/substitute/assignments/logical_memory.rs
@@ -20,6 +20,11 @@ impl LogicalMemoryProfile for AcyclicAssignments {
         let edge_bytes = self.dependency.edge_count() * (size_of::<crate::VariableID>() * 2);
         let total_bytes = graph_overhead + node_bytes + edge_bytes;
         visitor.visit_leaf(&path.with("AcyclicAssignments.dependency"), total_bytes);
+
+        self.topological_order.visit_logical_memory(
+            path.with("AcyclicAssignments.topological_order").as_mut(),
+            visitor,
+        );
     }
 }
 
@@ -37,6 +42,7 @@ mod tests {
         insta::assert_snapshot!(folded, @r###"
         AcyclicAssignments.assignments;FnvHashMap[stack] 32
         AcyclicAssignments.dependency 144
+        AcyclicAssignments.topological_order;Vec[stack] 24
         "###);
     }
 
@@ -55,6 +61,8 @@ mod tests {
         AcyclicAssignments.assignments;FnvHashMap[stack] 32
         AcyclicAssignments.assignments;Linear;PolynomialBase.terms 160
         AcyclicAssignments.dependency 224
+        AcyclicAssignments.topological_order 32
+        AcyclicAssignments.topological_order;Vec[stack] 24
         "###);
     }
 }

--- a/rust/ommx/src/substitute/assignments/mod.rs
+++ b/rust/ommx/src/substitute/assignments/mod.rs
@@ -17,6 +17,8 @@ pub struct AcyclicAssignments {
     assignments: FnvHashMap<VariableID, Function>,
     // The directed graph representing dependencies between assignments, assigned -> required.
     dependency: DiGraphMap<VariableID, ()>,
+    // Topological order of `dependency`, cached at construction time.
+    topological_order: Vec<VariableID>,
 }
 
 impl AcyclicAssignments {
@@ -45,14 +47,13 @@ impl AcyclicAssignments {
             }
         }
 
-        // Check if the dependency graph is acyclic
-        if algo::is_cyclic_directed(&dependency) {
-            return Err(SubstitutionError::CyclicAssignmentDetected);
-        }
+        let topological_order = algo::toposort(&dependency, None)
+            .map_err(|_| SubstitutionError::CyclicAssignmentDetected)?;
 
         Ok(Self {
             assignments,
             dependency,
+            topological_order,
         })
     }
 
@@ -70,10 +71,6 @@ impl AcyclicAssignments {
 
     pub fn iter(&self) -> impl Iterator<Item = (&VariableID, &Function)> {
         self.assignments.iter()
-    }
-
-    fn sorted_ids(&self) -> Vec<VariableID> {
-        algo::toposort(&self.dependency, None).expect("Graph should be acyclic by construction")
     }
 
     /// Get the assignments in substitution order (variables that need to be replaced first).
@@ -97,8 +94,9 @@ impl AcyclicAssignments {
     /// assert_eq!(order, vec![4, 1]);
     /// ```
     pub fn substitution_order_iter(&self) -> impl Iterator<Item = (VariableID, &Function)> {
-        self.sorted_ids()
-            .into_iter()
+        self.topological_order
+            .iter()
+            .copied()
             .filter_map(move |var_id| self.assignments.get(&var_id).map(|linear| (var_id, linear)))
     }
 
@@ -132,8 +130,9 @@ impl AcyclicAssignments {
     /// assert_eq!(result.entries[&4], 5.0);
     /// ```
     pub fn evaluation_order_iter(&self) -> impl Iterator<Item = (VariableID, &Function)> {
-        self.sorted_ids()
-            .into_iter()
+        self.topological_order
+            .iter()
+            .copied()
             .rev()
             .filter_map(move |var_id| self.assignments.get(&var_id).map(|linear| (var_id, linear)))
     }

--- a/rust/ommx/src/substitute/assignments/mod.rs
+++ b/rust/ommx/src/substitute/assignments/mod.rs
@@ -78,8 +78,8 @@ impl AcyclicAssignments {
 
     /// Get the assignments in substitution order (variables that need to be replaced first).
     ///
-    /// This order is used when performing substitution operations where variables
-    /// that are depended upon by others should be substituted first.
+    /// This order is used when performing substitution operations where assigned
+    /// variables that depend on other assigned variables are substituted first.
     ///
     /// # Example
     ///
@@ -226,7 +226,8 @@ impl Evaluate for AcyclicAssignments {
     fn evaluate(&self, state: &State, atol: ATol) -> crate::Result<Self::Output> {
         let mut extended_state = state.clone();
 
-        // Evaluate assignments in topological order
+        // Evaluate assignments in dependency-first order, the reverse of the dependency graph's
+        // topological order.
         //
         // When the assignment is x1 <- x2 + x3, x4 <- x1 + 2, and state is {x2: 1, x3: 2},
         // we first evaluate x1 = 3, then x4 = 5. Finally returns extended state {x1: 3, x2: 1, x3: 2, x4: 5}.

--- a/rust/ommx/src/substitute/assignments/mod.rs
+++ b/rust/ommx/src/substitute/assignments/mod.rs
@@ -48,7 +48,10 @@ impl AcyclicAssignments {
         }
 
         let topological_order = algo::toposort(&dependency, None)
-            .map_err(|_| SubstitutionError::CyclicAssignmentDetected)?;
+            .map_err(|_| SubstitutionError::CyclicAssignmentDetected)?
+            .into_iter()
+            .filter(|var_id| assignments.contains_key(var_id))
+            .collect();
 
         Ok(Self {
             assignments,
@@ -94,10 +97,13 @@ impl AcyclicAssignments {
     /// assert_eq!(order, vec![4, 1]);
     /// ```
     pub fn substitution_order_iter(&self) -> impl Iterator<Item = (VariableID, &Function)> {
-        self.topological_order
-            .iter()
-            .copied()
-            .filter_map(move |var_id| self.assignments.get(&var_id).map(|linear| (var_id, linear)))
+        self.topological_order.iter().copied().map(move |var_id| {
+            let function = self
+                .assignments
+                .get(&var_id)
+                .expect("topological_order only contains assigned variables");
+            (var_id, function)
+        })
     }
 
     /// Get the assignments in evaluation order (variables that should be evaluated first).
@@ -134,7 +140,13 @@ impl AcyclicAssignments {
             .iter()
             .copied()
             .rev()
-            .filter_map(move |var_id| self.assignments.get(&var_id).map(|linear| (var_id, linear)))
+            .map(move |var_id| {
+                let function = self
+                    .assignments
+                    .get(&var_id)
+                    .expect("topological_order only contains assigned variables");
+                (var_id, function)
+            })
     }
 
     pub fn keys(&self) -> impl Iterator<Item = VariableID> + '_ {
@@ -220,6 +232,11 @@ impl Evaluate for AcyclicAssignments {
         // we first evaluate x1 = 3, then x4 = 5. Finally returns extended state {x1: 3, x2: 1, x3: 2, x4: 5}.
         for (var_id, function) in self.evaluation_order_iter() {
             let value = function.evaluate(&extended_state, atol)?;
+            if !value.is_finite() {
+                return Err(crate::error!(
+                    "Assignment for variable {var_id:?} evaluated to non-finite value: {value}"
+                ));
+            }
             extended_state.entries.insert(var_id.into_inner(), value);
         }
         Ok(extended_state)
@@ -368,5 +385,30 @@ mod tests {
         assert_eq!(result.entries[&2], 1.0); // x2 = 1 (original)
         assert_eq!(result.entries[&3], 2.0); // x3 = 2 (original)
         assert_eq!(result.entries[&4], 5.0); // x4 = x1 + 2 = 3 + 2 = 5
+    }
+
+    #[test]
+    fn test_topological_order_contains_only_assigned_variables() {
+        let assignments = assign! {
+            1 <- linear!(2) + linear!(3),
+            4 <- linear!(1) + linear!(5)
+        };
+
+        assert_eq!(assignments.topological_order.len(), assignments.len());
+        assert!(assignments
+            .topological_order
+            .iter()
+            .all(|var_id| assignments.assignments.contains_key(var_id)));
+    }
+
+    #[test]
+    fn test_evaluate_rejects_non_finite_assignment_value() {
+        let assignments = assign! {
+            1 <- linear!(2)
+        };
+        let state = State::from_iter([(2, f64::INFINITY)]);
+
+        let err = assignments.evaluate(&state, ATol::default()).unwrap_err();
+        assert!(err.to_string().contains("evaluated to non-finite value"));
     }
 }


### PR DESCRIPTION
## Summary

- Move solver state validation and population out of `DecisionVariableAnalysis` and into `Instance::populate_state`.
- Route `Instance::evaluate` and `Instance::evaluate_samples` through an `Instance`-owned population plan that uses the canonical `decision_variable_dependency`.
- Keep `DecisionVariableAnalysis` as a classification view and clarify that its constraint breakdown is for regular constraints.
- Cache `AcyclicAssignments` topological order at construction time and update logical-memory snapshots.
- Expose `Instance.populate_state` in Python and regenerate stubs/API docs.

## Motivation

`DecisionVariableAnalysis` is a derived reporting and solver-facing classification view, while `Instance` owns the canonical decision variables, fixed values, irrelevant variables, and dependent-variable assignments. Keeping population on the analysis object duplicated dependency ownership and required rebuilding an `AcyclicAssignments` during population. Moving the operation to `Instance` keeps the responsibility with the domain owner and lets sample evaluation reuse the existing dependency assignment structure.