### PR TITLE
Normalize decision variable table ownership

### DIFF
--- a/python/ommx/src/constraint.rs
+++ b/python/ommx/src/constraint.rs
@@ -249,7 +249,7 @@ impl Constraint {
         indicator_variable: &crate::DecisionVariable,
     ) -> crate::IndicatorConstraint {
         let ic = ommx::IndicatorConstraint::new(
-            indicator_variable.0.id(),
+            indicator_variable.0,
             self.0.equality,
             self.0.stage.function.clone(),
         );

--- a/python/ommx/src/decision_variable.rs
+++ b/python/ommx/src/decision_variable.rs
@@ -1,6 +1,6 @@
 use crate::{Constraint, Function, Linear, Polynomial, Quadratic, VariableBound};
 use anyhow::Result;
-use ommx::{v1, ATol, LinearMonomial, VariableID};
+use ommx::{v1, LinearMonomial, VariableID};
 use pyo3::{prelude::*, Bound, PyAny};
 use std::collections::HashMap;
 
@@ -131,7 +131,7 @@ impl DecisionVariable {
         let variable_id = VariableID::from(id);
         let kind = v1::decision_variable::Kind::try_from(kind)?.try_into()?;
 
-        let decision_variable = ommx::DecisionVariable::new(kind, bound.0, ATol::default())?;
+        let decision_variable = ommx::DecisionVariable::new(kind, bound.0)?;
 
         let label = ommx::DecisionVariableLabel {
             name,

--- a/python/ommx/src/decision_variable.rs
+++ b/python/ommx/src/decision_variable.rs
@@ -30,20 +30,24 @@ use std::collections::HashMap;
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
 #[derive(Clone)]
-pub struct DecisionVariable(pub ommx::DecisionVariable, pub ommx::DecisionVariableLabel);
+pub struct DecisionVariable(
+    pub VariableID,
+    pub ommx::DecisionVariable,
+    pub ommx::DecisionVariableLabel,
+);
 
 impl DecisionVariable {
     /// Helper to create a Linear term from this decision variable with coefficient 1
     fn as_linear(&self) -> ommx::Linear {
-        ommx::Linear::single_term(LinearMonomial::Variable(self.0.id()), ommx::coeff!(1.0))
+        ommx::Linear::single_term(LinearMonomial::Variable(self.0), ommx::coeff!(1.0))
     }
 
-    pub fn standalone(inner: ommx::DecisionVariable) -> Self {
-        Self(inner, ommx::DecisionVariableLabel::default())
-    }
-
-    pub fn from_parts(inner: ommx::DecisionVariable, label: ommx::DecisionVariableLabel) -> Self {
-        Self(inner, label)
+    pub fn from_parts(
+        id: VariableID,
+        inner: ommx::DecisionVariable,
+        label: ommx::DecisionVariableLabel,
+    ) -> Self {
+        Self(id, inner, label)
     }
 }
 
@@ -127,8 +131,7 @@ impl DecisionVariable {
         let variable_id = VariableID::from(id);
         let kind = v1::decision_variable::Kind::try_from(kind)?.try_into()?;
 
-        let decision_variable =
-            ommx::DecisionVariable::new(variable_id, kind, bound.0, ATol::default())?;
+        let decision_variable = ommx::DecisionVariable::new(kind, bound.0, ATol::default())?;
 
         let label = ommx::DecisionVariableLabel {
             name,
@@ -137,38 +140,38 @@ impl DecisionVariable {
             description,
         };
 
-        Ok(Self(decision_variable, label))
+        Ok(Self(variable_id, decision_variable, label))
     }
 
     #[getter]
     pub fn id(&self) -> u64 {
-        self.0.id().into_inner()
+        self.0.into_inner()
     }
 
     #[getter]
     pub fn kind(&self) -> i32 {
-        let kind: v1::decision_variable::Kind = self.0.kind().into();
+        let kind: v1::decision_variable::Kind = self.1.kind().into();
         kind as i32
     }
 
     #[getter]
     pub fn bound(&self) -> VariableBound {
-        VariableBound(self.0.bound())
+        VariableBound(self.1.bound())
     }
 
     #[getter]
     pub fn name(&self) -> String {
-        self.1.name.clone().unwrap_or_default()
+        self.2.name.clone().unwrap_or_default()
     }
 
     #[getter]
     pub fn subscripts(&self) -> Vec<i64> {
-        self.1.subscripts.clone()
+        self.2.subscripts.clone()
     }
 
     #[getter]
     pub fn parameters(&self) -> HashMap<String, String> {
-        self.1
+        self.2
             .parameters
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
@@ -177,7 +180,7 @@ impl DecisionVariable {
 
     #[getter]
     pub fn description(&self) -> String {
-        self.1.description.clone().unwrap_or_default()
+        self.2.description.clone().unwrap_or_default()
     }
 
     #[staticmethod]
@@ -294,8 +297,8 @@ impl DecisionVariable {
             self.id(),
             self.kind(),
             self.name(),
-            self.0.bound().lower(),
-            self.0.bound().upper()
+            self.1.bound().lower(),
+            self.1.bound().upper()
         )
     }
 
@@ -338,9 +341,7 @@ impl DecisionVariable {
     /// This is different from `__eq__` which creates a Constraint.
     /// Use this method when you want to check if two variables represent the same variable.
     pub fn equals_to(&self, other: &DecisionVariable) -> bool {
-        self.0.id() == other.0.id()
-            && self.0.kind() == other.0.kind()
-            && self.0.bound() == other.0.bound()
+        self.0 == other.0 && self.1.kind() == other.1.kind() && self.1.bound() == other.1.bound()
     }
 
     // =====================
@@ -350,7 +351,7 @@ impl DecisionVariable {
     /// Negation operator: -x → Linear(-1 * x)
     pub fn __neg__(&self) -> Linear {
         Linear(ommx::Linear::single_term(
-            LinearMonomial::Variable(self.0.id()),
+            LinearMonomial::Variable(self.0),
             ommx::coeff!(-1.0),
         ))
     }
@@ -698,13 +699,13 @@ impl AttachedDecisionVariable {
                 let inst = p.borrow(py);
                 let v = lookup_variable(&inst.inner, self.id)?.clone();
                 let label = inst.inner.variable_labels().collect_for(self.id);
-                Ok(DecisionVariable::from_parts(v, label))
+                Ok(DecisionVariable::from_parts(self.id, v, label))
             }
             crate::ConstraintHost::Parametric(p) => {
                 let inst = p.borrow(py);
                 let v = lookup_variable_parametric(&inst.inner, self.id)?.clone();
                 let label = inst.inner.variable_labels().collect_for(self.id);
-                Ok(DecisionVariable::from_parts(v, label))
+                Ok(DecisionVariable::from_parts(self.id, v, label))
             }
         }
     }
@@ -762,22 +763,23 @@ impl AttachedDecisionVariable {
     }
 
     pub fn __repr__(&self, py: Python<'_>) -> String {
-        let render = |v: &ommx::DecisionVariable, name: Option<&str>| -> String {
-            let kind: ommx::v1::decision_variable::Kind = v.kind().into();
-            format!(
-                "AttachedDecisionVariable(id={}, kind={}, name=\"{}\", bound=[{}, {}])",
-                v.id().into_inner(),
-                kind as i32,
-                name.unwrap_or(""),
-                v.bound().lower(),
-                v.bound().upper()
-            )
-        };
+        let render =
+            |id: ommx::VariableID, v: &ommx::DecisionVariable, name: Option<&str>| -> String {
+                let kind: ommx::v1::decision_variable::Kind = v.kind().into();
+                format!(
+                    "AttachedDecisionVariable(id={}, kind={}, name=\"{}\", bound=[{}, {}])",
+                    id.into_inner(),
+                    kind as i32,
+                    name.unwrap_or(""),
+                    v.bound().lower(),
+                    v.bound().upper()
+                )
+            };
         match &self.host {
             crate::ConstraintHost::Instance(p) => {
                 let inst = p.borrow(py);
                 match lookup_variable(&inst.inner, self.id) {
-                    Ok(v) => render(v, inst.inner.variable_labels().name(self.id)),
+                    Ok(v) => render(self.id, v, inst.inner.variable_labels().name(self.id)),
                     Err(_) => format!(
                         "AttachedDecisionVariable(id={}, dropped)",
                         self.id.into_inner()
@@ -787,7 +789,7 @@ impl AttachedDecisionVariable {
             crate::ConstraintHost::Parametric(p) => {
                 let inst = p.borrow(py);
                 match lookup_variable_parametric(&inst.inner, self.id) {
-                    Ok(v) => render(v, inst.inner.variable_labels().name(self.id)),
+                    Ok(v) => render(self.id, v, inst.inner.variable_labels().name(self.id)),
                     Err(_) => format!(
                         "AttachedDecisionVariable(id={}, dropped)",
                         self.id.into_inner()

--- a/python/ommx/src/decision_variable.rs
+++ b/python/ommx/src/decision_variable.rs
@@ -1,6 +1,6 @@
 use crate::{Constraint, Function, Linear, Polynomial, Quadratic, VariableBound};
 use anyhow::Result;
-use ommx::{v1, LinearMonomial, VariableID};
+use ommx::{v1, ATol, LinearMonomial, VariableID};
 use pyo3::{prelude::*, Bound, PyAny};
 use std::collections::HashMap;
 
@@ -131,7 +131,7 @@ impl DecisionVariable {
         let variable_id = VariableID::from(id);
         let kind = v1::decision_variable::Kind::try_from(kind)?.try_into()?;
 
-        let decision_variable = ommx::DecisionVariable::new(kind, bound.0)?;
+        let decision_variable = ommx::DecisionVariable::new(kind, bound.0, ATol::default())?;
 
         let label = ommx::DecisionVariableLabel {
             name,

--- a/python/ommx/src/evaluated_decision_variable.rs
+++ b/python/ommx/src/evaluated_decision_variable.rs
@@ -3,20 +3,18 @@ use pyo3::prelude::*;
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
 pub struct EvaluatedDecisionVariable(
+    pub ommx::VariableID,
     pub ommx::EvaluatedDecisionVariable,
     pub ommx::DecisionVariableLabel,
 );
 
 impl EvaluatedDecisionVariable {
-    pub fn standalone(inner: ommx::EvaluatedDecisionVariable) -> Self {
-        Self(inner, ommx::DecisionVariableLabel::default())
-    }
-
     pub fn from_parts(
+        id: ommx::VariableID,
         inner: ommx::EvaluatedDecisionVariable,
         label: ommx::DecisionVariableLabel,
     ) -> Self {
-        Self(inner, label)
+        Self(id, inner, label)
     }
 }
 
@@ -26,49 +24,49 @@ impl EvaluatedDecisionVariable {
     /// Get the variable ID
     #[getter]
     pub fn id(&self) -> u64 {
-        self.0.id().into_inner()
+        self.0.into_inner()
     }
 
     /// Get the variable kind
     #[getter]
     pub fn kind(&self) -> crate::Kind {
-        (*self.0.kind()).into()
+        (*self.1.kind()).into()
     }
 
     /// Get the evaluated value
     #[getter]
     pub fn value(&self) -> f64 {
-        *self.0.value()
+        *self.1.value()
     }
 
     /// Get the lower bound
     #[getter]
     pub fn lower_bound(&self) -> f64 {
-        self.0.bound().lower()
+        self.1.bound().lower()
     }
 
     /// Get the upper bound
     #[getter]
     pub fn upper_bound(&self) -> f64 {
-        self.0.bound().upper()
+        self.1.bound().upper()
     }
 
     /// Get the variable name
     #[getter]
     pub fn name(&self) -> Option<String> {
-        self.1.name.clone()
+        self.2.name.clone()
     }
 
     /// Get the subscripts
     #[getter]
     pub fn subscripts(&self) -> Vec<i64> {
-        self.1.subscripts.clone()
+        self.2.subscripts.clone()
     }
 
     /// Get the parameters
     #[getter]
     pub fn parameters(&self) -> std::collections::HashMap<String, String> {
-        self.1
+        self.2
             .parameters
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
@@ -78,6 +76,6 @@ impl EvaluatedDecisionVariable {
     /// Get the description
     #[getter]
     pub fn description(&self) -> Option<String> {
-        self.1.description.clone()
+        self.2.description.clone()
     }
 }

--- a/python/ommx/src/function.rs
+++ b/python/ommx/src/function.rs
@@ -138,7 +138,7 @@ impl<'py> FromPyObject<'_, 'py> for FunctionInput {
         }
         if let Ok(dv) = ob.extract::<PyRef<DecisionVariable>>() {
             return Ok(Self::Linear(ommx::Linear::single_term(
-                LinearMonomial::Variable(dv.0.id()),
+                LinearMonomial::Variable(dv.0),
                 ommx::coeff!(1.0),
             )));
         }

--- a/python/ommx/src/indicator_constraint.rs
+++ b/python/ommx/src/indicator_constraint.rs
@@ -46,8 +46,7 @@ impl IndicatorConstraint {
         description: Option<String>,
         parameters: HashMap<String, String>,
     ) -> PyResult<Self> {
-        let ic =
-            ommx::IndicatorConstraint::new(indicator_variable.0.id(), equality.into(), function.0);
+        let ic = ommx::IndicatorConstraint::new(indicator_variable.0, equality.into(), function.0);
         let context = ommx::ConstraintContext {
             label: ommx::ModelingLabel {
                 name,

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -109,9 +109,9 @@ impl Instance {
         let mut rust_decision_variables = BTreeMap::new();
         let mut variable_labels = ommx::VariableLabelStore::default();
         for var in decision_variables {
-            let id = var.0.id();
-            variable_labels.insert(id, var.1);
-            if rust_decision_variables.insert(id, var.0).is_some() {
+            let id = var.0;
+            variable_labels.insert(id, var.2);
+            if rust_decision_variables.insert(id, var.1).is_some() {
                 anyhow::bail!("Duplicate decision variable ID: {}", id.into_inner());
             }
         }
@@ -326,7 +326,8 @@ impl Instance {
     ) -> Result<crate::AttachedDecisionVariable> {
         let id = {
             let mut inst = slf.borrow_mut();
-            inst.inner.add_decision_variable(variable.0, variable.1)?
+            inst.inner
+                .add_decision_variable(variable.0, variable.1, variable.2)?
         };
         Ok(crate::AttachedDecisionVariable::from_instance(
             slf.unbind(),
@@ -691,7 +692,9 @@ impl Instance {
         self.inner
             .used_decision_variables()
             .iter()
-            .map(|(id, &var)| DecisionVariable::from_parts(var.clone(), labels.collect_for(*id)))
+            .map(|(id, &var)| {
+                DecisionVariable::from_parts(*id, var.clone(), labels.collect_for(*id))
+            })
             .collect()
     }
 
@@ -2007,7 +2010,7 @@ impl Instance {
             .map(|(id, dv)| {
                 let label = label_store.collect_for(*id);
                 let dict = crate::pandas::WithModelingContext::new(
-                    (dv, self.inner.fixed_decision_variable_value(*id)),
+                    (*id, dv, self.inner.fixed_decision_variable_value(*id)),
                     &label,
                 )
                 .to_pandas_entry(py)?;
@@ -2406,7 +2409,9 @@ impl Instance {
         self.inner
             .decision_variables()
             .get(&var_id)
-            .map(|var| DecisionVariable::from_parts(var.clone(), labels.collect_for(var_id)))
+            .map(|var| {
+                DecisionVariable::from_parts(var_id, var.clone(), labels.collect_for(var_id))
+            })
             .ok_or_else(|| {
                 PyKeyError::new_err(format!("Decision variable with ID {variable_id} not found"))
             })

--- a/python/ommx/src/pandas.rs
+++ b/python/ommx/src/pandas.rs
@@ -865,13 +865,14 @@ pub fn set_function_type(dict: &Bound<PyDict>, function: &ommx::Function) -> PyR
 
 fn decision_variable_to_pandas_entry<'py>(
     py: Python<'py>,
+    id: ommx::VariableID,
     dv: &ommx::DecisionVariable,
     label: &DecisionVariableLabel,
     fixed_value: Option<f64>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let na = get_na(py)?;
     let dict = PyDict::new(py);
-    dict.set_item("id", dv.id().into_inner())?;
+    dict.set_item("id", id.into_inner())?;
     set_kind(&dict, dv.kind())?;
     dict.set_item("lower", dv.bound().lower())?;
     dict.set_item("upper", dv.bound().upper())?;
@@ -889,18 +890,25 @@ fn decision_variable_to_pandas_entry<'py>(
     Ok(dict)
 }
 
-impl<'m> ToPandasEntry for WithModelingContext<'m, &ommx::DecisionVariable, DecisionVariableLabel> {
+impl<'m> ToPandasEntry
+    for WithModelingContext<'m, (ommx::VariableID, &ommx::DecisionVariable), DecisionVariableLabel>
+{
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        decision_variable_to_pandas_entry(py, self.item, self.context, None)
+        let (id, dv) = self.item;
+        decision_variable_to_pandas_entry(py, id, dv, self.context, None)
     }
 }
 
 impl<'m> ToPandasEntry
-    for WithModelingContext<'m, (&ommx::DecisionVariable, Option<f64>), DecisionVariableLabel>
+    for WithModelingContext<
+        'm,
+        (ommx::VariableID, &ommx::DecisionVariable, Option<f64>),
+        DecisionVariableLabel,
+    >
 {
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let (dv, fixed_value) = self.item;
-        decision_variable_to_pandas_entry(py, dv, self.context, fixed_value)
+        let (id, dv, fixed_value) = self.item;
+        decision_variable_to_pandas_entry(py, id, dv, self.context, fixed_value)
     }
 }
 
@@ -1321,14 +1329,18 @@ impl ToPandasEntry for ommx::v1::Parameter {
 // ---------------------------------------------------------------------------
 
 impl<'m> ToPandasEntry
-    for WithModelingContext<'m, &ommx::EvaluatedDecisionVariable, DecisionVariableLabel>
+    for WithModelingContext<
+        'm,
+        (ommx::VariableID, &ommx::EvaluatedDecisionVariable),
+        DecisionVariableLabel,
+    >
 {
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let dv = self.item;
+        let (id, dv) = self.item;
         let m = self.context;
         let na = get_na(py)?;
         let dict = PyDict::new(py);
-        dict.set_item("id", dv.id().into_inner())?;
+        dict.set_item("id", id.into_inner())?;
         set_kind(&dict, *dv.kind())?;
         dict.set_item("lower", dv.bound().lower())?;
         dict.set_item("upper", dv.bound().upper())?;
@@ -1409,15 +1421,15 @@ pub struct WithSampleIds<'a, T> {
 impl<'a, 'm> ToPandasEntry
     for WithModelingContext<
         'm,
-        WithSampleIds<'a, &'a ommx::SampledDecisionVariable>,
+        WithSampleIds<'a, (ommx::VariableID, &'a ommx::SampledDecisionVariable)>,
         DecisionVariableLabel,
     >
 {
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let dv = self.item.item;
+        let (id, dv) = self.item.item;
         let m = self.context;
         let dict = PyDict::new(py);
-        dict.set_item("id", dv.id().into_inner())?;
+        dict.set_item("id", id.into_inner())?;
         set_kind(&dict, *dv.kind())?;
         dict.set_item("lower", dv.bound().lower())?;
         dict.set_item("upper", dv.bound().upper())?;

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -53,9 +53,9 @@ impl ParametricInstance {
         let mut rust_decision_variables = BTreeMap::new();
         let mut variable_labels = ommx::VariableLabelStore::default();
         for var in decision_variables {
-            let id = var.0.id();
-            variable_labels.insert(id, var.1);
-            if rust_decision_variables.insert(id, var.0).is_some() {
+            let id = var.0;
+            variable_labels.insert(id, var.2);
+            if rust_decision_variables.insert(id, var.1).is_some() {
                 anyhow::bail!("Duplicate decision variable ID: {}", id.into_inner());
             }
         }
@@ -276,7 +276,8 @@ impl ParametricInstance {
     ) -> Result<crate::AttachedDecisionVariable> {
         let id = {
             let mut inst = slf.borrow_mut();
-            inst.inner.add_decision_variable(variable.0, variable.1)?
+            inst.inner
+                .add_decision_variable(variable.0, variable.1, variable.2)?
         };
         Ok(crate::AttachedDecisionVariable::from_parametric(
             slf.unbind(),
@@ -625,7 +626,9 @@ impl ParametricInstance {
         self.inner
             .decision_variables()
             .get(&var_id)
-            .map(|var| DecisionVariable::from_parts(var.clone(), labels.collect_for(var_id)))
+            .map(|var| {
+                DecisionVariable::from_parts(var_id, var.clone(), labels.collect_for(var_id))
+            })
             .ok_or_else(|| {
                 PyKeyError::new_err(format!("Decision variable with ID {variable_id} not found"))
             })
@@ -702,6 +705,7 @@ impl ParametricInstance {
         let var_meta_store = self.inner.variable_labels().clone();
         let view: Vec<(
             ommx::DecisionVariableLabel,
+            ommx::VariableID,
             &ommx::DecisionVariable,
             Option<f64>,
         )> = self
@@ -711,6 +715,7 @@ impl ParametricInstance {
             .map(|(id, dv)| {
                 (
                     var_meta_store.collect_for(*id),
+                    *id,
                     dv,
                     self.inner.fixed_decision_variable_value(*id),
                 )
@@ -718,8 +723,8 @@ impl ParametricInstance {
             .collect();
         entries_to_dataframe(
             py,
-            view.iter().map(|(m, dv, fixed_value)| {
-                crate::pandas::WithModelingContext::new((*dv, *fixed_value), m)
+            view.iter().map(|(m, id, dv, fixed_value)| {
+                crate::pandas::WithModelingContext::new((*id, *dv, *fixed_value), m)
             }),
             "id",
             flags,

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -260,6 +260,7 @@ impl SampleSet {
             .iter()
             .map(|(id, variable)| {
                 crate::SampledDecisionVariable::from_parts(
+                    *id,
                     variable.clone(),
                     labels.collect_for(*id),
                 )
@@ -436,7 +437,11 @@ impl SampleSet {
             .decision_variables()
             .get(&var_id)
             .map(|dv| {
-                crate::SampledDecisionVariable::from_parts(dv.clone(), labels.collect_for(var_id))
+                crate::SampledDecisionVariable::from_parts(
+                    var_id,
+                    dv.clone(),
+                    labels.collect_for(var_id),
+                )
             })
             .ok_or_else(|| {
                 pyo3::exceptions::PyKeyError::new_err(format!(
@@ -602,18 +607,22 @@ impl SampleSet {
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let sample_ids = sorted_sample_ids(&self.inner);
         let var_meta_store = self.inner.variable_labels().clone();
-        let view: Vec<(ommx::DecisionVariableLabel, &ommx::SampledDecisionVariable)> = self
+        let view: Vec<(
+            ommx::DecisionVariableLabel,
+            ommx::VariableID,
+            &ommx::SampledDecisionVariable,
+        )> = self
             .inner
             .decision_variables()
             .iter()
-            .map(|(id, dv)| (var_meta_store.collect_for(*id), dv))
+            .map(|(id, dv)| (var_meta_store.collect_for(*id), *id, dv))
             .collect();
         entries_to_dataframe(
             py,
-            view.iter().map(|(m, dv)| {
+            view.iter().map(|(m, id, dv)| {
                 crate::pandas::WithModelingContext::new(
                     WithSampleIds {
-                        item: *dv,
+                        item: (*id, *dv),
                         sample_ids: &sample_ids,
                     },
                     m,

--- a/python/ommx/src/sampled_decision_variable.rs
+++ b/python/ommx/src/sampled_decision_variable.rs
@@ -4,20 +4,18 @@ use std::collections::BTreeMap;
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
 pub struct SampledDecisionVariable(
+    pub ommx::VariableID,
     pub ommx::SampledDecisionVariable,
     pub ommx::DecisionVariableLabel,
 );
 
 impl SampledDecisionVariable {
-    pub fn standalone(inner: ommx::SampledDecisionVariable) -> Self {
-        Self(inner, ommx::DecisionVariableLabel::default())
-    }
-
     pub fn from_parts(
+        id: ommx::VariableID,
         inner: ommx::SampledDecisionVariable,
         label: ommx::DecisionVariableLabel,
     ) -> Self {
-        Self(inner, label)
+        Self(id, inner, label)
     }
 }
 
@@ -27,43 +25,43 @@ impl SampledDecisionVariable {
     /// Get the decision variable ID
     #[getter]
     pub fn id(&self) -> u64 {
-        self.0.id().into_inner()
+        self.0.into_inner()
     }
 
     /// Get the decision variable kind
     #[getter]
     pub fn kind(&self) -> crate::Kind {
-        (*self.0.kind()).into()
+        (*self.1.kind()).into()
     }
 
     /// Get the decision variable bound
     #[getter]
     pub fn bound(&self) -> crate::VariableBound {
-        crate::VariableBound(*self.0.bound())
+        crate::VariableBound(*self.1.bound())
     }
 
     /// Get the decision variable name
     #[getter]
     pub fn name(&self) -> Option<String> {
-        self.1.name.clone()
+        self.2.name.clone()
     }
 
     /// Get the subscripts
     #[getter]
     pub fn subscripts(&self) -> Vec<i64> {
-        self.1.subscripts.clone()
+        self.2.subscripts.clone()
     }
 
     /// Get the description
     #[getter]
     pub fn description(&self) -> Option<String> {
-        self.1.description.clone()
+        self.2.description.clone()
     }
 
     /// Get the parameters
     #[getter]
     pub fn parameters(&self) -> std::collections::HashMap<String, String> {
-        self.1
+        self.2
             .parameters
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
@@ -73,7 +71,7 @@ impl SampledDecisionVariable {
     /// Get the sampled values for all samples
     #[getter]
     pub fn samples(&self) -> BTreeMap<u64, f64> {
-        self.0
+        self.1
             .samples()
             .iter()
             .map(|(sample_id, value)| (sample_id.into_inner(), *value))

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -145,7 +145,11 @@ impl Solution {
             .decision_variables()
             .iter()
             .map(|(id, dv)| {
-                crate::EvaluatedDecisionVariable::from_parts(dv.clone(), labels.collect_for(*id))
+                crate::EvaluatedDecisionVariable::from_parts(
+                    *id,
+                    dv.clone(),
+                    labels.collect_for(*id),
+                )
             })
             .collect()
     }
@@ -392,7 +396,11 @@ impl Solution {
             .decision_variables()
             .get(&var_id)
             .map(|dv| {
-                crate::EvaluatedDecisionVariable::from_parts(dv.clone(), labels.collect_for(var_id))
+                crate::EvaluatedDecisionVariable::from_parts(
+                    var_id,
+                    dv.clone(),
+                    labels.collect_for(var_id),
+                )
             })
             .ok_or_else(|| {
                 PyKeyError::new_err(format!("Unknown decision variable ID: {variable_id}"))
@@ -488,17 +496,18 @@ impl Solution {
         let var_meta_store = self.inner.variable_labels().clone();
         let view: Vec<(
             ommx::DecisionVariableLabel,
+            ommx::VariableID,
             &ommx::EvaluatedDecisionVariable,
         )> = self
             .inner
             .decision_variables()
             .iter()
-            .map(|(id, dv)| (var_meta_store.collect_for(*id), dv))
+            .map(|(id, dv)| (var_meta_store.collect_for(*id), *id, dv))
             .collect();
         entries_to_dataframe(
             py,
             view.iter()
-                .map(|(m, dv)| crate::pandas::WithModelingContext::new(*dv, m)),
+                .map(|(m, id, dv)| crate::pandas::WithModelingContext::new((*id, *dv), m)),
             "id",
             flags,
         )

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -574,6 +574,11 @@ the enclosing map key, and fixed values are owned by the enclosing
 [`ParametricInstance`](crate::ParametricInstance), where they can be validated
 against the full model.
 
+The row still owns the `kind`/`bound` invariant: `DecisionVariable::new` and
+bound mutation normalize `bound` through `kind.consistent_bound(bound, atol)`.
+This preserves the main-branch guarantee that a safely constructed
+`DecisionVariable` never stores an unnormalized bound for its kind.
+
 Construction signatures changed accordingly:
 
 ```rust,ignore

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -588,7 +588,7 @@ let evaluated = EvaluatedDecisionVariable::new(dv, value, atol)?;
 let sampled = SampledDecisionVariable::new(dv, samples, atol)?;
 
 // ✅ After
-let y = DecisionVariable::new(kind, bound, atol)?;
+let y = DecisionVariable::new(kind, bound)?;
 let z = DecisionVariable::binary();
 
 let instance = Instance::builder()
@@ -648,7 +648,7 @@ pub struct ConstraintContext {
 - [ ] Remove any `getset` usage for constraint types
 - [ ] Update any `InstanceError` / `MpsParseError` / `QplibParseError` / `StateValidationError` / `LogEncodingError` / `UnknownSampleIDError` matches → inspect `err.to_string()` or use `err.downcast_ref::<T>()` for signal types
 - [ ] Replace `Result<T, UnknownSampleIDError>` key-lookup methods with `Option<T>` on the call site
-- [ ] Replace `DecisionVariable::new(id, kind, bound, ..., atol)` with `DecisionVariable::new(kind, bound, atol)`, and insert it under the desired `VariableID` key in the host table
+- [ ] Replace `DecisionVariable::new(id, kind, bound, ..., atol)` with `DecisionVariable::new(kind, bound)`, and insert it under the desired `VariableID` key in the host table
 - [ ] Replace `DecisionVariable::binary(id)` / `integer(id)` / `continuous(id)` / etc. with the no-argument row factories, and keep the ID on the enclosing map key
 - [ ] Replace `DecisionVariable::substituted_value()` and `DecisionVariable::substitute(...)` with host-owned fixed values: `InstanceBuilder::fixed_decision_variable_values(...)`, `Instance::fixed_decision_variable_value(id)`, or `Instance::fixed_decision_variable_values()`
 - [ ] Update `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`: drop the `atol` argument, pass the `VariableID` separately for diagnostics, and keep using the enclosing `Solution` / `SampleSet` map key as the source of truth

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -565,10 +565,12 @@ subscripts via `set_subscripts(id, new_vec)` instead.
 
 ### Fixed decision-variable values
 
-Fixed decision-variable values no longer live on
-[`DecisionVariable`](crate::DecisionVariable). The variable struct now contains
-only its intrinsic definition (`id`, `kind`, `bound`); fixed values are owned by
-the enclosing [`Instance`](crate::Instance) /
+Decision-variable IDs and fixed values no longer live on
+[`DecisionVariable`](crate::DecisionVariable). The variable struct is now the
+row data of the host's decision-variable table and contains only its intrinsic
+definition (`kind`, `bound`). The [`VariableID`](crate::VariableID) is owned by
+the enclosing map key, and fixed values are owned by the enclosing
+[`Instance`](crate::Instance) /
 [`ParametricInstance`](crate::ParametricInstance), where they can be validated
 against the full model.
 
@@ -578,6 +580,7 @@ Construction signatures changed accordingly:
 // ❌ Before
 let x = DecisionVariable::new(id, kind, bound, Some(value), atol)?;
 let y = DecisionVariable::new(id, kind, bound, None, atol)?;
+let z = DecisionVariable::binary(id);
 dv.substitute(value, atol)?;
 let fixed = dv.substituted_value();
 
@@ -585,7 +588,8 @@ let evaluated = EvaluatedDecisionVariable::new(dv, value, atol)?;
 let sampled = SampledDecisionVariable::new(dv, samples, atol)?;
 
 // ✅ After
-let y = DecisionVariable::new(id, kind, bound, atol)?;
+let y = DecisionVariable::new(kind, bound, atol)?;
+let z = DecisionVariable::binary();
 
 let instance = Instance::builder()
     .decision_variables(BTreeMap::from([(id, y.clone())]))
@@ -595,8 +599,8 @@ let instance = Instance::builder()
 let fixed = instance.fixed_decision_variable_value(id);
 let all_fixed = instance.fixed_decision_variable_values();
 
-let evaluated = EvaluatedDecisionVariable::new(y, value)?;
-let sampled = SampledDecisionVariable::new(y, samples)?;
+let evaluated = EvaluatedDecisionVariable::new(id, y, value)?;
+let sampled = SampledDecisionVariable::new(id, y, samples)?;
 ```
 
 `Instance::partial_evaluate` writes new fixed values into the host-owned table.
@@ -605,6 +609,11 @@ the parser drains them into the same host-owned table before constructing the
 domain model. The host builder rejects states where a fixed variable is also
 solver-used or dependent; this invariant can no longer be checked by an
 individual `DecisionVariable`.
+
+`EvaluatedDecisionVariable::new(id, ...)` and
+`SampledDecisionVariable::new(id, ...)` accept an ID so non-finite value errors
+can still report the table key. The evaluated/sampled row data itself does not
+store the ID; `Solution` and `SampleSet` own it as the map key.
 
 ### ConstraintContext
 
@@ -639,8 +648,10 @@ pub struct ConstraintContext {
 - [ ] Remove any `getset` usage for constraint types
 - [ ] Update any `InstanceError` / `MpsParseError` / `QplibParseError` / `StateValidationError` / `LogEncodingError` / `UnknownSampleIDError` matches → inspect `err.to_string()` or use `err.downcast_ref::<T>()` for signal types
 - [ ] Replace `Result<T, UnknownSampleIDError>` key-lookup methods with `Option<T>` on the call site
-- [ ] Replace `DecisionVariable::new(..., substituted_value, atol)`, `DecisionVariable::substituted_value()`, and `DecisionVariable::substitute(...)` with host-owned fixed values: `InstanceBuilder::fixed_decision_variable_values(...)`, `Instance::fixed_decision_variable_value(id)`, or `Instance::fixed_decision_variable_values()`
-- [ ] Drop the `atol` argument from `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`
+- [ ] Replace `DecisionVariable::new(id, kind, bound, ..., atol)` with `DecisionVariable::new(kind, bound, atol)`, and insert it under the desired `VariableID` key in the host table
+- [ ] Replace `DecisionVariable::binary(id)` / `integer(id)` / `continuous(id)` / etc. with the no-argument row factories, and keep the ID on the enclosing map key
+- [ ] Replace `DecisionVariable::substituted_value()` and `DecisionVariable::substitute(...)` with host-owned fixed values: `InstanceBuilder::fixed_decision_variable_values(...)`, `Instance::fixed_decision_variable_value(id)`, or `Instance::fixed_decision_variable_values()`
+- [ ] Update `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`: drop the `atol` argument, pass the `VariableID` separately for diagnostics, and keep using the enclosing `Solution` / `SampleSet` map key as the source of truth
 
 ---
 

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -588,7 +588,7 @@ let evaluated = EvaluatedDecisionVariable::new(dv, value, atol)?;
 let sampled = SampledDecisionVariable::new(dv, samples, atol)?;
 
 // ✅ After
-let y = DecisionVariable::new(kind, bound)?;
+let y = DecisionVariable::new(kind, bound, atol)?;
 let z = DecisionVariable::binary();
 
 let instance = Instance::builder()
@@ -648,7 +648,7 @@ pub struct ConstraintContext {
 - [ ] Remove any `getset` usage for constraint types
 - [ ] Update any `InstanceError` / `MpsParseError` / `QplibParseError` / `StateValidationError` / `LogEncodingError` / `UnknownSampleIDError` matches → inspect `err.to_string()` or use `err.downcast_ref::<T>()` for signal types
 - [ ] Replace `Result<T, UnknownSampleIDError>` key-lookup methods with `Option<T>` on the call site
-- [ ] Replace `DecisionVariable::new(id, kind, bound, ..., atol)` with `DecisionVariable::new(kind, bound)`, and insert it under the desired `VariableID` key in the host table
+- [ ] Replace `DecisionVariable::new(id, kind, bound, ..., atol)` with `DecisionVariable::new(kind, bound, atol)`, and insert it under the desired `VariableID` key in the host table
 - [ ] Replace `DecisionVariable::binary(id)` / `integer(id)` / `continuous(id)` / etc. with the no-argument row factories, and keep the ID on the enclosing map key
 - [ ] Replace `DecisionVariable::substituted_value()` and `DecisionVariable::substitute(...)` with host-owned fixed values: `InstanceBuilder::fixed_decision_variable_values(...)`, `Instance::fixed_decision_variable_value(id)`, or `Instance::fixed_decision_variable_values()`
 - [ ] Update `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`: drop the `atol` argument, pass the `VariableID` separately for diagnostics, and keep using the enclosing `Solution` / `SampleSet` map key as the source of truth

--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -204,7 +204,9 @@ variables.
 This removes the remaining duplicate ID source from the Rust-side row structs.
 Construct `DecisionVariable` rows with `DecisionVariable::new(kind, bound, atol)`
 or no-argument factories such as `DecisionVariable::binary()`, then insert them
-under the desired `VariableID` key. `EvaluatedDecisionVariable::new`
+under the desired `VariableID` key. The row still owns the `kind`/`bound`
+invariant: safe construction and bound mutation normalize `bound` with the
+caller-provided `ATol`. `EvaluatedDecisionVariable::new`
 and `SampledDecisionVariable::new` still take the ID as a separate argument so
 non-finite value errors can report the table key, but the resulting row data
 does not store that ID.

--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -202,8 +202,8 @@ is used by `Solution` and `SampleSet` for evaluated and sampled decision
 variables.
 
 This removes the remaining duplicate ID source from the Rust-side row structs.
-Construct `DecisionVariable` rows with `DecisionVariable::new(kind, bound)` or
-no-argument factories such as `DecisionVariable::binary()`, then insert them
+Construct `DecisionVariable` rows with `DecisionVariable::new(kind, bound, atol)`
+or no-argument factories such as `DecisionVariable::binary()`, then insert them
 under the desired `VariableID` key. `EvaluatedDecisionVariable::new`
 and `SampledDecisionVariable::new` still take the ID as a separate argument so
 non-finite value errors can report the table key, but the resulting row data

--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -202,9 +202,9 @@ is used by `Solution` and `SampleSet` for evaluated and sampled decision
 variables.
 
 This removes the remaining duplicate ID source from the Rust-side row structs.
-Construct `DecisionVariable` rows with `DecisionVariable::new(kind, bound,
-atol)` or no-argument factories such as `DecisionVariable::binary()`, then
-insert them under the desired `VariableID` key. `EvaluatedDecisionVariable::new`
+Construct `DecisionVariable` rows with `DecisionVariable::new(kind, bound)` or
+no-argument factories such as `DecisionVariable::binary()`, then insert them
+under the desired `VariableID` key. `EvaluatedDecisionVariable::new`
 and `SampledDecisionVariable::new` still take the ID as a separate argument so
 non-finite value errors can report the table key, but the resulting row data
 does not store that ID.

--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -31,6 +31,11 @@ The 3.0.0 line is a major revision of the Rust SDK:
   `instance.named_function_labels()`, …). One canonical store per
   collection, two views on top: per-id wrapper getters for one-off
   reads and `*_df` for bulk analysis.
+- Decision variables now follow the same table ownership rule:
+  [`DecisionVariable`](crate::DecisionVariable) is row data containing
+  only `kind` and `bound`; the [`VariableID`](crate::VariableID) and
+  fixed values live on the enclosing `Instance` /
+  `ParametricInstance` / `Solution` / `SampleSet` tables.
 - A **capability model** lets adapters declare what they natively
   support and auto-converts unsupported kinds at the boundary, so a
   valid OMMX instance can be fed to any adapter (the conversion path
@@ -186,6 +191,23 @@ See [`PYTHON_SDK_MIGRATION_GUIDE.md`](https://github.com/Jij-Inc/ommx/blob/main/
 
 The migration guide's [Modeling labels and constraint context](crate::doc::migration_guide#modeling-labels-and-constraint-context)
 section has the per-host accessor list and the store API reference.
+
+## Decision-variable table ownership ([#958](https://github.com/Jij-Inc/ommx/issues/958))
+
+The Rust SDK now treats `Instance::decision_variables` as the
+decision-variable table: the map key owns the `VariableID`, the row owns only
+`kind` and `bound`, `variable_labels` owns modeling labels, and
+`fixed_decision_variable_values` owns fixed values. The same key-owned ID model
+is used by `Solution` and `SampleSet` for evaluated and sampled decision
+variables.
+
+This removes the remaining duplicate ID source from the Rust-side row structs.
+Construct `DecisionVariable` rows with `DecisionVariable::new(kind, bound,
+atol)` or no-argument factories such as `DecisionVariable::binary()`, then
+insert them under the desired `VariableID` key. `EvaluatedDecisionVariable::new`
+and `SampledDecisionVariable::new` still take the ID as a separate argument so
+non-finite value errors can report the table key, but the resulting row data
+does not store that ID.
 
 ## Capability model ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#805](https://github.com/Jij-Inc/ommx/pull/805), [#810](https://github.com/Jij-Inc/ommx/pull/810), [#811](https://github.com/Jij-Inc/ommx/pull/811), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 

--- a/rust/ommx/doc/tutorial/decision_variables.md
+++ b/rust/ommx/doc/tutorial/decision_variables.md
@@ -4,21 +4,21 @@ Decision variables define the unknowns in optimization problems. Each variable h
 (continuous, binary, integer, etc.) and [`Bound`](crate::Bound) (lower/upper limits).
 
 ```rust
-use ommx::{DecisionVariable, Kind, Bound, VariableID, ATol};
+use ommx::{DecisionVariable, Kind, Bound, ATol};
 
-// Binary decision variable with ID 1
-let binary_var = DecisionVariable::binary(VariableID::from(1));
+// Binary decision variable row
+let binary_var = DecisionVariable::binary();
 assert_eq!(binary_var.kind(), Kind::Binary);
 assert_eq!(binary_var.bound(), Bound::new(0.0, 1.0)?); // Default binary bound is [0, 1]
 
 // Integer variable with bound [0, 3]
-let integer_var = DecisionVariable::integer(VariableID::from(2))
+let integer_var = DecisionVariable::integer()
     .with_bound(Bound::new(0.0, 3.0)?, ATol::default())?;
 assert_eq!(integer_var.kind(), Kind::Integer);
 assert_eq!(integer_var.bound(), Bound::new(0.0, 3.0)?);
 
-// Continuous variable with ID 3
-let continuous_var = DecisionVariable::continuous(VariableID::from(3));
+// Continuous decision variable row
+let continuous_var = DecisionVariable::continuous();
 assert_eq!(continuous_var.kind(), Kind::Continuous);
 assert_eq!(continuous_var.bound(), Bound::unbounded()); // Default is unbounded (-inf, inf)
 # Ok::<(), Box<dyn std::error::Error>>(())

--- a/rust/ommx/doc/tutorial/instance.md
+++ b/rust/ommx/doc/tutorial/instance.md
@@ -11,8 +11,8 @@ use std::collections::BTreeMap;
 
 // Create decision variables
 let decision_variables = btreemap! {
-    VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-    VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
+    VariableID::from(1) => DecisionVariable::binary(),
+    VariableID::from(2) => DecisionVariable::continuous(),
 };
 
 // Create objective function: minimize x1 + 2*x2

--- a/rust/ommx/doc/tutorial/solution.md
+++ b/rust/ommx/doc/tutorial/solution.md
@@ -21,8 +21,8 @@ use std::collections::{BTreeMap, HashMap};
 
 // Create an instance with variables and constraints
 let decision_variables = btreemap! {
-    VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
-    VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
+    VariableID::from(1) => DecisionVariable::continuous(),
+    VariableID::from(2) => DecisionVariable::continuous(),
 };
 
 let objective = Function::from((linear!(1) + (coeff!(2.0) * linear!(2))?)?);
@@ -87,8 +87,8 @@ use maplit::btreemap;
 use std::collections::HashMap;
 
 let decision_variables = btreemap! {
-    VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
-    VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
+    VariableID::from(1) => DecisionVariable::continuous(),
+    VariableID::from(2) => DecisionVariable::continuous(),
 };
 let objective = Function::from((linear!(1) + (coeff!(2.0) * linear!(2))?)?);
 let constraints = btreemap! {

--- a/rust/ommx/examples/create_qubo_manually.rs
+++ b/rust/ommx/examples/create_qubo_manually.rs
@@ -22,15 +22,9 @@ fn main() -> Result<()> {
     let mut decision_variables = BTreeMap::new();
 
     // Binary variable x_{0, 0}
-    decision_variables.insert(
-        VariableID::from(0),
-        DecisionVariable::binary(VariableID::from(0)),
-    );
+    decision_variables.insert(VariableID::from(0), DecisionVariable::binary());
     // Binary variable x_{1, 0}
-    decision_variables.insert(
-        VariableID::from(1),
-        DecisionVariable::binary(VariableID::from(1)),
-    );
+    decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
 
     // Objective function: 2.0 * x_{0, 0} * x_{1, 0} - x_{0, 0} - x_{1, 0} + 3.0
     // Quadratic term: 2.0 * x_{0,0} * x_{1, 0}

--- a/rust/ommx/examples/dependent_variables.rs
+++ b/rust/ommx/examples/dependent_variables.rs
@@ -24,22 +24,10 @@ fn main() -> Result<()> {
 
     // Create initial instance: minimize x1 + x2 subject to x1 + x2 <= 10
     let mut decision_variables = BTreeMap::new();
-    decision_variables.insert(
-        VariableID::from(1),
-        DecisionVariable::continuous(VariableID::from(1)),
-    );
-    decision_variables.insert(
-        VariableID::from(2),
-        DecisionVariable::continuous(VariableID::from(2)),
-    );
-    decision_variables.insert(
-        VariableID::from(3),
-        DecisionVariable::continuous(VariableID::from(3)),
-    );
-    decision_variables.insert(
-        VariableID::from(4),
-        DecisionVariable::continuous(VariableID::from(4)),
-    );
+    decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+    decision_variables.insert(VariableID::from(2), DecisionVariable::continuous());
+    decision_variables.insert(VariableID::from(3), DecisionVariable::continuous());
+    decision_variables.insert(VariableID::from(4), DecisionVariable::continuous());
 
     let objective = Function::from((linear!(1) + linear!(2))?);
     let constraint = Constraint::less_than_or_equal_to_zero(Function::from(

--- a/rust/ommx/src/annotations.rs
+++ b/rust/ommx/src/annotations.rs
@@ -572,11 +572,11 @@ mod tests {
         let decision_variables = BTreeMap::from([
             (
                 crate::VariableID::from(1),
-                crate::DecisionVariable::binary(crate::VariableID::from(1)),
+                crate::DecisionVariable::binary(),
             ),
             (
                 crate::VariableID::from(2),
-                crate::DecisionVariable::binary(crate::VariableID::from(2)),
+                crate::DecisionVariable::binary(),
             ),
         ]);
         let one_hot = crate::OneHotConstraint::new(BTreeSet::from([

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -179,7 +179,15 @@ pub struct DecisionVariable {
 
 impl DecisionVariable {
     /// Create a new decision variable.
-    pub fn new(kind: Kind, bound: Bound, atol: ATol) -> Result<Self, DecisionVariableError> {
+    pub fn new(kind: Kind, bound: Bound) -> Result<Self, DecisionVariableError> {
+        Self::new_with_atol(kind, bound, ATol::default())
+    }
+
+    pub(crate) fn new_with_atol(
+        kind: Kind,
+        bound: Bound,
+        atol: ATol,
+    ) -> Result<Self, DecisionVariableError> {
         Ok(Self {
             kind,
             bound: kind
@@ -189,27 +197,27 @@ impl DecisionVariable {
     }
 
     pub fn binary() -> Self {
-        Self::new(Kind::Binary, Bound::of_binary(), ATol::default()).unwrap()
+        Self::new(Kind::Binary, Bound::of_binary()).unwrap()
     }
 
     /// Unbounded integer decision variable.
     pub fn integer() -> Self {
-        Self::new(Kind::Integer, Bound::default(), ATol::default()).unwrap()
+        Self::new(Kind::Integer, Bound::default()).unwrap()
     }
 
     /// Unbounded continuous decision variable.
     pub fn continuous() -> Self {
-        Self::new(Kind::Continuous, Bound::default(), ATol::default()).unwrap()
+        Self::new(Kind::Continuous, Bound::default()).unwrap()
     }
 
     /// Unbounded semi-integer decision variable.
     pub fn semi_integer() -> Self {
-        Self::new(Kind::SemiInteger, Bound::default(), ATol::default()).unwrap()
+        Self::new(Kind::SemiInteger, Bound::default()).unwrap()
     }
 
     /// Unbounded semi-continuous decision variable.
     pub fn semi_continuous() -> Self {
-        Self::new(Kind::SemiContinuous, Bound::default(), ATol::default()).unwrap()
+        Self::new(Kind::SemiContinuous, Bound::default()).unwrap()
     }
 
     /// Check if the substituted value is consistent to the bound and kind
@@ -223,7 +231,6 @@ impl DecisionVariable {
     /// let dv = DecisionVariable::new(
     ///     Kind::Integer,
     ///     Bound::new(0.0, 2.0).unwrap(),
-    ///     ATol::default(),
     /// ).unwrap();
     ///
     /// // 1 \in [0, 2]

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -166,8 +166,10 @@ fn ensure_finite_value(id: VariableID, value: f64) -> Result<(), DecisionVariabl
 ///
 /// Invariants
 /// ----------
-/// - `kind` and `bound` are consistent
-///   - i.e. `bound` is invariant under `|bound| kind.consistent_bound(bound, atol).unwrap()` for appropriate `atol`.
+/// - `bound` is normalized for `kind` at construction or bound mutation time.
+///   - i.e. `bound` is invariant under `|bound| kind.consistent_bound(bound, atol).unwrap()` for the caller-provided `atol`.
+/// - A [`DecisionVariable`] row therefore never stores an unnormalized
+///   integer, binary, or semi-integer bound when built through the safe API.
 ///
 #[derive(Debug, Clone, PartialEq, CopyGetters, LogicalMemoryProfile)]
 pub struct DecisionVariable {

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -154,11 +154,12 @@ fn ensure_finite_value(id: VariableID, value: f64) -> Result<(), DecisionVariabl
     }
 }
 
-/// The decision variable's intrinsic data.
+/// Row data for a decision variable table.
 ///
-/// Holds only `id`, `kind`, and `bound` as its intrinsic definition. Auxiliary
-/// modeling label (`name`, `subscripts`, `parameters`, `description`) lives on
-/// the enclosing [`Instance`](crate::Instance)'s
+/// Holds only `kind` and `bound` as its intrinsic definition. The
+/// [`VariableID`] is owned by the enclosing decision-variable table key.
+/// Auxiliary modeling label (`name`, `subscripts`, `parameters`,
+/// `description`) lives on the enclosing [`Instance`](crate::Instance)'s
 /// [`VariableLabelStore`](crate::VariableLabelStore) keyed by
 /// [`VariableID`]; per-element label storage was retired in the v3
 /// redesign.
@@ -171,8 +172,6 @@ fn ensure_finite_value(id: VariableID, value: f64) -> Result<(), DecisionVariabl
 #[derive(Debug, Clone, PartialEq, CopyGetters, LogicalMemoryProfile)]
 pub struct DecisionVariable {
     #[getset(get_copy = "pub")]
-    id: VariableID,
-    #[getset(get_copy = "pub")]
     kind: Kind,
     #[getset(get_copy = "pub")]
     bound: Bound,
@@ -180,43 +179,37 @@ pub struct DecisionVariable {
 
 impl DecisionVariable {
     /// Create a new decision variable.
-    pub fn new(
-        id: VariableID,
-        kind: Kind,
-        bound: Bound,
-        atol: ATol,
-    ) -> Result<Self, DecisionVariableError> {
+    pub fn new(kind: Kind, bound: Bound, atol: ATol) -> Result<Self, DecisionVariableError> {
         Ok(Self {
-            id,
             kind,
             bound: kind
                 .consistent_bound(bound, atol)
-                .ok_or(DecisionVariableError::BoundInconsistentToKind { id, kind, bound })?,
+                .ok_or(DecisionVariableError::BoundInconsistentToKind { kind, bound })?,
         })
     }
 
-    pub fn binary(id: VariableID) -> Self {
-        Self::new(id, Kind::Binary, Bound::of_binary(), ATol::default()).unwrap()
+    pub fn binary() -> Self {
+        Self::new(Kind::Binary, Bound::of_binary(), ATol::default()).unwrap()
     }
 
     /// Unbounded integer decision variable.
-    pub fn integer(id: VariableID) -> Self {
-        Self::new(id, Kind::Integer, Bound::default(), ATol::default()).unwrap()
+    pub fn integer() -> Self {
+        Self::new(Kind::Integer, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Unbounded continuous decision variable.
-    pub fn continuous(id: VariableID) -> Self {
-        Self::new(id, Kind::Continuous, Bound::default(), ATol::default()).unwrap()
+    pub fn continuous() -> Self {
+        Self::new(Kind::Continuous, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Unbounded semi-integer decision variable.
-    pub fn semi_integer(id: VariableID) -> Self {
-        Self::new(id, Kind::SemiInteger, Bound::default(), ATol::default()).unwrap()
+    pub fn semi_integer() -> Self {
+        Self::new(Kind::SemiInteger, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Unbounded semi-continuous decision variable.
-    pub fn semi_continuous(id: VariableID) -> Self {
-        Self::new(id, Kind::SemiContinuous, Bound::default(), ATol::default()).unwrap()
+    pub fn semi_continuous() -> Self {
+        Self::new(Kind::SemiContinuous, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Check if the substituted value is consistent to the bound and kind
@@ -228,32 +221,32 @@ impl DecisionVariable {
     /// use ommx::{DecisionVariable, Kind, Bound, ATol};
     ///
     /// let dv = DecisionVariable::new(
-    ///     0.into(),
     ///     Kind::Integer,
     ///     Bound::new(0.0, 2.0).unwrap(),
     ///     ATol::default(),
     /// ).unwrap();
     ///
     /// // 1 \in [0, 2]
-    /// assert!(dv.check_value_consistency(1.0, ATol::default()).is_ok());
+    /// assert!(dv.check_value_consistency(0.into(), 1.0, ATol::default()).is_ok());
     /// // 3 \in [0, 2]
-    /// assert!(dv.check_value_consistency(3.0, ATol::default()).is_err());
+    /// assert!(dv.check_value_consistency(0.into(), 3.0, ATol::default()).is_err());
     /// // 0.5 \in [0, 2], but not consistent to Kind::Integer
-    /// assert!(dv.check_value_consistency(0.5, ATol::default()).is_err());
+    /// assert!(dv.check_value_consistency(0.into(), 0.5, ATol::default()).is_err());
     /// ```
     pub fn check_value_consistency(
         &self,
+        id: VariableID,
         value: f64,
         atol: ATol,
     ) -> Result<(), DecisionVariableError> {
         let err = || DecisionVariableError::SubstitutedValueInconsistent {
-            id: self.id,
+            id,
             kind: self.kind,
             bound: self.bound,
             substituted_value: value,
             atol,
         };
-        ensure_finite_value(self.id, value)?;
+        ensure_finite_value(id, value)?;
         if !self.bound.contains(value, atol) {
             return Err(err());
         }
@@ -273,7 +266,6 @@ impl DecisionVariable {
     pub fn set_bound(&mut self, bound: Bound, atol: ATol) -> Result<(), DecisionVariableError> {
         let bound = self.kind.consistent_bound(bound, atol).ok_or(
             DecisionVariableError::BoundInconsistentToKind {
-                id: self.id,
                 kind: self.kind,
                 bound,
             },
@@ -296,10 +288,15 @@ impl DecisionVariable {
     ///
     /// Returns `Ok(true)` if the bound was actually changed, `Ok(false)` if the bound
     /// remained the same.
-    pub fn clip_bound(&mut self, bound: Bound, atol: ATol) -> Result<bool, DecisionVariableError> {
+    pub fn clip_bound(
+        &mut self,
+        id: VariableID,
+        bound: Bound,
+        atol: ATol,
+    ) -> Result<bool, DecisionVariableError> {
         let intersected = self.bound.intersection(&bound).ok_or(
             DecisionVariableError::EmptyBoundIntersection {
-                id: self.id,
+                id,
                 existing_bound: self.bound,
                 new_bound: bound,
             },
@@ -318,12 +315,8 @@ impl DecisionVariable {
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum DecisionVariableError {
-    #[error("Bound for ID={id} is inconsistent to kind: kind={kind:?}, bound={bound}")]
-    BoundInconsistentToKind {
-        id: VariableID,
-        kind: Kind,
-        bound: Bound,
-    },
+    #[error("Bound is inconsistent to kind: kind={kind:?}, bound={bound}")]
+    BoundInconsistentToKind { kind: Kind, bound: Bound },
 
     #[error("Decision variable value for ID={id} must be finite: value={value}")]
     NonFiniteValue { id: VariableID, value: f64 },
@@ -360,8 +353,6 @@ pub type DecisionVariableLabel = crate::ModelingLabel;
 #[derive(Debug, Clone, PartialEq, Getters)]
 pub struct EvaluatedDecisionVariable {
     #[getset(get = "pub")]
-    id: VariableID,
-    #[getset(get = "pub")]
     kind: Kind,
     #[getset(get = "pub")]
     bound: Bound,
@@ -370,21 +361,23 @@ pub struct EvaluatedDecisionVariable {
 }
 
 impl EvaluatedDecisionVariable {
-    /// Create a new EvaluatedDecisionVariable from a DecisionVariable and value
+    /// Create a new evaluated decision-variable row from an ID, row definition,
+    /// and value.
     ///
     /// This method does not enforce kind or bound constraints - those are checked
-    /// as part of solution feasibility validation.
+    /// as part of solution feasibility validation. The ID is used for error
+    /// reporting only; the returned row does not store it.
     pub fn new(
+        id: VariableID,
         decision_variable: DecisionVariable,
         value: f64,
     ) -> Result<Self, DecisionVariableError> {
-        ensure_finite_value(decision_variable.id, value)?;
+        ensure_finite_value(id, value)?;
 
         // Note: Kind and bound checking is intentionally omitted to allow infeasible solutions.
         // These will be checked as part of Solution::feasible() validation.
 
         Ok(Self {
-            id: decision_variable.id,
             kind: decision_variable.kind,
             bound: decision_variable.bound,
             value,
@@ -417,8 +410,6 @@ impl EvaluatedDecisionVariable {
 #[derive(Debug, Clone, Getters)]
 pub struct SampledDecisionVariable {
     #[getset(get = "pub")]
-    id: VariableID,
-    #[getset(get = "pub")]
     kind: Kind,
     #[getset(get = "pub")]
     bound: Bound,
@@ -427,22 +418,24 @@ pub struct SampledDecisionVariable {
 }
 
 impl SampledDecisionVariable {
-    /// Create a new SampledDecisionVariable from a DecisionVariable and samples
+    /// Create a new sampled decision-variable row from an ID, row definition,
+    /// and samples.
     ///
     /// This method does not enforce kind or bound constraints - those are checked
-    /// as part of sample-set feasibility validation.
+    /// as part of sample-set feasibility validation. The ID is used for error
+    /// reporting only; the returned row does not store it.
     pub fn new(
+        id: VariableID,
         decision_variable: DecisionVariable,
         samples: Sampled<f64>,
     ) -> Result<Self, DecisionVariableError> {
         for (_, &sample_value) in samples.iter() {
-            ensure_finite_value(decision_variable.id, sample_value)?;
+            ensure_finite_value(id, sample_value)?;
         }
 
         // Note: Kind and bound checking is intentionally omitted to allow infeasible solutions.
 
         Ok(Self {
-            id: decision_variable.id,
             kind: decision_variable.kind,
             bound: decision_variable.bound,
             samples,
@@ -452,80 +445,16 @@ impl SampledDecisionVariable {
     /// Get a specific evaluated decision variable by sample ID.
     ///
     /// Returns [`None`] if `sample_id` is not present in the sampled data.
-    pub fn get(&self, sample_id: SampleID) -> Option<EvaluatedDecisionVariable> {
+    pub fn get(&self, id: VariableID, sample_id: SampleID) -> Option<EvaluatedDecisionVariable> {
         let value = *self.samples.get(sample_id)?;
 
         // Create a DecisionVariable to use with EvaluatedDecisionVariable::new
         let dv = DecisionVariable {
-            id: self.id,
             kind: self.kind,
             bound: self.bound,
         };
 
-        Some(EvaluatedDecisionVariable::new(dv, value).unwrap())
-    }
-}
-
-impl crate::Evaluate for DecisionVariable {
-    type Output = EvaluatedDecisionVariable;
-    type SampledOutput = SampledDecisionVariable;
-
-    fn evaluate(
-        &self,
-        state: &crate::v1::State,
-        _atol: crate::ATol,
-    ) -> crate::Result<Self::Output> {
-        let value = state
-            .entries
-            .get(&self.id.into_inner())
-            .copied()
-            .ok_or_else(|| crate::error!("Variable ID {} not found in state", self.id))?;
-
-        Ok(EvaluatedDecisionVariable::new(self.clone(), value)?)
-    }
-
-    fn evaluate_samples(
-        &self,
-        samples: &crate::Sampled<crate::v1::State>,
-        _atol: crate::ATol,
-    ) -> crate::Result<Self::SampledOutput> {
-        let variable_id = self.id.into_inner();
-
-        // Extract values for this variable from all samples
-        let mut grouped_values: std::collections::HashMap<
-            ordered_float::OrderedFloat<f64>,
-            Vec<crate::SampleID>,
-        > = std::collections::HashMap::new();
-        for (sample_id, state) in samples.iter() {
-            if let Some(value) = state.entries.get(&variable_id) {
-                grouped_values
-                    .entry(ordered_float::OrderedFloat(*value))
-                    .or_default()
-                    .push(*sample_id);
-            }
-        }
-
-        // Convert to Sampled format
-        let ids: Vec<Vec<crate::SampleID>> = grouped_values.values().cloned().collect();
-        let values: Vec<f64> = grouped_values.keys().map(|k| k.into_inner()).collect();
-        let samples = crate::Sampled::new(ids, values)?;
-
-        Ok(SampledDecisionVariable::new(self.clone(), samples)?)
-    }
-
-    fn partial_evaluate(
-        &mut self,
-        state: &crate::v1::State,
-        atol: crate::ATol,
-    ) -> crate::Result<()> {
-        if let Some(value) = state.entries.get(&self.id.into_inner()) {
-            self.check_value_consistency(*value, atol)?;
-        }
-        Ok(())
-    }
-
-    fn required_ids(&self) -> crate::VariableIDSet {
-        [self.id].into_iter().collect()
+        Some(EvaluatedDecisionVariable::new(id, dv, value).unwrap())
     }
 }
 
@@ -533,11 +462,12 @@ impl crate::Evaluate for DecisionVariable {
 /// modeling label. The label comes from the enclosing collection's
 /// [`VariableLabelStore`]; the per-element struct no longer carries it.
 pub(crate) fn evaluated_decision_variable_to_v1(
+    id: VariableID,
     eval_dv: EvaluatedDecisionVariable,
     label: DecisionVariableLabel,
 ) -> crate::v1::DecisionVariable {
     crate::v1::DecisionVariable {
-        id: eval_dv.id.into_inner(),
+        id: id.into_inner(),
         kind: eval_dv.kind.into(),
         bound: Some(eval_dv.bound.into()),
         substituted_value: Some(eval_dv.value),
@@ -578,7 +508,7 @@ impl std::convert::TryFrom<crate::v1::DecisionVariable> for EvaluatedDecisionVar
             .context(message, "substituted_value"),
         )?;
 
-        EvaluatedDecisionVariable::new(dv, value)
+        EvaluatedDecisionVariable::new(parsed.id, dv, value)
             .map_err(|e| crate::RawParseError::InvalidDecisionVariable(e).into())
     }
 }
@@ -591,51 +521,71 @@ mod tests {
     #[test]
     fn test_clip_bound_normal_intersection() {
         // Test case 1: Normal intersection
-        let mut dv = DecisionVariable::continuous(VariableID::from(1))
+        let mut dv = DecisionVariable::continuous()
             .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
             .unwrap();
         let changed = dv
-            .clip_bound(Bound::new(5.0, 15.0).unwrap(), ATol::default())
+            .clip_bound(
+                VariableID::from(1),
+                Bound::new(5.0, 15.0).unwrap(),
+                ATol::default(),
+            )
             .unwrap();
         assert!(changed);
         assert_eq!(dv.bound(), Bound::new(5.0, 10.0).unwrap());
 
         // Test case 2: Intersection with infinite bounds
-        let mut dv = DecisionVariable::continuous(VariableID::from(2))
+        let mut dv = DecisionVariable::continuous()
             .with_bound(
                 Bound::new(f64::NEG_INFINITY, 10.0).unwrap(),
                 ATol::default(),
             )
             .unwrap();
         let changed = dv
-            .clip_bound(Bound::new(5.0, f64::INFINITY).unwrap(), ATol::default())
+            .clip_bound(
+                VariableID::from(2),
+                Bound::new(5.0, f64::INFINITY).unwrap(),
+                ATol::default(),
+            )
             .unwrap();
         assert!(changed);
         assert_eq!(dv.bound(), Bound::new(5.0, 10.0).unwrap());
 
         // Test case 3: Clip bound is completely contained
-        let mut dv = DecisionVariable::continuous(VariableID::from(3))
+        let mut dv = DecisionVariable::continuous()
             .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
             .unwrap();
         let changed = dv
-            .clip_bound(Bound::new(2.0, 8.0).unwrap(), ATol::default())
+            .clip_bound(
+                VariableID::from(3),
+                Bound::new(2.0, 8.0).unwrap(),
+                ATol::default(),
+            )
             .unwrap();
         assert!(changed);
         assert_eq!(dv.bound(), Bound::new(2.0, 8.0).unwrap());
 
         // Test case 4: No change (clip with same bound)
-        let mut dv = DecisionVariable::continuous(VariableID::from(4))
+        let mut dv = DecisionVariable::continuous()
             .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
             .unwrap();
         let changed = dv
-            .clip_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
+            .clip_bound(
+                VariableID::from(4),
+                Bound::new(0.0, 10.0).unwrap(),
+                ATol::default(),
+            )
             .unwrap();
         assert!(!changed);
         assert_eq!(dv.bound(), Bound::new(0.0, 10.0).unwrap());
 
         // Test case 5: No change (clip with larger bound)
         let changed = dv
-            .clip_bound(Bound::new(-5.0, 15.0).unwrap(), ATol::default())
+            .clip_bound(
+                VariableID::from(4),
+                Bound::new(-5.0, 15.0).unwrap(),
+                ATol::default(),
+            )
             .unwrap();
         assert!(!changed);
         assert_eq!(dv.bound(), Bound::new(0.0, 10.0).unwrap());
@@ -644,20 +594,28 @@ mod tests {
     #[test]
     fn test_clip_bound_empty_intersection() {
         // Test case 1: Non-overlapping bounds [0, 5] and [10, 15]
-        let mut dv = DecisionVariable::continuous(VariableID::from(1))
+        let mut dv = DecisionVariable::continuous()
             .with_bound(Bound::new(0.0, 5.0).unwrap(), ATol::default())
             .unwrap();
-        let result = dv.clip_bound(Bound::new(10.0, 15.0).unwrap(), ATol::default());
+        let result = dv.clip_bound(
+            VariableID::from(1),
+            Bound::new(10.0, 15.0).unwrap(),
+            ATol::default(),
+        );
         assert!(matches!(
             result,
             Err(DecisionVariableError::EmptyBoundIntersection { .. })
         ));
 
         // Test case 2: Reverse order
-        let mut dv = DecisionVariable::continuous(VariableID::from(2))
+        let mut dv = DecisionVariable::continuous()
             .with_bound(Bound::new(10.0, 15.0).unwrap(), ATol::default())
             .unwrap();
-        let result = dv.clip_bound(Bound::new(0.0, 5.0).unwrap(), ATol::default());
+        let result = dv.clip_bound(
+            VariableID::from(2),
+            Bound::new(0.0, 5.0).unwrap(),
+            ATol::default(),
+        );
         assert!(matches!(
             result,
             Err(DecisionVariableError::EmptyBoundIntersection { .. })
@@ -667,28 +625,40 @@ mod tests {
     #[test]
     fn test_clip_bound_with_kinds() {
         // Test with Integer kind
-        let mut dv = DecisionVariable::integer(VariableID::from(1))
+        let mut dv = DecisionVariable::integer()
             .with_bound(Bound::new(1.1, 5.9).unwrap(), ATol::default())
             .unwrap();
         assert_eq!(dv.bound(), Bound::new(2.0, 5.0).unwrap()); // Rounded to integer bounds
         let changed = dv
-            .clip_bound(Bound::new(2.1, 4.9).unwrap(), ATol::default())
+            .clip_bound(
+                VariableID::from(1),
+                Bound::new(2.1, 4.9).unwrap(),
+                ATol::default(),
+            )
             .unwrap();
         assert!(changed);
         assert_eq!(dv.bound(), Bound::new(3.0, 4.0).unwrap());
 
         // Test with Binary kind - clip to [0, 0]
-        let mut dv = DecisionVariable::binary(VariableID::from(2));
+        let mut dv = DecisionVariable::binary();
         assert_eq!(dv.bound(), Bound::new(0.0, 1.0).unwrap());
         let changed = dv
-            .clip_bound(Bound::new(-1.0, 0.5).unwrap(), ATol::default())
+            .clip_bound(
+                VariableID::from(2),
+                Bound::new(-1.0, 0.5).unwrap(),
+                ATol::default(),
+            )
             .unwrap();
         assert!(changed);
         assert_eq!(dv.bound(), Bound::new(0.0, 0.0).unwrap());
 
         // Test with Binary kind - empty intersection
-        let mut dv = DecisionVariable::binary(VariableID::from(3));
-        let result = dv.clip_bound(Bound::new(1.1, 2.0).unwrap(), ATol::default());
+        let mut dv = DecisionVariable::binary();
+        let result = dv.clip_bound(
+            VariableID::from(3),
+            Bound::new(1.1, 2.0).unwrap(),
+            ATol::default(),
+        );
         assert!(matches!(
             result,
             Err(DecisionVariableError::EmptyBoundIntersection { .. })
@@ -698,18 +668,18 @@ mod tests {
     #[test]
     fn test_decision_variable_rejects_non_finite_values() {
         let id = VariableID::from(1);
-        let dv = DecisionVariable::continuous(id);
+        let dv = DecisionVariable::continuous();
 
         assert!(matches!(
-            dv.check_value_consistency(f64::NAN, ATol::default()),
+            dv.check_value_consistency(id, f64::NAN, ATol::default()),
             Err(DecisionVariableError::NonFiniteValue { .. })
         ));
         assert!(matches!(
-            dv.check_value_consistency(f64::INFINITY, ATol::default()),
+            dv.check_value_consistency(id, f64::INFINITY, ATol::default()),
             Err(DecisionVariableError::NonFiniteValue { .. })
         ));
         assert!(matches!(
-            EvaluatedDecisionVariable::new(dv, f64::NEG_INFINITY),
+            EvaluatedDecisionVariable::new(id, dv, f64::NEG_INFINITY),
             Err(DecisionVariableError::NonFiniteValue { .. })
         ));
     }
@@ -717,11 +687,11 @@ mod tests {
     #[test]
     fn test_sampled_decision_variable_rejects_non_finite_values() {
         let id = VariableID::from(1);
-        let dv = DecisionVariable::continuous(id);
+        let dv = DecisionVariable::continuous();
         let samples = Sampled::new([vec![crate::SampleID::from(0)]], [f64::NAN]).unwrap();
 
         assert!(matches!(
-            SampledDecisionVariable::new(dv, samples),
+            SampledDecisionVariable::new(id, dv, samples),
             Err(DecisionVariableError::NonFiniteValue { .. })
         ));
     }
@@ -747,7 +717,6 @@ mod tests {
 
         let evaluated_dv: EvaluatedDecisionVariable = v1_dv.try_into().unwrap();
 
-        assert_eq!(*evaluated_dv.id(), VariableID::from(42));
         assert_eq!(*evaluated_dv.kind(), crate::Kind::Integer);
         assert_eq!(*evaluated_dv.value(), 5.0);
 
@@ -756,7 +725,11 @@ mod tests {
         // Solution / SampleSet, which carry a VariableLabelStore.
         // Test round-trip conversion at the intrinsic-data level via the
         // explicit `evaluated_decision_variable_to_v1` helper.
-        let v1_converted = evaluated_decision_variable_to_v1(evaluated_dv, Default::default());
+        let v1_converted = evaluated_decision_variable_to_v1(
+            VariableID::from(42),
+            evaluated_dv,
+            Default::default(),
+        );
         assert_eq!(v1_converted.id, 42);
         assert_eq!(v1_converted.substituted_value, Some(5.0));
     }

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -320,6 +320,12 @@ pub enum DecisionVariableError {
     #[error("Bound is inconsistent to kind: kind={kind:?}, bound={bound}")]
     BoundInconsistentToKind { kind: Kind, bound: Bound },
 
+    #[error("Invalid decision variable ID={id}: {source}")]
+    InvalidDefinition {
+        id: VariableID,
+        source: Box<DecisionVariableError>,
+    },
+
     #[error("Decision variable value for ID={id} must be finite: value={value}")]
     NonFiniteValue { id: VariableID, value: f64 },
 

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -179,15 +179,7 @@ pub struct DecisionVariable {
 
 impl DecisionVariable {
     /// Create a new decision variable.
-    pub fn new(kind: Kind, bound: Bound) -> Result<Self, DecisionVariableError> {
-        Self::new_with_atol(kind, bound, ATol::default())
-    }
-
-    pub(crate) fn new_with_atol(
-        kind: Kind,
-        bound: Bound,
-        atol: ATol,
-    ) -> Result<Self, DecisionVariableError> {
+    pub fn new(kind: Kind, bound: Bound, atol: ATol) -> Result<Self, DecisionVariableError> {
         Ok(Self {
             kind,
             bound: kind
@@ -197,27 +189,27 @@ impl DecisionVariable {
     }
 
     pub fn binary() -> Self {
-        Self::new(Kind::Binary, Bound::of_binary()).unwrap()
+        Self::new(Kind::Binary, Bound::of_binary(), ATol::default()).unwrap()
     }
 
     /// Unbounded integer decision variable.
     pub fn integer() -> Self {
-        Self::new(Kind::Integer, Bound::default()).unwrap()
+        Self::new(Kind::Integer, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Unbounded continuous decision variable.
     pub fn continuous() -> Self {
-        Self::new(Kind::Continuous, Bound::default()).unwrap()
+        Self::new(Kind::Continuous, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Unbounded semi-integer decision variable.
     pub fn semi_integer() -> Self {
-        Self::new(Kind::SemiInteger, Bound::default()).unwrap()
+        Self::new(Kind::SemiInteger, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Unbounded semi-continuous decision variable.
     pub fn semi_continuous() -> Self {
-        Self::new(Kind::SemiContinuous, Bound::default()).unwrap()
+        Self::new(Kind::SemiContinuous, Bound::default(), ATol::default()).unwrap()
     }
 
     /// Check if the substituted value is consistent to the bound and kind
@@ -231,6 +223,7 @@ impl DecisionVariable {
     /// let dv = DecisionVariable::new(
     ///     Kind::Integer,
     ///     Bound::new(0.0, 2.0).unwrap(),
+    ///     ATol::default(),
     /// ).unwrap();
     ///
     /// // 1 \in [0, 2]

--- a/rust/ommx/src/decision_variable/approx.rs
+++ b/rust/ommx/src/decision_variable/approx.rs
@@ -68,9 +68,19 @@ mod tests {
 
     #[test]
     fn test_equal_rows_are_equal_independent_of_table_key() {
-        let var1 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 1.0).unwrap()).unwrap();
+        let var1 = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let var2 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 1.0).unwrap()).unwrap();
+        let var2 = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         assert_abs_diff_eq!(var1, var2);
     }
@@ -78,9 +88,19 @@ mod tests {
     #[test]
     fn test_different_bounds_not_equal() {
         // Variables with different bounds are not equal
-        let var1 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 1.0).unwrap()).unwrap();
+        let var1 = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let var2 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 2.0).unwrap()).unwrap();
+        let var2 = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 2.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         assert_abs_diff_ne!(var1, var2);
     }
@@ -88,9 +108,19 @@ mod tests {
     #[test]
     fn test_same_kind_and_bound_equal() {
         // Variables with same ID, kind, and bounds are equal
-        let var1 = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 10.0).unwrap()).unwrap();
+        let var1 = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let var2 = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 10.0).unwrap()).unwrap();
+        let var2 = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         assert_abs_diff_eq!(var1, var2);
     }
@@ -98,9 +128,19 @@ mod tests {
     #[test]
     fn test_point_bound_continuous_integer_equal() {
         // Continuous[a, a] and Integer[a, a] are equal for point bounds
-        let var1 = DecisionVariable::new(Kind::Continuous, Bound::new(5.0, 5.0).unwrap()).unwrap();
+        let var1 = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let var2 = DecisionVariable::new(Kind::Integer, Bound::new(5.0, 5.0).unwrap()).unwrap();
+        let var2 = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         assert_abs_diff_eq!(var1, var2);
     }
@@ -108,18 +148,40 @@ mod tests {
     #[test]
     fn test_point_bound_zero_all_kinds_equal() {
         // For point bound [0, 0], all kinds are considered equal
-        let continuous =
-            DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 0.0).unwrap()).unwrap();
+        let continuous = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 0.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let integer = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 0.0).unwrap()).unwrap();
+        let integer = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(0.0, 0.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let binary = DecisionVariable::new(Kind::Binary, Bound::new(0.0, 0.0).unwrap()).unwrap();
+        let binary = DecisionVariable::new(
+            Kind::Binary,
+            Bound::new(0.0, 0.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let semi_continuous =
-            DecisionVariable::new(Kind::SemiContinuous, Bound::new(0.0, 0.0).unwrap()).unwrap();
+        let semi_continuous = DecisionVariable::new(
+            Kind::SemiContinuous,
+            Bound::new(0.0, 0.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let semi_integer =
-            DecisionVariable::new(Kind::SemiInteger, Bound::new(0.0, 0.0).unwrap()).unwrap();
+        let semi_integer = DecisionVariable::new(
+            Kind::SemiInteger,
+            Bound::new(0.0, 0.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         // All combinations should be equal
         assert_abs_diff_eq!(continuous, integer);
@@ -133,11 +195,19 @@ mod tests {
     fn test_point_bound_nonzero_semi_not_equal() {
         // For point bound [a, a] where a != 0, semi-continuous/semi-integer
         // are not equal to continuous/integer/binary
-        let continuous =
-            DecisionVariable::new(Kind::Continuous, Bound::new(5.0, 5.0).unwrap()).unwrap();
+        let continuous = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let semi_continuous =
-            DecisionVariable::new(Kind::SemiContinuous, Bound::new(5.0, 5.0).unwrap()).unwrap();
+        let semi_continuous = DecisionVariable::new(
+            Kind::SemiContinuous,
+            Bound::new(5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         assert_abs_diff_ne!(continuous, semi_continuous);
     }
@@ -145,26 +215,52 @@ mod tests {
     #[test]
     fn test_bound_contains_zero_semi_equal() {
         // When bound contains 0, semi-integer equals integer and semi-continuous equals continuous
-        let integer = DecisionVariable::new(Kind::Integer, Bound::new(-5.0, 5.0).unwrap()).unwrap();
+        let integer = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let semi_integer =
-            DecisionVariable::new(Kind::SemiInteger, Bound::new(-5.0, 5.0).unwrap()).unwrap();
+        let semi_integer = DecisionVariable::new(
+            Kind::SemiInteger,
+            Bound::new(-5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let continuous =
-            DecisionVariable::new(Kind::Continuous, Bound::new(-5.0, 5.0).unwrap()).unwrap();
+        let continuous = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(-5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let semi_continuous =
-            DecisionVariable::new(Kind::SemiContinuous, Bound::new(-5.0, 5.0).unwrap()).unwrap();
+        let semi_continuous = DecisionVariable::new(
+            Kind::SemiContinuous,
+            Bound::new(-5.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         assert_abs_diff_eq!(integer, semi_integer);
         assert_abs_diff_eq!(continuous, semi_continuous);
 
         // Test binary-integer equality with compatible bounds
         // Binary is always [0, 1], so test with integer that has same bound
-        let binary = DecisionVariable::new(Kind::Binary, Bound::new(0.0, 1.0).unwrap()).unwrap();
+        let binary = DecisionVariable::new(
+            Kind::Binary,
+            Bound::new(0.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let integer_01 =
-            DecisionVariable::new(Kind::Integer, Bound::new(0.0, 1.0).unwrap()).unwrap();
+        let integer_01 = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(0.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         assert_abs_diff_eq!(binary, integer_01);
     }
@@ -173,12 +269,26 @@ mod tests {
     fn test_point_bound_nonzero_all_basic_kinds_equal() {
         // For point bound [a, a] where a != 0, binary, integer, and continuous are all equal
         // This is according to the logic in lines 36-43 of the implementation
-        let binary = DecisionVariable::new(Kind::Binary, Bound::new(1.0, 1.0).unwrap()).unwrap();
+        let binary = DecisionVariable::new(
+            Kind::Binary,
+            Bound::new(1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let integer = DecisionVariable::new(Kind::Integer, Bound::new(1.0, 1.0).unwrap()).unwrap();
+        let integer = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let continuous =
-            DecisionVariable::new(Kind::Continuous, Bound::new(1.0, 1.0).unwrap()).unwrap();
+        let continuous = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         // For point bound [1,1] (not zero), binary, integer, and continuous are all equal
         assert_abs_diff_eq!(binary, integer);
@@ -189,11 +299,19 @@ mod tests {
     #[test]
     fn test_tolerance_in_point_bound() {
         // Test that tolerance is considered for point bounds
-        let var1 =
-            DecisionVariable::new(Kind::Continuous, Bound::new(1.0, 1.0 + 1e-10).unwrap()).unwrap();
+        let var1 = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(1.0, 1.0 + 1e-10).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
-        let var2 =
-            DecisionVariable::new(Kind::Integer, Bound::new(1.0, 1.0 + 1e-10).unwrap()).unwrap();
+        let var2 = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(1.0, 1.0 + 1e-10).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         // Should be equal with default tolerance
         assert_abs_diff_eq!(var1, var2);

--- a/rust/ommx/src/decision_variable/approx.rs
+++ b/rust/ommx/src/decision_variable/approx.rs
@@ -63,24 +63,14 @@ fn same_kind_class(a: Kind, b: Kind, class1: &[Kind], class2: &[Kind]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ATol, Bound, DecisionVariable};
+    use crate::{Bound, DecisionVariable};
     use ::approx::{assert_abs_diff_eq, assert_abs_diff_ne};
 
     #[test]
     fn test_equal_rows_are_equal_independent_of_table_key() {
-        let var1 = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(0.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var1 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 1.0).unwrap()).unwrap();
 
-        let var2 = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(0.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var2 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 1.0).unwrap()).unwrap();
 
         assert_abs_diff_eq!(var1, var2);
     }
@@ -88,19 +78,9 @@ mod tests {
     #[test]
     fn test_different_bounds_not_equal() {
         // Variables with different bounds are not equal
-        let var1 = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(0.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var1 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 1.0).unwrap()).unwrap();
 
-        let var2 = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(0.0, 2.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var2 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 2.0).unwrap()).unwrap();
 
         assert_abs_diff_ne!(var1, var2);
     }
@@ -108,19 +88,9 @@ mod tests {
     #[test]
     fn test_same_kind_and_bound_equal() {
         // Variables with same ID, kind, and bounds are equal
-        let var1 = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(0.0, 10.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var1 = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 10.0).unwrap()).unwrap();
 
-        let var2 = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(0.0, 10.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var2 = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 10.0).unwrap()).unwrap();
 
         assert_abs_diff_eq!(var1, var2);
     }
@@ -128,19 +98,9 @@ mod tests {
     #[test]
     fn test_point_bound_continuous_integer_equal() {
         // Continuous[a, a] and Integer[a, a] are equal for point bounds
-        let var1 = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var1 = DecisionVariable::new(Kind::Continuous, Bound::new(5.0, 5.0).unwrap()).unwrap();
 
-        let var2 = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var2 = DecisionVariable::new(Kind::Integer, Bound::new(5.0, 5.0).unwrap()).unwrap();
 
         assert_abs_diff_eq!(var1, var2);
     }
@@ -148,37 +108,18 @@ mod tests {
     #[test]
     fn test_point_bound_zero_all_kinds_equal() {
         // For point bound [0, 0], all kinds are considered equal
-        let continuous = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(0.0, 0.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let continuous =
+            DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 0.0).unwrap()).unwrap();
 
-        let integer = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(0.0, 0.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let integer = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 0.0).unwrap()).unwrap();
 
-        let binary =
-            DecisionVariable::new(Kind::Binary, Bound::new(0.0, 0.0).unwrap(), ATol::default())
-                .unwrap();
+        let binary = DecisionVariable::new(Kind::Binary, Bound::new(0.0, 0.0).unwrap()).unwrap();
 
-        let semi_continuous = DecisionVariable::new(
-            Kind::SemiContinuous,
-            Bound::new(0.0, 0.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let semi_continuous =
+            DecisionVariable::new(Kind::SemiContinuous, Bound::new(0.0, 0.0).unwrap()).unwrap();
 
-        let semi_integer = DecisionVariable::new(
-            Kind::SemiInteger,
-            Bound::new(0.0, 0.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let semi_integer =
+            DecisionVariable::new(Kind::SemiInteger, Bound::new(0.0, 0.0).unwrap()).unwrap();
 
         // All combinations should be equal
         assert_abs_diff_eq!(continuous, integer);
@@ -192,19 +133,11 @@ mod tests {
     fn test_point_bound_nonzero_semi_not_equal() {
         // For point bound [a, a] where a != 0, semi-continuous/semi-integer
         // are not equal to continuous/integer/binary
-        let continuous = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let continuous =
+            DecisionVariable::new(Kind::Continuous, Bound::new(5.0, 5.0).unwrap()).unwrap();
 
-        let semi_continuous = DecisionVariable::new(
-            Kind::SemiContinuous,
-            Bound::new(5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let semi_continuous =
+            DecisionVariable::new(Kind::SemiContinuous, Bound::new(5.0, 5.0).unwrap()).unwrap();
 
         assert_abs_diff_ne!(continuous, semi_continuous);
     }
@@ -212,49 +145,26 @@ mod tests {
     #[test]
     fn test_bound_contains_zero_semi_equal() {
         // When bound contains 0, semi-integer equals integer and semi-continuous equals continuous
-        let integer = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(-5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let integer = DecisionVariable::new(Kind::Integer, Bound::new(-5.0, 5.0).unwrap()).unwrap();
 
-        let semi_integer = DecisionVariable::new(
-            Kind::SemiInteger,
-            Bound::new(-5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let semi_integer =
+            DecisionVariable::new(Kind::SemiInteger, Bound::new(-5.0, 5.0).unwrap()).unwrap();
 
-        let continuous = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(-5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let continuous =
+            DecisionVariable::new(Kind::Continuous, Bound::new(-5.0, 5.0).unwrap()).unwrap();
 
-        let semi_continuous = DecisionVariable::new(
-            Kind::SemiContinuous,
-            Bound::new(-5.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let semi_continuous =
+            DecisionVariable::new(Kind::SemiContinuous, Bound::new(-5.0, 5.0).unwrap()).unwrap();
 
         assert_abs_diff_eq!(integer, semi_integer);
         assert_abs_diff_eq!(continuous, semi_continuous);
 
         // Test binary-integer equality with compatible bounds
         // Binary is always [0, 1], so test with integer that has same bound
-        let binary =
-            DecisionVariable::new(Kind::Binary, Bound::new(0.0, 1.0).unwrap(), ATol::default())
-                .unwrap();
+        let binary = DecisionVariable::new(Kind::Binary, Bound::new(0.0, 1.0).unwrap()).unwrap();
 
-        let integer_01 = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(0.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let integer_01 =
+            DecisionVariable::new(Kind::Integer, Bound::new(0.0, 1.0).unwrap()).unwrap();
 
         assert_abs_diff_eq!(binary, integer_01);
     }
@@ -263,23 +173,12 @@ mod tests {
     fn test_point_bound_nonzero_all_basic_kinds_equal() {
         // For point bound [a, a] where a != 0, binary, integer, and continuous are all equal
         // This is according to the logic in lines 36-43 of the implementation
-        let binary =
-            DecisionVariable::new(Kind::Binary, Bound::new(1.0, 1.0).unwrap(), ATol::default())
-                .unwrap();
+        let binary = DecisionVariable::new(Kind::Binary, Bound::new(1.0, 1.0).unwrap()).unwrap();
 
-        let integer = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(1.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let integer = DecisionVariable::new(Kind::Integer, Bound::new(1.0, 1.0).unwrap()).unwrap();
 
-        let continuous = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(1.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let continuous =
+            DecisionVariable::new(Kind::Continuous, Bound::new(1.0, 1.0).unwrap()).unwrap();
 
         // For point bound [1,1] (not zero), binary, integer, and continuous are all equal
         assert_abs_diff_eq!(binary, integer);
@@ -290,19 +189,11 @@ mod tests {
     #[test]
     fn test_tolerance_in_point_bound() {
         // Test that tolerance is considered for point bounds
-        let var1 = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(1.0, 1.0 + 1e-10).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var1 =
+            DecisionVariable::new(Kind::Continuous, Bound::new(1.0, 1.0 + 1e-10).unwrap()).unwrap();
 
-        let var2 = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(1.0, 1.0 + 1e-10).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let var2 =
+            DecisionVariable::new(Kind::Integer, Bound::new(1.0, 1.0 + 1e-10).unwrap()).unwrap();
 
         // Should be equal with default tolerance
         assert_abs_diff_eq!(var1, var2);

--- a/rust/ommx/src/decision_variable/approx.rs
+++ b/rust/ommx/src/decision_variable/approx.rs
@@ -10,10 +10,6 @@ impl AbsDiffEq for DecisionVariable {
     }
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        // Must be same ID
-        if self.id != other.id {
-            return false;
-        }
         // For different bounds, they are always different.
         if !self.bound.abs_diff_eq(&other.bound, epsilon) {
             return false;
@@ -67,14 +63,12 @@ fn same_kind_class(a: Kind, b: Kind, class1: &[Kind], class2: &[Kind]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ATol, Bound, DecisionVariable, VariableID};
+    use crate::{ATol, Bound, DecisionVariable};
     use ::approx::{assert_abs_diff_eq, assert_abs_diff_ne};
 
     #[test]
-    fn test_different_ids_not_equal() {
-        // Variables with different IDs are never equal
+    fn test_equal_rows_are_equal_independent_of_table_key() {
         let var1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(0.0, 1.0).unwrap(),
             ATol::default(),
@@ -82,21 +76,19 @@ mod tests {
         .unwrap();
 
         let var2 = DecisionVariable::new(
-            VariableID::from(2),
             Kind::Continuous,
             Bound::new(0.0, 1.0).unwrap(),
             ATol::default(),
         )
         .unwrap();
 
-        assert_abs_diff_ne!(var1, var2);
+        assert_abs_diff_eq!(var1, var2);
     }
 
     #[test]
     fn test_different_bounds_not_equal() {
         // Variables with different bounds are not equal
         let var1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(0.0, 1.0).unwrap(),
             ATol::default(),
@@ -104,7 +96,6 @@ mod tests {
         .unwrap();
 
         let var2 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(0.0, 2.0).unwrap(),
             ATol::default(),
@@ -118,7 +109,6 @@ mod tests {
     fn test_same_kind_and_bound_equal() {
         // Variables with same ID, kind, and bounds are equal
         let var1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(0.0, 10.0).unwrap(),
             ATol::default(),
@@ -126,7 +116,6 @@ mod tests {
         .unwrap();
 
         let var2 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(0.0, 10.0).unwrap(),
             ATol::default(),
@@ -140,7 +129,6 @@ mod tests {
     fn test_point_bound_continuous_integer_equal() {
         // Continuous[a, a] and Integer[a, a] are equal for point bounds
         let var1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(5.0, 5.0).unwrap(),
             ATol::default(),
@@ -148,7 +136,6 @@ mod tests {
         .unwrap();
 
         let var2 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(5.0, 5.0).unwrap(),
             ATol::default(),
@@ -162,7 +149,6 @@ mod tests {
     fn test_point_bound_zero_all_kinds_equal() {
         // For point bound [0, 0], all kinds are considered equal
         let continuous = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(0.0, 0.0).unwrap(),
             ATol::default(),
@@ -170,23 +156,17 @@ mod tests {
         .unwrap();
 
         let integer = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(0.0, 0.0).unwrap(),
             ATol::default(),
         )
         .unwrap();
 
-        let binary = DecisionVariable::new(
-            VariableID::from(1),
-            Kind::Binary,
-            Bound::new(0.0, 0.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let binary =
+            DecisionVariable::new(Kind::Binary, Bound::new(0.0, 0.0).unwrap(), ATol::default())
+                .unwrap();
 
         let semi_continuous = DecisionVariable::new(
-            VariableID::from(1),
             Kind::SemiContinuous,
             Bound::new(0.0, 0.0).unwrap(),
             ATol::default(),
@@ -194,7 +174,6 @@ mod tests {
         .unwrap();
 
         let semi_integer = DecisionVariable::new(
-            VariableID::from(1),
             Kind::SemiInteger,
             Bound::new(0.0, 0.0).unwrap(),
             ATol::default(),
@@ -214,7 +193,6 @@ mod tests {
         // For point bound [a, a] where a != 0, semi-continuous/semi-integer
         // are not equal to continuous/integer/binary
         let continuous = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(5.0, 5.0).unwrap(),
             ATol::default(),
@@ -222,7 +200,6 @@ mod tests {
         .unwrap();
 
         let semi_continuous = DecisionVariable::new(
-            VariableID::from(1),
             Kind::SemiContinuous,
             Bound::new(5.0, 5.0).unwrap(),
             ATol::default(),
@@ -236,7 +213,6 @@ mod tests {
     fn test_bound_contains_zero_semi_equal() {
         // When bound contains 0, semi-integer equals integer and semi-continuous equals continuous
         let integer = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(-5.0, 5.0).unwrap(),
             ATol::default(),
@@ -244,7 +220,6 @@ mod tests {
         .unwrap();
 
         let semi_integer = DecisionVariable::new(
-            VariableID::from(1),
             Kind::SemiInteger,
             Bound::new(-5.0, 5.0).unwrap(),
             ATol::default(),
@@ -252,7 +227,6 @@ mod tests {
         .unwrap();
 
         let continuous = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(-5.0, 5.0).unwrap(),
             ATol::default(),
@@ -260,7 +234,6 @@ mod tests {
         .unwrap();
 
         let semi_continuous = DecisionVariable::new(
-            VariableID::from(1),
             Kind::SemiContinuous,
             Bound::new(-5.0, 5.0).unwrap(),
             ATol::default(),
@@ -272,16 +245,11 @@ mod tests {
 
         // Test binary-integer equality with compatible bounds
         // Binary is always [0, 1], so test with integer that has same bound
-        let binary = DecisionVariable::new(
-            VariableID::from(1),
-            Kind::Binary,
-            Bound::new(0.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let binary =
+            DecisionVariable::new(Kind::Binary, Bound::new(0.0, 1.0).unwrap(), ATol::default())
+                .unwrap();
 
         let integer_01 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(0.0, 1.0).unwrap(),
             ATol::default(),
@@ -295,16 +263,11 @@ mod tests {
     fn test_point_bound_nonzero_all_basic_kinds_equal() {
         // For point bound [a, a] where a != 0, binary, integer, and continuous are all equal
         // This is according to the logic in lines 36-43 of the implementation
-        let binary = DecisionVariable::new(
-            VariableID::from(1),
-            Kind::Binary,
-            Bound::new(1.0, 1.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let binary =
+            DecisionVariable::new(Kind::Binary, Bound::new(1.0, 1.0).unwrap(), ATol::default())
+                .unwrap();
 
         let integer = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(1.0, 1.0).unwrap(),
             ATol::default(),
@@ -312,7 +275,6 @@ mod tests {
         .unwrap();
 
         let continuous = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(1.0, 1.0).unwrap(),
             ATol::default(),
@@ -329,7 +291,6 @@ mod tests {
     fn test_tolerance_in_point_bound() {
         // Test that tolerance is considered for point bounds
         let var1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(1.0, 1.0 + 1e-10).unwrap(),
             ATol::default(),
@@ -337,7 +298,6 @@ mod tests {
         .unwrap();
 
         let var2 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(1.0, 1.0 + 1e-10).unwrap(),
             ATol::default(),

--- a/rust/ommx/src/decision_variable/arbitrary.rs
+++ b/rust/ommx/src/decision_variable/arbitrary.rs
@@ -46,11 +46,7 @@ impl Arbitrary for DecisionVariable {
                 let bound = kind.consistent_bound(bound, ATol::default())?;
                 Some((kind, bound))
             })
-            .prop_map(|(kind, bound)| DecisionVariable {
-                id: VariableID::from(0), // Should be replaced with a unique ID, but cannot be generated here
-                kind,
-                bound,
-            })
+            .prop_map(|(kind, bound)| DecisionVariable { kind, bound })
             .boxed()
     }
 }
@@ -73,14 +69,6 @@ pub fn arbitrary_decision_variables(
         unique_ids.len(),
     );
     (Just(unique_ids), variables)
-        .prop_map(|(ids, variables)| {
-            ids.into_iter()
-                .zip(variables)
-                .map(|(id, mut variable)| {
-                    variable.id = id;
-                    (id, variable)
-                })
-                .collect()
-        })
+        .prop_map(|(ids, variables)| ids.into_iter().zip(variables).collect())
         .boxed()
 }

--- a/rust/ommx/src/decision_variable/logical_memory.rs
+++ b/rust/ommx/src/decision_variable/logical_memory.rs
@@ -42,7 +42,12 @@ mod tests {
     // `Instance::variable_labels` SoA-store level.
     #[test]
     fn test_decision_variable_minimal_no_label_snapshot() {
-        let dv = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 10.0).unwrap()).unwrap();
+        let dv = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
 
         let folded = logical_memory_to_folded(&dv);
         insta::assert_snapshot!(folded, @r###"

--- a/rust/ommx/src/decision_variable/logical_memory.rs
+++ b/rust/ommx/src/decision_variable/logical_memory.rs
@@ -21,7 +21,7 @@ impl LogicalMemoryProfile for Kind {
 mod tests {
     use crate::decision_variable::{DecisionVariable, Kind};
     use crate::logical_memory::logical_memory_to_folded;
-    use crate::{ATol, Bound};
+    use crate::Bound;
 
     #[test]
     fn test_decision_variable_minimal_snapshot() {
@@ -42,12 +42,7 @@ mod tests {
     // `Instance::variable_labels` SoA-store level.
     #[test]
     fn test_decision_variable_minimal_no_label_snapshot() {
-        let dv = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(0.0, 10.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let dv = DecisionVariable::new(Kind::Integer, Bound::new(0.0, 10.0).unwrap()).unwrap();
 
         let folded = logical_memory_to_folded(&dv);
         insta::assert_snapshot!(folded, @r###"

--- a/rust/ommx/src/decision_variable/logical_memory.rs
+++ b/rust/ommx/src/decision_variable/logical_memory.rs
@@ -19,20 +19,19 @@ impl LogicalMemoryProfile for Kind {
 
 #[cfg(test)]
 mod tests {
-    use crate::decision_variable::{DecisionVariable, Kind, VariableID};
+    use crate::decision_variable::{DecisionVariable, Kind};
     use crate::logical_memory::logical_memory_to_folded;
     use crate::{ATol, Bound};
 
     #[test]
     fn test_decision_variable_minimal_snapshot() {
-        let dv = DecisionVariable::binary(VariableID::from(1));
+        let dv = DecisionVariable::binary();
         let folded = logical_memory_to_folded(&dv);
         // Per-element label storage was retired in v3 — only the
         // intrinsic fields appear here; per-variable modeling labels live at
         // `Instance::variable_labels` (see `instance/logical_memory.rs`).
         insta::assert_snapshot!(folded, @r###"
         DecisionVariable.bound 16
-        DecisionVariable.id 8
         DecisionVariable.kind 1
         "###);
     }
@@ -44,7 +43,6 @@ mod tests {
     #[test]
     fn test_decision_variable_minimal_no_label_snapshot() {
         let dv = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Integer,
             Bound::new(0.0, 10.0).unwrap(),
             ATol::default(),
@@ -54,7 +52,6 @@ mod tests {
         let folded = logical_memory_to_folded(&dv);
         insta::assert_snapshot!(folded, @r###"
         DecisionVariable.bound 16
-        DecisionVariable.id 8
         DecisionVariable.kind 1
         "###);
     }

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -56,6 +56,7 @@ impl From<Kind> for i32 {
 /// parse can drain it into the [`VariableLabelStore`].
 #[derive(Debug)]
 pub struct ParsedDecisionVariable {
+    pub id: VariableID,
     pub variable: DecisionVariable,
     pub label: DecisionVariableLabel,
     pub fixed_value: Option<f64>,
@@ -71,16 +72,12 @@ impl Parse for v1::DecisionVariable {
             .bound
             .unwrap_or_default()
             .parse_as(&(), message, "bound")?;
-        let dv = DecisionVariable::new(
-            VariableID(self.id),
-            kind,
-            bound,
-            ATol::default(), // FIXME: user should provide this
-        )
+        let id = VariableID::from(self.id);
+        let dv = DecisionVariable::new(kind, bound, ATol::default()) // FIXME: user should provide this
         .map_err(|e| RawParseError::InvalidDecisionVariable(e).context(message, "bound"))?;
         let fixed_value = self.substituted_value;
         if let Some(value) = fixed_value {
-            dv.check_value_consistency(value, ATol::default())
+            dv.check_value_consistency(id, value, ATol::default())
                 .map_err(|e| {
                     RawParseError::InvalidDecisionVariable(e).context(message, "substituted_value")
                 })?;
@@ -92,6 +89,7 @@ impl Parse for v1::DecisionVariable {
             description: self.description,
         };
         Ok(ParsedDecisionVariable {
+            id,
             variable: dv,
             label,
             fixed_value,
@@ -119,7 +117,7 @@ impl Parse for Vec<v1::DecisionVariable> {
         let mut fixed_values = BTreeMap::default();
         for v in self {
             let parsed: ParsedDecisionVariable = v.parse(&())?;
-            let id = parsed.variable.id;
+            let id = parsed.id;
             if decision_variables.insert(id, parsed.variable).is_some() {
                 return Err(RawParseError::InvalidInstance(format!(
                     "Duplicated variable ID is found in definition: {id:?}"
@@ -137,7 +135,8 @@ impl Parse for Vec<v1::DecisionVariable> {
 
 /// Build a v1 `DecisionVariable` from its intrinsic data plus drained modeling label.
 pub(crate) fn decision_variable_to_v1(
-    DecisionVariable { id, kind, bound }: DecisionVariable,
+    id: VariableID,
+    DecisionVariable { kind, bound }: DecisionVariable,
     label: DecisionVariableLabel,
 ) -> v1::DecisionVariable {
     decision_variable_fields_to_v1(id, kind, bound, label, None)
@@ -145,7 +144,8 @@ pub(crate) fn decision_variable_to_v1(
 
 /// Build a v1 `DecisionVariable` and overlay the root-owned fixed value.
 pub(crate) fn decision_variable_to_v1_with_fixed_value(
-    DecisionVariable { id, kind, bound }: DecisionVariable,
+    id: VariableID,
+    DecisionVariable { kind, bound }: DecisionVariable,
     label: DecisionVariableLabel,
     substituted_value: Option<f64>,
 ) -> v1::DecisionVariable {
@@ -174,6 +174,7 @@ fn decision_variable_fields_to_v1(
 /// Parsed v1 `SampledDecisionVariable` together with its drained modeling label.
 #[derive(Debug)]
 pub struct ParsedSampledDecisionVariable {
+    pub id: VariableID,
     pub variable: SampledDecisionVariable,
     pub label: DecisionVariableLabel,
 }
@@ -209,7 +210,7 @@ impl Parse for v1::SampledDecisionVariable {
                 if !sample_value.is_finite() {
                     return Err(RawParseError::InvalidDecisionVariable(
                         DecisionVariableError::NonFiniteValue {
-                            id: parsed_dv.variable.id,
+                            id: parsed_dv.id,
                             value: sample_value,
                         },
                     )
@@ -218,7 +219,7 @@ impl Parse for v1::SampledDecisionVariable {
                 if (sample_value - fixed_value).abs() > *atol {
                     return Err(RawParseError::InvalidDecisionVariable(
                         DecisionVariableError::SubstitutedValueOverwrite {
-                            id: parsed_dv.variable.id,
+                            id: parsed_dv.id,
                             previous_value: fixed_value,
                             new_value: sample_value,
                             atol,
@@ -230,9 +231,11 @@ impl Parse for v1::SampledDecisionVariable {
         }
 
         // Create SampledDecisionVariable with validation
-        let sampled = crate::SampledDecisionVariable::new(parsed_dv.variable, samples)
-            .map_err(RawParseError::InvalidDecisionVariable)?;
+        let sampled =
+            crate::SampledDecisionVariable::new(parsed_dv.id, parsed_dv.variable, samples)
+                .map_err(RawParseError::InvalidDecisionVariable)?;
         Ok(ParsedSampledDecisionVariable {
+            id: parsed_dv.id,
             variable: sampled,
             label: parsed_dv.label,
         })
@@ -248,17 +251,17 @@ impl TryFrom<v1::SampledDecisionVariable> for SampledDecisionVariable {
 
 /// Build a v1 `SampledDecisionVariable` from its intrinsic data plus drained modeling label.
 pub(crate) fn sampled_decision_variable_to_v1(
+    id: VariableID,
     sampled_dv: SampledDecisionVariable,
     label: DecisionVariableLabel,
 ) -> v1::SampledDecisionVariable {
     let dv = DecisionVariable {
-        id: sampled_dv.id,
         kind: sampled_dv.kind,
         bound: sampled_dv.bound,
     };
 
     v1::SampledDecisionVariable {
-        decision_variable: Some(decision_variable_to_v1(dv, label)),
+        decision_variable: Some(decision_variable_to_v1(id, dv, label)),
         samples: Some(sampled_dv.samples.into()),
     }
 }
@@ -282,7 +285,7 @@ mod tests {
         insta::assert_snapshot!(res.unwrap_err(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.DecisionVariable[bound]
-        Bound for ID=1 is inconsistent to kind: kind=Integer, bound=[1.1, 1.9]
+        Bound is inconsistent to kind: kind=Integer, bound=[1.1, 1.9]
         "###);
     }
 
@@ -319,10 +322,11 @@ mod tests {
         };
 
         let parsed: ParsedSampledDecisionVariable = v1_sampled_dv.parse(&()).unwrap();
+        let sampled_id = parsed.id;
         let sampled_dv = parsed.variable;
         let label = parsed.label;
 
-        assert_eq!(*sampled_dv.id(), VariableID::from(42));
+        assert_eq!(sampled_id, VariableID::from(42));
         assert_eq!(*sampled_dv.kind(), Kind::Continuous);
         assert_eq!(label.name, Some("test_var".to_string()));
         assert_eq!(label.subscripts, vec![1, 2]);
@@ -330,7 +334,7 @@ mod tests {
 
         // Test round-trip conversion: name is reattached at serialize time
         // by `sampled_decision_variable_to_v1`.
-        let v1_converted = sampled_decision_variable_to_v1(sampled_dv, label);
+        let v1_converted = sampled_decision_variable_to_v1(sampled_id, sampled_dv, label);
         let decision_variable = v1_converted.decision_variable.unwrap();
         assert_eq!(decision_variable.id, 42);
         assert_eq!(decision_variable.name, Some("test_var".to_string()));

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -73,7 +73,7 @@ impl Parse for v1::DecisionVariable {
             .unwrap_or_default()
             .parse_as(&(), message, "bound")?;
         let id = VariableID::from(self.id);
-        let dv = DecisionVariable::new(kind, bound, ATol::default()) // FIXME: user should provide this
+        let dv = DecisionVariable::new(kind, bound) // FIXME: user should provide this
         .map_err(|e| RawParseError::InvalidDecisionVariable(e).context(message, "bound"))?;
         let fixed_value = self.substituted_value;
         if let Some(value) = fixed_value {

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -73,7 +73,7 @@ impl Parse for v1::DecisionVariable {
             .unwrap_or_default()
             .parse_as(&(), message, "bound")?;
         let id = VariableID::from(self.id);
-        let dv = DecisionVariable::new(kind, bound) // FIXME: user should provide this
+        let dv = DecisionVariable::new(kind, bound, ATol::default()) // FIXME: user should provide this
         .map_err(|e| RawParseError::InvalidDecisionVariable(e).context(message, "bound"))?;
         let fixed_value = self.substituted_value;
         if let Some(value) = fixed_value {
@@ -205,7 +205,7 @@ impl Parse for v1::SampledDecisionVariable {
             .parse_as(&(), message, "samples")?;
 
         if let Some(fixed_value) = parsed_dv.fixed_value {
-            let atol = crate::ATol::default();
+            let atol = ATol::default();
             for (_, &sample_value) in samples.iter() {
                 if !sample_value.is_finite() {
                     return Err(RawParseError::InvalidDecisionVariable(
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_parse_sampled_decision_variable_accepts_substituted_value_at_atol_boundary() {
-        let atol = *crate::ATol::default();
+        let atol = *ATol::default();
         let v1_sampled_dv = v1::SampledDecisionVariable {
             decision_variable: Some(v1::DecisionVariable {
                 id: 42,

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -74,7 +74,13 @@ impl Parse for v1::DecisionVariable {
             .parse_as(&(), message, "bound")?;
         let id = VariableID::from(self.id);
         let dv = DecisionVariable::new(kind, bound, ATol::default()) // FIXME: user should provide this
-        .map_err(|e| RawParseError::InvalidDecisionVariable(e).context(message, "bound"))?;
+            .map_err(|source| {
+                RawParseError::InvalidDecisionVariable(DecisionVariableError::InvalidDefinition {
+                    id,
+                    source: Box::new(source),
+                })
+                .context(message, "bound")
+            })?;
         let fixed_value = self.substituted_value;
         if let Some(value) = fixed_value {
             dv.check_value_consistency(id, value, ATol::default())
@@ -285,7 +291,7 @@ mod tests {
         insta::assert_snapshot!(res.unwrap_err(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.DecisionVariable[bound]
-        Bound is inconsistent to kind: kind=Integer, bound=[1.1, 1.9]
+        Invalid decision variable ID=1: Bound is inconsistent to kind: kind=Integer, bound=[1.1, 1.9]
         "###);
     }
 

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -929,10 +929,10 @@ mod reduce_capabilities_tests {
     /// for Big-M conversion (binary variables have bound [0, 1]).
     fn instance_with_all_capabilities() -> Instance {
         let decision_variables = btreemap! {
-            VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(0) => DecisionVariable::binary(),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
         let one_hot = OneHotConstraint::new(
             [VariableID::from(0), VariableID::from(1)]
@@ -1038,8 +1038,8 @@ mod reduce_capabilities_tests {
         // as converted; Indicator / SOS1 aren't in the returned set since they
         // were never present to begin with.
         let decision_variables = btreemap! {
-            VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(0) => DecisionVariable::binary(),
+            VariableID::from(1) => DecisionVariable::binary(),
         };
         let one_hot = OneHotConstraint::new(
             [VariableID::from(0), VariableID::from(1)]
@@ -1068,7 +1068,7 @@ mod reduce_capabilities_tests {
     fn conversion_failure_is_propagated() {
         // SOS1 over a continuous variable with infinite bound cannot be Big-M
         // converted; reduce_capabilities surfaces the underlying error.
-        let dv = DecisionVariable::continuous(VariableID::from(0));
+        let dv = DecisionVariable::continuous();
         let sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect::<BTreeSet<_>>())
             .unwrap();
         let mut instance = Instance::builder()
@@ -1091,7 +1091,6 @@ mod reduce_capabilities_tests {
         // reduce_capabilities should invoke the SOS1 Big-M conversion which
         // allocates a fresh binary indicator.
         let dv = DecisionVariable::new(
-            VariableID::from(0),
             Kind::Integer,
             Bound::new(-2.0, 3.0).unwrap(),
             crate::ATol::default(),

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -1090,7 +1090,12 @@ mod reduce_capabilities_tests {
         // A single SOS1 over an integer variable with finite bound [-2, 3]:
         // reduce_capabilities should invoke the SOS1 Big-M conversion which
         // allocates a fresh binary indicator.
-        let dv = DecisionVariable::new(Kind::Integer, Bound::new(-2.0, 3.0).unwrap()).unwrap();
+        let dv = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-2.0, 3.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
         let sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect::<BTreeSet<_>>())
             .unwrap();
         let mut instance = Instance::builder()

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -1090,12 +1090,7 @@ mod reduce_capabilities_tests {
         // A single SOS1 over an integer variable with finite bound [-2, 3]:
         // reduce_capabilities should invoke the SOS1 Big-M conversion which
         // allocates a fresh binary indicator.
-        let dv = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(-2.0, 3.0).unwrap(),
-            crate::ATol::default(),
-        )
-        .unwrap();
+        let dv = DecisionVariable::new(Kind::Integer, Bound::new(-2.0, 3.0).unwrap()).unwrap();
         let sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect::<BTreeSet<_>>())
             .unwrap();
         let mut instance = Instance::builder()

--- a/rust/ommx/src/instance/analysis.rs
+++ b/rust/ommx/src/instance/analysis.rs
@@ -495,10 +495,7 @@ mod tests {
         // Create instance with 5 binary variables
         let mut decision_variables = BTreeMap::new();
         for i in 0..5 {
-            decision_variables.insert(
-                VariableID::from(i),
-                crate::DecisionVariable::binary(VariableID::from(i)),
-            );
+            decision_variables.insert(VariableID::from(i), crate::DecisionVariable::binary());
         }
 
         // Objective: x0 + x1 + x2
@@ -570,10 +567,10 @@ mod tests {
         //
         // Note: x_5 < x_10 in BTreeMap order, but x_10 must be evaluated first
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
-            VariableID::from(5) => DecisionVariable::continuous(VariableID::from(5)),
-            VariableID::from(10) => DecisionVariable::continuous(VariableID::from(10)),
+            VariableID::from(1) => DecisionVariable::continuous(),
+            VariableID::from(2) => DecisionVariable::continuous(),
+            VariableID::from(5) => DecisionVariable::continuous(),
+            VariableID::from(10) => DecisionVariable::continuous(),
         };
 
         // x_10 = x_1 + x_2
@@ -619,8 +616,8 @@ mod tests {
         use maplit::btreemap;
 
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::continuous(),
+            VariableID::from(2) => DecisionVariable::continuous(),
         };
         let named_function = NamedFunction {
             id: NamedFunctionID::from(7),

--- a/rust/ommx/src/instance/builder.rs
+++ b/rust/ommx/src/instance/builder.rs
@@ -222,7 +222,7 @@ impl InstanceBuilder {
     /// # Errors
     /// Returns an error if:
     /// - Required fields (`sense`, `objective`, `decision_variables`, `constraints`) are not set
-    /// - Map keys don't match their value's ID (decision_variables, constraints, removed_constraints)
+    /// - Named-function map keys don't match their value's ID
     /// - The objective function or constraints reference undefined variable IDs
     /// - The keys of `constraints` and `removed_constraints` are not disjoint
     /// - Label/context stores contain IDs that are not owned by the

--- a/rust/ommx/src/instance/builder.rs
+++ b/rust/ommx/src/instance/builder.rs
@@ -243,17 +243,6 @@ impl InstanceBuilder {
             .constraints
             .ok_or_else(|| crate::error!("Required field is missing: constraints"))?;
 
-        // Validate that decision variable map keys match their value's id
-        for (key, value) in &decision_variables {
-            if *key != value.id() {
-                let value_id = value.id();
-                crate::bail!(
-                    { ?key, ?value_id },
-                    "Decision variable map key {key:?} does not match value's id {value_id:?}",
-                );
-            }
-        }
-
         // Collect all variable IDs for validation
         let variable_ids: VariableIDSet = decision_variables.keys().cloned().collect();
         crate::modeling_label::validate_modeling_label_ids(
@@ -270,7 +259,7 @@ impl InstanceBuilder {
                     "Fixed decision-variable value references unknown decision variable ID {id:?}",
                 );
             };
-            dv.check_value_consistency(*value, crate::ATol::default())?;
+            dv.check_value_consistency(*id, *value, crate::ATol::default())?;
         }
 
         // Validate that all variable IDs in objective and constraints are defined
@@ -604,7 +593,7 @@ mod tests {
         let instance = Instance::builder()
             .sense(Sense::Minimize)
             .objective(Function::Zero)
-            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary(var_id))]))
+            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary())]))
             .variable_labels(variable_labels)
             .constraints(BTreeMap::from([(
                 constraint_id,
@@ -639,7 +628,7 @@ mod tests {
         let instance = Instance::builder()
             .sense(Sense::Minimize)
             .objective(Function::Zero)
-            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary(var_id))]))
+            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary())]))
             .constraints(BTreeMap::new())
             .indicator_constraints(BTreeMap::from([(
                 indicator_id,
@@ -866,7 +855,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                var_id => DecisionVariable::binary(var_id),
+                var_id => DecisionVariable::binary(),
             })
             .constraints(BTreeMap::new())
             .one_hot_constraints(btreemap! {
@@ -889,7 +878,7 @@ mod tests {
         let var_id = VariableID::from(1);
         let undefined_var_id = VariableID::from(999);
         let decision_variables = btreemap! {
-            var_id => DecisionVariable::binary(var_id),
+            var_id => DecisionVariable::binary(),
         };
 
         // Create a dependency that references a variable not in decision_variables
@@ -921,7 +910,7 @@ mod tests {
 
         let var_id = VariableID::from(1);
         let decision_variables = btreemap! {
-            var_id => DecisionVariable::binary(var_id),
+            var_id => DecisionVariable::binary(),
         };
 
         // Create a dependency for a variable that IS in decision_variables (this is valid)
@@ -950,7 +939,7 @@ mod tests {
 
         let var_id = VariableID::from(1);
         let decision_variables = btreemap! {
-            var_id => DecisionVariable::binary(var_id),
+            var_id => DecisionVariable::binary(),
         };
 
         // Create a dependency for var_id
@@ -985,7 +974,7 @@ mod tests {
         let var_id = VariableID::from(1);
         let constraint_id = ConstraintID::from(1);
         let decision_variables = btreemap! {
-            var_id => DecisionVariable::binary(var_id),
+            var_id => DecisionVariable::binary(),
         };
 
         // Create a dependency for var_id
@@ -1018,7 +1007,7 @@ mod tests {
         use maplit::btreemap;
 
         let var_id = VariableID::from(1);
-        let dv = DecisionVariable::binary(var_id);
+        let dv = DecisionVariable::binary();
         let decision_variables = btreemap! {
             var_id => dv,
         };
@@ -1084,7 +1073,7 @@ mod tests {
         use maplit::btreemap;
 
         let var_id = VariableID::from(1);
-        let dv = DecisionVariable::binary(var_id);
+        let dv = DecisionVariable::binary();
         let decision_variables = btreemap! {
             var_id => dv,
         };

--- a/rust/ommx/src/instance/clip_bounds.rs
+++ b/rust/ommx/src/instance/clip_bounds.rs
@@ -21,7 +21,7 @@ impl Instance {
 
                 // Store original bound only if it actually changes
                 let original_bound = decision_variable.bound();
-                let changed = decision_variable.clip_bound(*new_bound, atol)?;
+                let changed = decision_variable.clip_bound(*id, *new_bound, atol)?;
 
                 if changed {
                     original_bounds.insert(*id, original_bound);
@@ -54,13 +54,13 @@ mod tests {
     fn test_clip_bounds_normal() {
         // Create instance with 3 variables
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1))
+            VariableID::from(1) => DecisionVariable::continuous()
                 .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
                 .unwrap(),
-            VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2))
+            VariableID::from(2) => DecisionVariable::continuous()
                 .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
                 .unwrap(),
-            VariableID::from(3) => DecisionVariable::continuous(VariableID::from(3))
+            VariableID::from(3) => DecisionVariable::continuous()
                 .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
                 .unwrap(),
         };
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn test_clip_bounds_undefined_variable() {
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
+            VariableID::from(1) => DecisionVariable::continuous(),
         };
 
         let mut instance = Instance {
@@ -120,7 +120,7 @@ mod tests {
         // Create instance with 3 variables
         let mut decision_variables = btreemap! {};
         for i in 1..=3 {
-            let dv = DecisionVariable::continuous(VariableID::from(i))
+            let dv = DecisionVariable::continuous()
                 .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
                 .unwrap();
             decision_variables.insert(VariableID::from(i), dv);
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_clip_bounds_empty() {
-        let dv = DecisionVariable::continuous(VariableID::from(1))
+        let dv = DecisionVariable::continuous()
             .with_bound(Bound::new(0.0, 10.0).unwrap(), ATol::default())
             .unwrap();
         let original_bound = dv.bound();

--- a/rust/ommx/src/instance/convert.rs
+++ b/rust/ommx/src/instance/convert.rs
@@ -207,8 +207,8 @@ mod with_parameters_tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                x => DecisionVariable::binary(x),
-                dep => DecisionVariable::binary(dep),
+                x => DecisionVariable::binary(),
+                dep => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 p => crate::v1::Parameter { id: 100, ..Default::default() },
@@ -254,7 +254,7 @@ mod with_parameters_tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                x => DecisionVariable::binary(x),
+                x => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 p => crate::v1::Parameter { id: 100, ..Default::default() },
@@ -310,8 +310,8 @@ mod with_parameters_tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                y => DecisionVariable::binary(y),
-                x => DecisionVariable::binary(x),
+                y => DecisionVariable::binary(),
+                x => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 p => crate::v1::Parameter { id: 100, ..Default::default() },
@@ -367,8 +367,8 @@ mod with_parameters_tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                y => DecisionVariable::binary(y),
-                x => DecisionVariable::binary(x),
+                y => DecisionVariable::binary(),
+                x => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 p => crate::v1::Parameter { id: 100, ..Default::default() },

--- a/rust/ommx/src/instance/decision_variable.rs
+++ b/rust/ommx/src/instance/decision_variable.rs
@@ -19,7 +19,7 @@ impl Instance {
     /// * `subscripts` - The subscripts of the decision variable (can be empty)
     ///
     /// # Returns
-    /// * `Some(&DecisionVariable)` if a variable with the given name and subscripts is found
+    /// * `Some((VariableID, &DecisionVariable))` if a variable with the given name and subscripts is found
     /// * `None` if no matching variable is found
     ///
     /// # Example
@@ -36,11 +36,11 @@ impl Instance {
         &self,
         name: &str,
         subscripts: Vec<i64>,
-    ) -> Option<&DecisionVariable> {
+    ) -> Option<(VariableID, &DecisionVariable)> {
         let store = self.variable_labels();
         self.decision_variables.iter().find_map(|(id, var)| {
             (store.name(*id) == Some(name) && store.subscripts(*id) == subscripts.as_slice())
-                .then_some(var)
+                .then_some((*id, var))
         })
     }
 
@@ -66,9 +66,9 @@ impl Instance {
         atol: ATol,
     ) -> Result<VariableID, DecisionVariableError> {
         let id = self.next_variable_id();
-        let dv = DecisionVariable::new(id, kind, bound, atol)?;
+        let dv = DecisionVariable::new(kind, bound, atol)?;
         if let Some(value) = fixed_value {
-            dv.check_value_consistency(value, atol)?;
+            dv.check_value_consistency(id, value, atol)?;
             self.fixed_decision_variable_values.insert(id, value);
         }
         self.decision_variables.insert(id, dv);
@@ -129,9 +129,9 @@ mod tests {
 
         // Instance with variables should return max_id + 1
         let decision_variables = btreemap! {
-            VariableID::from(5) => DecisionVariable::binary(VariableID::from(5)),
-            VariableID::from(8) => DecisionVariable::binary(VariableID::from(8)),
-            VariableID::from(100) => DecisionVariable::binary(VariableID::from(100)),
+            VariableID::from(5) => DecisionVariable::binary(),
+            VariableID::from(8) => DecisionVariable::binary(),
+            VariableID::from(100) => DecisionVariable::binary(),
         };
         let objective = (linear!(5) + coeff!(1.0)).into();
         let instance = Instance::new(

--- a/rust/ommx/src/instance/decision_variable.rs
+++ b/rust/ommx/src/instance/decision_variable.rs
@@ -66,7 +66,7 @@ impl Instance {
         atol: ATol,
     ) -> Result<VariableID, DecisionVariableError> {
         let id = self.next_variable_id();
-        let dv = DecisionVariable::new(kind, bound, atol)?;
+        let dv = DecisionVariable::new_with_atol(kind, bound, atol)?;
         if let Some(value) = fixed_value {
             dv.check_value_consistency(id, value, atol)?;
             self.fixed_decision_variable_values.insert(id, value);

--- a/rust/ommx/src/instance/decision_variable.rs
+++ b/rust/ommx/src/instance/decision_variable.rs
@@ -66,7 +66,7 @@ impl Instance {
         atol: ATol,
     ) -> Result<VariableID, DecisionVariableError> {
         let id = self.next_variable_id();
-        let dv = DecisionVariable::new_with_atol(kind, bound, atol)?;
+        let dv = DecisionVariable::new(kind, bound, atol)?;
         if let Some(value) = fixed_value {
             dv.check_value_consistency(id, value, atol)?;
             self.fixed_decision_variable_values.insert(id, value);

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -53,10 +53,8 @@ fn evaluate_decision_variable_samples(
     samples: &crate::Sampled<v1::State>,
 ) -> Result<crate::SampledDecisionVariable> {
     let variable_id = id.into_inner();
-    let mut grouped_values: std::collections::HashMap<
-        ordered_float::OrderedFloat<f64>,
-        Vec<crate::SampleID>,
-    > = std::collections::HashMap::new();
+    let mut grouped_values: BTreeMap<ordered_float::OrderedFloat<f64>, Vec<crate::SampleID>> =
+        BTreeMap::new();
     for (sample_id, state) in samples.iter() {
         if let Some(value) = state.entries.get(&variable_id) {
             grouped_values
@@ -66,8 +64,10 @@ fn evaluate_decision_variable_samples(
         }
     }
 
-    let ids: Vec<Vec<crate::SampleID>> = grouped_values.values().cloned().collect();
-    let values: Vec<f64> = grouped_values.keys().map(|k| k.into_inner()).collect();
+    let (ids, values): (Vec<Vec<crate::SampleID>>, Vec<f64>) = grouped_values
+        .into_iter()
+        .map(|(value, ids)| (ids, value.into_inner()))
+        .unzip();
     let samples = crate::Sampled::new(ids, values)?;
     Ok(crate::SampledDecisionVariable::new(
         id,
@@ -626,6 +626,56 @@ mod tests {
             instance.fixed_decision_variable_value(VariableID::from(2)),
             Some(0.0)
         );
+    }
+
+    #[test]
+    fn test_evaluate_samples_preserves_sample_groups_for_decision_variables() {
+        let instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(linear!(1)))
+            .decision_variables(BTreeMap::from([(
+                VariableID::from(1),
+                crate::DecisionVariable::continuous(),
+            )]))
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap();
+        let samples = crate::Sampled::new(
+            [
+                vec![crate::SampleID::from(0)],
+                vec![crate::SampleID::from(1)],
+                vec![crate::SampleID::from(2)],
+            ],
+            [
+                v1::State::from(HashMap::from([(1, 2.0)])),
+                v1::State::from(HashMap::from([(1, 7.0)])),
+                v1::State::from(HashMap::from([(1, 2.0)])),
+            ],
+        )
+        .unwrap();
+
+        let sample_set = instance
+            .evaluate_samples(&samples, ATol::default())
+            .unwrap();
+        let sampled = sample_set
+            .decision_variables()
+            .get(&VariableID::from(1))
+            .unwrap()
+            .samples();
+
+        assert_eq!(sampled.get(crate::SampleID::from(0)), Some(&2.0));
+        assert_eq!(sampled.get(crate::SampleID::from(1)), Some(&7.0));
+        assert_eq!(sampled.get(crate::SampleID::from(2)), Some(&2.0));
+
+        let chunks = sampled.clone().chunk();
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].0, 2.0);
+        assert_eq!(chunks[0].1.len(), 2);
+        assert!(chunks[0].1.contains(&crate::SampleID::from(0)));
+        assert!(chunks[0].1.contains(&crate::SampleID::from(2)));
+        assert_eq!(chunks[1].0, 7.0);
+        assert_eq!(chunks[1].1.len(), 1);
+        assert!(chunks[1].1.contains(&crate::SampleID::from(1)));
     }
 
     #[test]

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -30,6 +30,52 @@ fn values_are_consistent(left: f64, right: f64, atol: ATol) -> bool {
     left.is_finite() && right.is_finite() && (left - right).abs() <= *atol
 }
 
+fn evaluate_decision_variable(
+    id: VariableID,
+    decision_variable: &DecisionVariable,
+    state: &v1::State,
+) -> Result<crate::EvaluatedDecisionVariable> {
+    let value = state
+        .entries
+        .get(&id.into_inner())
+        .copied()
+        .ok_or_else(|| crate::error!("Variable ID {id} not found in state"))?;
+    Ok(crate::EvaluatedDecisionVariable::new(
+        id,
+        decision_variable.clone(),
+        value,
+    )?)
+}
+
+fn evaluate_decision_variable_samples(
+    id: VariableID,
+    decision_variable: &DecisionVariable,
+    samples: &crate::Sampled<v1::State>,
+) -> Result<crate::SampledDecisionVariable> {
+    let variable_id = id.into_inner();
+    let mut grouped_values: std::collections::HashMap<
+        ordered_float::OrderedFloat<f64>,
+        Vec<crate::SampleID>,
+    > = std::collections::HashMap::new();
+    for (sample_id, state) in samples.iter() {
+        if let Some(value) = state.entries.get(&variable_id) {
+            grouped_values
+                .entry(ordered_float::OrderedFloat(*value))
+                .or_default()
+                .push(*sample_id);
+        }
+    }
+
+    let ids: Vec<Vec<crate::SampleID>> = grouped_values.values().cloned().collect();
+    let values: Vec<f64> = grouped_values.keys().map(|k| k.into_inner()).collect();
+    let samples = crate::Sampled::new(ids, values)?;
+    Ok(crate::SampledDecisionVariable::new(
+        id,
+        decision_variable.clone(),
+        samples,
+    )?)
+}
+
 /// Merge additional variable fixings from propagation into `expanded` state.
 ///
 /// Returns `Err` if any fixing conflicts with an existing value in `expanded`
@@ -221,9 +267,9 @@ impl Evaluate for Instance {
         let evaluated_sos1_constraints = self.sos1_constraint_collection.evaluate(&state, atol)?;
 
         let mut decision_variables = BTreeMap::default();
-        for dv in self.decision_variables.values() {
-            let evaluated_dv = dv.evaluate(&state, atol)?;
-            decision_variables.insert(*evaluated_dv.id(), evaluated_dv);
+        for (id, dv) in self.decision_variables.iter() {
+            let evaluated_dv = evaluate_decision_variable(*id, dv, &state)?;
+            decision_variables.insert(*id, evaluated_dv);
         }
 
         let mut evaluated_named_functions = BTreeMap::default();
@@ -294,9 +340,9 @@ impl Evaluate for Instance {
 
         // Reconstruct decision variable values
         let mut decision_variables = std::collections::BTreeMap::new();
-        for dv in self.decision_variables.values() {
-            let sampled_dv = dv.evaluate_samples(&samples, atol)?;
-            decision_variables.insert(dv.id(), sampled_dv);
+        for (id, dv) in self.decision_variables.iter() {
+            let sampled_dv = evaluate_decision_variable_samples(*id, dv, &samples)?;
+            decision_variables.insert(*id, sampled_dv);
         }
 
         // Reconstruct named function values
@@ -337,8 +383,8 @@ impl Evaluate for Instance {
                     "Unknown decision variable (ID={id}) in state."
                 ));
             };
-            dv.check_value_consistency(*value, atol)?;
             let var_id = VariableID::from(*id);
+            dv.check_value_consistency(var_id, *value, atol)?;
             if let Some(previous_value) = working.fixed_decision_variable_values.get(&var_id) {
                 if !values_are_consistent(*previous_value, *value, atol) {
                     return Err(crate::DecisionVariableError::SubstitutedValueOverwrite {
@@ -535,14 +581,8 @@ mod tests {
     #[test]
     fn test_populate_state_rejects_non_finite_fixed_value_from_state() {
         let decision_variables = BTreeMap::from([
-            (
-                VariableID::from(1),
-                crate::DecisionVariable::continuous(VariableID::from(1)),
-            ),
-            (
-                VariableID::from(2),
-                crate::DecisionVariable::continuous(VariableID::from(2)),
-            ),
+            (VariableID::from(1), crate::DecisionVariable::continuous()),
+            (VariableID::from(2), crate::DecisionVariable::continuous()),
         ]);
         let instance = Instance::builder()
             .sense(Sense::Minimize)
@@ -561,14 +601,8 @@ mod tests {
     #[test]
     fn test_partial_evaluate_accepts_existing_fixed_value_at_atol_boundary() {
         let decision_variables = BTreeMap::from([
-            (
-                VariableID::from(1),
-                crate::DecisionVariable::continuous(VariableID::from(1)),
-            ),
-            (
-                VariableID::from(2),
-                crate::DecisionVariable::continuous(VariableID::from(2)),
-            ),
+            (VariableID::from(1), crate::DecisionVariable::continuous()),
+            (VariableID::from(2), crate::DecisionVariable::continuous()),
         ]);
         let mut instance = Instance::builder()
             .sense(Sense::Minimize)
@@ -592,14 +626,8 @@ mod tests {
     #[test]
     fn test_populate_state_rejects_non_finite_existing_dependent_value() {
         let decision_variables = BTreeMap::from([
-            (
-                VariableID::from(1),
-                crate::DecisionVariable::continuous(VariableID::from(1)),
-            ),
-            (
-                VariableID::from(10),
-                crate::DecisionVariable::continuous(VariableID::from(10)),
-            ),
+            (VariableID::from(1), crate::DecisionVariable::continuous()),
+            (VariableID::from(10), crate::DecisionVariable::continuous()),
         ]);
         let mut instance = Instance::new(
             Sense::Minimize,
@@ -620,14 +648,8 @@ mod tests {
     #[test]
     fn test_populate_state_rejects_non_finite_dependent_evaluation() {
         let decision_variables = BTreeMap::from([
-            (
-                VariableID::from(1),
-                crate::DecisionVariable::continuous(VariableID::from(1)),
-            ),
-            (
-                VariableID::from(10),
-                crate::DecisionVariable::continuous(VariableID::from(10)),
-            ),
+            (VariableID::from(1), crate::DecisionVariable::continuous()),
+            (VariableID::from(10), crate::DecisionVariable::continuous()),
         ]);
         let mut instance = Instance::new(
             Sense::Minimize,
@@ -658,11 +680,11 @@ mod tests {
         // x4 (id=4): irrelevant (not used in objective/constraints)
         // x5 (id=5): only used in named_functions
 
-        let x1 = DecisionVariable::continuous(VariableID::from(1));
-        let x2 = DecisionVariable::continuous(VariableID::from(2));
-        let x3 = DecisionVariable::continuous(VariableID::from(3));
-        let x4 = DecisionVariable::continuous(VariableID::from(4));
-        let x5 = DecisionVariable::continuous(VariableID::from(5));
+        let x1 = DecisionVariable::continuous();
+        let x2 = DecisionVariable::continuous();
+        let x3 = DecisionVariable::continuous();
+        let x4 = DecisionVariable::continuous();
+        let x5 = DecisionVariable::continuous();
 
         let decision_variables = btreemap! {
             VariableID::from(1) => x1,
@@ -761,9 +783,9 @@ mod tests {
 
         // Binary variables x1, x2, x3 with OneHot{x1, x2, x3}
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
         let objective = Function::from(((linear!(1) + linear!(2)).unwrap() + linear!(3)).unwrap());
 
@@ -811,9 +833,9 @@ mod tests {
         use maplit::btreemap;
 
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
         let objective = Function::from(((linear!(1) + linear!(2)).unwrap() + linear!(3)).unwrap());
 
@@ -853,9 +875,9 @@ mod tests {
         // x1, x2 in OneHot; x2, x3 in SOS1
         // Fix x1=1 → OneHot propagates x2=0 → SOS1 shrinks (x2 removed)
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::continuous(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::continuous(),
         };
         let objective = Function::from(((linear!(1) + linear!(2)).unwrap() + linear!(3)).unwrap());
 
@@ -905,9 +927,9 @@ mod tests {
 
         // x10 (indicator), x1, x2 (function variables)
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
-            VariableID::from(10) => DecisionVariable::binary(VariableID::from(10)),
+            VariableID::from(1) => DecisionVariable::continuous(),
+            VariableID::from(2) => DecisionVariable::continuous(),
+            VariableID::from(10) => DecisionVariable::binary(),
         };
         let objective = Function::from(linear!(1) + linear!(2));
 
@@ -964,8 +986,8 @@ mod tests {
         use maplit::btreemap;
 
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
-            VariableID::from(10) => DecisionVariable::binary(VariableID::from(10)),
+            VariableID::from(1) => DecisionVariable::continuous(),
+            VariableID::from(10) => DecisionVariable::binary(),
         };
         let objective = Function::from(linear!(1));
 

--- a/rust/ommx/src/instance/indicator.rs
+++ b/rust/ommx/src/instance/indicator.rs
@@ -278,14 +278,8 @@ mod tests {
         equality: Equality,
         function: Function,
     ) -> Instance {
-        let x = DecisionVariable::new(
-            VariableID::from(1),
-            Kind::Continuous,
-            x_bound,
-            ATol::default(),
-        )
-        .unwrap();
-        let y = DecisionVariable::binary(VariableID::from(10));
+        let x = DecisionVariable::new(Kind::Continuous, x_bound, ATol::default()).unwrap();
+        let y = DecisionVariable::binary();
 
         let ic = IndicatorConstraint::new(VariableID::from(10), equality, function);
 
@@ -434,8 +428,8 @@ mod tests {
     fn infinite_bound_is_rejected_without_mutation() {
         // Continuous x with default (infinite) bound → upper side bound = +∞.
         // Conversion must bail before any mutation.
-        let x = DecisionVariable::continuous(VariableID::from(1));
-        let y = DecisionVariable::binary(VariableID::from(10));
+        let x = DecisionVariable::continuous();
+        let y = DecisionVariable::binary();
         let ic = IndicatorConstraint::new(
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
@@ -504,13 +498,12 @@ mod tests {
         // Since this is unsafe, planner must reject semi kinds before using
         // `evaluate_bound`, matching `convert_sos1_to_constraints`.
         let x_semi = DecisionVariable::new(
-            VariableID::from(1),
             Kind::SemiContinuous,
             Bound::new(2.0, 5.0).unwrap(),
             ATol::default(),
         )
         .unwrap();
-        let y = DecisionVariable::binary(VariableID::from(10));
+        let y = DecisionVariable::binary();
         let ic = IndicatorConstraint::new(
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,
@@ -574,13 +567,12 @@ mod tests {
         // #1: y=1 → x - 2 <= 0   → 1 big-M upper
         // #2: y=1 → x - 2 = 0    → 2 big-M (upper + lower)
         let x = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(0.0, 5.0).unwrap(),
             ATol::default(),
         )
         .unwrap();
-        let y = DecisionVariable::binary(VariableID::from(10));
+        let y = DecisionVariable::binary();
         let f = || Function::from(linear!(1) + coeff!(-2.0));
         let ic_le =
             IndicatorConstraint::new(VariableID::from(10), Equality::LessThanOrEqualToZero, f());
@@ -615,14 +607,13 @@ mod tests {
         // variable in its function. The bulk call must fail without applying the
         // first one either.
         let x1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             Bound::new(0.0, 5.0).unwrap(),
             ATol::default(),
         )
         .unwrap();
-        let x2 = DecisionVariable::continuous(VariableID::from(2)); // infinite bound
-        let y = DecisionVariable::binary(VariableID::from(10));
+        let x2 = DecisionVariable::continuous(); // infinite bound
+        let y = DecisionVariable::binary();
         let ic_ok = IndicatorConstraint::new(
             VariableID::from(10),
             Equality::LessThanOrEqualToZero,

--- a/rust/ommx/src/instance/indicator.rs
+++ b/rust/ommx/src/instance/indicator.rs
@@ -278,7 +278,7 @@ mod tests {
         equality: Equality,
         function: Function,
     ) -> Instance {
-        let x = DecisionVariable::new(Kind::Continuous, x_bound).unwrap();
+        let x = DecisionVariable::new(Kind::Continuous, x_bound, crate::ATol::default()).unwrap();
         let y = DecisionVariable::binary();
 
         let ic = IndicatorConstraint::new(VariableID::from(10), equality, function);
@@ -497,8 +497,12 @@ mod tests {
         // but the true `sup f = 0.5` at `x = 0` means the upper Big-M is needed.
         // Since this is unsafe, planner must reject semi kinds before using
         // `evaluate_bound`, matching `convert_sos1_to_constraints`.
-        let x_semi =
-            DecisionVariable::new(Kind::SemiContinuous, Bound::new(2.0, 5.0).unwrap()).unwrap();
+        let x_semi = DecisionVariable::new(
+            Kind::SemiContinuous,
+            Bound::new(2.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
         let y = DecisionVariable::binary();
         let ic = IndicatorConstraint::new(
             VariableID::from(10),
@@ -562,7 +566,12 @@ mod tests {
         // Two indicators on the same indicator variable, both convertible:
         // #1: y=1 → x - 2 <= 0   → 1 big-M upper
         // #2: y=1 → x - 2 = 0    → 2 big-M (upper + lower)
-        let x = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 5.0).unwrap()).unwrap();
+        let x = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
         let y = DecisionVariable::binary();
         let f = || Function::from(linear!(1) + coeff!(-2.0));
         let ic_le =
@@ -597,7 +606,12 @@ mod tests {
         // Two indicators: first is convertible (bounded x), second has an unbounded
         // variable in its function. The bulk call must fail without applying the
         // first one either.
-        let x1 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 5.0).unwrap()).unwrap();
+        let x1 = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
         let x2 = DecisionVariable::continuous(); // infinite bound
         let y = DecisionVariable::binary();
         let ic_ok = IndicatorConstraint::new(

--- a/rust/ommx/src/instance/indicator.rs
+++ b/rust/ommx/src/instance/indicator.rs
@@ -263,7 +263,7 @@ impl Instance {
 mod tests {
     use super::*;
     use crate::{
-        coeff, indicator_constraint::IndicatorConstraint, linear, ATol, Bound, DecisionVariable,
+        coeff, indicator_constraint::IndicatorConstraint, linear, Bound, DecisionVariable,
         Function, Kind, Sense, VariableID,
     };
     use ::approx::assert_abs_diff_eq;
@@ -278,7 +278,7 @@ mod tests {
         equality: Equality,
         function: Function,
     ) -> Instance {
-        let x = DecisionVariable::new(Kind::Continuous, x_bound, ATol::default()).unwrap();
+        let x = DecisionVariable::new(Kind::Continuous, x_bound).unwrap();
         let y = DecisionVariable::binary();
 
         let ic = IndicatorConstraint::new(VariableID::from(10), equality, function);
@@ -497,12 +497,8 @@ mod tests {
         // but the true `sup f = 0.5` at `x = 0` means the upper Big-M is needed.
         // Since this is unsafe, planner must reject semi kinds before using
         // `evaluate_bound`, matching `convert_sos1_to_constraints`.
-        let x_semi = DecisionVariable::new(
-            Kind::SemiContinuous,
-            Bound::new(2.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let x_semi =
+            DecisionVariable::new(Kind::SemiContinuous, Bound::new(2.0, 5.0).unwrap()).unwrap();
         let y = DecisionVariable::binary();
         let ic = IndicatorConstraint::new(
             VariableID::from(10),
@@ -566,12 +562,7 @@ mod tests {
         // Two indicators on the same indicator variable, both convertible:
         // #1: y=1 → x - 2 <= 0   → 1 big-M upper
         // #2: y=1 → x - 2 = 0    → 2 big-M (upper + lower)
-        let x = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(0.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let x = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 5.0).unwrap()).unwrap();
         let y = DecisionVariable::binary();
         let f = || Function::from(linear!(1) + coeff!(-2.0));
         let ic_le =
@@ -606,12 +597,7 @@ mod tests {
         // Two indicators: first is convertible (bounded x), second has an unbounded
         // variable in its function. The bulk call must fail without applying the
         // first one either.
-        let x1 = DecisionVariable::new(
-            Kind::Continuous,
-            Bound::new(0.0, 5.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let x1 = DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 5.0).unwrap()).unwrap();
         let x2 = DecisionVariable::continuous(); // infinite bound
         let y = DecisionVariable::binary();
         let ic_ok = IndicatorConstraint::new(

--- a/rust/ommx/src/instance/log_encode.rs
+++ b/rust/ommx/src/instance/log_encode.rs
@@ -90,7 +90,12 @@ mod tests {
         // Create instance with integer variable in range [2, 7]
         let mut instance = Instance::default();
         let id = VariableID::from(0);
-        let var = DecisionVariable::new(Kind::Integer, Bound::new(2.0, 7.0).unwrap()).unwrap();
+        let var = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(2.0, 7.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
         instance.decision_variables.insert(id, var);
 
         // Perform log encoding

--- a/rust/ommx/src/instance/log_encode.rs
+++ b/rust/ommx/src/instance/log_encode.rs
@@ -91,7 +91,6 @@ mod tests {
         let mut instance = Instance::default();
         let id = VariableID::from(0);
         let var = DecisionVariable::new(
-            id,
             Kind::Integer,
             Bound::new(2.0, 7.0).unwrap(),
             crate::ATol::default(),

--- a/rust/ommx/src/instance/log_encode.rs
+++ b/rust/ommx/src/instance/log_encode.rs
@@ -90,12 +90,7 @@ mod tests {
         // Create instance with integer variable in range [2, 7]
         let mut instance = Instance::default();
         let id = VariableID::from(0);
-        let var = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(2.0, 7.0).unwrap(),
-            crate::ATol::default(),
-        )
-        .unwrap();
+        let var = DecisionVariable::new(Kind::Integer, Bound::new(2.0, 7.0).unwrap()).unwrap();
         instance.decision_variables.insert(id, var);
 
         // Perform log encoding

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -146,7 +146,9 @@ mod tests {
     use super::*;
     use crate::constraint::CreatedData;
     use crate::logical_memory::logical_memory_to_folded;
-    use crate::{coeff, linear, Constraint, ConstraintID, DecisionVariable, Equality, Function};
+    use crate::{
+        coeff, linear, Constraint, ConstraintID, DecisionVariable, Equality, Function, VariableID,
+    };
     use std::collections::BTreeMap;
 
     #[test]
@@ -207,12 +209,12 @@ mod tests {
 
     #[test]
     fn test_instance_with_objective_and_variables_snapshot() {
-        let dv1 = DecisionVariable::continuous(1.into());
-        let dv2 = DecisionVariable::continuous(2.into());
+        let dv1 = DecisionVariable::continuous();
+        let dv2 = DecisionVariable::continuous();
 
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(dv1.id(), dv1);
-        decision_variables.insert(dv2.id(), dv2);
+        decision_variables.insert(VariableID::from(1), dv1);
+        decision_variables.insert(VariableID::from(2), dv2);
 
         let objective = Function::Linear(
             ((coeff!(2.0) * linear!(1)).unwrap() + (coeff!(3.0) * linear!(2)).unwrap()).unwrap(),
@@ -242,7 +244,6 @@ mod tests {
         Instance.decision_variables;BTreeMap[key] 16
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 32
-        Instance.decision_variables;DecisionVariable.id 16
         Instance.decision_variables;DecisionVariable.kind 2
         Instance.description;Option[stack] 168
         Instance.fixed_decision_variable_values;BTreeMap[stack] 24
@@ -284,12 +285,12 @@ mod tests {
 
     #[test]
     fn test_instance_with_constraints_snapshot() {
-        let dv1 = DecisionVariable::continuous(1.into());
-        let dv2 = DecisionVariable::continuous(2.into());
+        let dv1 = DecisionVariable::continuous();
+        let dv2 = DecisionVariable::continuous();
 
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(dv1.id(), dv1);
-        decision_variables.insert(dv2.id(), dv2);
+        decision_variables.insert(VariableID::from(1), dv1);
+        decision_variables.insert(VariableID::from(2), dv2);
 
         let objective = Function::Linear(
             ((coeff!(2.0) * linear!(1)).unwrap() + (coeff!(3.0) * linear!(2)).unwrap()).unwrap(),
@@ -332,7 +333,6 @@ mod tests {
         Instance.decision_variables;BTreeMap[key] 16
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 32
-        Instance.decision_variables;DecisionVariable.id 16
         Instance.decision_variables;DecisionVariable.kind 2
         Instance.description;Option[stack] 168
         Instance.fixed_decision_variable_values;BTreeMap[stack] 24
@@ -375,14 +375,14 @@ mod tests {
     #[test]
     fn test_instance_with_multiple_variables_with_labels_snapshot() {
         // Create 3 decision variables with names (stored in the SoA store)
-        let dv1 = DecisionVariable::continuous(1.into());
-        let dv2 = DecisionVariable::continuous(2.into());
-        let dv3 = DecisionVariable::continuous(3.into());
+        let dv1 = DecisionVariable::continuous();
+        let dv2 = DecisionVariable::continuous();
+        let dv3 = DecisionVariable::continuous();
 
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(dv1.id(), dv1);
-        decision_variables.insert(dv2.id(), dv2);
-        decision_variables.insert(dv3.id(), dv3);
+        decision_variables.insert(VariableID::from(1), dv1);
+        decision_variables.insert(VariableID::from(2), dv2);
+        decision_variables.insert(VariableID::from(3), dv3);
 
         let mut instance = Instance::new(
             crate::instance::Sense::Minimize,
@@ -414,7 +414,6 @@ mod tests {
         Instance.decision_variables;BTreeMap[key] 24
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 48
-        Instance.decision_variables;DecisionVariable.id 24
         Instance.decision_variables;DecisionVariable.kind 3
         Instance.description;Option[stack] 168
         Instance.fixed_decision_variable_values;BTreeMap[stack] 24
@@ -458,9 +457,9 @@ mod tests {
 
     #[test]
     fn test_instance_with_parameters_and_description_snapshot() {
-        let dv1 = DecisionVariable::continuous(1.into());
+        let dv1 = DecisionVariable::continuous();
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(dv1.id(), dv1);
+        decision_variables.insert(VariableID::from(1), dv1);
 
         let mut instance = Instance::new(
             crate::instance::Sense::Minimize,
@@ -506,7 +505,6 @@ mod tests {
         Instance.decision_variables;BTreeMap[key] 8
         Instance.decision_variables;BTreeMap[stack] 24
         Instance.decision_variables;DecisionVariable.bound 16
-        Instance.decision_variables;DecisionVariable.id 8
         Instance.decision_variables;DecisionVariable.kind 1
         Instance.description;Description.authors 56
         Instance.description;Description.authors;Vec[stack] 24

--- a/rust/ommx/src/instance/new.rs
+++ b/rust/ommx/src/instance/new.rs
@@ -50,8 +50,8 @@ mod tests {
     fn test_instance_new_fails_with_undefined_variable_in_objective() {
         // Create decision variables that do not include variable ID 999
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         // Create objective function that uses undefined variable ID 999
@@ -76,8 +76,8 @@ mod tests {
     fn test_instance_new_fails_with_undefined_variable_in_constraint() {
         // Create decision variables that do not include variable ID 999
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         // Create simple objective function using defined variables
@@ -105,8 +105,8 @@ mod tests {
     fn test_parametric_instance_new_succeeds() {
         // Test successful creation with decision variables and parameters in both objective and constraints
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         let parameters = btreemap! {
@@ -144,8 +144,8 @@ mod tests {
     fn test_parametric_instance_new_fails_with_duplicated_variable_id() {
         // Test detection of ID collision between decision variables and parameters
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         // Parameter with same ID as decision variable
@@ -174,8 +174,8 @@ mod tests {
     fn test_parametric_instance_new_fails_with_undefined_variable_in_objective() {
         // Test detection of undefined variable ID in objective function
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         let parameters = btreemap! {
@@ -204,8 +204,8 @@ mod tests {
     fn test_parametric_instance_new_fails_with_undefined_variable_in_constraint() {
         // Test detection of undefined variable ID in constraint
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         let parameters = btreemap! {

--- a/rust/ommx/src/instance/one_hot.rs
+++ b/rust/ommx/src/instance/one_hot.rs
@@ -98,10 +98,7 @@ mod tests {
     fn instance_with_one_one_hot() -> Instance {
         let mut decision_variables = BTreeMap::new();
         for id in [1u64, 2] {
-            decision_variables.insert(
-                VariableID::from(id),
-                DecisionVariable::binary(VariableID::from(id)),
-            );
+            decision_variables.insert(VariableID::from(id), DecisionVariable::binary());
         }
         let vars: BTreeSet<_> = [1u64, 2].into_iter().map(VariableID::from).collect();
         let one_hot = OneHotConstraint::new(vars).unwrap();
@@ -182,10 +179,7 @@ mod tests {
         // Two disjoint one-hots → both converted, none left active.
         let mut decision_variables = BTreeMap::new();
         for id in [1u64, 2, 3, 4] {
-            decision_variables.insert(
-                VariableID::from(id),
-                DecisionVariable::binary(VariableID::from(id)),
-            );
+            decision_variables.insert(VariableID::from(id), DecisionVariable::binary());
         }
         let a =
             OneHotConstraint::new([1u64, 2].into_iter().map(VariableID::from).collect()).unwrap();

--- a/rust/ommx/src/instance/parametric_builder.rs
+++ b/rust/ommx/src/instance/parametric_builder.rs
@@ -246,17 +246,6 @@ impl ParametricInstanceBuilder {
             .constraints
             .ok_or_else(|| crate::error!("Required field is missing: constraints"))?;
 
-        // Validate that decision variable map keys match their value's id
-        for (key, value) in &decision_variables {
-            if *key != value.id() {
-                let value_id = value.id();
-                crate::bail!(
-                    { ?key, ?value_id },
-                    "Decision variable map key {key:?} does not match value's id {value_id:?}",
-                );
-            }
-        }
-
         // Validate that parameter map keys match their value's id
         for (key, value) in &parameters {
             if key.into_inner() != value.id {
@@ -285,7 +274,7 @@ impl ParametricInstanceBuilder {
                     "Fixed decision-variable value references unknown decision variable ID {id:?}",
                 );
             };
-            dv.check_value_consistency(*value, crate::ATol::default())?;
+            dv.check_value_consistency(*id, *value, crate::ATol::default())?;
         }
 
         let intersection: VariableIDSet = decision_variable_ids
@@ -607,7 +596,7 @@ mod tests {
         let instance = ParametricInstance::builder()
             .sense(Sense::Minimize)
             .objective(Function::Zero)
-            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary(var_id))]))
+            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary())]))
             .variable_labels(variable_labels)
             .parameters(BTreeMap::new())
             .constraints(BTreeMap::from([(
@@ -642,7 +631,7 @@ mod tests {
         let instance = ParametricInstance::builder()
             .sense(Sense::Minimize)
             .objective(Function::Zero)
-            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary(var_id))]))
+            .decision_variables(BTreeMap::from([(var_id, DecisionVariable::binary())]))
             .parameters(BTreeMap::new())
             .constraints(BTreeMap::new())
             .indicator_constraints(BTreeMap::from([(
@@ -842,7 +831,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                var_id => DecisionVariable::binary(var_id),
+                var_id => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 var_id => v1::Parameter { id: 1, ..Default::default() },
@@ -936,8 +925,8 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-                VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+                VariableID::from(1) => DecisionVariable::binary(),
+                VariableID::from(2) => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 VariableID::from(100) => v1::Parameter { id: 100, ..Default::default() },
@@ -972,8 +961,8 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                dep => DecisionVariable::binary(dep),
-                x => DecisionVariable::binary(x),
+                dep => DecisionVariable::binary(),
+                x => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 p => v1::Parameter { id: 100, ..Default::default() },
@@ -1001,7 +990,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                dep => DecisionVariable::binary(dep),
+                dep => DecisionVariable::binary(),
             })
             .parameters(BTreeMap::new())
             .constraints(BTreeMap::new())
@@ -1034,7 +1023,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1) => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 VariableID::from(100) => v1::Parameter { id: 100, ..Default::default() },
@@ -1069,8 +1058,8 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                VariableID::from(1) => DecisionVariable::integer(VariableID::from(1)),
-                VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+                VariableID::from(1) => DecisionVariable::integer(),
+                VariableID::from(2) => DecisionVariable::binary(),
             })
             .parameters(BTreeMap::new())
             .constraints(BTreeMap::new())
@@ -1099,7 +1088,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1) => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 VariableID::from(100) => v1::Parameter { id: 100, ..Default::default() },
@@ -1131,7 +1120,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1) => DecisionVariable::binary(),
             })
             .parameters(BTreeMap::new())
             .constraints(BTreeMap::new())
@@ -1166,7 +1155,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::Zero)
             .decision_variables(btreemap! {
-                var_id => DecisionVariable::binary(var_id),
+                var_id => DecisionVariable::binary(),
             })
             .parameters(btreemap! {
                 param_id => v1::Parameter { id: 2, ..Default::default() },

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -391,6 +391,7 @@ impl From<Instance> for v1::Instance {
             .map(|(id, dv)| {
                 let label = variable_labels.collect_for(id);
                 crate::decision_variable::parse::decision_variable_to_v1_with_fixed_value(
+                    id,
                     dv,
                     label,
                     fixed_decision_variable_values.get(&id).copied(),
@@ -688,6 +689,7 @@ impl From<ParametricInstance> for v1::ParametricInstance {
             .map(|(id, dv)| {
                 let label = variable_labels.collect_for(id);
                 crate::decision_variable::parse::decision_variable_to_v1_with_fixed_value(
+                    id,
                     dv,
                     label,
                     fixed_decision_variable_values.get(&id).copied(),
@@ -743,7 +745,8 @@ mod tests {
             .into_iter()
             .map(|id| {
                 crate::decision_variable::parse::decision_variable_to_v1(
-                    crate::DecisionVariable::binary(VariableID::from(id)),
+                    crate::VariableID::from(id),
+                    crate::DecisionVariable::binary(),
                     Default::default(),
                 )
             })
@@ -972,7 +975,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(999) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             parameters: vec![v1::Parameter {
@@ -1010,7 +1014,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             parameters: vec![v1::Parameter {
@@ -1050,7 +1055,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(999) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             constraints: vec![],
@@ -1117,7 +1123,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             constraints: vec![constraint_to_v1(
@@ -1164,7 +1171,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             parameters: vec![v1::Parameter {
@@ -1211,7 +1219,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             constraints: vec![constraint_to_v1(cid, constraint, Default::default())],
@@ -1243,7 +1252,8 @@ mod tests {
             sense: 999, // Invalid sense value
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             parameters: vec![v1::Parameter {
@@ -1277,7 +1287,8 @@ mod tests {
             sense: 999, // Invalid sense value
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             constraints: vec![],
@@ -1307,7 +1318,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: None, // Missing objective
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             parameters: vec![v1::Parameter {
@@ -1342,7 +1354,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: None, // Missing objective
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             constraints: vec![],
@@ -1373,7 +1386,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             parameters: vec![v1::Parameter {
@@ -1415,7 +1429,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             parameters: vec![v1::Parameter {
@@ -1460,7 +1475,8 @@ mod tests {
             sense: v1::instance::Sense::Minimize as i32,
             objective: Some(Function::from(linear!(1) + coeff!(1.0)).into()),
             decision_variables: vec![crate::decision_variable::parse::decision_variable_to_v1(
-                DecisionVariable::binary(VariableID::from(1)),
+                VariableID::from(1),
+                DecisionVariable::binary(),
                 Default::default(),
             )],
             constraints: vec![
@@ -1540,7 +1556,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::from(linear!(1)))
             .decision_variables(maplit::btreemap! {
-                var_id => DecisionVariable::binary(var_id),
+                var_id => DecisionVariable::binary(),
             })
             .parameters(BTreeMap::new())
             .constraints(maplit::btreemap! {
@@ -1605,7 +1621,7 @@ mod tests {
             .sense(Sense::Minimize)
             .objective(Function::from(linear!(1)))
             .decision_variables(maplit::btreemap! {
-                var_id => DecisionVariable::binary(var_id),
+                var_id => DecisionVariable::binary(),
             })
             .constraints(BTreeMap::new())
             .build()

--- a/rust/ommx/src/instance/pass.rs
+++ b/rust/ommx/src/instance/pass.rs
@@ -137,14 +137,8 @@ mod tests {
     #[test]
     fn test_restore_constraint_with_fixed_variable() {
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::continuous(VariableID::from(2)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::continuous());
 
         let constraint_function =
             Function::from(((linear!(1) + linear!(2)).unwrap() + coeff!(-10.0)).unwrap());
@@ -188,10 +182,7 @@ mod tests {
     fn test_restore_constraint_with_dependent_variable() {
         let mut decision_variables = BTreeMap::new();
         for i in 1..=3 {
-            decision_variables.insert(
-                VariableID::from(i),
-                DecisionVariable::continuous(VariableID::from(i)),
-            );
+            decision_variables.insert(VariableID::from(i), DecisionVariable::continuous());
         }
 
         let mut constraints = BTreeMap::new();
@@ -235,10 +226,7 @@ mod tests {
     fn test_restore_constraint_with_fixed_variable_in_dependency() {
         let mut decision_variables = BTreeMap::new();
         for i in 1..=3 {
-            decision_variables.insert(
-                VariableID::from(i),
-                DecisionVariable::continuous(VariableID::from(i)),
-            );
+            decision_variables.insert(VariableID::from(i), DecisionVariable::continuous());
         }
 
         let mut constraints = BTreeMap::new();
@@ -290,14 +278,8 @@ mod tests {
         use crate::IndicatorConstraintID;
 
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(10),
-            DecisionVariable::binary(VariableID::from(10)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(10), DecisionVariable::binary());
 
         let mut instance = Instance::new(
             Sense::Minimize,
@@ -339,14 +321,8 @@ mod tests {
         use crate::IndicatorConstraintID;
 
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(10),
-            DecisionVariable::binary(VariableID::from(10)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(10), DecisionVariable::binary());
 
         let mut instance = Instance::new(
             Sense::Minimize,
@@ -394,18 +370,9 @@ mod tests {
         use crate::IndicatorConstraintID;
 
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::continuous(VariableID::from(2)),
-        );
-        decision_variables.insert(
-            VariableID::from(10),
-            DecisionVariable::binary(VariableID::from(10)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(10), DecisionVariable::binary());
 
         let mut instance = Instance::new(
             Sense::Minimize,
@@ -467,18 +434,9 @@ mod tests {
         use crate::IndicatorConstraintID;
 
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(10),
-            DecisionVariable::binary(VariableID::from(10)),
-        );
-        decision_variables.insert(
-            VariableID::from(20),
-            DecisionVariable::binary(VariableID::from(20)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(10), DecisionVariable::binary());
+        decision_variables.insert(VariableID::from(20), DecisionVariable::binary());
 
         let mut instance = Instance::new(
             Sense::Minimize,

--- a/rust/ommx/src/instance/penalty.rs
+++ b/rust/ommx/src/instance/penalty.rs
@@ -292,14 +292,8 @@ mod tests {
     /// Helper function to create a test instance with two decision variables and two constraints
     fn create_test_instance_with_constraints() -> Instance {
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::continuous(VariableID::from(2)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::continuous());
 
         let objective = Function::from((linear!(1) + linear!(2)).unwrap());
 
@@ -415,10 +409,7 @@ mod tests {
     fn test_penalty_methods_with_no_constraints() {
         // Create instance without constraints
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
 
         let objective = Function::from(linear!(1));
         let constraints = BTreeMap::new();

--- a/rust/ommx/src/instance/qubo.rs
+++ b/rust/ommx/src/instance/qubo.rs
@@ -117,7 +117,7 @@ mod tests {
         ids.into_iter()
             .map(|i| {
                 let id = VariableID::from(i);
-                (id, DecisionVariable::binary(id))
+                (id, DecisionVariable::binary())
             })
             .collect()
     }
@@ -177,7 +177,7 @@ mod tests {
     fn qubo_rejects_non_binary_decision_variables() {
         let mut dv = binary_vars([1]);
         let id = VariableID::from(2);
-        dv.insert(id, DecisionVariable::integer(id));
+        dv.insert(id, DecisionVariable::integer());
         let instance = Instance::new(
             Sense::Minimize,
             (linear!(1) + linear!(2)).into(),

--- a/rust/ommx/src/instance/reduce_binary_power.rs
+++ b/rust/ommx/src/instance/reduce_binary_power.rs
@@ -38,14 +38,10 @@ mod tests {
     fn test_instance_reduce_binary_power() {
         // Create instance with binary and continuous variables
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::binary(VariableID::from(1)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
         decision_variables.insert(
             VariableID::from(2),
             DecisionVariable::new(
-                VariableID::from(2),
                 Kind::Continuous,
                 Bound::new(0.0, 10.0).unwrap(),
                 ATol::default(),
@@ -110,14 +106,8 @@ mod tests {
     fn test_instance_reduce_binary_power_no_binary() {
         // Create instance with only continuous variables
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::integer(VariableID::from(2)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::integer());
 
         let objective = Function::Quadratic(
             (quadratic!(1, 1) + (coeff!(2.0) * quadratic!(2, 2)).unwrap()).unwrap(),
@@ -140,10 +130,7 @@ mod tests {
     #[test]
     fn reduce_binary_power_preserves_instance_on_coefficient_error() {
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::binary(VariableID::from(1)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
 
         let objective = Function::Quadratic(quadratic!(1, 1).into());
         let huge = Coefficient::try_from(f64::MAX).unwrap();

--- a/rust/ommx/src/instance/reduce_binary_power.rs
+++ b/rust/ommx/src/instance/reduce_binary_power.rs
@@ -28,7 +28,7 @@ impl Instance {
 mod tests {
     use super::*;
     use crate::{
-        coeff, constraint::CreatedData, quadratic, ATol, Bound, Coefficient, Constraint,
+        coeff, constraint::CreatedData, quadratic, Bound, Coefficient, Constraint,
         DecisionVariable, Equality, Kind, Sense,
     };
     use ::approx::assert_abs_diff_eq;
@@ -41,12 +41,7 @@ mod tests {
         decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
         decision_variables.insert(
             VariableID::from(2),
-            DecisionVariable::new(
-                Kind::Continuous,
-                Bound::new(0.0, 10.0).unwrap(),
-                ATol::default(),
-            )
-            .unwrap(),
+            DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 10.0).unwrap()).unwrap(),
         );
 
         // Objective: x1^2 + x1*x2 + x2^2

--- a/rust/ommx/src/instance/reduce_binary_power.rs
+++ b/rust/ommx/src/instance/reduce_binary_power.rs
@@ -41,7 +41,12 @@ mod tests {
         decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
         decision_variables.insert(
             VariableID::from(2),
-            DecisionVariable::new(Kind::Continuous, Bound::new(0.0, 10.0).unwrap()).unwrap(),
+            DecisionVariable::new(
+                Kind::Continuous,
+                Bound::new(0.0, 10.0).unwrap(),
+                crate::ATol::default(),
+            )
+            .unwrap(),
         );
 
         // Objective: x1^2 + x1*x2 + x2^2

--- a/rust/ommx/src/instance/setter.rs
+++ b/rust/ommx/src/instance/setter.rs
@@ -177,15 +177,15 @@ impl Instance {
 
     /// Insert a decision variable with its modeling label.
     ///
-    /// The decision variable's `id()` must not collide with any existing
-    /// variable, and must not be a substitution-dependency key. Returns the
-    /// inserted variable's id for symmetry with `add_constraint`.
+    /// The table key must not collide with any existing variable and must not
+    /// be a substitution-dependency key. Returns the inserted variable's id for
+    /// symmetry with `add_constraint`.
     pub fn add_decision_variable(
         &mut self,
+        id: crate::VariableID,
         variable: crate::DecisionVariable,
         label: crate::DecisionVariableLabel,
     ) -> crate::Result<crate::VariableID> {
-        let id = variable.id();
         if self.decision_variables.contains_key(&id) {
             crate::bail!({ ?id }, "Duplicate decision variable ID: {id:?}");
         }
@@ -509,14 +509,14 @@ impl ParametricInstance {
 
     /// Insert a decision variable with its modeling label.
     ///
-    /// The variable's id must not collide with any existing decision
+    /// The table key must not collide with any existing decision
     /// variable, parameter, or substitution-dependency key.
     pub fn add_decision_variable(
         &mut self,
+        id: crate::VariableID,
         variable: crate::DecisionVariable,
         label: crate::DecisionVariableLabel,
     ) -> crate::Result<crate::VariableID> {
-        let id = variable.id();
         if self.decision_variables().contains_key(&id) {
             crate::bail!({ ?id }, "Duplicate decision variable ID: {id:?}");
         }
@@ -563,8 +563,8 @@ mod tests {
     fn test_insert_constraint_success() {
         // Create a simple instance with two decision variables
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         let objective = linear!(1) + coeff!(1.0);
@@ -596,14 +596,8 @@ mod tests {
     fn test_insert_constraint_replace_existing() {
         // Create instance with one constraint
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::binary(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::binary(VariableID::from(2)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::binary());
 
         let objective = Function::Linear(Linear::single_term(
             LinearMonomial::Variable(VariableID::from(1)),
@@ -636,14 +630,8 @@ mod tests {
     fn test_insert_constraint_undefined_variable() {
         // Create instance with only variable 1 and 2
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::binary(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::binary(VariableID::from(2)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::binary());
 
         let objective = Function::Linear(Linear::single_term(
             LinearMonomial::Variable(VariableID::from(1)),
@@ -677,18 +665,9 @@ mod tests {
     fn test_insert_constraint_multiple_operations() {
         // Test multiple insertions and replacements
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::binary(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::binary(VariableID::from(2)),
-        );
-        decision_variables.insert(
-            VariableID::from(3),
-            DecisionVariable::binary(VariableID::from(3)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::binary());
+        decision_variables.insert(VariableID::from(3), DecisionVariable::binary());
 
         let objective = Function::Linear(Linear::single_term(
             LinearMonomial::Variable(VariableID::from(1)),
@@ -739,9 +718,9 @@ mod tests {
     fn test_insert_constraint_with_dependency_key() {
         // Create instance with decision variables and dependency
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
         let objective = linear!(1) + coeff!(1.0);
         let mut instance = Instance::new(
@@ -773,8 +752,8 @@ mod tests {
         // Pin variable 2's value, then try to add a constraint that references it.
         // The setter must reject — same rule the builder enforces (used ∩ fixed = ∅).
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         let objective = linear!(1) + coeff!(1.0);
@@ -853,8 +832,8 @@ mod tests {
     fn test_set_objective_with_dependency_key() {
         // Create instance with decision variables and dependency
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
         let objective = linear!(1) + coeff!(1.0);
         let mut instance = Instance::new(
@@ -887,8 +866,8 @@ mod tests {
     fn test_insert_constraint_replace_removed_constraint() {
         // Create instance with one active constraint and one removed constraint
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
 
         let objective = (linear!(1) + coeff!(1.0)).into();
@@ -939,9 +918,9 @@ mod tests {
     fn test_insert_constraints_bulk() {
         // Create instance with decision variables
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
         let objective = linear!(1) + coeff!(1.0);
         let mut instance = Instance::new(
@@ -984,8 +963,8 @@ mod tests {
     fn test_insert_constraints_bulk_with_undefined_variable() {
         // Create instance with only variables 1 and 2
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
         let objective = linear!(1) + coeff!(1.0);
         let mut instance = Instance::new(
@@ -1028,8 +1007,8 @@ mod tests {
     fn test_insert_constraints_bulk_replace_existing() {
         // Create instance with existing constraints
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
         let objective = linear!(1) + coeff!(1.0);
         let constraints = btreemap! {
@@ -1072,8 +1051,8 @@ mod tests {
     fn test_insert_constraints_bulk_replace_removed() {
         // Create instance with a removed constraint
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
         };
         let objective = linear!(1) + coeff!(1.0);
         let constraints = btreemap! {
@@ -1114,9 +1093,9 @@ mod tests {
     fn test_insert_constraints_bulk_with_dependent_variable() {
         // Create instance with decision variables and dependency
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
         let objective = linear!(1) + coeff!(1.0);
         let mut instance = Instance::new(
@@ -1160,7 +1139,7 @@ mod tests {
     fn test_next_constraint_id() {
         // Test basic case: empty instance
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(1) => DecisionVariable::binary(),
         };
         let objective = (linear!(1) + coeff!(1.0)).into();
         let instance = Instance::new(
@@ -1174,7 +1153,7 @@ mod tests {
 
         // Test considering both active and removed constraints
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(1) => DecisionVariable::binary(),
         };
         let objective = (linear!(1) + coeff!(1.0)).into();
         let constraints = btreemap! {

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -219,10 +219,10 @@ mod tests {
         // min x1 + x2 s.t. x1 + x2 - 4 <= 0, with x1, x2 integer in [0, 3]
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
             ).unwrap(),
             VariableID::from(2) => DecisionVariable::new(
-                VariableID::from(2), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
             ).unwrap(),
         };
         let objective = (Function::from(linear!(1)) + Function::from(linear!(2))).unwrap();
@@ -257,7 +257,7 @@ mod tests {
         // min x1 s.t. x1 - 2 <= 0, x1 integer in [0, 3]
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -291,7 +291,7 @@ mod tests {
         // x1 - 10 <= 0 with x1 in [0, 3] is always satisfied
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -315,7 +315,7 @@ mod tests {
         // leaving behind an orphan slack decision variable.
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -344,7 +344,7 @@ mod tests {
         // `add_integer_slack_to_inequality`.
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                VariableID::from(1), Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn rejects_constraint_with_continuous_variable() {
         let dv = btreemap! {
-            VariableID::from(1) => DecisionVariable::continuous(VariableID::from(1)),
+            VariableID::from(1) => DecisionVariable::continuous(),
         };
         let objective = Function::from(linear!(1));
         let constraint_fn = (Function::from(linear!(1)) + coeff!(-2.0)).unwrap();

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -219,10 +219,14 @@ mod tests {
         // min x1 + x2 s.t. x1 + x2 - 4 <= 0, with x1, x2 integer in [0, 3]
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
             ).unwrap(),
             VariableID::from(2) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
             ).unwrap(),
         };
         let objective = (Function::from(linear!(1)) + Function::from(linear!(2))).unwrap();
@@ -257,7 +261,9 @@ mod tests {
         // min x1 s.t. x1 - 2 <= 0, x1 integer in [0, 3]
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -291,7 +297,9 @@ mod tests {
         // x1 - 10 <= 0 with x1 in [0, 3] is always satisfied
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -315,7 +323,9 @@ mod tests {
         // leaving behind an orphan slack decision variable.
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -344,7 +354,9 @@ mod tests {
         // `add_integer_slack_to_inequality`.
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -219,10 +219,10 @@ mod tests {
         // min x1 + x2 s.t. x1 + x2 - 4 <= 0, with x1, x2 integer in [0, 3]
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
             ).unwrap(),
             VariableID::from(2) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
             ).unwrap(),
         };
         let objective = (Function::from(linear!(1)) + Function::from(linear!(2))).unwrap();
@@ -257,7 +257,7 @@ mod tests {
         // min x1 s.t. x1 - 2 <= 0, x1 integer in [0, 3]
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -291,7 +291,7 @@ mod tests {
         // x1 - 10 <= 0 with x1 in [0, 3] is always satisfied
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -315,7 +315,7 @@ mod tests {
         // leaving behind an orphan slack decision variable.
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));
@@ -344,7 +344,7 @@ mod tests {
         // `add_integer_slack_to_inequality`.
         let dv = btreemap! {
             VariableID::from(1) => DecisionVariable::new(
-                Kind::Integer, Bound::new(0.0, 3.0).unwrap(), ATol::default()
+                Kind::Integer, Bound::new(0.0, 3.0).unwrap()
             ).unwrap(),
         };
         let objective = Function::from(linear!(1));

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -272,9 +272,7 @@ impl Instance {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        constraint::Equality, sos1_constraint::Sos1Constraint, ATol, DecisionVariable, Sense,
-    };
+    use crate::{constraint::Equality, sos1_constraint::Sos1Constraint, DecisionVariable, Sense};
     use ::approx::assert_abs_diff_eq;
     use maplit::btreemap;
     use std::collections::{BTreeMap, BTreeSet};
@@ -300,12 +298,7 @@ mod tests {
 
     /// Build an instance with a single integer x0 in [-2, 3] and a SOS1 over just {x0}.
     fn integer_sos1_instance(lower: f64, upper: f64) -> Instance {
-        let dv = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(lower, upper).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
+        let dv = DecisionVariable::new(Kind::Integer, Bound::new(lower, upper).unwrap()).unwrap();
         let vars: BTreeSet<_> = [VariableID::from(0)].into_iter().collect();
         let sos1 = Sos1Constraint::new(vars).unwrap();
         Instance::builder()

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -282,8 +282,8 @@ mod tests {
     /// Build an instance with binary x0, x1 and a SOS1 over {x0, x1}.
     fn binary_sos1_instance() -> Instance {
         let decision_variables = btreemap! {
-            VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(0) => DecisionVariable::binary(),
+            VariableID::from(1) => DecisionVariable::binary(),
         };
         let vars: BTreeSet<_> = [0u64, 1].into_iter().map(VariableID::from).collect();
         let sos1 = Sos1Constraint::new(vars).unwrap();
@@ -301,7 +301,6 @@ mod tests {
     /// Build an instance with a single integer x0 in [-2, 3] and a SOS1 over just {x0}.
     fn integer_sos1_instance(lower: f64, upper: f64) -> Instance {
         let dv = DecisionVariable::new(
-            VariableID::from(0),
             Kind::Integer,
             Bound::new(lower, upper).unwrap(),
             ATol::default(),
@@ -443,7 +442,7 @@ mod tests {
     #[test]
     fn infinite_bound_is_rejected_without_mutation() {
         // Continuous x0 with default (infinite) bound cannot be Big-M converted.
-        let dv = DecisionVariable::continuous(VariableID::from(0));
+        let dv = DecisionVariable::continuous();
         let vars: BTreeSet<_> = [VariableID::from(0)].into_iter().collect();
         let sos1 = Sos1Constraint::new(vars).unwrap();
         let mut instance = Instance::builder()
@@ -484,8 +483,8 @@ mod tests {
         // isn't uniformly implemented across the codebase; Big-M conversion is
         // explicitly not supported for them and must error before mutation.
         for dv in [
-            DecisionVariable::semi_integer(VariableID::from(0)),
-            DecisionVariable::semi_continuous(VariableID::from(0)),
+            DecisionVariable::semi_integer(),
+            DecisionVariable::semi_continuous(),
         ] {
             let kind = dv.kind();
             let sos1 =
@@ -536,10 +535,10 @@ mod tests {
     fn bulk_conversion_returns_per_sos1_ids() {
         // Two disjoint SOS1 constraints, both binary — bulk call produces one entry each.
         let decision_variables = btreemap! {
-            VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(0) => DecisionVariable::binary(),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
         let a = Sos1Constraint::new(
             [VariableID::from(0), VariableID::from(1)]
@@ -580,7 +579,7 @@ mod tests {
         // An empty Sos1Constraint carries no variables to constrain, so the
         // Big-M cardinality constraint would degenerate to the tautology `-1 <= 0`.
         // The builder should reject empty SOS1 instead of letting it through.
-        let dv = DecisionVariable::binary(VariableID::from(0));
+        let dv = DecisionVariable::binary();
         let empty_sos1 = Sos1Constraint {
             variables: BTreeSet::new(),
             stage: crate::Sos1CreatedData,
@@ -606,9 +605,9 @@ mod tests {
         // (continuous with default, infinite bound). The bulk call must fail
         // without applying the valid one either.
         let decision_variables = btreemap! {
-            VariableID::from(0) => DecisionVariable::binary(VariableID::from(0)),
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::continuous(VariableID::from(2)),
+            VariableID::from(0) => DecisionVariable::binary(),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::continuous(),
         };
         let valid = Sos1Constraint::new(
             [VariableID::from(0), VariableID::from(1)]

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -298,7 +298,12 @@ mod tests {
 
     /// Build an instance with a single integer x0 in [-2, 3] and a SOS1 over just {x0}.
     fn integer_sos1_instance(lower: f64, upper: f64) -> Instance {
-        let dv = DecisionVariable::new(Kind::Integer, Bound::new(lower, upper).unwrap()).unwrap();
+        let dv = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(lower, upper).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
         let vars: BTreeSet<_> = [VariableID::from(0)].into_iter().collect();
         let sos1 = Sos1Constraint::new(vars).unwrap();
         Instance::builder()

--- a/rust/ommx/src/instance/stats.rs
+++ b/rust/ommx/src/instance/stats.rs
@@ -202,10 +202,10 @@ mod tests {
     #[test]
     fn test_instance_with_variables_stats() {
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::integer(VariableID::from(3)),
-            VariableID::from(4) => DecisionVariable::continuous(VariableID::from(4)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::integer(),
+            VariableID::from(4) => DecisionVariable::continuous(),
         };
 
         // Set objective using variable 1 and 2
@@ -233,9 +233,9 @@ mod tests {
     #[test]
     fn test_instance_with_constraints_stats() {
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::binary(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::binary(),
         };
 
         let objective = (linear!(1) + coeff!(1.0)).unwrap().into();
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn test_stats_serialization() {
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
+            VariableID::from(1) => DecisionVariable::binary(),
         };
 
         let objective = (linear!(1) + coeff!(1.0)).into();
@@ -302,11 +302,11 @@ mod tests {
     #[test]
     fn test_stats_snapshot_with_variables() {
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::integer(VariableID::from(3)),
-            VariableID::from(4) => DecisionVariable::continuous(VariableID::from(4)),
-            VariableID::from(5) => DecisionVariable::semi_integer(VariableID::from(5)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::integer(),
+            VariableID::from(4) => DecisionVariable::continuous(),
+            VariableID::from(5) => DecisionVariable::semi_integer(),
         };
 
         let objective = (linear!(1) + linear!(2)).into();
@@ -326,9 +326,9 @@ mod tests {
     #[test]
     fn test_stats_snapshot_with_constraints() {
         let decision_variables = btreemap! {
-            VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-            VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
-            VariableID::from(3) => DecisionVariable::integer(VariableID::from(3)),
+            VariableID::from(1) => DecisionVariable::binary(),
+            VariableID::from(2) => DecisionVariable::binary(),
+            VariableID::from(3) => DecisionVariable::integer(),
         };
 
         let objective = (linear!(1) + coeff!(1.0)).unwrap().into();

--- a/rust/ommx/src/instance/substitute.rs
+++ b/rust/ommx/src/instance/substitute.rs
@@ -228,14 +228,8 @@ mod tests {
     fn test_instance_substitute() {
         // Create decision variables
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::continuous(VariableID::from(2)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::continuous());
 
         // Create a simple instance: minimize x1 + 2*x2, subject to x1 + x2 <= 10
         let objective = Function::from((linear!(1) + coeff!(2.0) * linear!(2)).unwrap());
@@ -271,14 +265,8 @@ mod tests {
     #[test]
     fn test_parametric_instance_substitute_parameterized_rhs() {
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(0),
-            DecisionVariable::continuous(VariableID::from(0)),
-        );
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
+        decision_variables.insert(VariableID::from(0), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
 
         let mut parameters = BTreeMap::new();
         parameters.insert(
@@ -326,10 +314,7 @@ mod tests {
     #[test]
     fn test_parametric_instance_substitute_parameter_target_fails() {
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(0),
-            DecisionVariable::continuous(VariableID::from(0)),
-        );
+        decision_variables.insert(VariableID::from(0), DecisionVariable::continuous());
 
         let mut parameters = BTreeMap::new();
         parameters.insert(
@@ -362,10 +347,7 @@ mod tests {
     #[test]
     fn test_parametric_instance_substitute_undefined_rhs_fails() {
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(0),
-            DecisionVariable::continuous(VariableID::from(0)),
-        );
+        decision_variables.insert(VariableID::from(0), DecisionVariable::continuous());
 
         let parametric = ParametricInstance::new(
             Sense::Minimize,
@@ -390,18 +372,9 @@ mod tests {
     fn test_substitute_indicator_function() {
         // Substituting a variable in the indicator's function should work
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(2),
-            DecisionVariable::continuous(VariableID::from(2)),
-        );
-        decision_variables.insert(
-            VariableID::from(10),
-            DecisionVariable::binary(VariableID::from(10)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(10), DecisionVariable::binary());
 
         let objective = Function::from(linear!(1));
 
@@ -441,14 +414,8 @@ mod tests {
     fn test_substitute_indicator_variable_fails() {
         // Substituting the indicator variable itself should fail
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(
-            VariableID::from(1),
-            DecisionVariable::continuous(VariableID::from(1)),
-        );
-        decision_variables.insert(
-            VariableID::from(10),
-            DecisionVariable::binary(VariableID::from(10)),
-        );
+        decision_variables.insert(VariableID::from(1), DecisionVariable::continuous());
+        decision_variables.insert(VariableID::from(10), DecisionVariable::binary());
 
         let objective = Function::from(linear!(1));
 

--- a/rust/ommx/src/mps/convert.rs
+++ b/rust/ommx/src/mps/convert.rs
@@ -106,8 +106,8 @@ fn convert_dvars(mps: &Mps) -> ConvertedDecisionVariables {
             // in the future
             let id = VariableID::from(i as u64);
             name_id_map.insert(var_name.clone(), id);
-            let dvar = DecisionVariable::new(kind, bound, crate::ATol::default())
-                .expect("Failed to create decision variable");
+            let dvar =
+                DecisionVariable::new(kind, bound).expect("Failed to create decision variable");
             dvars.insert(id, dvar);
             var_names.push((id, var_name.0.clone()));
         }
@@ -121,8 +121,8 @@ fn convert_dvars(mps: &Mps) -> ConvertedDecisionVariables {
             let bound = get_dvar_bound(var_name, l, u);
             let id = VariableID::from(id_value);
             name_id_map.insert(var_name.clone(), id);
-            let dvar = DecisionVariable::new(kind, bound, crate::ATol::default())
-                .expect("Failed to create decision variable");
+            let dvar =
+                DecisionVariable::new(kind, bound).expect("Failed to create decision variable");
             // Do not add name here since it means OMMX ID, not user-defined name
             dvars.insert(id, dvar);
         }

--- a/rust/ommx/src/mps/convert.rs
+++ b/rust/ommx/src/mps/convert.rs
@@ -106,8 +106,8 @@ fn convert_dvars(mps: &Mps) -> ConvertedDecisionVariables {
             // in the future
             let id = VariableID::from(i as u64);
             name_id_map.insert(var_name.clone(), id);
-            let dvar =
-                DecisionVariable::new(kind, bound).expect("Failed to create decision variable");
+            let dvar = DecisionVariable::new(kind, bound, crate::ATol::default())
+                .expect("Failed to create decision variable");
             dvars.insert(id, dvar);
             var_names.push((id, var_name.0.clone()));
         }
@@ -121,8 +121,8 @@ fn convert_dvars(mps: &Mps) -> ConvertedDecisionVariables {
             let bound = get_dvar_bound(var_name, l, u);
             let id = VariableID::from(id_value);
             name_id_map.insert(var_name.clone(), id);
-            let dvar =
-                DecisionVariable::new(kind, bound).expect("Failed to create decision variable");
+            let dvar = DecisionVariable::new(kind, bound, crate::ATol::default())
+                .expect("Failed to create decision variable");
             // Do not add name here since it means OMMX ID, not user-defined name
             dvars.insert(id, dvar);
         }

--- a/rust/ommx/src/mps/convert.rs
+++ b/rust/ommx/src/mps/convert.rs
@@ -106,7 +106,7 @@ fn convert_dvars(mps: &Mps) -> ConvertedDecisionVariables {
             // in the future
             let id = VariableID::from(i as u64);
             name_id_map.insert(var_name.clone(), id);
-            let dvar = DecisionVariable::new(id, kind, bound, crate::ATol::default())
+            let dvar = DecisionVariable::new(kind, bound, crate::ATol::default())
                 .expect("Failed to create decision variable");
             dvars.insert(id, dvar);
             var_names.push((id, var_name.0.clone()));
@@ -121,7 +121,7 @@ fn convert_dvars(mps: &Mps) -> ConvertedDecisionVariables {
             let bound = get_dvar_bound(var_name, l, u);
             let id = VariableID::from(id_value);
             name_id_map.insert(var_name.clone(), id);
-            let dvar = DecisionVariable::new(id, kind, bound, crate::ATol::default())
+            let dvar = DecisionVariable::new(kind, bound, crate::ATol::default())
                 .expect("Failed to create decision variable");
             // Do not add name here since it means OMMX ID, not user-defined name
             dvars.insert(id, dvar);

--- a/rust/ommx/src/mps/format.rs
+++ b/rust/ommx/src/mps/format.rs
@@ -379,7 +379,6 @@ mod tests {
     fn test_write_bounds_unbounded() {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
-                VariableID::from(0),
                 Kind::Continuous,
                 Bound::unbounded(),
                 crate::ATol::default()
@@ -408,7 +407,6 @@ mod tests {
     fn test_write_bounds_positive() {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
-                VariableID::from(0),
                 Kind::Continuous,
                 Bound::positive(),
                 crate::ATol::default()
@@ -438,7 +436,6 @@ mod tests {
     fn test_write_bounds_negative() {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
-                VariableID::from(0),
                 Kind::Continuous,
                 Bound::negative(),
                 crate::ATol::default()
@@ -468,13 +465,11 @@ mod tests {
     fn test_write_bounds_integer_types() {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
-                VariableID::from(0),
                 Kind::Binary,
                 Bound::of_binary(),
                 crate::ATol::default()
             ).unwrap(),
             VariableID::from(1) => DecisionVariable::new(
-                VariableID::from(1),
                 Kind::Integer,
                 Bound::new(-10.0, 20.0).unwrap(),
                 crate::ATol::default()
@@ -506,19 +501,16 @@ mod tests {
     fn test_write_bounds_mixed_types() {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
-                VariableID::from(0),
                 Kind::Continuous,
                 Bound::unbounded(),
                 crate::ATol::default()
             ).unwrap(),
             VariableID::from(1) => DecisionVariable::new(
-                VariableID::from(1),
                 Kind::Continuous,
                 Bound::positive(),
                 crate::ATol::default()
             ).unwrap(),
             VariableID::from(2) => DecisionVariable::new(
-                VariableID::from(2),
                 Kind::Integer,
                 Bound::negative(),
                 crate::ATol::default()

--- a/rust/ommx/src/mps/format.rs
+++ b/rust/ommx/src/mps/format.rs
@@ -380,8 +380,7 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::unbounded(),
-                crate::ATol::default()
+                Bound::unbounded()
             ).unwrap(),
         };
 
@@ -408,8 +407,7 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::positive(),
-                crate::ATol::default()
+                Bound::positive()
             ).unwrap(),
         };
 
@@ -437,8 +435,7 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::negative(),
-                crate::ATol::default()
+                Bound::negative()
             ).unwrap(),
         };
 
@@ -466,13 +463,11 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Binary,
-                Bound::of_binary(),
-                crate::ATol::default()
+                Bound::of_binary()
             ).unwrap(),
             VariableID::from(1) => DecisionVariable::new(
                 Kind::Integer,
-                Bound::new(-10.0, 20.0).unwrap(),
-                crate::ATol::default()
+                Bound::new(-10.0, 20.0).unwrap()
             ).unwrap(),
         };
 
@@ -502,18 +497,15 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::unbounded(),
-                crate::ATol::default()
+                Bound::unbounded()
             ).unwrap(),
             VariableID::from(1) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::positive(),
-                crate::ATol::default()
+                Bound::positive()
             ).unwrap(),
             VariableID::from(2) => DecisionVariable::new(
                 Kind::Integer,
-                Bound::negative(),
-                crate::ATol::default()
+                Bound::negative()
             ).unwrap(),
         };
 

--- a/rust/ommx/src/mps/format.rs
+++ b/rust/ommx/src/mps/format.rs
@@ -380,7 +380,8 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::unbounded()
+                Bound::unbounded(),
+                crate::ATol::default(),
             ).unwrap(),
         };
 
@@ -407,7 +408,8 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::positive()
+                Bound::positive(),
+                crate::ATol::default(),
             ).unwrap(),
         };
 
@@ -435,7 +437,8 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::negative()
+                Bound::negative(),
+                crate::ATol::default(),
             ).unwrap(),
         };
 
@@ -463,11 +466,13 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Binary,
-                Bound::of_binary()
+                Bound::of_binary(),
+                crate::ATol::default(),
             ).unwrap(),
             VariableID::from(1) => DecisionVariable::new(
                 Kind::Integer,
-                Bound::new(-10.0, 20.0).unwrap()
+                Bound::new(-10.0, 20.0).unwrap(),
+                crate::ATol::default(),
             ).unwrap(),
         };
 
@@ -497,15 +502,18 @@ mod tests {
         let decision_variables = btreemap! {
             VariableID::from(0) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::unbounded()
+                Bound::unbounded(),
+                crate::ATol::default(),
             ).unwrap(),
             VariableID::from(1) => DecisionVariable::new(
                 Kind::Continuous,
-                Bound::positive()
+                Bound::positive(),
+                crate::ATol::default(),
             ).unwrap(),
             VariableID::from(2) => DecisionVariable::new(
                 Kind::Integer,
-                Bound::negative()
+                Bound::negative(),
+                crate::ATol::default(),
             ).unwrap(),
         };
 

--- a/rust/ommx/src/mps/tests/edge_cases.rs
+++ b/rust/ommx/src/mps/tests/edge_cases.rs
@@ -11,15 +11,18 @@ fn test_unused_variable_filtering() {
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap()
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
         ).unwrap(),
         VariableID::from(1) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap()
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
         ).unwrap(),
         VariableID::from(2) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap()
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
         ).unwrap(),  // This variable is unused
     };
 
@@ -60,11 +63,13 @@ fn test_removed_constraint_variable_preservation() {
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap()
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
         ).unwrap(),
         VariableID::from(1) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap()
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
         ).unwrap(),
     };
 
@@ -117,7 +122,8 @@ fn test_removed_constraint_information_loss() {
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap()
+            Bound::new(0.0, 10.0).unwrap(),
+            crate::ATol::default(),
         ).unwrap(),
     };
 

--- a/rust/ommx/src/mps/tests/edge_cases.rs
+++ b/rust/ommx/src/mps/tests/edge_cases.rs
@@ -11,18 +11,15 @@ fn test_unused_variable_filtering() {
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap(),
-            crate::ATol::default()
+            Bound::new(0.0, 10.0).unwrap()
         ).unwrap(),
         VariableID::from(1) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap(),
-            crate::ATol::default()
+            Bound::new(0.0, 10.0).unwrap()
         ).unwrap(),
         VariableID::from(2) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap(),
-            crate::ATol::default()
+            Bound::new(0.0, 10.0).unwrap()
         ).unwrap(),  // This variable is unused
     };
 
@@ -63,13 +60,11 @@ fn test_removed_constraint_variable_preservation() {
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap(),
-            crate::ATol::default()
+            Bound::new(0.0, 10.0).unwrap()
         ).unwrap(),
         VariableID::from(1) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap(),
-            crate::ATol::default()
+            Bound::new(0.0, 10.0).unwrap()
         ).unwrap(),
     };
 
@@ -122,8 +117,7 @@ fn test_removed_constraint_information_loss() {
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
             crate::decision_variable::Kind::Continuous,
-            Bound::new(0.0, 10.0).unwrap(),
-            crate::ATol::default()
+            Bound::new(0.0, 10.0).unwrap()
         ).unwrap(),
     };
 

--- a/rust/ommx/src/mps/tests/edge_cases.rs
+++ b/rust/ommx/src/mps/tests/edge_cases.rs
@@ -10,19 +10,16 @@ fn test_unused_variable_filtering() {
     // Create instance with 3 variables but only use 2
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
-            VariableID::from(0),
             crate::decision_variable::Kind::Continuous,
             Bound::new(0.0, 10.0).unwrap(),
             crate::ATol::default()
         ).unwrap(),
         VariableID::from(1) => DecisionVariable::new(
-            VariableID::from(1),
             crate::decision_variable::Kind::Continuous,
             Bound::new(0.0, 10.0).unwrap(),
             crate::ATol::default()
         ).unwrap(),
         VariableID::from(2) => DecisionVariable::new(
-            VariableID::from(2),
             crate::decision_variable::Kind::Continuous,
             Bound::new(0.0, 10.0).unwrap(),
             crate::ATol::default()
@@ -65,13 +62,11 @@ fn test_removed_constraint_variable_preservation() {
     // Create instance with variables and constraints, then relax one
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
-            VariableID::from(0),
             crate::decision_variable::Kind::Continuous,
             Bound::new(0.0, 10.0).unwrap(),
             crate::ATol::default()
         ).unwrap(),
         VariableID::from(1) => DecisionVariable::new(
-            VariableID::from(1),
             crate::decision_variable::Kind::Continuous,
             Bound::new(0.0, 10.0).unwrap(),
             crate::ATol::default()
@@ -126,7 +121,6 @@ fn test_removed_constraint_information_loss() {
     // Create instance with both active and removed constraints
     let decision_variables = btreemap! {
         VariableID::from(0) => DecisionVariable::new(
-            VariableID::from(0),
             crate::decision_variable::Kind::Continuous,
             Bound::new(0.0, 10.0).unwrap(),
             crate::ATol::default()

--- a/rust/ommx/src/mps/tests/invalid_cases.rs
+++ b/rust/ommx/src/mps/tests/invalid_cases.rs
@@ -9,8 +9,8 @@ use std::collections::BTreeMap;
 #[test]
 fn test_nonlinear_objective_error() {
     let decision_variables = btreemap! {
-        VariableID::from(1) => DecisionVariable::binary(VariableID::from(1)),
-        VariableID::from(2) => DecisionVariable::binary(VariableID::from(2)),
+        VariableID::from(1) => DecisionVariable::binary(),
+        VariableID::from(2) => DecisionVariable::binary(),
     };
     // Create a cubic function: x1 * x2 * x1 (degree 3, not supported)
     let cubic_function = (quadratic!(1, 2) * quadratic!(1)).into();
@@ -34,7 +34,7 @@ fn test_nonlinear_objective_error() {
 #[test]
 fn test_nonlinear_constraint_error() {
     let decision_variables = btreemap! {
-        VariableID::from(0) => DecisionVariable::continuous(VariableID::from(0))
+        VariableID::from(0) => DecisionVariable::continuous()
     };
 
     // Create constraint with cubic function: x^3 <= 0 (degree 3, not supported)

--- a/rust/ommx/src/mps/tests/read_tests.rs
+++ b/rust/ommx/src/mps/tests/read_tests.rs
@@ -34,14 +34,14 @@ ENDATA
     assert_eq!(var.bound(), Bound::new(0.0, 4.0).unwrap());
 
     // Check objective: x1
-    assert_abs_diff_eq!(instance.objective(), &Function::from(linear!(var.id())));
+    assert_abs_diff_eq!(instance.objective(), &Function::from(linear!(*var_id)));
 
     // Check constraint: x1 - 5 <= 0
     assert_eq!(instance.constraints().len(), 1);
     let (cid, constraint) = instance.constraints().iter().next().unwrap();
     assert_abs_diff_eq!(
         constraint.function(),
-        &Function::from(linear!(var.id()) + coeff!(-5.0))
+        &Function::from(linear!(*var_id) + coeff!(-5.0))
     );
     assert_eq!(constraint.equality, crate::Equality::LessThanOrEqualToZero);
     assert_eq!(
@@ -94,7 +94,7 @@ ENDATA
     // Check objective: x1 + 2*x2
     assert_abs_diff_eq!(
         instance.objective(),
-        &Function::from(linear!(x1.id()) + coeff!(2.0) * linear!(x2.id()))
+        &Function::from(linear!(*x1_id) + coeff!(2.0) * linear!(*x2_id))
     );
 
     // Check constraints
@@ -109,7 +109,7 @@ ENDATA
     assert_abs_diff_eq!(
         r1.function(),
         &Function::from(
-            ((linear!(x1.id()) + coeff!(2.0) * linear!(x2.id())).unwrap() + coeff!(-10.0)).unwrap()
+            ((linear!(*x1_id) + coeff!(2.0) * linear!(*x2_id)).unwrap() + coeff!(-10.0)).unwrap()
         )
     );
     assert_eq!(r1.equality, crate::Equality::LessThanOrEqualToZero);
@@ -117,7 +117,7 @@ ENDATA
     // -x1 - x2 + 5 <= 0
     assert_abs_diff_eq!(
         r2.function(),
-        &Function::from(((-linear!(x1.id()) - linear!(x2.id())).unwrap() + coeff!(5.0)).unwrap())
+        &Function::from(((-linear!(*x1_id) - linear!(*x2_id)).unwrap() + coeff!(5.0)).unwrap())
     );
     assert_eq!(r2.equality, crate::Equality::LessThanOrEqualToZero);
     assert_eq!(constraint_context.name(*r2_id), Some("R2"));
@@ -125,7 +125,7 @@ ENDATA
     assert_abs_diff_eq!(
         r1_range.function(),
         &Function::from(
-            ((-linear!(x1.id()) - coeff!(2.0) * linear!(x2.id())).unwrap() + coeff!(8.0)).unwrap()
+            ((-linear!(*x1_id) - coeff!(2.0) * linear!(*x2_id)).unwrap() + coeff!(8.0)).unwrap()
         )
     );
     assert_eq!(r1_range.equality, crate::Equality::LessThanOrEqualToZero);
@@ -133,7 +133,7 @@ ENDATA
     // x1 + x2 - 8 <= 0
     assert_abs_diff_eq!(
         r2_range.function(),
-        &Function::from(((linear!(x1.id()) + linear!(x2.id())).unwrap() + coeff!(-8.0)).unwrap())
+        &Function::from(((linear!(*x1_id) + linear!(*x2_id)).unwrap() + coeff!(-8.0)).unwrap())
     );
     assert_eq!(r2_range.equality, crate::Equality::LessThanOrEqualToZero);
     assert_eq!(constraint_context.name(*r2_range_id), Some("R2_"));
@@ -189,8 +189,8 @@ ENDATA
     assert_abs_diff_eq!(
         instance.objective(),
         &Function::from(
-            ((linear!(x1.id()) + coeff!(2.0) * linear!(x2.id())).unwrap()
-                + (coeff!(3.0) * linear!(x3.id())).unwrap())
+            ((linear!(*x1_id) + coeff!(2.0) * linear!(*x2_id)).unwrap()
+                + (coeff!(3.0) * linear!(*x3_id)).unwrap())
             .unwrap()
         )
     );
@@ -201,7 +201,7 @@ ENDATA
     assert_abs_diff_eq!(
         constraint.function(),
         &Function::from(
-            (((linear!(x1.id()) + linear!(x2.id())).unwrap() + linear!(x3.id())).unwrap()
+            (((linear!(*x1_id) + linear!(*x2_id)).unwrap() + linear!(*x3_id)).unwrap()
                 + coeff!(-10.0))
             .unwrap()
         )
@@ -256,7 +256,7 @@ ENDATA
     // Check objective: x1 + 2*x2
     assert_abs_diff_eq!(
         instance.objective(),
-        &Function::from(linear!(x1.id()) + coeff!(2.0) * linear!(x2.id()))
+        &Function::from(linear!(*x1_id) + coeff!(2.0) * linear!(*x2_id))
     );
 
     // Check constraint: x1 + x2 - 1 <= 0
@@ -264,7 +264,7 @@ ENDATA
     let (cid, constraint) = instance.constraints().iter().next().unwrap();
     assert_abs_diff_eq!(
         constraint.function(),
-        &Function::from(((linear!(x1.id()) + linear!(x2.id())).unwrap() + coeff!(-1.0)).unwrap())
+        &Function::from(((linear!(*x1_id) + linear!(*x2_id)).unwrap() + coeff!(-1.0)).unwrap())
     );
     assert_eq!(constraint.equality, crate::Equality::LessThanOrEqualToZero);
     assert_eq!(
@@ -322,7 +322,7 @@ ENDATA
     // Check objective: x1 - x2
     assert_abs_diff_eq!(
         instance.objective(),
-        &Function::from(linear!(x1.id()) + coeff!(-1.0) * linear!(x2.id()))
+        &Function::from(linear!(*x1_id) + coeff!(-1.0) * linear!(*x2_id))
     );
 
     // Check constraint: x1 - x2 = 0
@@ -330,7 +330,7 @@ ENDATA
     let (cid, constraint) = instance.constraints().iter().next().unwrap();
     assert_abs_diff_eq!(
         constraint.function(),
-        &Function::from(linear!(x1.id()) + coeff!(-1.0) * linear!(x2.id()))
+        &Function::from(linear!(*x1_id) + coeff!(-1.0) * linear!(*x2_id))
     );
     assert_eq!(constraint.equality, crate::Equality::EqualToZero);
     assert_eq!(
@@ -370,8 +370,8 @@ ENDATA
     // Check variables
     assert_eq!(instance.decision_variables().len(), 2);
     let mut iter = instance.decision_variables().iter();
-    let (x1_id, x1) = iter.next().unwrap();
-    let (x2_id, x2) = iter.next().unwrap();
+    let (x1_id, _x1) = iter.next().unwrap();
+    let (x2_id, _x2) = iter.next().unwrap();
     // Check variable names
     assert_eq!(instance.variable_labels().name(*x1_id).unwrap(), "X1");
     assert_eq!(instance.variable_labels().name(*x2_id).unwrap(), "X2");
@@ -379,7 +379,7 @@ ENDATA
     // Check objective: x1 + 2*x2
     assert_abs_diff_eq!(
         instance.objective(),
-        &Function::from(linear!(x1.id()) + coeff!(2.0) * linear!(x2.id()))
+        &Function::from(linear!(*x1_id) + coeff!(2.0) * linear!(*x2_id))
     );
 
     // Check constraint: x1 + x2 - 10 <= 0
@@ -387,7 +387,7 @@ ENDATA
     let (cid, constraint) = instance.constraints().iter().next().unwrap();
     assert_abs_diff_eq!(
         constraint.function(),
-        &Function::from(((linear!(x1.id()) + linear!(x2.id())).unwrap() + coeff!(-10.0)).unwrap())
+        &Function::from(((linear!(*x1_id) + linear!(*x2_id)).unwrap() + coeff!(-10.0)).unwrap())
     );
     assert_eq!(constraint.equality, crate::Equality::LessThanOrEqualToZero);
     assert_eq!(
@@ -455,8 +455,8 @@ ENDATA
     assert_abs_diff_eq!(
         instance.objective(),
         &Function::from(
-            ((linear!(x1.id()) + coeff!(4.0) * linear!(x2.id())).unwrap()
-                + (coeff!(9.0) * linear!(x3.id())).unwrap())
+            ((linear!(*x1_id) + coeff!(4.0) * linear!(*x2_id)).unwrap()
+                + (coeff!(9.0) * linear!(*x3_id)).unwrap())
             .unwrap()
         )
     );
@@ -513,14 +513,12 @@ ENDATA
     assert_eq!(instance.objective().degree(), 2);
 
     // Get variables using the new helper method
-    let x1 = instance
+    let (x1_id, _x1) = instance
         .get_decision_variable_by_name("X1", vec![])
         .unwrap();
-    let x2 = instance
+    let (x2_id, _x2) = instance
         .get_decision_variable_by_name("X2", vec![])
         .unwrap();
-    let x1_id = x1.id();
-    let x2_id = x2.id();
 
     // Build expected objective function: x1 + 3*x2 + 0.5*x1^2 + x1*x2 + 2*x2^2
     let expected_objective =
@@ -564,14 +562,12 @@ ENDATA
     assert_eq!(instance.constraints().len(), 1);
 
     // Get variables using the helper method
-    let x1 = instance
+    let (x1_id, _x1) = instance
         .get_decision_variable_by_name("X1", vec![])
         .unwrap();
-    let x2 = instance
+    let (x2_id, _x2) = instance
         .get_decision_variable_by_name("X2", vec![])
         .unwrap();
-    let x1_id = x1.id();
-    let x2_id = x2.id();
 
     // The constraint should be quadratic
     let (_cid, constraint) = instance.constraints().iter().next().unwrap();

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -36,6 +36,9 @@ pub enum SampleSetError {
         found: SampleIDSet,
     },
 
+    #[error("Duplicated variable ID is found in definition: {id:?}")]
+    DuplicatedVariableID { id: VariableID },
+
     #[error("Duplicate subscripts for {name}: {subscripts:?}")]
     DuplicateSubscripts { name: String, subscripts: Vec<i64> },
 

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -522,7 +522,6 @@ impl SampleSetBuilder {
     /// Returns an error if:
     /// - Required fields (`decision_variables`, `objectives`, `constraints`, `sense`) are not set
     /// - Sample IDs are inconsistent across decision variables, objectives, constraints, and named functions
-    /// - Sample IDs are inconsistent across decision variables, objectives, constraints, and named functions
     pub fn build(self) -> Result<SampleSet, SampleSetError> {
         let decision_variables =
             self.decision_variables

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -75,12 +75,6 @@ pub enum SampleSetError {
     #[error("Required field is missing: {field}")]
     MissingRequiredField { field: &'static str },
 
-    #[error("Decision variable key {key:?} does not match value's id {value_id:?}")]
-    InconsistentDecisionVariableID {
-        key: VariableID,
-        value_id: VariableID,
-    },
-
     #[error("Named function key {key:?} does not match value's id {value_id:?}")]
     InconsistentNamedFunctionID {
         key: NamedFunctionID,
@@ -209,7 +203,7 @@ impl SampleSet {
         let mut decision_variables: BTreeMap<VariableID, EvaluatedDecisionVariable> =
             BTreeMap::default();
         for (variable_id, sampled_dv) in &self.decision_variables {
-            let evaluated_dv = sampled_dv.get(sample_id)?;
+            let evaluated_dv = sampled_dv.get(*variable_id, sample_id)?;
             decision_variables.insert(*variable_id, evaluated_dv);
         }
 
@@ -526,7 +520,7 @@ impl SampleSetBuilder {
     /// # Errors
     /// Returns an error if:
     /// - Required fields (`decision_variables`, `objectives`, `constraints`, `sense`) are not set
-    /// - Keys do not match the `id()` of their values
+    /// - Sample IDs are inconsistent across decision variables, objectives, constraints, and named functions
     /// - Sample IDs are inconsistent across decision variables, objectives, constraints, and named functions
     pub fn build(self) -> Result<SampleSet, SampleSetError> {
         let decision_variables =
@@ -547,16 +541,6 @@ impl SampleSetBuilder {
         let sense = self
             .sense
             .ok_or(SampleSetError::MissingRequiredField { field: "sense" })?;
-
-        // Validate key/id consistency
-        for (key, value) in &decision_variables {
-            if key != value.id() {
-                return Err(SampleSetError::InconsistentDecisionVariableID {
-                    key: *key,
-                    value_id: *value.id(),
-                });
-            }
-        }
 
         for (key, value) in &self.named_functions {
             if key != value.id() {
@@ -690,7 +674,6 @@ impl SampleSetBuilder {
     /// # Safety
     /// This method does not validate that the SampleSet invariants hold.
     /// The caller must ensure:
-    /// - Decision variable keys match their value's `id()`
     /// - Constraint keys match their value's `id()`
     /// - Named function keys match their value's `id()`
     /// - Sample IDs are consistent across all components
@@ -792,11 +775,12 @@ mod tests {
         let sample_id = SampleID::from(0);
         let unexpected_sample_id = SampleID::from(1);
 
-        let decision_variable = DecisionVariable::binary(var_id);
+        let decision_variable = DecisionVariable::binary();
         let mut variable_samples = crate::Sampled::default();
         variable_samples.append([sample_id], 1.0).unwrap();
         let sampled_variable =
-            SampledDecisionVariable::new(decision_variable.clone(), variable_samples).unwrap();
+            SampledDecisionVariable::new(var_id, decision_variable.clone(), variable_samples)
+                .unwrap();
 
         let mut objectives = crate::Sampled::default();
         objectives.append([sample_id], 0.0).unwrap();
@@ -864,11 +848,14 @@ mod tests {
         let sample_id = SampleID::from(0);
 
         // Decision variable + sample
-        let dv = DecisionVariable::binary(var_id);
+        let dv = DecisionVariable::binary();
         let mut x_samples = crate::Sampled::default();
         x_samples.append([sample_id], 1.0).unwrap();
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(var_id, SampledDecisionVariable::new(dv, x_samples).unwrap());
+        decision_variables.insert(
+            var_id,
+            SampledDecisionVariable::new(var_id, dv, x_samples).unwrap(),
+        );
 
         let mut variable_labels = crate::VariableLabelStore::default();
         variable_labels.set_name(var_id, "x");

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -89,7 +89,8 @@ pub enum SampleSetError {
 ///
 /// Invariants
 /// -----------
-/// - The keys of [`Self::decision_variables`] match the `id()` of their values.
+/// - [`Self::decision_variables`] is keyed by the table-owned
+///   [`VariableID`]; sampled decision-variable rows do not carry IDs.
 /// - The keys of [`Self::named_functions`] match the `id()` of their values.
 /// - All [`Self::decision_variables`], [`Self::objectives`], sampled constraint
 ///   collections, and [`Self::named_functions`] have the same sample ID set.
@@ -674,7 +675,8 @@ impl SampleSetBuilder {
     /// # Safety
     /// This method does not validate that the SampleSet invariants hold.
     /// The caller must ensure:
-    /// - Constraint keys match their value's `id()`
+    /// - `decision_variables` is keyed by the intended [`VariableID`] for each row
+    /// - Sampled constraint collection keys and sidecars are internally consistent
     /// - Named function keys match their value's `id()`
     /// - Sample IDs are consistent across all components
     ///

--- a/rust/ommx/src/sample_set/extract.rs
+++ b/rust/ommx/src/sample_set/extract.rs
@@ -262,7 +262,6 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -278,7 +277,6 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -294,7 +292,6 @@ mod tests {
         let dv3 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -399,7 +396,6 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -414,7 +410,6 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -501,7 +496,6 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -516,7 +510,6 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -531,7 +524,6 @@ mod tests {
         let dv3 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -598,7 +590,6 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -613,7 +604,6 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -628,7 +618,6 @@ mod tests {
         let dv3 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -710,7 +699,6 @@ mod tests {
         let dv = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -774,7 +762,6 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -803,7 +790,6 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(

--- a/rust/ommx/src/sample_set/extract.rs
+++ b/rust/ommx/src/sample_set/extract.rs
@@ -260,7 +260,6 @@ mod tests {
 
         // Variable x[0]
         let dv1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -277,7 +276,6 @@ mod tests {
 
         // Variable x[1]
         let dv2 = DecisionVariable::new(
-            VariableID::from(2),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -294,7 +292,6 @@ mod tests {
 
         // Variable y[0]
         let dv3 = DecisionVariable::new(
-            VariableID::from(3),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -324,15 +321,15 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            SampledDecisionVariable::new(dv1, x0_samples).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(1), dv1, x0_samples).unwrap(),
         );
         decision_variables.insert(
             VariableID::from(2),
-            SampledDecisionVariable::new(dv2, x1_samples).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(2), dv2, x1_samples).unwrap(),
         );
         decision_variables.insert(
             VariableID::from(3),
-            SampledDecisionVariable::new(dv3, y0_samples).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(3), dv3, y0_samples).unwrap(),
         );
 
         // Create objectives
@@ -400,7 +397,6 @@ mod tests {
         let mut variable_labels = crate::VariableLabelStore::default();
 
         let dv1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -416,7 +412,6 @@ mod tests {
         );
 
         let dv2 = DecisionVariable::new(
-            VariableID::from(2),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -440,11 +435,11 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            SampledDecisionVariable::new(dv1, samples1).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(1), dv1, samples1).unwrap(),
         );
         decision_variables.insert(
             VariableID::from(2),
-            SampledDecisionVariable::new(dv2, samples2).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(2), dv2, samples2).unwrap(),
         );
 
         // Create objectives
@@ -504,7 +499,6 @@ mod tests {
         let mut variable_labels = crate::VariableLabelStore::default();
 
         let dv1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -520,7 +514,6 @@ mod tests {
         );
 
         let dv2 = DecisionVariable::new(
-            VariableID::from(2),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -536,7 +529,6 @@ mod tests {
         );
 
         let dv3 = DecisionVariable::new(
-            VariableID::from(3),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -562,15 +554,15 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            SampledDecisionVariable::new(dv1, samples1).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(1), dv1, samples1).unwrap(),
         );
         decision_variables.insert(
             VariableID::from(2),
-            SampledDecisionVariable::new(dv2, samples2).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(2), dv2, samples2).unwrap(),
         );
         decision_variables.insert(
             VariableID::from(3),
-            SampledDecisionVariable::new(dv3, samples3).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(3), dv3, samples3).unwrap(),
         );
 
         let mut objectives = crate::Sampled::default();
@@ -604,7 +596,6 @@ mod tests {
         let mut variable_labels = crate::VariableLabelStore::default();
 
         let dv1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -620,7 +611,6 @@ mod tests {
         );
 
         let dv2 = DecisionVariable::new(
-            VariableID::from(2),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -636,7 +626,6 @@ mod tests {
         );
 
         let dv3 = DecisionVariable::new(
-            VariableID::from(3),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -662,15 +651,15 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            SampledDecisionVariable::new(dv1, samples1).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(1), dv1, samples1).unwrap(),
         );
         decision_variables.insert(
             VariableID::from(2),
-            SampledDecisionVariable::new(dv2, samples2).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(2), dv2, samples2).unwrap(),
         );
         decision_variables.insert(
             VariableID::from(3),
-            SampledDecisionVariable::new(dv3, samples3).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(3), dv3, samples3).unwrap(),
         );
 
         let mut objectives = crate::Sampled::default();
@@ -719,7 +708,6 @@ mod tests {
         let mut variable_labels = crate::VariableLabelStore::default();
 
         let dv = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -745,7 +733,7 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            SampledDecisionVariable::new(dv, samples).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(1), dv, samples).unwrap(),
         );
 
         // Create objectives
@@ -784,7 +772,6 @@ mod tests {
 
         // First variable with param1
         let dv1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -809,12 +796,11 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            SampledDecisionVariable::new(dv1, samples1).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(1), dv1, samples1).unwrap(),
         );
 
         // Second variable with param2 but same name and subscripts
         let dv2 = DecisionVariable::new(
-            VariableID::from(2),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -839,7 +825,7 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(2),
-            SampledDecisionVariable::new(dv2, samples2).unwrap(),
+            SampledDecisionVariable::new(VariableID::from(2), dv2, samples2).unwrap(),
         );
 
         // Create objectives

--- a/rust/ommx/src/sample_set/extract.rs
+++ b/rust/ommx/src/sample_set/extract.rs
@@ -262,6 +262,7 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -277,6 +278,7 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -292,6 +294,7 @@ mod tests {
         let dv3 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -396,6 +399,7 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -410,6 +414,7 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -496,6 +501,7 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -510,6 +516,7 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -524,6 +531,7 @@ mod tests {
         let dv3 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -590,6 +598,7 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -604,6 +613,7 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -618,6 +628,7 @@ mod tests {
         let dv3 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -699,6 +710,7 @@ mod tests {
         let dv = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -762,6 +774,7 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -790,6 +803,7 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -19,7 +19,12 @@ impl Parse for crate::v1::SampleSet {
                 v1_sampled_dv.parse_as(&(), message, "decision_variables")?;
             let dv_id = parsed.id;
             variable_labels.insert(dv_id, parsed.label);
-            decision_variables.insert(dv_id, parsed.variable);
+            if decision_variables.insert(dv_id, parsed.variable).is_some() {
+                return Err(crate::RawParseError::InvalidInstance(format!(
+                    "Duplicated variable ID is found in definition: {dv_id:?}"
+                ))
+                .context(message, "decision_variables"));
+            }
         }
 
         // Parse objectives - required, not optional
@@ -429,6 +434,46 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.SampleSet[format_version]
         Unsupported ommx format version: data has format_version=1, but this SDK supports up to 0. Please upgrade the OMMX SDK.
+        "###);
+    }
+
+    #[test]
+    fn test_sample_set_parse_fails_with_duplicated_variable_id() {
+        let sample_id = crate::SampleID::from(0);
+        let v1_sampled_dv = crate::v1::SampledDecisionVariable {
+            decision_variable: Some(crate::v1::DecisionVariable {
+                id: 1,
+                kind: crate::v1::decision_variable::Kind::Continuous as i32,
+                bound: Some(crate::v1::Bound {
+                    lower: 0.0,
+                    upper: 10.0,
+                }),
+                ..Default::default()
+            }),
+            samples: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![sample_id.into_inner()],
+                    value: 2.0,
+                }],
+            }),
+        };
+        let v1_sample_set = crate::v1::SampleSet {
+            decision_variables: vec![v1_sampled_dv.clone(), v1_sampled_dv],
+            objectives: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![sample_id.into_inner()],
+                    value: 0.0,
+                }],
+            }),
+            sense: crate::v1::instance::Sense::Minimize as i32,
+            ..Default::default()
+        };
+
+        let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
+        insta::assert_snapshot!(result.unwrap_err().to_string(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.SampleSet[decision_variables]
+        Duplicated variable ID is found in definition: VariableID(1)
         "###);
     }
 

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -20,9 +20,9 @@ impl Parse for crate::v1::SampleSet {
             let dv_id = parsed.id;
             variable_labels.insert(dv_id, parsed.label);
             if decision_variables.insert(dv_id, parsed.variable).is_some() {
-                return Err(crate::RawParseError::InvalidInstance(format!(
-                    "Duplicated variable ID is found in definition: {dv_id:?}"
-                ))
+                return Err(crate::RawParseError::SampleSetError(
+                    crate::SampleSetError::DuplicatedVariableID { id: dv_id },
+                )
                 .context(message, "decision_variables"));
             }
         }
@@ -470,7 +470,13 @@ mod tests {
         };
 
         let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
-        insta::assert_snapshot!(result.unwrap_err().to_string(), @r###"
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error.error,
+            crate::RawParseError::SampleSetError(crate::SampleSetError::DuplicatedVariableID { id })
+                if id == crate::VariableID::from(1)
+        ));
+        insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.SampleSet[decision_variables]
         Duplicated variable ID is found in definition: VariableID(1)

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -17,7 +17,7 @@ impl Parse for crate::v1::SampleSet {
         for v1_sampled_dv in self.decision_variables {
             let parsed: crate::decision_variable::parse::ParsedSampledDecisionVariable =
                 v1_sampled_dv.parse_as(&(), message, "decision_variables")?;
-            let dv_id = *parsed.variable.id();
+            let dv_id = parsed.id;
             variable_labels.insert(dv_id, parsed.label);
             decision_variables.insert(dv_id, parsed.variable);
         }
@@ -154,7 +154,7 @@ impl From<SampleSet> for crate::v1::SampleSet {
             .iter()
             .map(|(id, dv)| {
                 let label = variable_labels.collect_for(*id);
-                crate::decision_variable::sampled_decision_variable_to_v1(dv.clone(), label)
+                crate::decision_variable::sampled_decision_variable_to_v1(*id, dv.clone(), label)
             })
             .collect();
         let objectives = Some(sample_set.objectives().clone().into());
@@ -451,11 +451,14 @@ mod tests {
         let nf_id = NamedFunctionID::from(0);
         let sample_id = SampleID::from(0);
 
-        let dv = DecisionVariable::binary(var_id);
+        let dv = DecisionVariable::binary();
         let mut x_samples = crate::Sampled::default();
         x_samples.append([sample_id], 1.0).unwrap();
         let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(var_id, SampledDecisionVariable::new(dv, x_samples).unwrap());
+        decision_variables.insert(
+            var_id,
+            SampledDecisionVariable::new(var_id, dv, x_samples).unwrap(),
+        );
 
         let mut variable_labels = crate::VariableLabelStore::default();
         variable_labels.set_name(var_id, "x");

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -90,8 +90,10 @@ pub enum SolutionError {
 ///
 /// Invariants
 /// -----------
-/// - The keys of [`Self::decision_variables`] match the `id()` of their values.
-/// - The keys of [`Self::evaluated_constraints`] match the `id()` of their values.
+/// - [`Self::decision_variables`] is keyed by the table-owned
+///   [`VariableID`]; evaluated decision-variable rows do not carry IDs.
+/// - The keys of the evaluated constraint collections are the table-owned
+///   constraint IDs for each constraint family.
 /// - The keys of [`Self::evaluated_named_functions`] match the `id()` of their values.
 /// - [`Self::decision_variables`] contains all variable IDs referenced in `used_decision_variable_ids` of each constraint.
 ///
@@ -697,7 +699,8 @@ impl SolutionBuilder {
     /// # Errors
     /// Returns an error if:
     /// - Required fields (`objective`, `evaluated_constraints`, `decision_variables`, `sense`) are not set
-    /// - Constraint keys don't match their value's `id()`
+    /// - Constraint collection sidecars contain invalid keys
+    /// - Named function keys don't match their value's `id()`
     /// - Variables referenced in constraints' `used_decision_variable_ids` are not in `decision_variables`
     pub fn build(self) -> crate::Result<Solution> {
         let objective = self
@@ -821,8 +824,8 @@ impl SolutionBuilder {
     /// # Safety
     /// This method does not validate that the Solution invariants hold.
     /// The caller must ensure:
-    /// - Decision variable keys match their value's `id()`
-    /// - Constraint keys match their value's `id()`
+    /// - `decision_variables` is keyed by the intended [`VariableID`] for each row
+    /// - Evaluated constraint collection keys and sidecars are internally consistent
     /// - Named function keys match their value's `id()`
     /// - All `used_decision_variable_ids` in constraints exist in `decision_variables`
     ///

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -1069,6 +1069,7 @@ mod tests {
         let dv = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         let mut variable_labels = VariableLabelStore::default();
@@ -1126,6 +1127,7 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -1151,6 +1153,7 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
+            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -1069,7 +1069,6 @@ mod tests {
         let dv = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         let mut variable_labels = VariableLabelStore::default();
@@ -1127,7 +1126,6 @@ mod tests {
         let dv1 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(
@@ -1153,7 +1151,6 @@ mod tests {
         let dv2 = DecisionVariable::new(
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
-            crate::ATol::default(),
         )
         .unwrap();
         variable_labels.insert(

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -71,12 +71,6 @@ pub enum SolutionError {
     #[error("Required field is missing: {field}")]
     MissingRequiredField { field: &'static str },
 
-    #[error("Decision variable key {key:?} does not match value's id {value_id:?}")]
-    InconsistentDecisionVariableID {
-        key: VariableID,
-        value_id: VariableID,
-    },
-
     #[error(
         "Variable ID {id:?} used in constraint {constraint_id:?} is not in decision_variables"
     )]
@@ -309,11 +303,11 @@ impl Solution {
         name: &str,
     ) -> Result<BTreeMap<Vec<i64>, f64>, SolutionError> {
         // Collect all variables with the given name from their modeling labels.
-        let variables_with_name: Vec<&EvaluatedDecisionVariable> = self
+        let variables_with_name: Vec<(VariableID, &EvaluatedDecisionVariable)> = self
             .decision_variables
             .iter()
             .filter(|(id, _)| self.variable_labels.name(**id) == Some(name))
-            .map(|(_, v)| v)
+            .map(|(id, v)| (*id, v))
             .collect();
         if variables_with_name.is_empty() {
             return Err(SolutionError::UnknownVariableName {
@@ -322,8 +316,8 @@ impl Solution {
         }
 
         let mut result = BTreeMap::new();
-        for dv in &variables_with_name {
-            let key = self.variable_labels.subscripts(*dv.id()).to_vec();
+        for (id, dv) in &variables_with_name {
+            let key = self.variable_labels.subscripts(*id).to_vec();
             if result.contains_key(&key) {
                 return Err(SolutionError::DuplicateSubscript { subscripts: key });
             }
@@ -703,7 +697,6 @@ impl SolutionBuilder {
     /// # Errors
     /// Returns an error if:
     /// - Required fields (`objective`, `evaluated_constraints`, `decision_variables`, `sense`) are not set
-    /// - Decision variable keys don't match their value's `id()`
     /// - Constraint keys don't match their value's `id()`
     /// - Variables referenced in constraints' `used_decision_variable_ids` are not in `decision_variables`
     pub fn build(self) -> crate::Result<Solution> {
@@ -723,17 +716,6 @@ impl SolutionBuilder {
         let sense = self
             .sense
             .ok_or(SolutionError::MissingRequiredField { field: "sense" })?;
-
-        // Validate decision variable keys match their id
-        for (key, value) in &decision_variables {
-            if key != value.id() {
-                return Err(SolutionError::InconsistentDecisionVariableID {
-                    key: *key,
-                    value_id: *value.id(),
-                }
-                .into());
-            }
-        }
 
         // Validate named function keys match their id
         for (key, value) in &self.evaluated_named_functions {
@@ -1082,7 +1064,6 @@ mod tests {
         let mut decision_variables = BTreeMap::new();
 
         let dv = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -1105,7 +1086,7 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            EvaluatedDecisionVariable::new(dv, 1.0).unwrap(),
+            EvaluatedDecisionVariable::new(VariableID::from(1), dv, 1.0).unwrap(),
         );
 
         // SAFETY: Test data is constructed to satisfy invariants
@@ -1141,7 +1122,6 @@ mod tests {
 
         // First variable
         let dv1 = DecisionVariable::new(
-            VariableID::from(1),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -1163,12 +1143,11 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(1),
-            EvaluatedDecisionVariable::new(dv1, 1.0).unwrap(),
+            EvaluatedDecisionVariable::new(VariableID::from(1), dv1, 1.0).unwrap(),
         );
 
         // Second variable with same name and subscripts
         let dv2 = DecisionVariable::new(
-            VariableID::from(2),
             Kind::Continuous,
             crate::Bound::new(f64::NEG_INFINITY, f64::INFINITY).unwrap(),
             crate::ATol::default(),
@@ -1190,7 +1169,7 @@ mod tests {
 
         decision_variables.insert(
             VariableID::from(2),
-            EvaluatedDecisionVariable::new(dv2, 2.0).unwrap(),
+            EvaluatedDecisionVariable::new(VariableID::from(2), dv2, 2.0).unwrap(),
         );
 
         // SAFETY: Test data is constructed to satisfy invariants
@@ -1264,34 +1243,6 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_inconsistent_decision_variable_id() {
-        use crate::DecisionVariable;
-
-        let var_id_1 = VariableID::from(1);
-        let var_id_2 = VariableID::from(2);
-        let dv = DecisionVariable::binary(var_id_1);
-        let evaluated_dv = EvaluatedDecisionVariable::new(dv, 1.0).unwrap();
-
-        // Map key (2) doesn't match value's id (1)
-        let mut decision_variables = BTreeMap::new();
-        decision_variables.insert(var_id_2, evaluated_dv);
-
-        let err = Solution::builder()
-            .objective(0.0)
-            .evaluated_constraints(BTreeMap::new())
-            .decision_variables(decision_variables)
-            .sense(Sense::Minimize)
-            .build()
-            .unwrap_err();
-        let solution_err = err.downcast_ref::<SolutionError>().unwrap();
-        assert!(matches!(
-            solution_err,
-            SolutionError::InconsistentDecisionVariableID { key, value_id }
-                if *key == var_id_2 && *value_id == var_id_1
-        ));
-    }
-
-    #[test]
     fn test_builder_undefined_variable_in_constraint() {
         use crate::linear;
 
@@ -1327,8 +1278,8 @@ mod tests {
         use crate::DecisionVariable;
 
         let var_id = VariableID::from(1);
-        let dv = DecisionVariable::binary(var_id);
-        let evaluated_dv = EvaluatedDecisionVariable::new(dv, 1.0).unwrap();
+        let dv = DecisionVariable::binary();
+        let evaluated_dv = EvaluatedDecisionVariable::new(var_id, dv, 1.0).unwrap();
 
         let mut decision_variables = BTreeMap::new();
         decision_variables.insert(var_id, evaluated_dv);

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -35,6 +35,9 @@ pub enum SolutionError {
     #[error("Missing value for variable {id}: not found in state and no substituted_value")]
     MissingVariableValue { id: u64 },
 
+    #[error("Duplicated variable ID is found in definition: {id:?}")]
+    DuplicatedVariableID { id: VariableID },
+
     #[deprecated(
         note = "Parameters are now ignored in extract_decision_variables and extract_all_decision_variables"
     )]

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -107,9 +107,9 @@ impl Parse for crate::v1::Solution {
 
             variable_labels.insert(parsed_id, label);
             if decision_variables.insert(parsed_id, evaluated_dv).is_some() {
-                return Err(crate::RawParseError::InvalidInstance(format!(
-                    "Duplicated variable ID is found in definition: {parsed_id:?}"
-                ))
+                return Err(crate::RawParseError::SolutionError(
+                    SolutionError::DuplicatedVariableID { id: parsed_id },
+                )
                 .context(message, "decision_variables"));
             }
         }
@@ -606,7 +606,13 @@ mod tests {
         };
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
-        insta::assert_snapshot!(result.unwrap_err().to_string(), @r###"
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error.error,
+            crate::RawParseError::SolutionError(SolutionError::DuplicatedVariableID { id })
+                if id == crate::VariableID::from(1)
+        ));
+        insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
         Duplicated variable ID is found in definition: VariableID(1)

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -106,7 +106,12 @@ impl Parse for crate::v1::Solution {
                 .map_err(|e| ParseError::from(e).context(message, "decision_variables"))?;
 
             variable_labels.insert(parsed_id, label);
-            decision_variables.insert(parsed_id, evaluated_dv);
+            if decision_variables.insert(parsed_id, evaluated_dv).is_some() {
+                return Err(crate::RawParseError::InvalidInstance(format!(
+                    "Duplicated variable ID is found in definition: {parsed_id:?}"
+                ))
+                .context(message, "decision_variables"));
+            }
         }
         let optimality = self
             .optimality
@@ -573,6 +578,38 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
         Missing value for variable 1: not found in state and no substituted_value
+        "###);
+    }
+
+    #[test]
+    fn test_solution_parse_fails_with_duplicated_variable_id() {
+        use crate::v1;
+
+        let decision_variable = v1::DecisionVariable {
+            id: 1,
+            kind: v1::decision_variable::Kind::Continuous as i32,
+            bound: Some(v1::Bound {
+                lower: 0.0,
+                upper: 10.0,
+            }),
+            ..Default::default()
+        };
+        let v1_solution = v1::Solution {
+            state: Some(v1::State {
+                entries: [(1, 2.0)].iter().cloned().collect(),
+            }),
+            objective: 42.5,
+            decision_variables: vec![decision_variable.clone(), decision_variable],
+            feasible: true,
+            feasible_relaxed: Some(true),
+            ..Default::default()
+        };
+
+        let result: Result<Solution, ParseError> = v1_solution.parse(&());
+        insta::assert_snapshot!(result.unwrap_err().to_string(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.Solution[decision_variables]
+        Duplicated variable ID is found in definition: VariableID(1)
         "###);
     }
 

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -66,10 +66,11 @@ impl Parse for crate::v1::Solution {
         let mut decision_variables = std::collections::BTreeMap::default();
         let mut variable_labels = crate::VariableLabelStore::default();
         for dv in self.decision_variables {
-            let dv_id = dv.id;
             // Parse the DecisionVariable to get strongly-typed version + drained label
             let parsed: crate::decision_variable::parse::ParsedDecisionVariable =
                 dv.parse_as(&(), message, "decision_variables")?;
+            let parsed_id = parsed.id;
+            let dv_id = parsed_id.into_inner();
             let parsed_dv = parsed.variable;
             let label = parsed.label;
             let parsed_fixed_value = parsed.fixed_value;
@@ -100,13 +101,12 @@ impl Parse for crate::v1::Solution {
                 }
             };
 
-            let evaluated_dv = crate::EvaluatedDecisionVariable::new(parsed_dv, value)
+            let evaluated_dv = crate::EvaluatedDecisionVariable::new(parsed_id, parsed_dv, value)
                 .map_err(crate::RawParseError::InvalidDecisionVariable)
                 .map_err(|e| ParseError::from(e).context(message, "decision_variables"))?;
 
-            let id = *evaluated_dv.id();
-            variable_labels.insert(id, label);
-            decision_variables.insert(id, evaluated_dv);
+            variable_labels.insert(parsed_id, label);
+            decision_variables.insert(parsed_id, evaluated_dv);
         }
         let optimality = self
             .optimality
@@ -227,7 +227,7 @@ impl From<Solution> for crate::v1::Solution {
             .iter()
             .map(|(id, dv)| {
                 let label = variable_labels_store.collect_for(*id);
-                crate::decision_variable::evaluated_decision_variable_to_v1(dv.clone(), label)
+                crate::decision_variable::evaluated_decision_variable_to_v1(*id, dv.clone(), label)
             })
             .collect();
         let feasible = solution.feasible();
@@ -610,8 +610,8 @@ mod tests {
         let cid = ConstraintID::from(10);
         let nf_id = NamedFunctionID::from(0);
 
-        let dv = DecisionVariable::binary(var_id);
-        let evaluated_dv = EvaluatedDecisionVariable::new(dv, 1.0).unwrap();
+        let dv = DecisionVariable::binary();
+        let evaluated_dv = EvaluatedDecisionVariable::new(var_id, dv, 1.0).unwrap();
         let mut decision_variables = BTreeMap::new();
         decision_variables.insert(var_id, evaluated_dv);
 


### PR DESCRIPTION
## Summary

Part of #958.

This PR normalizes the Rust SDK decision-variable representation so the owning table is the single source of truth for `VariableID`.

- Remove inline IDs from Rust `DecisionVariable`, `EvaluatedDecisionVariable`, and `SampledDecisionVariable` row data.
- Keep IDs on `Instance`, `ParametricInstance`, `Solution`, and `SampleSet` map keys, and thread those keys through parse/write/evaluate/extract paths.
- Keep `DecisionVariable::new(kind, bound, atol)` responsible for normalizing `bound` against `kind`, preserving the main-branch invariant while removing only the duplicate ID source.
- Preserve the Python public modeling surface by storing the ID in the PyO3 wrapper while keeping the Rust row data ID-less.
- Update Rust migration docs, release notes, and tutorials to describe decision variables as table rows with key-owned identity.

## Design impact

`Instance::decision_variables` is now represented as a decision-variable table: the key column owns `VariableID`, the row value owns only `kind` and `bound`, and side columns such as modeling labels and fixed values remain owner-side stores. This matches the v3 root-owned entity model being prepared before the forward-incompatible protobuf redesign.

Bound normalization remains a `DecisionVariable` row invariant. Construction and bound mutation still require an explicit `ATol`, so callers choose the tolerance at the boundary instead of silently falling back to a default in the public Rust constructor.
