### PR TITLE
Clarify review guidance and release note scope for OMMX skills

### DIFF
--- a/.agents/skills/domain-responsibility-review/SKILL.md
+++ b/.agents/skills/domain-responsibility-review/SKILL.md
@@ -38,6 +38,16 @@ Treat this as a review pre-pass, not as the required final response order. When 
    - Proposed fixes should name the owning abstraction and route the operation through it.
    - If the task is addressing review feedback rather than writing a review, combine this pre-pass with the user-level `review-response` skill: reconstruct the reviewer concern, search for sibling defects, and fix the responsibility boundary rather than only the commented line.
 
+## Recurring OMMX Review Checks
+
+- Check every root object and constraint family affected by a change: `Instance`, `ParametricInstance`, `Solution`, `SampleSet`, regular constraints, indicator, one-hot, and SOS1. A fix for only the regular path is suspect when sidecars, annotations, parsing, serialization, or statistics are involved.
+- For parse/serialize/projection changes, verify round-trips preserve one source of truth: prune or transfer sidecars when absorbing constraints, reject or filter reserved annotation keys at protobuf boundaries, and make projected counts include special constraint families.
+- For fallible mutation paths, check atomicity before side effects. Build fallible derived values before inserting constraints, clear stale cached outputs before retryable operations, and validate reserved IDs before registry or storage writes.
+- For numeric consistency checks, handle boundary and invalid values explicitly. Absolute tolerances are inclusive unless the API documents otherwise, and NaN/Inf must not pass through `(a - b).abs() > atol` style comparisons silently.
+- For public API changes, check all user-facing surfaces together: Rust docs, Python docs, migration guides, stubs, examples, DataFrame flags, docstrings, and Python magic-method return contracts.
+- For new builder/setter/attachment APIs, add focused tests for both preservation and rejection paths, such as sidecar round-trips and orphan-ID validation.
+- For derived analysis or table-building code, avoid recomputing whole-instance partitions inside per-variable or per-row loops; compute the owner-side role/set partition once when the operation needs it repeatedly.
+
 ## Review Checklist
 
 - What is the global domain meaning of this change?

--- a/.agents/skills/domain-responsibility-review/SKILL.md
+++ b/.agents/skills/domain-responsibility-review/SKILL.md
@@ -5,7 +5,9 @@ description: Use when reviewing OMMX code, PR diffs, or proposed fixes to analyz
 
 # Domain Responsibility Review
 
-Use this skill at the start of every review. The goal is to review code shape through OMMX domain semantics before judging implementation details.
+Use this skill at the start of every OMMX review. The goal is to review code shape through OMMX domain semantics before judging implementation details.
+
+Treat this as a review pre-pass, not as the required final response order. When writing a code review, still lead with actionable findings; use the domain model to decide which findings matter and how to explain them.
 
 ## Review Flow
 
@@ -34,6 +36,7 @@ Use this skill at the start of every review. The goal is to review code shape th
    - Lead each finding with the broken responsibility or invariant.
    - Then point to the concrete code path and explain how the operation can violate that domain rule.
    - Proposed fixes should name the owning abstraction and route the operation through it.
+   - If the task is addressing review feedback rather than writing a review, combine this pre-pass with the user-level `review-response` skill: reconstruct the reviewer concern, search for sibling defects, and fix the responsibility boundary rather than only the commented line.
 
 ## Review Checklist
 

--- a/.agents/skills/domain-responsibility-review/SKILL.md
+++ b/.agents/skills/domain-responsibility-review/SKILL.md
@@ -45,6 +45,7 @@ Treat this as a review pre-pass, not as the required final response order. When 
 - For fallible mutation paths, check atomicity before side effects. Build fallible derived values before inserting constraints, clear stale cached outputs before retryable operations, and validate reserved IDs before registry or storage writes.
 - For numeric consistency checks, handle boundary and invalid values explicitly. Absolute tolerances are inclusive unless the API documents otherwise, and NaN/Inf must not pass through `(a - b).abs() > atol` style comparisons silently.
 - For public API changes, check all user-facing surfaces together: Rust docs, Python docs, migration guides, stubs, examples, DataFrame flags, docstrings, and Python magic-method return contracts.
+- For public Rust structs, check whether the struct-level Rustdoc states the invariants that the type owns: valid IDs, active/removed disjointness, sidecar key coverage, non-empty sets, finite/non-zero numeric values, reserved annotation namespaces, or host-level serialization requirements. If callers can construct or mutate the struct, the docs should name the intended constructors or owner APIs that preserve those invariants.
 - For new builder/setter/attachment APIs, add focused tests for both preservation and rejection paths, such as sidecar round-trips and orphan-ID validation.
 - For derived analysis or table-building code, avoid recomputing whole-instance partitions inside per-variable or per-row loops; compute the owner-side role/set partition once when the operation needs it repeatedly.
 

--- a/.agents/skills/domain-responsibility-review/SKILL.md
+++ b/.agents/skills/domain-responsibility-review/SKILL.md
@@ -36,7 +36,7 @@ Treat this as a review pre-pass, not as the required final response order. When 
    - Lead each finding with the broken responsibility or invariant.
    - Then point to the concrete code path and explain how the operation can violate that domain rule.
    - Proposed fixes should name the owning abstraction and route the operation through it.
-   - If the task is addressing review feedback rather than writing a review, combine this pre-pass with the user-level `review-response` skill: reconstruct the reviewer concern, search for sibling defects, and fix the responsibility boundary rather than only the commented line.
+   - If the task is addressing review feedback rather than writing a review, keep the workflow self-contained: read the exact comment and surrounding diff, reconstruct the reviewer concern, search for sibling defects, and fix the responsibility boundary rather than only the commented line.
 
 ## Recurring OMMX Review Checks
 

--- a/.agents/skills/release-note/SKILL.md
+++ b/.agents/skills/release-note/SKILL.md
@@ -1,72 +1,107 @@
 ---
 name: release-note
-description: Append release note entries for the current PR to both English and Japanese release notes
-argument-hint: "[version e.g. 3.0]"
-disable-model-invocation: true
-allowed-tools: "Bash(git *) Bash(gh *) Read Edit"
+description: Append release note entries for the current PR to the relevant OMMX Python SDK and/or Rust SDK release notes
 ---
 
 # Release Note Writer
 
-Write release note entries for the current branch's PR in both English and Japanese.
+Write release note entries for the current branch's PR in the relevant SDK release notes.
 
 ## Scope
 
-This is the **Python SDK** release note. Only include changes visible to Python SDK users:
+OMMX has separate release note surfaces:
+
+- **Python SDK**: `docs/en/release_note/ommx-{version}.md` and `docs/ja/release_note/ommx-{version}.md`
+- **Rust SDK**: `rust/ommx/doc/release_note.md`
+
+Add entries only to the surfaces affected by the PR.
+
+For the **Python SDK** release note, include changes visible to Python users:
 - New Python API, classes, methods, properties
 - Behavior changes in Python SDK
 - Bug fixes affecting Python users
 - Adapter changes
 
+For the **Rust SDK** release note, include changes visible to Rust crate users:
+- New or changed public Rust API
+- Behavior changes in the Rust SDK
+- Bug fixes affecting Rust SDK users
+- Serialization, schema, or error-surface changes exposed through Rust APIs
+
 Do NOT include:
-- Rust SDK internal changes (unless they surface as Python API changes)
+- Rust SDK internal changes that do not affect the public Rust API or user-visible behavior
+- Python SDK internal changes that do not affect Python users
 - CI/CD, documentation-only, or tooling changes
 - AGENTS.md or development workflow changes
 
 ## Steps
 
-1. Determine the target version from `$ARGUMENTS` (e.g. "3.0"). If not provided, infer from the latest file in `docs/en/release_note/`.
-
-2. Identify the current PR:
+1. Identify the current PR:
    ```
    gh pr view --json number,title,body,url
    ```
 
-3. Understand what changed by reviewing the full diff against main:
+2. Understand what changed by reviewing the full diff against main:
    ```
    git diff main...HEAD
    ```
 
-4. Read the existing release note files:
-   - `docs/en/release_note/ommx-{version}.md`
-   - `docs/ja/release_note/ommx-{version}.md`
+3. Decide which release note surfaces are affected:
+   - Python SDK changes go to both language files:
+     - `docs/en/release_note/ommx-{version}.md`
+     - `docs/ja/release_note/ommx-{version}.md`
+   - Rust SDK changes go to:
+     - `rust/ommx/doc/release_note.md`
+   - If a PR affects both SDKs, update all affected files.
 
-5. Check whether the same user-facing behavior is already explained in Tutorial
+4. Determine the target Python SDK version only if Python release notes are
+   affected. Use `$ARGUMENTS` (e.g. "3.0") when provided; otherwise infer from
+   the latest file in `docs/en/release_note/`.
+
+5. Read the existing release note files for the affected surfaces. For Rust-only
+   changes, do not edit the Python release note files.
+
+6. Check whether the same user-facing behavior is already explained in Tutorial
    or User Guide pages under `docs/en/` and `docs/ja/`. When detailed docs
    already exist, keep the release note concise and link readers to the
-   relevant Tutorial/User Guide section instead of duplicating the full
-   explanation.
+   relevant Tutorial/User Guide section instead of duplicating the full explanation.
+   For Rust SDK changes, also check `rust/ommx/doc/` and prefer concise links to
+   existing Rust docs such as the migration guide when appropriate.
 
-6. Append entries to both files following the existing format:
+7. Append Python SDK entries to both language files following the existing format:
    - Use `###` headings with PR link: `### Feature name ([#NNN](https://github.com/Jij-Inc/ommx/pull/NNN))`
    - Place under appropriate `##` section (New Features, Bug Fixes, Breaking Changes, etc.)
    - Include code examples if the change adds new API
    - English first, then write the Japanese version as a natural translation (not machine-translated tone)
 
-7. Show the user the diff of what was added for review.
+8. Append Rust SDK entries to `rust/ommx/doc/release_note.md` following the existing format:
+   - Use `##` headings with PR link: `## Feature name ([#NNN](https://github.com/Jij-Inc/ommx/pull/NNN))`
+   - Write in English for docs.rs.
+   - Use Rustdoc links such as ``[`Instance`](crate::Instance)`` for public Rust items.
+   - Keep the entry focused on the Rust user's migration or behavior impact.
+
+9. Show the user the diff of what was added for review.
 
 ## Format reference
 
-English:
+Python English:
 ```markdown
 ### Feature name ([#123](https://github.com/Jij-Inc/ommx/pull/123))
 
 Description of the change from the user's perspective. Include code examples for new API.
 ```
 
-Japanese:
+Python Japanese:
 ```markdown
 ### 機能名 ([#123](https://github.com/Jij-Inc/ommx/pull/123))
 
 ユーザー視点での変更の説明。新しいAPIにはコード例を含める。
+```
+
+Rust:
+```markdown
+## Feature name ([#123](https://github.com/Jij-Inc/ommx/pull/123))
+
+Describe the Rust SDK API or behavior impact. Use Rustdoc links such as
+[`Instance`](crate::Instance) when naming public items.
 ```

--- a/.agents/skills/rust-module-boundary/SKILL.md
+++ b/.agents/skills/rust-module-boundary/SKILL.md
@@ -24,12 +24,17 @@ Use `.agents/skills/domain-responsibility-review/SKILL.md` first when a change h
    - Use public crate API only when the item is an intentional SDK commitment.
    - Use `pub(crate)` only when the item must cross top-level module boundaries in this crate.
 
-3. Avoid visibility as a shortcut.
+3. Document public owner invariants.
+   - For each public Rust struct, put the invariants it owns in the struct-level Rustdoc when possible.
+   - Name the constructor, parser, builder, or owning host API that preserves those invariants.
+   - If public fields or public mutation methods exist, the docs should make clear which values callers may set directly and which owner-level invariants still must hold.
+
+4. Avoid visibility as a shortcut.
    - Do not use `pub(super)` or `pub(in ...)` to patch around an awkward module hierarchy.
    - First reconsider whether the module tree should express the ownership boundary more directly.
    - Do not expose raw registry, descriptor, config, or persistence plumbing just to make a caller convenient.
 
-4. Document crate-wide visibility.
+5. Document crate-wide visibility.
    - If `pub(crate)` is necessary, add a short comment or documentation explaining why the item must cross top-level module boundaries.
    - The reason should name the owner boundary or cross-module contract, not just "used elsewhere".
 
@@ -42,6 +47,7 @@ Use `.agents/skills/domain-responsibility-review/SKILL.md` first when a change h
 2. Check for hidden API commitments.
    - Public Rust items are SDK commitments unless they are protected by a private module boundary.
    - Raw OCI descriptors, registry handles, config internals, and persistence helpers should not leak into public APIs unless the low-level API is explicitly intended.
+   - Public structs should document the invariants they expect callers and owner APIs to preserve; missing Rustdoc is a review risk when the struct has public fields or construction paths.
 
 3. Check for invariant bypass.
    - A caller should not be able to mutate or construct state in a way that skips the owning abstraction's validation.
@@ -57,6 +63,7 @@ Use `.agents/skills/domain-responsibility-review/SKILL.md` first when a change h
 - Which domain abstraction or subsystem owns this item?
 - Which callers genuinely need access?
 - Is this an SDK commitment, crate-internal contract, private-module contract, or implementation detail?
+- Does each public struct document its owned invariants and intended construction/mutation paths?
 - Does the module tree express that boundary without `pub(super)` or `pub(in ...)`?
 - If `pub(crate)` is used, is the cross-module reason documented?
 - Can any visible item let callers bypass validation, persistence, or source-of-truth invariants?


### PR DESCRIPTION
## Summary
- Refines the domain-responsibility review skill so it is explicitly a review pre-pass, while keeping actionable findings first.
- Adds recurring OMMX review checks for constraint families, round-trip behavior, atomic mutation paths, numeric edge cases, and public API surfaces.
- Expands the release-note skill to distinguish Python SDK and Rust SDK release note surfaces and to route changes to the relevant files only.
- Updates release-note instructions and examples to match the separate Python and Rust formats.

## Notes
- Not run (documentation-only change).