### PR TITLE
Reject dependent variable fixes in partial evaluation

### DIFF
--- a/python/ommx-tests/tests/test_decision_variable_usage.py
+++ b/python/ommx-tests/tests/test_decision_variable_usage.py
@@ -61,10 +61,10 @@ def test_partial_evaluate_rejects_dependent_variable_value():
     )
     instance.substitute({10: x[1] + x[1]})
 
-    with pytest.raises(ValueError, match="cannot be fixed"):
+    with pytest.raises(ValueError, match=r"ID=10.*cannot be fixed"):
         instance.partial_evaluate({10: 4.0})
 
-    with pytest.raises(ValueError, match="cannot be fixed"):
+    with pytest.raises(ValueError, match=r"ID=10.*cannot be fixed"):
         instance.partial_evaluate({1: 2.0, 10: 4.0})
 
     assert instance.fixed_decision_variables() == {}

--- a/python/ommx-tests/tests/test_decision_variable_usage.py
+++ b/python/ommx-tests/tests/test_decision_variable_usage.py
@@ -64,6 +64,9 @@ def test_partial_evaluate_rejects_dependent_variable_value():
     with pytest.raises(ValueError, match="cannot be fixed"):
         instance.partial_evaluate({10: 4.0})
 
+    with pytest.raises(ValueError, match="cannot be fixed"):
+        instance.partial_evaluate({1: 2.0, 10: 4.0})
+
     assert instance.fixed_decision_variables() == {}
     assert instance.dependent_decision_variable_ids() == {10}
 

--- a/python/ommx-tests/tests/test_decision_variable_usage.py
+++ b/python/ommx-tests/tests/test_decision_variable_usage.py
@@ -1,5 +1,7 @@
 """Test decision-variable role and used-variable APIs."""
 
+import pytest
+
 from ommx.v1 import DecisionVariable, DecisionVariableRole, Instance
 
 
@@ -46,6 +48,43 @@ def test_decision_variable_role_partitions():
     assert instance.attached_decision_variable(1).substituted_value == 2.0
     assert instance.dependent_decision_variable_ids() == {2}
     assert instance.irrelevant_decision_variable_ids() == {3}
+
+
+def test_partial_evaluate_rejects_dependent_variable_value():
+    """A dependent variable is owned by decision_variable_dependency, not fixed values."""
+    x = {i: DecisionVariable.continuous(i) for i in [1, 10]}
+    instance = Instance.from_components(
+        decision_variables=list(x.values()),
+        objective=x[1],
+        constraints={},
+        sense=Instance.MINIMIZE,
+    )
+    instance.substitute({10: x[1] + x[1]})
+
+    with pytest.raises(ValueError, match="cannot be fixed"):
+        instance.partial_evaluate({10: 4.0})
+
+    assert instance.fixed_decision_variables() == {}
+    assert instance.dependent_decision_variable_ids() == {10}
+
+
+def test_partial_evaluate_keeps_constant_dependency_dependent():
+    """Fixing dependency inputs can make the RHS constant without making the key fixed."""
+    x = {i: DecisionVariable.continuous(i) for i in [1, 10]}
+    instance = Instance.from_components(
+        decision_variables=list(x.values()),
+        objective=x[1],
+        constraints={},
+        sense=Instance.MINIMIZE,
+    )
+    instance.substitute({10: x[1] + x[1]})
+
+    updated = instance.partial_evaluate({1: 2.0})
+
+    assert updated.fixed_decision_variables() == {1: 2.0}
+    assert updated.dependent_decision_variable_ids() == {10}
+    assert updated.decision_variable_role(10) == DecisionVariableRole.Dependent
+    assert updated.populate_state({}).entries == {1: 2.0, 10: 4.0}
 
 
 def test_bound_wrapper_functionality():

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -332,13 +332,18 @@ impl Evaluate for Instance {
 
         // Phase 2: Store fixed values in the root-owned table.
         for (id, value) in expanded_state.entries.iter() {
-            let Some(dv) = working.decision_variables.get_mut(&VariableID::from(*id)) else {
+            let var_id = VariableID::from(*id);
+            if working.decision_variable_dependency.get(&var_id).is_some() {
+                return Err(crate::error!(
+                    "Dependent variable {var_id:?} cannot be fixed by partial_evaluate"
+                ));
+            }
+            let Some(dv) = working.decision_variables.get_mut(&var_id) else {
                 return Err(crate::error!(
                     "Unknown decision variable (ID={id}) in state."
                 ));
             };
             dv.check_value_consistency(*value, atol)?;
-            let var_id = VariableID::from(*id);
             if let Some(previous_value) = working.fixed_decision_variable_values.get(&var_id) {
                 if !values_are_consistent(*previous_value, *value, atol) {
                     return Err(crate::DecisionVariableError::SubstitutedValueOverwrite {
@@ -587,6 +592,48 @@ mod tests {
             instance.fixed_decision_variable_value(VariableID::from(2)),
             Some(0.0)
         );
+    }
+
+    #[test]
+    fn test_partial_evaluate_rejects_dependent_variable_fixing() {
+        let decision_variables = BTreeMap::from([
+            (
+                VariableID::from(1),
+                crate::DecisionVariable::continuous(VariableID::from(1)),
+            ),
+            (
+                VariableID::from(10),
+                crate::DecisionVariable::continuous(VariableID::from(10)),
+            ),
+        ]);
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(linear!(1)))
+            .decision_variables(decision_variables)
+            .constraints(BTreeMap::new())
+            .decision_variable_dependency(crate::assign! {
+                10 <- linear!(1)
+            })
+            .build()
+            .unwrap();
+
+        let state = v1::State::from(HashMap::from([(10, 1.0)]));
+        let err = instance
+            .partial_evaluate(&state, ATol::default())
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("cannot be fixed"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            instance.fixed_decision_variable_value(VariableID::from(10)),
+            None
+        );
+        assert!(instance
+            .decision_variable_dependency
+            .get(&VariableID::from(10))
+            .is_some());
     }
 
     #[test]

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -612,12 +612,12 @@ mod tests {
             .decision_variables(decision_variables)
             .constraints(BTreeMap::new())
             .decision_variable_dependency(crate::assign! {
-                10 <- linear!(1)
+                10 <- coeff!(2.0) * linear!(1)
             })
             .build()
             .unwrap();
 
-        let state = v1::State::from(HashMap::from([(10, 1.0)]));
+        let state = v1::State::from(HashMap::from([(1, 2.0), (10, 4.0)]));
         let err = instance
             .partial_evaluate(&state, ATol::default())
             .unwrap_err();

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -335,7 +335,7 @@ impl Evaluate for Instance {
             let var_id = VariableID::from(*id);
             if working.decision_variable_dependency.get(&var_id).is_some() {
                 return Err(crate::error!(
-                    "Dependent variable {var_id:?} cannot be fixed by partial_evaluate"
+                    "Dependent variable (ID={id}) cannot be fixed by partial_evaluate"
                 ));
             }
             let Some(dv) = working.decision_variables.get_mut(&var_id) else {
@@ -623,7 +623,8 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            err.to_string().contains("cannot be fixed"),
+            err.to_string()
+                .contains("Dependent variable (ID=10) cannot be fixed"),
             "unexpected error: {err}"
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- Reject `Instance::partial_evaluate` states that try to fix a dependent decision variable.
- Return before writing root-owned fixed values, preserving `partial_evaluate` atomicity on invalid input.
- Add Rust and Python SDK regression coverage for the fixed/dependent role partition.

## Root Cause

Before #959, `partial_evaluate` wrote fixed values into each `DecisionVariable.substituted_value`. That already allowed a dependent variable to become both substituted and dependent when the state contained a `decision_variable_dependency` key. The value could remain consistent at evaluation time, but the instance role partition was no longer normalized.

PR #959 moved substituted decision-variable values into the `Instance`-owned fixed-value table. The same behavior then became an explicit overlap between `fixed_decision_variable_values` and `decision_variable_dependency`, bypassing the builder invariant that fixed and dependent variables are disjoint.

## Impact

This keeps `Instance` role ownership consistent after partial evaluation: dependent variables remain owned by `decision_variable_dependency`, while root-owned fixed values are limited to non-dependent variables.

For a dependency such as `y = 2 * x`, `partial_evaluate({x: 2})` may reduce the dependency to a constant RHS while keeping `y` dependent. `partial_evaluate({y: 4})` and even the redundant consistent state `partial_evaluate({x: 2, y: 4})` are rejected because they try to fix the dependent key itself.
