### PR TITLE
Add scalar division for Function

### DIFF
--- a/rust/ommx/src/coefficient.rs
+++ b/rust/ommx/src/coefficient.rs
@@ -3,7 +3,7 @@ use ordered_float::NotNan;
 use proptest::prelude::*;
 use std::{
     fmt::{Debug, Display},
-    ops::{Add, Deref, Mul, MulAssign, Neg, Sub},
+    ops::{Add, Deref, Div, DivAssign, Mul, MulAssign, Neg, Sub},
 };
 
 use crate::ATol;
@@ -109,6 +109,19 @@ impl MulAssign for Coefficient {
     }
 }
 
+impl Div for Coefficient {
+    type Output = Self;
+    fn div(self, rhs: Self) -> Self::Output {
+        Self(self.0 / rhs.0)
+    }
+}
+
+impl DivAssign for Coefficient {
+    fn div_assign(&mut self, rhs: Self) {
+        self.0 /= rhs.0;
+    }
+}
+
 impl Neg for Coefficient {
     type Output = Self;
     fn neg(self) -> Self::Output {
@@ -173,5 +186,16 @@ impl PartialEq<ATol> for Coefficient {
 impl PartialOrd<ATol> for Coefficient {
     fn partial_cmp(&self, other: &ATol) -> Option<std::cmp::Ordering> {
         self.into_inner().partial_cmp(&other.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn div_uses_direct_floating_point_division() {
+        let tiny = Coefficient::try_from(f64::from_bits(1)).unwrap();
+        assert_eq!((tiny / tiny).into_inner(), 1.0);
     }
 }

--- a/rust/ommx/src/coefficient.rs
+++ b/rust/ommx/src/coefficient.rs
@@ -22,9 +22,10 @@ pub enum CoefficientError {
 /// Coefficient of polynomial terms.
 ///
 /// `Coefficient::try_from` rejects zero, infinite, and NaN inputs. Arithmetic
-/// operations use unchecked floating-point operations for performance: overflow
-/// can produce infinity, and underflow can produce zero. This type only
-/// guarantees that stored values are not NaN.
+/// operations use unchecked floating-point operations for performance, then wrap
+/// the result as `NotNan`: overflow can produce infinity, underflow can produce
+/// zero, and NaN results panic while being wrapped. `Inv::inv` follows the same
+/// model. This type only guarantees that stored values are not NaN.
 #[derive(
     Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
@@ -212,6 +213,15 @@ mod tests {
     fn arithmetic_can_create_zero_and_infinity() {
         assert_eq!(zero_by_underflow().into_inner(), 0.0);
         assert!(infinity_by_overflow().into_inner().is_infinite());
+    }
+
+    #[test]
+    fn inv_allows_zero_and_infinity_created_by_arithmetic() {
+        let zero = zero_by_underflow();
+        assert!(zero.inv().into_inner().is_infinite());
+
+        let infinity = infinity_by_overflow();
+        assert_eq!(infinity.inv().into_inner(), 0.0);
     }
 
     // FIXME: Revisit the Coefficient invariant; arithmetic currently permits zero and infinity,

--- a/rust/ommx/src/coefficient.rs
+++ b/rust/ommx/src/coefficient.rs
@@ -21,9 +21,10 @@ pub enum CoefficientError {
 
 /// Coefficient of polynomial terms.
 ///
-/// Invariants
-/// -----------
-/// - The value is not zero and finite.
+/// `Coefficient::try_from` rejects zero, infinite, and NaN inputs. Arithmetic
+/// operations use unchecked floating-point operations for performance: overflow
+/// can produce infinity, and underflow can produce zero. This type only
+/// guarantees that stored values are not NaN.
 #[derive(
     Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
@@ -47,7 +48,7 @@ impl Coefficient {
         self.0.into_inner()
     }
 
-    /// ABS of the coefficient is also a coefficient.
+    /// ABS of the coefficient.
     pub fn abs(&self) -> Self {
         Self(self.0.abs().try_into().unwrap())
     }
@@ -95,7 +96,6 @@ impl Add for Coefficient {
     }
 }
 
-// Non-zero * Non-zero = Non-zero
 impl Mul for Coefficient {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self::Output {
@@ -145,7 +145,6 @@ impl One for Coefficient {
 impl Inv for Coefficient {
     type Output = Self;
     fn inv(self) -> Self::Output {
-        // Non-zero coefficient is invertible
         Self(self.0.into_inner().recip().try_into().unwrap())
     }
 }
@@ -193,9 +192,61 @@ impl PartialOrd<ATol> for Coefficient {
 mod tests {
     use super::*;
 
+    fn zero_by_underflow() -> Coefficient {
+        let tiny = Coefficient::try_from(f64::from_bits(1)).unwrap();
+        tiny * tiny
+    }
+
+    fn infinity_by_overflow() -> Coefficient {
+        let max = Coefficient::try_from(f64::MAX).unwrap();
+        max * max
+    }
+
     #[test]
     fn div_uses_direct_floating_point_division() {
         let tiny = Coefficient::try_from(f64::from_bits(1)).unwrap();
         assert_eq!((tiny / tiny).into_inner(), 1.0);
+    }
+
+    #[test]
+    fn arithmetic_can_create_zero_and_infinity() {
+        assert_eq!(zero_by_underflow().into_inner(), 0.0);
+        assert!(infinity_by_overflow().into_inner().is_infinite());
+    }
+
+    // FIXME: Revisit the Coefficient invariant; arithmetic currently permits zero and infinity,
+    // and only NaN-producing operations are rejected by NotNan panics.
+    #[test]
+    #[should_panic]
+    fn add_opposite_infinities_panics() {
+        let infinity = infinity_by_overflow();
+        let _ = infinity + (-infinity);
+    }
+
+    #[test]
+    #[should_panic]
+    fn subtract_infinities_panics() {
+        let infinity = infinity_by_overflow();
+        let _ = infinity - infinity;
+    }
+
+    #[test]
+    #[should_panic]
+    fn multiply_infinity_by_zero_panics() {
+        let _ = infinity_by_overflow() * zero_by_underflow();
+    }
+
+    #[test]
+    #[should_panic]
+    fn divide_infinity_by_infinity_panics() {
+        let infinity = infinity_by_overflow();
+        let _ = infinity / infinity;
+    }
+
+    #[test]
+    #[should_panic]
+    fn divide_zero_by_zero_panics() {
+        let zero = zero_by_underflow();
+        let _ = zero / zero;
     }
 }

--- a/rust/ommx/src/function.rs
+++ b/rust/ommx/src/function.rs
@@ -26,10 +26,10 @@ mod substitute;
 pub enum Function {
     #[default]
     Zero,
-    /// Constant term.
+    /// Constant term stored as a [`Coefficient`].
     ///
-    /// Constructors avoid zero constants, but coefficient arithmetic is unchecked and can
-    /// underflow to zero.
+    /// This variant inherits `Coefficient`'s unchecked arithmetic behavior: constructing from an
+    /// existing coefficient or applying later arithmetic can carry zero or +/-infinity.
     Constant(Coefficient),
     Linear(Linear),
     Quadratic(Quadratic),

--- a/rust/ommx/src/function.rs
+++ b/rust/ommx/src/function.rs
@@ -26,7 +26,10 @@ mod substitute;
 pub enum Function {
     #[default]
     Zero,
-    /// Non-zero constant
+    /// Constant term.
+    ///
+    /// Constructors avoid zero constants, but coefficient arithmetic is unchecked and can
+    /// underflow to zero.
     Constant(Coefficient),
     Linear(Linear),
     Quadratic(Quadratic),

--- a/rust/ommx/src/function.rs
+++ b/rust/ommx/src/function.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 mod add;
 mod approx;
 mod arbitrary;
+mod div;
 mod evaluate;
 mod evaluate_bound;
 mod logical_memory;

--- a/rust/ommx/src/function/div.rs
+++ b/rust/ommx/src/function/div.rs
@@ -4,8 +4,13 @@ use super::*;
 
 impl DivAssign<Coefficient> for Function {
     fn div_assign(&mut self, rhs: Coefficient) {
-        self.values_mut()
-            .for_each(|coefficient| *coefficient /= rhs);
+        match self {
+            Function::Zero => {}
+            Function::Constant(c) => *c /= rhs,
+            Function::Linear(l) => l.values_mut().for_each(|coefficient| *coefficient /= rhs),
+            Function::Quadratic(q) => q.values_mut().for_each(|coefficient| *coefficient /= rhs),
+            Function::Polynomial(p) => p.values_mut().for_each(|coefficient| *coefficient /= rhs),
+        }
     }
 }
 

--- a/rust/ommx/src/function/div.rs
+++ b/rust/ommx/src/function/div.rs
@@ -1,0 +1,87 @@
+use std::ops::{Div, DivAssign};
+
+use super::*;
+
+impl DivAssign<Coefficient> for Function {
+    fn div_assign(&mut self, rhs: Coefficient) {
+        self.values_mut()
+            .for_each(|coefficient| *coefficient /= rhs);
+    }
+}
+
+impl DivAssign<&Coefficient> for Function {
+    fn div_assign(&mut self, rhs: &Coefficient) {
+        *self /= *rhs;
+    }
+}
+
+impl Div<Coefficient> for Function {
+    type Output = Self;
+
+    fn div(mut self, rhs: Coefficient) -> Self::Output {
+        self /= rhs;
+        self
+    }
+}
+
+impl Div<&Coefficient> for Function {
+    type Output = Self;
+
+    fn div(mut self, rhs: &Coefficient) -> Self::Output {
+        self /= rhs;
+        self
+    }
+}
+
+impl Div<Coefficient> for &Function {
+    type Output = Function;
+
+    fn div(self, rhs: Coefficient) -> Self::Output {
+        self.clone() / rhs
+    }
+}
+
+impl Div<&Coefficient> for &Function {
+    type Output = Function;
+
+    fn div(self, rhs: &Coefficient) -> Self::Output {
+        self.clone() / rhs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::approx::assert_abs_diff_eq;
+    use num::{One, Zero};
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn div_ref(a in any::<Function>(), c in any::<Coefficient>()) {
+            let expected = a.clone() / c;
+            assert_abs_diff_eq!(&a / c, expected);
+            assert_abs_diff_eq!(a.clone() / &c, expected);
+            assert_abs_diff_eq!(&a / &c, expected);
+        }
+
+        #[test]
+        fn div_inverse_of_mul(a in any::<Function>(), c in any::<Coefficient>()) {
+            assert_abs_diff_eq!((a.clone() / c) * c, a);
+        }
+
+        #[test]
+        fn zero(a in any::<Coefficient>()) {
+            assert_abs_diff_eq!(Function::zero() / a, Function::zero());
+        }
+    }
+
+    #[test]
+    fn div_uses_direct_floating_point_division() {
+        let tiny = Coefficient::try_from(f64::from_bits(1)).unwrap();
+        assert_abs_diff_eq!(
+            Function::from(tiny) / tiny,
+            Function::from(Coefficient::one())
+        );
+    }
+}

--- a/rust/ommx/src/function/div.rs
+++ b/rust/ommx/src/function/div.rs
@@ -52,6 +52,7 @@ impl Div<&Coefficient> for &Function {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{coeff, linear};
     use ::approx::assert_abs_diff_eq;
     use num::{One, Zero};
     use proptest::prelude::*;
@@ -83,5 +84,40 @@ mod tests {
             Function::from(tiny) / tiny,
             Function::from(Coefficient::one())
         );
+    }
+
+    #[test]
+    fn div_by_zero_coefficient_created_by_arithmetic_produces_infinities() {
+        let tiny = Coefficient::try_from(f64::from_bits(1)).unwrap();
+        let zero = tiny * tiny;
+        assert_eq!(zero.into_inner(), 0.0);
+
+        let function =
+            Function::from(coeff!(2.0) * linear!(1) + (-coeff!(3.0)) * linear!(2) + coeff!(4.0));
+        let divided = function / zero;
+        let values = divided
+            .values()
+            .map(|coefficient| coefficient.into_inner())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values.len(), 3);
+        assert!(values.iter().all(|value| value.is_infinite()));
+        assert!(values.iter().any(|value| value.is_sign_positive()));
+        assert!(values.iter().any(|value| value.is_sign_negative()));
+    }
+
+    #[test]
+    fn zero_function_div_by_zero_coefficient_is_noop() {
+        let tiny = Coefficient::try_from(f64::from_bits(1)).unwrap();
+        let zero = tiny * tiny;
+        assert_abs_diff_eq!(Function::zero() / zero, Function::zero());
+    }
+
+    #[test]
+    #[should_panic]
+    fn zero_coefficient_div_by_zero_coefficient_panics() {
+        let tiny = Coefficient::try_from(f64::from_bits(1)).unwrap();
+        let zero = tiny * tiny;
+        let _ = Function::from(zero) / zero;
     }
 }


### PR DESCRIPTION
## Summary

This adds scalar division support for `ommx::Function` through `Coefficient` operands, including owned and borrowed RHS variants. `Function` division scales coefficients directly with `Coefficient` division instead of multiplying by an inverse, so tiny coefficient ratios follow direct floating-point division behavior.

The change also adds `Coefficient` division operators used by `Function`, documents the current unchecked arithmetic model, and records existing edge-case behavior around arithmetic-created zero and infinity values. The tests make explicit that `Coefficient` construction rejects zero, infinity, and NaN, while later arithmetic can still underflow to zero or overflow to infinity, with NaN-producing combinations left to `NotNan` panics.

## Impact

Rust users can now write `function / coefficient` and `function /= coefficient` consistently with existing scalar multiplication. The documentation no longer claims a stronger finite non-zero invariant than the current implementation provides.