### PR TITLE
Add HiGHS diagnostics progress history

### DIFF
--- a/docs/en/user_guide/adapter_diagnostics.md
+++ b/docs/en/user_guide/adapter_diagnostics.md
@@ -77,12 +77,42 @@ For the complete member lists, see the API Reference for
 {class}`~ommx_pyscipopt_adapter.SCIPTerminationReport`, and
 {class}`~ommx_pyscipopt_adapter.SCIPDiagnosticsAnalyzer`.
 
+## Record Diagnostics with the HiGHS Adapter
+
+The HiGHS Adapter records a termination report when you pass a
+{class}`~ommx.adapter.DiagnosticCollector` to `solve()`. Read that data through
+{class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer`.
+
+```python
+from ommx import adapter
+from ommx_highs_adapter import OMMXHighsAdapter, HighsDiagnosticsAnalyzer
+
+diag = adapter.DiagnosticCollector()
+solution = OMMXHighsAdapter.solve(instance, diagnostics=diag)
+
+analysis = HighsDiagnosticsAnalyzer(diag.diagnostics)
+
+print(analysis.dual_bound)
+print(analysis.gap)
+print(analysis.termination_result)
+```
+
+{class}`~ommx_highs_adapter.HighsTerminationReport` is recorded after
+`model.run()` finishes and before the HiGHS model is decoded back into an OMMX
+Solution. It includes fields such as `status`, `objective_value`,
+`mip_dual_bound`, `mip_gap`, `mip_node_count`, iteration counts, feasibility
+violation summaries, runtime, and HiGHS version metadata.
+
+`dual_bound`, `gap`, and `node_count` on
+{class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer` are aliases for the HiGHS
+MIP fields `mip_dual_bound`, `mip_gap`, and `mip_node_count`.
+
 ### Failure Handling
 
 Direct collection is useful when OMMX Solution decoding fails. The PySCIPOpt
-Adapter records the termination report before decoding, so the collector can
-still contain the final SCIP status and bounds when the solve raises an adapter
-exception such as {exc}`~ommx.adapter.InfeasibleDetected` or
+and HiGHS Adapters record the termination report before decoding, so the
+collector can still contain the final solver status and bounds when the solve
+raises an adapter exception such as {exc}`~ommx.adapter.InfeasibleDetected` or
 {exc}`~ommx.adapter.UnboundedDetected`.
 
 ```python

--- a/docs/en/user_guide/adapter_diagnostics.md
+++ b/docs/en/user_guide/adapter_diagnostics.md
@@ -79,9 +79,9 @@ For the complete member lists, see the API Reference for
 
 ## Record Diagnostics with the HiGHS Adapter
 
-The HiGHS Adapter records a termination report when you pass a
-{class}`~ommx.adapter.DiagnosticCollector` to `solve()`. Read that data through
-{class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer`.
+The HiGHS Adapter records MIP progress and termination information when you
+pass a {class}`~ommx.adapter.DiagnosticCollector` to `solve()`. Read that data
+through {class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer`.
 
 ```python
 from ommx import adapter
@@ -92,20 +92,27 @@ solution = OMMXHighsAdapter.solve(instance, diagnostics=diag)
 
 analysis = HighsDiagnosticsAnalyzer(diag.diagnostics)
 
+analysis.progress_history_df[["mip_primal_bound", "mip_dual_bound"]].plot()
 print(analysis.dual_bound)
-print(analysis.gap)
 print(analysis.termination_result)
 ```
+
+`progress_history_df` is a pandas DataFrame indexed by `running_time_sec`.
+Series properties such as `dual_bound`, `gap`, and `primal_bound` use the same
+time index, so they are ready for time-based plots.
+
+{class}`~ommx_highs_adapter.HighsProgressSnapshot` is recorded from HiGHS MIP
+logging callbacks. A progress snapshot includes fields such as
+`running_time_sec`, `mip_node_count`, `mip_primal_bound`, `mip_dual_bound`, and
+`mip_gap`.
 
 {class}`~ommx_highs_adapter.HighsTerminationReport` is recorded after
 `model.run()` finishes and before the HiGHS model is decoded back into an OMMX
 Solution. It includes fields such as `status`, `objective_value`,
 `mip_dual_bound`, `mip_gap`, `mip_node_count`, iteration counts, feasibility
-violation summaries, runtime, and HiGHS version metadata.
-
-`dual_bound`, `gap`, and `node_count` on
-{class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer` are aliases for the HiGHS
-MIP fields `mip_dual_bound`, `mip_gap`, and `mip_node_count`.
+violation summaries, runtime, and HiGHS version metadata. Use
+`termination_result` or the `termination_*` properties when you need terminal
+scalar values.
 
 ### Failure Handling
 

--- a/docs/en/user_guide/adapter_diagnostics.md
+++ b/docs/en/user_guide/adapter_diagnostics.md
@@ -92,19 +92,18 @@ solution = OMMXHighsAdapter.solve(instance, diagnostics=diag)
 
 analysis = HighsDiagnosticsAnalyzer(diag.diagnostics)
 
-analysis.progress_history_df[["mip_primal_bound", "mip_dual_bound"]].plot()
+analysis.progress_history_df[["primal_bound", "dual_bound"]].plot()
 print(analysis.dual_bound)
 print(analysis.termination_result)
 ```
 
-`progress_history_df` is a pandas DataFrame indexed by `running_time_sec`.
+`progress_history_df` is a pandas DataFrame indexed by `solving_time_sec`.
 Series properties such as `dual_bound`, `gap`, and `primal_bound` use the same
 time index, so they are ready for time-based plots.
 
 {class}`~ommx_highs_adapter.HighsProgressSnapshot` is recorded from HiGHS MIP
 logging callbacks. A progress snapshot includes fields such as
-`running_time_sec`, `mip_node_count`, `mip_primal_bound`, `mip_dual_bound`, and
-`mip_gap`.
+`solving_time_sec`, `mip_node_count`, `primal_bound`, `dual_bound`, and `gap`.
 
 {class}`~ommx_highs_adapter.HighsTerminationReport` is recorded after
 `model.run()` finishes and before the HiGHS model is decoded back into an OMMX

--- a/docs/ja/user_guide/adapter_diagnostics.md
+++ b/docs/ja/user_guide/adapter_diagnostics.md
@@ -86,18 +86,18 @@ solution = OMMXHighsAdapter.solve(instance, diagnostics=diag)
 
 analysis = HighsDiagnosticsAnalyzer(diag.diagnostics)
 
-analysis.progress_history_df[["mip_primal_bound", "mip_dual_bound"]].plot()
+analysis.progress_history_df[["primal_bound", "dual_bound"]].plot()
 print(analysis.dual_bound)
 print(analysis.termination_result)
 ```
 
-`progress_history_df` は `running_time_sec` を index にした pandas DataFrame です。
+`progress_history_df` は `solving_time_sec` を index にした pandas DataFrame です。
 `dual_bound`、`gap`、`primal_bound` などの Series property も同じ time index を使うので、
 そのまま時間軸の plot に使えます。
 
 {class}`~ommx_highs_adapter.HighsProgressSnapshot` は、HiGHS の MIP logging callback から
-記録される progress sample です。progress snapshot には `running_time_sec`、
-`mip_node_count`、`mip_primal_bound`、`mip_dual_bound`、`mip_gap` などが含まれます。
+記録される progress sample です。progress snapshot には `solving_time_sec`、
+`mip_node_count`、`primal_bound`、`dual_bound`、`gap` などが含まれます。
 
 {class}`~ommx_highs_adapter.HighsTerminationReport` は、`model.run()` が終了した後、
 HiGHS model を OMMX Solution に decode する前に記録される最終 report です。

--- a/docs/ja/user_guide/adapter_diagnostics.md
+++ b/docs/ja/user_guide/adapter_diagnostics.md
@@ -74,7 +74,7 @@ progress snapshot は callback 時点の観測値です。SCIP は `BESTSOLFOUND
 ## HiGHS で diagnostics を記録する
 
 HiGHS Adapter は、`solve()` に {class}`~ommx.adapter.DiagnosticCollector` を渡すと
-termination report を記録します。通常は
+MIP progress と termination 情報を記録します。通常は
 {class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer` を通して読みます。
 
 ```python
@@ -86,19 +86,24 @@ solution = OMMXHighsAdapter.solve(instance, diagnostics=diag)
 
 analysis = HighsDiagnosticsAnalyzer(diag.diagnostics)
 
+analysis.progress_history_df[["mip_primal_bound", "mip_dual_bound"]].plot()
 print(analysis.dual_bound)
-print(analysis.gap)
 print(analysis.termination_result)
 ```
+
+`progress_history_df` は `running_time_sec` を index にした pandas DataFrame です。
+`dual_bound`、`gap`、`primal_bound` などの Series property も同じ time index を使うので、
+そのまま時間軸の plot に使えます。
+
+{class}`~ommx_highs_adapter.HighsProgressSnapshot` は、HiGHS の MIP logging callback から
+記録される progress sample です。progress snapshot には `running_time_sec`、
+`mip_node_count`、`mip_primal_bound`、`mip_dual_bound`、`mip_gap` などが含まれます。
 
 {class}`~ommx_highs_adapter.HighsTerminationReport` は、`model.run()` が終了した後、
 HiGHS model を OMMX Solution に decode する前に記録される最終 report です。
 `status`、`objective_value`、`mip_dual_bound`、`mip_gap`、`mip_node_count`、
 iteration count、feasibility violation summary、runtime、HiGHS version metadata などが含まれます。
-
-{class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer` の `dual_bound`、`gap`、
-`node_count` は、それぞれ HiGHS の MIP field である `mip_dual_bound`、`mip_gap`、
-`mip_node_count` への alias です。
+終了時点の scalar 値が必要な場合は、`termination_result` または `termination_*` property を使ってください。
 
 ### 失敗時の処理
 

--- a/docs/ja/user_guide/adapter_diagnostics.md
+++ b/docs/ja/user_guide/adapter_diagnostics.md
@@ -71,12 +71,41 @@ progress snapshot は callback 時点の観測値です。SCIP は `BESTSOLFOUND
 {class}`~ommx_pyscipopt_adapter.SCIPTerminationReport`、
 {class}`~ommx_pyscipopt_adapter.SCIPDiagnosticsAnalyzer` を参照してください。
 
+## HiGHS で diagnostics を記録する
+
+HiGHS Adapter は、`solve()` に {class}`~ommx.adapter.DiagnosticCollector` を渡すと
+termination report を記録します。通常は
+{class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer` を通して読みます。
+
+```python
+from ommx import adapter
+from ommx_highs_adapter import OMMXHighsAdapter, HighsDiagnosticsAnalyzer
+
+diag = adapter.DiagnosticCollector()
+solution = OMMXHighsAdapter.solve(instance, diagnostics=diag)
+
+analysis = HighsDiagnosticsAnalyzer(diag.diagnostics)
+
+print(analysis.dual_bound)
+print(analysis.gap)
+print(analysis.termination_result)
+```
+
+{class}`~ommx_highs_adapter.HighsTerminationReport` は、`model.run()` が終了した後、
+HiGHS model を OMMX Solution に decode する前に記録される最終 report です。
+`status`、`objective_value`、`mip_dual_bound`、`mip_gap`、`mip_node_count`、
+iteration count、feasibility violation summary、runtime、HiGHS version metadata などが含まれます。
+
+{class}`~ommx_highs_adapter.HighsDiagnosticsAnalyzer` の `dual_bound`、`gap`、
+`node_count` は、それぞれ HiGHS の MIP field である `mip_dual_bound`、`mip_gap`、
+`mip_node_count` への alias です。
+
 ### 失敗時の処理
 
-直接取得は、OMMX Solution への decode が失敗する場合にも有用です。PySCIPOpt Adapter は
-decode の前に termination report を記録するため、{exc}`~ommx.adapter.InfeasibleDetected` や
-{exc}`~ommx.adapter.UnboundedDetected` などの adapter exception が発生しても、collector には
-SCIP の最終 status や bound が残ります。
+直接取得は、OMMX Solution への decode が失敗する場合にも有用です。PySCIPOpt Adapter と
+HiGHS Adapter は decode の前に termination report を記録するため、
+{exc}`~ommx.adapter.InfeasibleDetected` や {exc}`~ommx.adapter.UnboundedDetected` などの
+adapter exception が発生しても、collector には solver の最終 status や bound が残ります。
 
 ```python
 from ommx.adapter import DiagnosticCollector, UnboundedDetected

--- a/python/ommx-highs-adapter/ommx_highs_adapter/__init__.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/__init__.py
@@ -1,8 +1,14 @@
-from .adapter import HighsDiagnosticsAnalyzer, HighsTerminationReport, OMMXHighsAdapter
+from .adapter import (
+    HighsDiagnosticsAnalyzer,
+    HighsProgressSnapshot,
+    HighsTerminationReport,
+    OMMXHighsAdapter,
+)
 from .exception import OMMXHighsAdapterError
 
 __all__ = [
     "HighsDiagnosticsAnalyzer",
+    "HighsProgressSnapshot",
     "HighsTerminationReport",
     "OMMXHighsAdapter",
     "OMMXHighsAdapterError",

--- a/python/ommx-highs-adapter/ommx_highs_adapter/__init__.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/__init__.py
@@ -1,4 +1,9 @@
-from .adapter import OMMXHighsAdapter
+from .adapter import HighsDiagnosticsAnalyzer, HighsTerminationReport, OMMXHighsAdapter
 from .exception import OMMXHighsAdapterError
 
-__all__ = ["OMMXHighsAdapter", "OMMXHighsAdapterError"]
+__all__ = [
+    "HighsDiagnosticsAnalyzer",
+    "HighsTerminationReport",
+    "OMMXHighsAdapter",
+    "OMMXHighsAdapterError",
+]

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, fields
-from typing import Any, Iterable, Mapping, cast
+from typing import Any, Callable, Iterable, Mapping, cast
 
 import highspy
 import numpy as np
@@ -20,6 +20,57 @@ from ommx.adapter import (
 from .exception import OMMXHighsAdapterError
 
 _tracer = trace.get_tracer("ommx.adapter.highs")
+
+
+@dataclass(frozen=True, slots=True)
+class HighsProgressSnapshot:
+    """HiGHS MIP solve progress observed from one logging callback."""
+
+    event: str
+    """HiGHS callback message, currently ``"MIP logging"``."""
+
+    running_time_sec: float
+    """HiGHS runtime when the callback ran."""
+
+    mip_node_count: int
+    """MIP branch-and-bound nodes processed at the callback."""
+
+    simplex_iteration_count: int
+    """Simplex iterations at the callback."""
+
+    ipm_iteration_count: int
+    """Interior-point iterations at the callback."""
+
+    pdlp_iteration_count: int
+    """PDLP iterations at the callback."""
+
+    objective_value: float
+    """Objective value reported at the callback."""
+
+    mip_primal_bound: float
+    """MIP primal bound reported at the callback."""
+
+    mip_dual_bound: float
+    """MIP dual bound reported at the callback."""
+
+    mip_gap: float
+    """MIP relative gap reported at the callback."""
+
+    @classmethod
+    def from_callback_event(cls, event: Any) -> HighsProgressSnapshot:
+        data = event.data_out
+        return cls(
+            event=event.message,
+            running_time_sec=data.running_time,
+            mip_node_count=int(data.mip_node_count),
+            simplex_iteration_count=int(data.simplex_iteration_count),
+            ipm_iteration_count=int(data.ipm_iteration_count),
+            pdlp_iteration_count=int(data.pdlp_iteration_count),
+            objective_value=data.objective_function_value,
+            mip_primal_bound=data.mip_primal_bound,
+            mip_dual_bound=data.mip_dual_bound,
+            mip_gap=data.mip_gap,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,18 +191,112 @@ class HighsDiagnosticsAnalyzer:
     :attr:`ommx.experiment.Solve.diagnostics`.
     """
 
+    _progress_snapshots: tuple[HighsProgressSnapshot, ...]
+    _progress_history_records: tuple[dict[str, object], ...]
     _termination_result: dict[str, object] | None
 
     def __init__(self, diagnostics: Iterable[Any]) -> None:
+        progress_snapshots: list[HighsProgressSnapshot] = []
+        progress_history_records: list[dict[str, object]] = []
         termination_results: list[dict[str, object]] = []
 
         for diagnostic in diagnostics:
+            if isinstance(diagnostic, HighsProgressSnapshot):
+                progress_snapshots.append(diagnostic)
+            if (record := _as_progress_history_record(diagnostic)) is not None:
+                progress_history_records.append(record)
             if (result := _as_termination_result(diagnostic)) is not None:
                 termination_results.append(result)
 
+        self._progress_snapshots = tuple(progress_snapshots)
+        self._progress_history_records = tuple(progress_history_records)
         self._termination_result = (
             termination_results[-1] if termination_results else None
         )
+
+    @property
+    def progress_snapshots(self) -> tuple[HighsProgressSnapshot, ...]:
+        """Typed progress snapshots in the order they were recorded."""
+        return self._progress_snapshots
+
+    @property
+    def progress_history_records(self) -> list[dict[str, object]]:
+        """Return one dictionary per HiGHS MIP logging callback."""
+        return [dict(record) for record in self._progress_history_records]
+
+    @property
+    def progress_history_df(self) -> Any:
+        """Return progress snapshots as a pandas DataFrame indexed by time."""
+        return _dataframe(
+            self.progress_history_records,
+            _dataclass_field_names(HighsProgressSnapshot),
+            index="running_time_sec",
+        )
+
+    @property
+    def event(self) -> Any:
+        """Return progress event names indexed by running time."""
+        return self._progress_series("event")
+
+    @property
+    def mip_node_count(self) -> Any:
+        """Return MIP node counts indexed by running time."""
+        return self._progress_series("mip_node_count")
+
+    @property
+    def node_count(self) -> Any:
+        """Alias for :attr:`mip_node_count`."""
+        return self.mip_node_count
+
+    @property
+    def simplex_iteration_count(self) -> Any:
+        """Return simplex iteration counts indexed by running time."""
+        return self._progress_series("simplex_iteration_count")
+
+    @property
+    def ipm_iteration_count(self) -> Any:
+        """Return interior-point iteration counts indexed by running time."""
+        return self._progress_series("ipm_iteration_count")
+
+    @property
+    def pdlp_iteration_count(self) -> Any:
+        """Return PDLP iteration counts indexed by running time."""
+        return self._progress_series("pdlp_iteration_count")
+
+    @property
+    def objective_value(self) -> Any:
+        """Return objective values indexed by running time."""
+        return self._progress_series("objective_value")
+
+    @property
+    def mip_primal_bound(self) -> Any:
+        """Return MIP primal bounds indexed by running time."""
+        return self._progress_series("mip_primal_bound")
+
+    @property
+    def primal_bound(self) -> Any:
+        """Alias for :attr:`mip_primal_bound`."""
+        return self.mip_primal_bound
+
+    @property
+    def mip_dual_bound(self) -> Any:
+        """Return MIP dual bounds indexed by running time."""
+        return self._progress_series("mip_dual_bound")
+
+    @property
+    def dual_bound(self) -> Any:
+        """Alias for :attr:`mip_dual_bound`."""
+        return self.mip_dual_bound
+
+    @property
+    def mip_gap(self) -> Any:
+        """Return MIP gaps indexed by running time."""
+        return self._progress_series("mip_gap")
+
+    @property
+    def gap(self) -> Any:
+        """Alias for :attr:`mip_gap`."""
+        return self.mip_gap
 
     @property
     def termination_result(self) -> dict[str, object] | None:
@@ -161,49 +306,47 @@ class HighsDiagnosticsAnalyzer:
         return dict(self._termination_result)
 
     @property
-    def status(self) -> str | None:
+    def termination_status(self) -> str | None:
         """Return the terminal HiGHS model status, if present."""
         return cast(str | None, self._termination_value("status"))
 
     @property
-    def objective_value(self) -> float | None:
+    def termination_objective_value(self) -> float | None:
         """Return the terminal objective value, if present."""
         return cast(float | None, self._termination_value("objective_value"))
 
     @property
-    def mip_dual_bound(self) -> float | None:
+    def termination_mip_dual_bound(self) -> float | None:
         """Return the terminal HiGHS MIP dual bound, if present."""
         return cast(float | None, self._termination_value("mip_dual_bound"))
 
     @property
-    def dual_bound(self) -> float | None:
-        """Alias for :attr:`mip_dual_bound`."""
-        return self.mip_dual_bound
-
-    @property
-    def mip_gap(self) -> float | None:
+    def termination_mip_gap(self) -> float | None:
         """Return the terminal HiGHS MIP gap, if present."""
         return cast(float | None, self._termination_value("mip_gap"))
 
     @property
-    def gap(self) -> float | None:
-        """Alias for :attr:`mip_gap`."""
-        return self.mip_gap
-
-    @property
-    def mip_node_count(self) -> int | None:
+    def termination_mip_node_count(self) -> int | None:
         """Return the terminal HiGHS MIP node count, if present."""
         return cast(int | None, self._termination_value("mip_node_count"))
-
-    @property
-    def node_count(self) -> int | None:
-        """Alias for :attr:`mip_node_count`."""
-        return self.mip_node_count
 
     def _termination_value(self, column: str) -> object | None:
         if self._termination_result is None:
             return None
         return self._termination_result[column]
+
+    def _progress_series(self, column: str) -> Any:
+        return self.progress_history_df[column]
+
+
+def _as_progress_history_record(diagnostic: Any) -> dict[str, object] | None:
+    if isinstance(diagnostic, HighsProgressSnapshot):
+        return cast(dict[str, object], asdict(diagnostic))
+    if not isinstance(diagnostic, Mapping):
+        return None
+    if not _has_dataclass_fields(diagnostic, HighsProgressSnapshot):
+        return None
+    return _select_dataclass_fields(diagnostic, HighsProgressSnapshot)
 
 
 def _as_termination_result(diagnostic: Any) -> dict[str, object] | None:
@@ -233,6 +376,22 @@ def _select_dataclass_fields(
         name: cast(object, diagnostic[name])
         for name in _dataclass_field_names(dataclass_type)
     }
+
+
+def _dataframe(
+    records: list[dict[str, object]], columns: list[str], *, index: str | None = None
+) -> Any:
+    try:
+        import pandas as pd
+    except ImportError as error:
+        raise ImportError(
+            "pandas is required for HighsDiagnosticsAnalyzer DataFrame and Series "
+            "properties. Use progress_history_records without pandas."
+        ) from error
+    dataframe = pd.DataFrame.from_records(records, columns=columns)
+    if index is not None:
+        dataframe = dataframe.set_index(index)
+    return dataframe
 
 
 class OMMXHighsAdapter(SolverAdapter):
@@ -538,8 +697,20 @@ class OMMXHighsAdapter(SolverAdapter):
             span.set_attribute("adapter", f"{cls.__module__}.{cls.__qualname__}")
             adapter = cls(ommx_instance, verbose=verbose)
             model = adapter.solver_input
+            diagnostics_callback: Callable[[Any], None] | None = None
+            if diagnostics is not None:
+
+                def record_progress(event: Any) -> None:
+                    diagnostics.record(HighsProgressSnapshot.from_callback_event(event))
+
+                diagnostics_callback = record_progress
+                model.cbMipLogging.subscribe(diagnostics_callback)
             with _tracer.start_as_current_span("call"):
-                model.run()
+                try:
+                    model.run()
+                finally:
+                    if diagnostics_callback is not None:
+                        model.cbMipLogging.unsubscribe(diagnostics_callback)
             if diagnostics is not None:
                 diagnostics.record(HighsTerminationReport.from_model(model))
             return adapter.decode(model)

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields
+from typing import Any, Iterable, Mapping, cast
+
 import highspy
 import numpy as np
 
@@ -15,6 +20,219 @@ from ommx.adapter import (
 from .exception import OMMXHighsAdapterError
 
 _tracer = trace.get_tracer("ommx.adapter.highs")
+
+
+@dataclass(frozen=True, slots=True)
+class HighsTerminationReport:
+    """HiGHS-side termination summary recorded after ``model.run()``.
+
+    The HiGHS adapter records this report before decoding the optimized HiGHS
+    model back into an OMMX solution. It is therefore available even when
+    decoding raises an adapter exception such as infeasible or unbounded
+    detection.
+    """
+
+    status: str
+    """HiGHS model status, such as ``"Optimal"`` or ``"Infeasible"``."""
+
+    objective_value: float | None
+    """Objective value reported by HiGHS, or ``None`` when no objective is valid."""
+
+    mip_dual_bound: float
+    """MIP dual bound reported by ``HighsInfo.mip_dual_bound``."""
+
+    mip_gap: float
+    """MIP relative gap reported by ``HighsInfo.mip_gap``."""
+
+    mip_node_count: int
+    """Number of MIP branch-and-bound nodes processed by HiGHS."""
+
+    simplex_iteration_count: int
+    """Number of simplex iterations."""
+
+    ipm_iteration_count: int
+    """Number of interior-point iterations."""
+
+    crossover_iteration_count: int
+    """Number of crossover iterations after interior-point optimization."""
+
+    pdlp_iteration_count: int
+    """Number of PDLP iterations."""
+
+    primal_dual_integral: float
+    """HiGHS primal-dual integral."""
+
+    primal_solution_status: int
+    """HiGHS primal solution status code."""
+
+    dual_solution_status: int
+    """HiGHS dual solution status code."""
+
+    max_integrality_violation: float
+    """Maximum integrality violation in the final solution."""
+
+    max_primal_infeasibility: float
+    """Maximum primal infeasibility in the final solution."""
+
+    max_dual_infeasibility: float
+    """Maximum dual infeasibility in the final solution."""
+
+    run_time_sec: float
+    """HiGHS runtime in seconds."""
+
+    highs_version: str
+    """HiGHS version used through highspy."""
+
+    highs_githash: str
+    """HiGHS git hash reported by highspy."""
+
+    @classmethod
+    def from_model(cls, model: highspy.Highs) -> HighsTerminationReport:
+        status = model.getModelStatus()
+        status_name = model.modelStatusToString(status)
+        if status == highspy.HighsModelStatus.kNotset:
+            raise OMMXHighsAdapterError(
+                f"The model may not be optimized. [status: {status_name}]"
+            )
+
+        info = model.getInfo()
+        objective_value = None
+        if status not in {
+            highspy.HighsModelStatus.kInfeasible,
+            highspy.HighsModelStatus.kUnbounded,
+            highspy.HighsModelStatus.kUnboundedOrInfeasible,
+            highspy.HighsModelStatus.kModelError,
+            highspy.HighsModelStatus.kPresolveError,
+            highspy.HighsModelStatus.kSolveError,
+            highspy.HighsModelStatus.kPostsolveError,
+            highspy.HighsModelStatus.kLoadError,
+            highspy.HighsModelStatus.kNotset,
+        }:
+            objective_value = info.objective_function_value
+
+        return cls(
+            status=status_name,
+            objective_value=objective_value,
+            mip_dual_bound=info.mip_dual_bound,
+            mip_gap=info.mip_gap,
+            mip_node_count=int(info.mip_node_count),
+            simplex_iteration_count=int(info.simplex_iteration_count),
+            ipm_iteration_count=int(info.ipm_iteration_count),
+            crossover_iteration_count=int(info.crossover_iteration_count),
+            pdlp_iteration_count=int(info.pdlp_iteration_count),
+            primal_dual_integral=float(getattr(info, "primal_dual_integral")),
+            primal_solution_status=int(info.primal_solution_status),
+            dual_solution_status=int(info.dual_solution_status),
+            max_integrality_violation=info.max_integrality_violation,
+            max_primal_infeasibility=info.max_primal_infeasibility,
+            max_dual_infeasibility=info.max_dual_infeasibility,
+            run_time_sec=model.getRunTime(),
+            highs_version=model.version(),
+            highs_githash=model.githash(),
+        )
+
+
+class HighsDiagnosticsAnalyzer:
+    """Post-processor for HiGHS diagnostics.
+
+    The analyzer accepts either typed diagnostics collected by
+    :class:`ommx.adapter.DiagnosticCollector` or dictionaries loaded from
+    :attr:`ommx.experiment.Solve.diagnostics`.
+    """
+
+    _termination_result: dict[str, object] | None
+
+    def __init__(self, diagnostics: Iterable[Any]) -> None:
+        termination_results: list[dict[str, object]] = []
+
+        for diagnostic in diagnostics:
+            if (result := _as_termination_result(diagnostic)) is not None:
+                termination_results.append(result)
+
+        self._termination_result = (
+            termination_results[-1] if termination_results else None
+        )
+
+    @property
+    def termination_result(self) -> dict[str, object] | None:
+        """Return the terminal HiGHS report as one dictionary, if present."""
+        if self._termination_result is None:
+            return None
+        return dict(self._termination_result)
+
+    @property
+    def status(self) -> str | None:
+        """Return the terminal HiGHS model status, if present."""
+        return cast(str | None, self._termination_value("status"))
+
+    @property
+    def objective_value(self) -> float | None:
+        """Return the terminal objective value, if present."""
+        return cast(float | None, self._termination_value("objective_value"))
+
+    @property
+    def mip_dual_bound(self) -> float | None:
+        """Return the terminal HiGHS MIP dual bound, if present."""
+        return cast(float | None, self._termination_value("mip_dual_bound"))
+
+    @property
+    def dual_bound(self) -> float | None:
+        """Alias for :attr:`mip_dual_bound`."""
+        return self.mip_dual_bound
+
+    @property
+    def mip_gap(self) -> float | None:
+        """Return the terminal HiGHS MIP gap, if present."""
+        return cast(float | None, self._termination_value("mip_gap"))
+
+    @property
+    def gap(self) -> float | None:
+        """Alias for :attr:`mip_gap`."""
+        return self.mip_gap
+
+    @property
+    def mip_node_count(self) -> int | None:
+        """Return the terminal HiGHS MIP node count, if present."""
+        return cast(int | None, self._termination_value("mip_node_count"))
+
+    @property
+    def node_count(self) -> int | None:
+        """Alias for :attr:`mip_node_count`."""
+        return self.mip_node_count
+
+    def _termination_value(self, column: str) -> object | None:
+        if self._termination_result is None:
+            return None
+        return self._termination_result[column]
+
+
+def _as_termination_result(diagnostic: Any) -> dict[str, object] | None:
+    if isinstance(diagnostic, HighsTerminationReport):
+        return cast(dict[str, object], asdict(diagnostic))
+    if not isinstance(diagnostic, Mapping):
+        return None
+    if not _has_dataclass_fields(diagnostic, HighsTerminationReport):
+        return None
+    return _select_dataclass_fields(diagnostic, HighsTerminationReport)
+
+
+def _dataclass_field_names(dataclass_type: type[Any]) -> list[str]:
+    return [field.name for field in fields(dataclass_type)]
+
+
+def _has_dataclass_fields(
+    diagnostic: Mapping[Any, Any], dataclass_type: type[Any]
+) -> bool:
+    return set(_dataclass_field_names(dataclass_type)) <= diagnostic.keys()
+
+
+def _select_dataclass_fields(
+    diagnostic: Mapping[Any, Any], dataclass_type: type[Any]
+) -> dict[str, object]:
+    return {
+        name: cast(object, diagnostic[name])
+        for name in _dataclass_field_names(dataclass_type)
+    }
 
 
 class OMMXHighsAdapter(SolverAdapter):
@@ -316,13 +534,14 @@ class OMMXHighsAdapter(SolverAdapter):
         #     ...
         # ommx.adapter.UnboundedDetected: Model was unbounded
         # ````
-        _ = diagnostics
         with _tracer.start_as_current_span("solve") as span:
             span.set_attribute("adapter", f"{cls.__module__}.{cls.__qualname__}")
             adapter = cls(ommx_instance, verbose=verbose)
             model = adapter.solver_input
             with _tracer.start_as_current_span("call"):
                 model.run()
+            if diagnostics is not None:
+                diagnostics.record(HighsTerminationReport.from_model(model))
             return adapter.decode(model)
 
     @property

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -29,7 +29,7 @@ class HighsProgressSnapshot:
     event: str
     """HiGHS callback message, currently ``"MIP logging"``."""
 
-    running_time_sec: float
+    solving_time_sec: float
     """HiGHS runtime when the callback ran."""
 
     mip_node_count: int
@@ -47,13 +47,13 @@ class HighsProgressSnapshot:
     objective_value: float
     """Objective value reported at the callback."""
 
-    mip_primal_bound: float
+    primal_bound: float
     """MIP primal bound reported at the callback."""
 
-    mip_dual_bound: float
+    dual_bound: float
     """MIP dual bound reported at the callback."""
 
-    mip_gap: float
+    gap: float
     """MIP relative gap reported at the callback."""
 
     @classmethod
@@ -61,15 +61,15 @@ class HighsProgressSnapshot:
         data = event.data_out
         return cls(
             event=event.message,
-            running_time_sec=data.running_time,
+            solving_time_sec=data.running_time,
             mip_node_count=int(data.mip_node_count),
             simplex_iteration_count=int(data.simplex_iteration_count),
             ipm_iteration_count=int(data.ipm_iteration_count),
             pdlp_iteration_count=int(data.pdlp_iteration_count),
             objective_value=data.objective_function_value,
-            mip_primal_bound=data.mip_primal_bound,
-            mip_dual_bound=data.mip_dual_bound,
-            mip_gap=data.mip_gap,
+            primal_bound=data.mip_primal_bound,
+            dual_bound=data.mip_dual_bound,
+            gap=data.mip_gap,
         )
 
 
@@ -230,17 +230,17 @@ class HighsDiagnosticsAnalyzer:
         return _dataframe(
             self.progress_history_records,
             _dataclass_field_names(HighsProgressSnapshot),
-            index="running_time_sec",
+            index="solving_time_sec",
         )
 
     @property
     def event(self) -> Any:
-        """Return progress event names indexed by running time."""
+        """Return progress event names indexed by solving time."""
         return self._progress_series("event")
 
     @property
     def mip_node_count(self) -> Any:
-        """Return MIP node counts indexed by running time."""
+        """Return MIP node counts indexed by solving time."""
         return self._progress_series("mip_node_count")
 
     @property
@@ -250,53 +250,53 @@ class HighsDiagnosticsAnalyzer:
 
     @property
     def simplex_iteration_count(self) -> Any:
-        """Return simplex iteration counts indexed by running time."""
+        """Return simplex iteration counts indexed by solving time."""
         return self._progress_series("simplex_iteration_count")
 
     @property
     def ipm_iteration_count(self) -> Any:
-        """Return interior-point iteration counts indexed by running time."""
+        """Return interior-point iteration counts indexed by solving time."""
         return self._progress_series("ipm_iteration_count")
 
     @property
     def pdlp_iteration_count(self) -> Any:
-        """Return PDLP iteration counts indexed by running time."""
+        """Return PDLP iteration counts indexed by solving time."""
         return self._progress_series("pdlp_iteration_count")
 
     @property
     def objective_value(self) -> Any:
-        """Return objective values indexed by running time."""
+        """Return objective values indexed by solving time."""
         return self._progress_series("objective_value")
 
     @property
     def mip_primal_bound(self) -> Any:
-        """Return MIP primal bounds indexed by running time."""
-        return self._progress_series("mip_primal_bound")
+        """Alias for :attr:`primal_bound`."""
+        return self.primal_bound
 
     @property
     def primal_bound(self) -> Any:
-        """Alias for :attr:`mip_primal_bound`."""
-        return self.mip_primal_bound
+        """Return MIP primal bounds indexed by solving time."""
+        return self._progress_series("primal_bound")
 
     @property
     def mip_dual_bound(self) -> Any:
-        """Return MIP dual bounds indexed by running time."""
-        return self._progress_series("mip_dual_bound")
+        """Alias for :attr:`dual_bound`."""
+        return self.dual_bound
 
     @property
     def dual_bound(self) -> Any:
-        """Alias for :attr:`mip_dual_bound`."""
-        return self.mip_dual_bound
+        """Return MIP dual bounds indexed by solving time."""
+        return self._progress_series("dual_bound")
 
     @property
     def mip_gap(self) -> Any:
-        """Return MIP gaps indexed by running time."""
-        return self._progress_series("mip_gap")
+        """Alias for :attr:`gap`."""
+        return self.gap
 
     @property
     def gap(self) -> Any:
-        """Alias for :attr:`mip_gap`."""
-        return self.mip_gap
+        """Return MIP gaps indexed by solving time."""
+        return self._progress_series("gap")
 
     @property
     def termination_result(self) -> dict[str, object] | None:

--- a/python/ommx-highs-adapter/tests/test_diagnostics.py
+++ b/python/ommx-highs-adapter/tests/test_diagnostics.py
@@ -53,24 +53,24 @@ def _infeasible_instance() -> Instance:
 def _progress_snapshot(
     *,
     event: str = "MIP logging",
-    running_time_sec: float = 0.25,
+    solving_time_sec: float = 0.25,
     mip_node_count: int = 0,
     objective_value: float = 10.0,
-    mip_primal_bound: float = 10.0,
-    mip_dual_bound: float = 12.0,
-    mip_gap: float = 0.2,
+    primal_bound: float = 10.0,
+    dual_bound: float = 12.0,
+    gap: float = 0.2,
 ) -> HighsProgressSnapshot:
     return HighsProgressSnapshot(
         event=event,
-        running_time_sec=running_time_sec,
+        solving_time_sec=solving_time_sec,
         mip_node_count=mip_node_count,
         simplex_iteration_count=-1,
         ipm_iteration_count=-1,
         pdlp_iteration_count=-1,
         objective_value=objective_value,
-        mip_primal_bound=mip_primal_bound,
-        mip_dual_bound=mip_dual_bound,
-        mip_gap=mip_gap,
+        primal_bound=primal_bound,
+        dual_bound=dual_bound,
+        gap=gap,
     )
 
 
@@ -140,22 +140,22 @@ def test_direct_solve_records_progress_snapshots():
     assert collector.diagnostics[-1].__class__ is HighsTerminationReport
     assert {snapshot.event for snapshot in progress_snapshots} == {"MIP logging"}
     for snapshot in progress_snapshots:
-        assert snapshot.running_time_sec >= 0.0
+        assert snapshot.solving_time_sec >= 0.0
         assert snapshot.mip_node_count >= 0
-        assert isinstance(snapshot.mip_primal_bound, float)
-        assert isinstance(snapshot.mip_dual_bound, float)
-        assert isinstance(snapshot.mip_gap, float)
+        assert isinstance(snapshot.primal_bound, float)
+        assert isinstance(snapshot.dual_bound, float)
+        assert isinstance(snapshot.gap, float)
 
 
 def test_analyzer_accepts_typed_reports():
     first = _progress_snapshot()
     second = _progress_snapshot(
-        running_time_sec=0.5,
+        solving_time_sec=0.5,
         mip_node_count=1,
         objective_value=10.0,
-        mip_primal_bound=10.0,
-        mip_dual_bound=10.0,
-        mip_gap=0.0,
+        primal_bound=10.0,
+        dual_bound=10.0,
+        gap=0.0,
     )
     report = _termination_report()
 
@@ -174,17 +174,17 @@ def test_analyzer_accepts_typed_reports():
         "ipm_iteration_count",
         "pdlp_iteration_count",
         "objective_value",
-        "mip_primal_bound",
-        "mip_dual_bound",
-        "mip_gap",
+        "primal_bound",
+        "dual_bound",
+        "gap",
     ]
-    assert analyzer.progress_history_df.index.name == "running_time_sec"
+    assert analyzer.progress_history_df.index.name == "solving_time_sec"
     assert list(analyzer.progress_history_df.index) == [0.25, 0.5]
     assert list(analyzer.dual_bound) == [12.0, 10.0]
     assert list(analyzer.gap) == [0.2, 0.0]
     assert list(analyzer.primal_bound) == [10.0, 10.0]
     assert list(analyzer.node_count) == [0, 1]
-    assert analyzer.dual_bound.index.name == "running_time_sec"
+    assert analyzer.dual_bound.index.name == "solving_time_sec"
     assert analyzer.termination_status == "Optimal"
     assert analyzer.termination_objective_value == pytest.approx(5.0)
     assert analyzer.termination_mip_dual_bound == pytest.approx(5.0)
@@ -225,7 +225,7 @@ def test_experiment_stores_diagnostics_as_dict_payload():
     assert diagnostics[-1]["status"] == "Optimal"
     assert analyzer.termination_result is not None
     assert analyzer.termination_result["mip_gap"] == pytest.approx(0.0)
-    assert analyzer.dual_bound.index.name == "running_time_sec"
+    assert analyzer.dual_bound.index.name == "solving_time_sec"
 
 
 def test_direct_collector_keeps_termination_report_before_decode_error():

--- a/python/ommx-highs-adapter/tests/test_diagnostics.py
+++ b/python/ommx-highs-adapter/tests/test_diagnostics.py
@@ -1,0 +1,148 @@
+from dataclasses import asdict
+
+import highspy
+import pytest
+
+from ommx.adapter import DiagnosticCollector, InfeasibleDetected
+from ommx.experiment import Experiment
+from ommx.v1 import DecisionVariable, Instance, Solution
+from ommx_highs_adapter import (
+    HighsDiagnosticsAnalyzer,
+    HighsTerminationReport,
+    OMMXHighsAdapter,
+    OMMXHighsAdapterError,
+)
+
+
+def _mip_instance() -> Instance:
+    x = DecisionVariable.integer(1, lower=0, upper=5)
+    return Instance.from_components(
+        decision_variables=[x],
+        objective=x,
+        constraints={},
+        sense=Instance.MAXIMIZE,
+    )
+
+
+def _infeasible_instance() -> Instance:
+    x = DecisionVariable.continuous(1)
+    return Instance.from_components(
+        decision_variables=[x],
+        objective=0,
+        constraints={0: x == 0, 1: x == 1},
+        sense=Instance.MINIMIZE,
+    )
+
+
+def _termination_report() -> HighsTerminationReport:
+    return HighsTerminationReport(
+        status="Optimal",
+        objective_value=5.0,
+        mip_dual_bound=5.0,
+        mip_gap=0.0,
+        mip_node_count=0,
+        simplex_iteration_count=0,
+        ipm_iteration_count=-1,
+        crossover_iteration_count=-1,
+        pdlp_iteration_count=-1,
+        primal_dual_integral=0.0,
+        primal_solution_status=2,
+        dual_solution_status=0,
+        max_integrality_violation=0.0,
+        max_primal_infeasibility=0.0,
+        max_dual_infeasibility=0.0,
+        run_time_sec=0.01,
+        highs_version="1.14.0",
+        highs_githash="7df0786",
+    )
+
+
+def test_direct_solve_records_termination_report():
+    collector = DiagnosticCollector()
+
+    solution = OMMXHighsAdapter.solve(_mip_instance(), diagnostics=collector)
+
+    assert solution.optimality == Solution.OPTIMAL
+    reports = [
+        diagnostic
+        for diagnostic in collector.diagnostics
+        if isinstance(diagnostic, HighsTerminationReport)
+    ]
+    assert reports
+    assert collector.diagnostics[-1] is reports[-1]
+
+    report = reports[-1]
+    assert report.status == "Optimal"
+    assert report.objective_value == pytest.approx(5.0)
+    assert report.mip_dual_bound == pytest.approx(5.0)
+    assert report.mip_gap == pytest.approx(0.0)
+    assert report.mip_node_count >= 0
+    assert isinstance(report.highs_version, str)
+    assert isinstance(report.highs_githash, str)
+
+
+def test_analyzer_accepts_typed_reports():
+    report = _termination_report()
+
+    analyzer = HighsDiagnosticsAnalyzer([report])
+
+    assert analyzer.termination_result == asdict(report)
+    assert analyzer.status == "Optimal"
+    assert analyzer.objective_value == pytest.approx(5.0)
+    assert analyzer.mip_dual_bound == pytest.approx(5.0)
+    assert analyzer.dual_bound == pytest.approx(5.0)
+    assert analyzer.mip_gap == pytest.approx(0.0)
+    assert analyzer.gap == pytest.approx(0.0)
+    assert analyzer.mip_node_count == 0
+    assert analyzer.node_count == 0
+
+
+def test_analyzer_accepts_experiment_dicts():
+    report = _termination_report()
+    payload = asdict(report)
+
+    analyzer = HighsDiagnosticsAnalyzer([payload])
+
+    assert analyzer.termination_result == payload
+    assert analyzer.dual_bound == pytest.approx(5.0)
+
+
+def test_experiment_stores_diagnostics_as_dict_payload():
+    with Experiment.with_temp_local_registry() as experiment:
+        with experiment.run() as run:
+            run.log_solve(
+                OMMXHighsAdapter,
+                _mip_instance(),
+                store_diagnostics=True,
+            )
+
+    diagnostics = experiment.runs[0].solves[0].diagnostics
+    analyzer = HighsDiagnosticsAnalyzer(diagnostics)
+
+    assert diagnostics
+    assert all(isinstance(diagnostic, dict) for diagnostic in diagnostics)
+    assert diagnostics[-1]["status"] == "Optimal"
+    assert analyzer.dual_bound == pytest.approx(5.0)
+    assert analyzer.gap == pytest.approx(0.0)
+
+
+def test_direct_collector_keeps_termination_report_before_decode_error():
+    collector = DiagnosticCollector()
+
+    with pytest.raises(InfeasibleDetected):
+        OMMXHighsAdapter.solve(_infeasible_instance(), diagnostics=collector)
+
+    diagnostic = collector.diagnostics[-1]
+    assert isinstance(diagnostic, HighsTerminationReport)
+    assert diagnostic.status == "Infeasible"
+    assert diagnostic.objective_value is None
+
+
+def test_highs_termination_report_rejects_unoptimized_model():
+    model = highspy.Highs()
+
+    with pytest.raises(
+        OMMXHighsAdapterError,
+        match=r"The model may not be optimized\. \[status: Not Set\]",
+    ):
+        HighsTerminationReport.from_model(model)

--- a/python/ommx-highs-adapter/tests/test_diagnostics.py
+++ b/python/ommx-highs-adapter/tests/test_diagnostics.py
@@ -1,13 +1,15 @@
 from dataclasses import asdict
+from typing import cast
 
 import highspy
 import pytest
 
 from ommx.adapter import DiagnosticCollector, InfeasibleDetected
 from ommx.experiment import Experiment
-from ommx.v1 import DecisionVariable, Instance, Solution
+from ommx.v1 import Constraint, DecisionVariable, Instance, Solution
 from ommx_highs_adapter import (
     HighsDiagnosticsAnalyzer,
+    HighsProgressSnapshot,
     HighsTerminationReport,
     OMMXHighsAdapter,
     OMMXHighsAdapterError,
@@ -24,6 +26,20 @@ def _mip_instance() -> Instance:
     )
 
 
+def _knapsack_instance() -> Instance:
+    values = [i % 11 + 1 for i in range(30)]
+    weights = [i % 7 + 1 for i in range(30)]
+    x = [DecisionVariable.binary(i) for i in range(30)]
+    return Instance.from_components(
+        decision_variables=x,
+        objective=sum(values[i] * x[i] for i in range(30)),
+        constraints={
+            0: cast(Constraint, sum(weights[i] * x[i] for i in range(30)) <= 60)
+        },
+        sense=Instance.MAXIMIZE,
+    )
+
+
 def _infeasible_instance() -> Instance:
     x = DecisionVariable.continuous(1)
     return Instance.from_components(
@@ -31,6 +47,30 @@ def _infeasible_instance() -> Instance:
         objective=0,
         constraints={0: x == 0, 1: x == 1},
         sense=Instance.MINIMIZE,
+    )
+
+
+def _progress_snapshot(
+    *,
+    event: str = "MIP logging",
+    running_time_sec: float = 0.25,
+    mip_node_count: int = 0,
+    objective_value: float = 10.0,
+    mip_primal_bound: float = 10.0,
+    mip_dual_bound: float = 12.0,
+    mip_gap: float = 0.2,
+) -> HighsProgressSnapshot:
+    return HighsProgressSnapshot(
+        event=event,
+        running_time_sec=running_time_sec,
+        mip_node_count=mip_node_count,
+        simplex_iteration_count=-1,
+        ipm_iteration_count=-1,
+        pdlp_iteration_count=-1,
+        objective_value=objective_value,
+        mip_primal_bound=mip_primal_bound,
+        mip_dual_bound=mip_dual_bound,
+        mip_gap=mip_gap,
     )
 
 
@@ -57,6 +97,10 @@ def _termination_report() -> HighsTerminationReport:
     )
 
 
+def _progress_snapshot_dict(snapshot: HighsProgressSnapshot) -> dict[str, object]:
+    return asdict(snapshot)
+
+
 def test_direct_solve_records_termination_report():
     collector = DiagnosticCollector()
 
@@ -81,30 +125,86 @@ def test_direct_solve_records_termination_report():
     assert isinstance(report.highs_githash, str)
 
 
+def test_direct_solve_records_progress_snapshots():
+    collector = DiagnosticCollector()
+
+    solution = OMMXHighsAdapter.solve(_knapsack_instance(), diagnostics=collector)
+
+    assert solution.optimality == Solution.OPTIMAL
+    progress_snapshots = [
+        diagnostic
+        for diagnostic in collector.diagnostics
+        if isinstance(diagnostic, HighsProgressSnapshot)
+    ]
+    assert progress_snapshots
+    assert collector.diagnostics[-1].__class__ is HighsTerminationReport
+    assert {snapshot.event for snapshot in progress_snapshots} == {"MIP logging"}
+    for snapshot in progress_snapshots:
+        assert snapshot.running_time_sec >= 0.0
+        assert snapshot.mip_node_count >= 0
+        assert isinstance(snapshot.mip_primal_bound, float)
+        assert isinstance(snapshot.mip_dual_bound, float)
+        assert isinstance(snapshot.mip_gap, float)
+
+
 def test_analyzer_accepts_typed_reports():
+    first = _progress_snapshot()
+    second = _progress_snapshot(
+        running_time_sec=0.5,
+        mip_node_count=1,
+        objective_value=10.0,
+        mip_primal_bound=10.0,
+        mip_dual_bound=10.0,
+        mip_gap=0.0,
+    )
     report = _termination_report()
 
-    analyzer = HighsDiagnosticsAnalyzer([report])
+    analyzer = HighsDiagnosticsAnalyzer([first, second, report])
 
+    assert analyzer.progress_snapshots == (first, second)
+    assert analyzer.progress_history_records == [
+        _progress_snapshot_dict(first),
+        _progress_snapshot_dict(second),
+    ]
     assert analyzer.termination_result == asdict(report)
-    assert analyzer.status == "Optimal"
-    assert analyzer.objective_value == pytest.approx(5.0)
-    assert analyzer.mip_dual_bound == pytest.approx(5.0)
-    assert analyzer.dual_bound == pytest.approx(5.0)
-    assert analyzer.mip_gap == pytest.approx(0.0)
-    assert analyzer.gap == pytest.approx(0.0)
-    assert analyzer.mip_node_count == 0
-    assert analyzer.node_count == 0
+    assert list(analyzer.progress_history_df.columns) == [
+        "event",
+        "mip_node_count",
+        "simplex_iteration_count",
+        "ipm_iteration_count",
+        "pdlp_iteration_count",
+        "objective_value",
+        "mip_primal_bound",
+        "mip_dual_bound",
+        "mip_gap",
+    ]
+    assert analyzer.progress_history_df.index.name == "running_time_sec"
+    assert list(analyzer.progress_history_df.index) == [0.25, 0.5]
+    assert list(analyzer.dual_bound) == [12.0, 10.0]
+    assert list(analyzer.gap) == [0.2, 0.0]
+    assert list(analyzer.primal_bound) == [10.0, 10.0]
+    assert list(analyzer.node_count) == [0, 1]
+    assert analyzer.dual_bound.index.name == "running_time_sec"
+    assert analyzer.termination_status == "Optimal"
+    assert analyzer.termination_objective_value == pytest.approx(5.0)
+    assert analyzer.termination_mip_dual_bound == pytest.approx(5.0)
+    assert analyzer.termination_mip_gap == pytest.approx(0.0)
+    assert analyzer.termination_mip_node_count == 0
 
 
 def test_analyzer_accepts_experiment_dicts():
+    progress = _progress_snapshot()
     report = _termination_report()
+    progress_payload = asdict(progress)
     payload = asdict(report)
 
-    analyzer = HighsDiagnosticsAnalyzer([payload])
+    analyzer = HighsDiagnosticsAnalyzer([progress_payload, payload])
 
+    assert analyzer.progress_snapshots == ()
+    assert analyzer.progress_history_records == [progress_payload]
     assert analyzer.termination_result == payload
-    assert analyzer.dual_bound == pytest.approx(5.0)
+    assert list(analyzer.dual_bound) == [12.0]
+    assert analyzer.termination_mip_dual_bound == pytest.approx(5.0)
 
 
 def test_experiment_stores_diagnostics_as_dict_payload():
@@ -112,7 +212,7 @@ def test_experiment_stores_diagnostics_as_dict_payload():
         with experiment.run() as run:
             run.log_solve(
                 OMMXHighsAdapter,
-                _mip_instance(),
+                _knapsack_instance(),
                 store_diagnostics=True,
             )
 
@@ -121,9 +221,11 @@ def test_experiment_stores_diagnostics_as_dict_payload():
 
     assert diagnostics
     assert all(isinstance(diagnostic, dict) for diagnostic in diagnostics)
+    assert analyzer.progress_history_records
     assert diagnostics[-1]["status"] == "Optimal"
-    assert analyzer.dual_bound == pytest.approx(5.0)
-    assert analyzer.gap == pytest.approx(0.0)
+    assert analyzer.termination_result is not None
+    assert analyzer.termination_result["mip_gap"] == pytest.approx(0.0)
+    assert analyzer.dual_bound.index.name == "running_time_sec"
 
 
 def test_direct_collector_keeps_termination_report_before_decode_error():


### PR DESCRIPTION
## Summary
- Record HiGHS MIP progress snapshots from the MIP logging callback, including `solving_time_sec`, `primal_bound`, `dual_bound`, `gap`, node counts, and iteration counters.
- Record a HiGHS termination report before decoding so final status, MIP bounds, gap, feasibility summaries, runtime, and version metadata remain available even when decoding raises.
- Add `HighsDiagnosticsAnalyzer` support for typed diagnostics and Experiment-stored dictionaries, with pandas history/Series helpers aligned with the PySCIPOpt diagnostics shape.
- Export the HiGHS diagnostics types from `ommx_highs_adapter` and document direct and Experiment-based diagnostics usage in the English and Japanese user guides.
- Add HiGHS diagnostics coverage for direct solves, progress history, analyzer parsing, Experiment persistence, decode-failure retention, and unoptimized-model rejection.
