### PR TITLE
Pin rusqlite below cfg_select build script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,9 @@ updates:
       - dependency-name: "prost-build"
       # Keep oci-spec aligned with the version re-exported by oci-client
       - dependency-name: "oci-spec"
+      # rusqlite 0.40 pulls in libsqlite3-sys 0.38, whose build script requires
+      # a newer Rust toolchain than the current OMMX MSRV and Pyodide build pin.
+      - dependency-name: "rusqlite"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,17 +1473,14 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2126,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3414,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -4102,7 +4099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ quote = "1.0.40"
 pyo3 = { version = "0.27.2", features = ["anyhow", "multiple-pymethods"] }
 pyo3-stub-gen = "0.22.3"
 pyo3-tracing-opentelemetry = "0.3.0"
-rusqlite = { version = "0.40.1", features = ["bundled"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 rmpv = "1.3.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde-pyobject = "0.8.0"


### PR DESCRIPTION
## Summary

- Revert the workspace `rusqlite` dependency to `0.39.0`, restoring `libsqlite3-sys 0.37.0` in `Cargo.lock`.
- Add a Dependabot ignore rule that prevents automatic `rusqlite` minor and major updates while still allowing patch updates.

## Background

The `rusqlite 0.40.1` update pulled in `libsqlite3-sys 0.38.1`. That build script uses `cfg_select!`, which requires a newer Rust toolchain than the current OMMX MSRV and the pinned Pyodide build toolchain. Keeping `rusqlite` on `0.39.x` avoids reintroducing the incompatible build script until the toolchain policy is updated deliberately.