### PR TITLE
Normalize named function table ownership

### DIFF
--- a/.agents/skills/domain-responsibility-review/SKILL.md
+++ b/.agents/skills/domain-responsibility-review/SKILL.md
@@ -18,6 +18,10 @@ Treat this as a review pre-pass, not as the required final response order. When 
 
 2. Identify domain invariants.
    - For each domain object or boundary, state the invariants it must preserve.
+   - Separate invariants by the layer that can actually know and enforce them.
+     A collection/table can usually own key and sidecar consistency, while a
+     top-level object such as `Instance`, `Solution`, or `SampleSet` must own
+     cross-table semantic invariants such as "referenced variable IDs exist".
    - Check whether those invariants are explicit in code, types, config schema, constructors, validation functions, documentation, or tests.
    - If an invariant is only implicit, treat that as a review risk unless the surrounding code makes it unavoidable.
 
@@ -28,6 +32,11 @@ Treat this as a review pre-pass, not as the required final response order. When 
 
 4. Verify invariant preservation.
    - Look for operations that can create invalid states, bypass validation, duplicate the source of truth, expose internal descriptors, or let callers mutate state outside the owner boundary.
+   - Check every construction layer that can bypass another layer: builders,
+     parsers, unchecked constructors, restore/projection helpers, per-sample
+     extraction, and Python wrappers. If a lower-level collection cannot
+     validate a semantic invariant alone, verify that every host-level entry
+     point validates it before exposing the object.
    - Check load/restore paths as carefully as write paths; persisted config and runtime state must preserve the same invariants.
    - Check dynamic and sealed views against the same domain model.
    - Check lock scopes against domain ownership: keep mutexes only around the shared state protected by that owner, and move slow I/O, registry writes, or storage writes outside the lock when the final owner mutation can still enforce the invariant.
@@ -46,6 +55,12 @@ Treat this as a review pre-pass, not as the required final response order. When 
 - For numeric consistency checks, handle boundary and invalid values explicitly. Absolute tolerances are inclusive unless the API documents otherwise, and NaN/Inf must not pass through `(a - b).abs() > atol` style comparisons silently.
 - For public API changes, check all user-facing surfaces together: Rust docs, Python docs, migration guides, stubs, examples, DataFrame flags, docstrings, and Python magic-method return contracts.
 - For public Rust structs, check whether the struct-level Rustdoc states the invariants that the type owns: valid IDs, active/removed disjointness, sidecar key coverage, non-empty sets, finite/non-zero numeric values, reserved annotation namespaces, or host-level serialization requirements. If callers can construct or mutate the struct, the docs should name the intended constructors or owner APIs that preserve those invariants.
+- For table/collection refactors, distinguish table-level invariants from
+  host-level invariants. A table may own row IDs and label/context sidecars,
+  but only the enclosing `Instance`, `Solution`, or `SampleSet` can prove that
+  row payloads reference known decision variables, parameters, samples, or
+  constraints. Review both the lower-level table API and every top-level
+  builder/parser/unchecked path.
 - For new builder/setter/attachment APIs, add focused tests for both preservation and rejection paths, such as sidecar round-trips and orphan-ID validation.
 - For derived analysis or table-building code, avoid recomputing whole-instance partitions inside per-variable or per-row loops; compute the owner-side role/set partition once when the operation needs it repeatedly.
 
@@ -53,8 +68,11 @@ Treat this as a review pre-pass, not as the required final response order. When 
 
 - What is the global domain meaning of this change?
 - Which object owns each source of truth?
-- Which invariants are required by each domain object or boundary?
+- Which invariants are required by each domain object or boundary, and at what
+  layer are they enforceable?
 - Are those invariants explicitly represented or validated?
+- Are lower-level collection invariants and top-level semantic invariants both
+  documented and tested?
 - Which operations can bypass the owner or invalidate the invariant?
 - Are mutex or lock scopes limited to the protected domain state, with slow I/O or persistence kept outside when possible?
 - Do sealed, dynamic, persisted, and Python-facing paths preserve the same model?

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -18176,7 +18176,7 @@
         {
           "kind": "Class",
           "name": "NamedFunction",
-          "doc": "NamedFunction wrapper for Python.\n\nHolds the Rust `NamedFunction` plus an owned snapshot of its label\n(`name` / `subscripts` / `parameters` / `description`). The label\nstore lives at the host (`Instance` / `Solution` / `SampleSet`) level;\nwhen a wrapper is created via a host accessor, the host snapshots its\nstore into the second tuple slot. Mutations on a wrapper do NOT\npropagate back to the host — re-insert via `Instance.from_components`\n(or equivalent) to apply changes. Same shape as `Constraint` /\n`DecisionVariable` after PR #843.",
+          "doc": "NamedFunction wrapper for Python.\n\nHolds the Rust `NamedFunction` plus an owned snapshot of its label\n(`name` / `subscripts` / `parameters` / `description`). The label\nstore lives at the host (`Instance` / `Solution` / `SampleSet`) level;\nwhen a wrapper is created via a host accessor, the host snapshots its\nstore into the third tuple slot. Mutations on a wrapper do NOT\npropagate back to the host — re-insert via `Instance.from_components`\n(or equivalent) to apply changes. Same shape as `Constraint` /\n`DecisionVariable` after PR #843.",
           "bases": [],
           "methods": [
             {

--- a/python/ommx-tests/tests/test_named_function.py
+++ b/python/ommx-tests/tests/test_named_function.py
@@ -6,10 +6,13 @@ from ommx.v1 import (
     Instance,
     Linear,
     NamedFunction,
+    Parameter,
+    ParametricInstance,
     Constraint,
     State,
 )
 import ommx._ommx_rust as rust
+import pytest
 
 
 def _make_instance_with_named_functions():
@@ -226,6 +229,64 @@ class TestInstanceNamedFunctions:
             sense=Instance.MINIMIZE,
         )
         assert instance.named_functions == []
+
+    def test_from_components_rejects_duplicate_named_function_ids(self):
+        x = DecisionVariable.binary(0)
+        first = NamedFunction(id=0, function=x, name="first")
+        second = NamedFunction(id=0, function=x + 1, name="second")
+
+        with pytest.raises(RuntimeError, match="Duplicate named function ID: 0"):
+            Instance.from_components(
+                decision_variables=[x],
+                objective=x,
+                constraints={},
+                sense=Instance.MINIMIZE,
+                named_functions=[first, second],
+            )
+
+    def test_from_components_rejects_named_function_unknown_variable(self):
+        x = DecisionVariable.binary(0)
+        rogue = NamedFunction(id=0, function=DecisionVariable.binary(999))
+
+        with pytest.raises(RuntimeError, match="VariableID\\(999\\)"):
+            Instance.from_components(
+                decision_variables=[x],
+                objective=x,
+                constraints={},
+                sense=Instance.MINIMIZE,
+                named_functions=[rogue],
+            )
+
+    def test_parametric_from_components_accepts_named_function_parameter(self):
+        x = DecisionVariable.binary(0)
+        p = Parameter(100, name="p")
+        nf = NamedFunction(id=0, function=x + p, name="with_parameter")
+
+        parametric = ParametricInstance.from_components(
+            decision_variables=[x],
+            parameters=[p],
+            objective=x + p,
+            constraints={},
+            sense=Instance.MINIMIZE,
+            named_functions=[nf],
+        )
+
+        assert parametric.named_functions[0].name == "with_parameter"
+
+    def test_parametric_from_components_rejects_named_function_unknown_id(self):
+        x = DecisionVariable.binary(0)
+        p = Parameter(100, name="p")
+        rogue = NamedFunction(id=0, function=DecisionVariable.binary(999))
+
+        with pytest.raises(RuntimeError, match="VariableID\\(999\\)"):
+            ParametricInstance.from_components(
+                decision_variables=[x],
+                parameters=[p],
+                objective=x + p,
+                constraints={},
+                sense=Instance.MINIMIZE,
+                named_functions=[rogue],
+            )
 
 
 class TestSolutionNamedFunctions:

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -4383,7 +4383,7 @@ class NamedFunction:
     (`name` / `subscripts` / `parameters` / `description`). The label
     store lives at the host (`Instance` / `Solution` / `SampleSet`) level;
     when a wrapper is created via a host accessor, the host snapshots its
-    store into the second tuple slot. Mutations on a wrapper do NOT
+    store into the third tuple slot. Mutations on a wrapper do NOT
     propagate back to the host — re-insert via `Instance.from_components`
     (or equivalent) to apply changes. Same shape as `Constraint` /
     `DecisionVariable` after PR #843.

--- a/python/ommx/src/evaluated_named_function.rs
+++ b/python/ommx/src/evaluated_named_function.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 #[pyclass]
 #[derive(Clone)]
 pub struct EvaluatedNamedFunction(
+    pub ommx::NamedFunctionID,
     pub ommx::EvaluatedNamedFunction,
     pub ommx::NamedFunctionLabel,
 );
@@ -18,37 +19,37 @@ pub struct EvaluatedNamedFunction(
 impl EvaluatedNamedFunction {
     #[getter]
     pub fn id(&self) -> u64 {
-        self.0.id.into_inner()
+        self.0.into_inner()
     }
 
     #[getter]
     pub fn evaluated_value(&self) -> f64 {
-        self.0.evaluated_value()
+        self.1.evaluated_value()
     }
 
     #[getter]
     pub fn name(&self) -> Option<String> {
-        self.1.name.clone()
+        self.2.name.clone()
     }
 
     #[getter]
     pub fn subscripts(&self) -> Vec<i64> {
-        self.1.subscripts.clone()
+        self.2.subscripts.clone()
     }
 
     #[getter]
     pub fn parameters(&self) -> HashMap<String, String> {
-        self.1.parameters.clone().into_iter().collect()
+        self.2.parameters.clone().into_iter().collect()
     }
 
     #[getter]
     pub fn description(&self) -> Option<String> {
-        self.1.description.clone()
+        self.2.description.clone()
     }
 
     #[getter]
     pub fn used_decision_variable_ids(&self) -> HashSet<u64> {
-        self.0
+        self.1
             .used_decision_variable_ids()
             .iter()
             .map(|id| id.into_inner())
@@ -56,7 +57,11 @@ impl EvaluatedNamedFunction {
     }
 
     pub fn __repr__(&self) -> String {
-        self.0.to_string()
+        format!(
+            "EvaluatedNamedFunction(id={}, value={})",
+            self.0.into_inner(),
+            self.1.evaluated_value()
+        )
     }
 
     fn __copy__(&self) -> Self {

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -185,9 +185,9 @@ impl Instance {
         if let Some(nfs) = named_functions {
             let mut rust_named_functions = BTreeMap::new();
             for nf in nfs {
-                let id = nf.0.id;
-                named_function_labels.insert(id, nf.1);
-                if rust_named_functions.insert(id, nf.0).is_some() {
+                let id = nf.0;
+                named_function_labels.insert(id, nf.2);
+                if rust_named_functions.insert(id, nf.1).is_some() {
                     anyhow::bail!("Duplicate named function ID: {}", id.into_inner());
                 }
             }
@@ -676,7 +676,7 @@ impl Instance {
             .named_functions()
             .iter()
             .map(|(id, named_function)| {
-                NamedFunction(named_function.clone(), labels.collect_for(*id))
+                NamedFunction(*id, named_function.clone(), labels.collect_for(*id))
             })
             .collect()
     }
@@ -2133,17 +2133,21 @@ impl Instance {
     ) -> PyResult<Bound<'py, PyDataFrame>> {
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let nf_meta_store = self.inner.named_function_labels().clone();
-        let nf_meta_view: Vec<(ommx::NamedFunctionLabel, &ommx::NamedFunction)> = self
+        let nf_meta_view: Vec<(
+            ommx::NamedFunctionLabel,
+            ommx::NamedFunctionID,
+            &ommx::NamedFunction,
+        )> = self
             .inner
             .named_functions()
             .iter()
-            .map(|(id, nf)| (nf_meta_store.collect_for(*id), nf))
+            .map(|(id, nf)| (nf_meta_store.collect_for(*id), *id, nf))
             .collect();
         entries_to_dataframe(
             py,
             nf_meta_view
                 .iter()
-                .map(|(m, nf)| crate::pandas::WithModelingContext::new(*nf, m)),
+                .map(|(m, id, nf)| crate::pandas::WithModelingContext::new((*id, *nf), m)),
             "id",
             flags,
         )
@@ -2456,6 +2460,7 @@ impl Instance {
             .get(&id)
             .map(|named_function| {
                 NamedFunction(
+                    id,
                     named_function.clone(),
                     self.inner.named_function_labels().collect_for(id),
                 )

--- a/python/ommx/src/named_function.rs
+++ b/python/ommx/src/named_function.rs
@@ -16,7 +16,11 @@ use std::collections::HashMap;
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
 #[derive(Clone)]
-pub struct NamedFunction(pub ommx::NamedFunction, pub ommx::NamedFunctionLabel);
+pub struct NamedFunction(
+    pub ommx::NamedFunctionID,
+    pub ommx::NamedFunction,
+    pub ommx::NamedFunctionLabel,
+);
 
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
@@ -45,7 +49,6 @@ impl NamedFunction {
         let named_function_id = NamedFunctionID::from(id);
 
         let named_function = ommx::NamedFunction {
-            id: named_function_id,
             function: rust_function,
         };
         let label = ommx::NamedFunctionLabel {
@@ -55,37 +58,37 @@ impl NamedFunction {
             description,
         };
 
-        Ok(Self(named_function, label))
+        Ok(Self(named_function_id, named_function, label))
     }
 
     #[getter]
     pub fn id(&self) -> u64 {
-        self.0.id.into_inner()
+        self.0.into_inner()
     }
 
     #[getter]
     pub fn function(&self) -> Function {
-        Function(self.0.function.clone())
+        Function(self.1.function.clone())
     }
 
     #[getter]
     pub fn name(&self) -> Option<String> {
-        self.1.name.clone()
+        self.2.name.clone()
     }
 
     #[getter]
     pub fn subscripts(&self) -> Vec<i64> {
-        self.1.subscripts.clone()
+        self.2.subscripts.clone()
     }
 
     #[getter]
     pub fn parameters(&self) -> HashMap<String, String> {
-        self.1.parameters.clone().into_iter().collect()
+        self.2.parameters.clone().into_iter().collect()
     }
 
     #[getter]
     pub fn description(&self) -> Option<String> {
-        self.1.description.clone()
+        self.2.description.clone()
     }
 
     /// Evaluate the named function with the given state.
@@ -104,12 +107,12 @@ impl NamedFunction {
             None => ommx::ATol::default(),
         };
         let evaluated = self
-            .0
+            .1
             .evaluate(&state.0, atol)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         // Per-element evaluate doesn't see the host's label store, so the
         // label snapshot from the source `NamedFunction` carries over.
-        Ok(EvaluatedNamedFunction(evaluated, self.1.clone()))
+        Ok(EvaluatedNamedFunction(self.0, evaluated, self.2.clone()))
     }
 
     /// Partially evaluate the named function with the given state.
@@ -129,7 +132,7 @@ impl NamedFunction {
                 .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?,
             None => ommx::ATol::default(),
         };
-        self.0
+        self.1
             .partial_evaluate(&state.0, atol)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         Ok(self.clone())
@@ -155,7 +158,7 @@ impl NamedFunction {
     /// Reverse subtraction: returns other - self.function
     pub fn __rsub__(&self, other: Function) -> PyResult<Function> {
         Ok(Function(
-            (&other.0 - &self.0.function).map_err(crate::coefficient_error_to_pyerr)?,
+            (&other.0 - &self.1.function).map_err(crate::coefficient_error_to_pyerr)?,
         ))
     }
 
@@ -171,7 +174,7 @@ impl NamedFunction {
 
     /// Negation: returns -self.function
     pub fn __neg__(&self) -> Function {
-        Function(-self.0.function.clone())
+        Function(-self.1.function.clone())
     }
 
     // Comparison operators - return Constraint
@@ -184,7 +187,7 @@ impl NamedFunction {
     #[gen_stub(type_ignore = ["override"])]
     #[pyo3(name = "__eq__")]
     pub fn py_eq(&self, other: Function) -> PyResult<Constraint> {
-        crate::comparison_constraint(-other.0 + &self.0.function, ommx::Equality::EqualToZero)
+        crate::comparison_constraint(-other.0 + &self.1.function, ommx::Equality::EqualToZero)
     }
 
     /// Create a less-than-or-equal constraint: self.function <= other → Constraint with LessThanOrEqualToZero
@@ -193,7 +196,7 @@ impl NamedFunction {
     #[pyo3(name = "__le__")]
     pub fn py_le(&self, other: Function) -> PyResult<Constraint> {
         crate::comparison_constraint(
-            -other.0 + &self.0.function,
+            -other.0 + &self.1.function,
             ommx::Equality::LessThanOrEqualToZero,
         )
     }
@@ -204,13 +207,17 @@ impl NamedFunction {
     #[pyo3(name = "__ge__")]
     pub fn py_ge(&self, other: Function) -> PyResult<Constraint> {
         crate::comparison_constraint(
-            other.0 - &self.0.function,
+            other.0 - &self.1.function,
             ommx::Equality::LessThanOrEqualToZero,
         )
     }
 
     pub fn __repr__(&self) -> String {
-        self.0.to_string()
+        format!(
+            "NamedFunction(id={}, {})",
+            self.0.into_inner(),
+            self.1.function
+        )
     }
 
     fn __copy__(&self) -> Self {

--- a/python/ommx/src/named_function.rs
+++ b/python/ommx/src/named_function.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 /// (`name` / `subscripts` / `parameters` / `description`). The label
 /// store lives at the host (`Instance` / `Solution` / `SampleSet`) level;
 /// when a wrapper is created via a host accessor, the host snapshots its
-/// store into the second tuple slot. Mutations on a wrapper do NOT
+/// store into the third tuple slot. Mutations on a wrapper do NOT
 /// propagate back to the host — re-insert via `Instance.from_components`
 /// (or equivalent) to apply changes. Same shape as `Constraint` /
 /// `DecisionVariable` after PR #843.

--- a/python/ommx/src/pandas.rs
+++ b/python/ommx/src/pandas.rs
@@ -1289,12 +1289,18 @@ impl<'m> ToPandasEntry
     }
 }
 
-impl<'m> ToPandasEntry for WithModelingContext<'m, &ommx::NamedFunction, ommx::NamedFunctionLabel> {
+impl<'m> ToPandasEntry
+    for WithModelingContext<
+        'm,
+        (ommx::NamedFunctionID, &ommx::NamedFunction),
+        ommx::NamedFunctionLabel,
+    >
+{
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let nf = self.item;
+        let (id, nf) = self.item;
         let m = self.context;
         let dict = PyDict::new(py);
-        dict.set_item("id", nf.id.into_inner())?;
+        dict.set_item("id", id.into_inner())?;
         set_function_type(&dict, &nf.function)?;
         dict.set_item("function", crate::Function(nf.function.clone()))?;
         set_used_ids(&dict, &nf.function.required_ids())?;
@@ -1387,13 +1393,17 @@ impl<'m> ToPandasEntry
 }
 
 impl<'m> ToPandasEntry
-    for WithModelingContext<'m, &ommx::EvaluatedNamedFunction, ommx::NamedFunctionLabel>
+    for WithModelingContext<
+        'm,
+        (ommx::NamedFunctionID, &ommx::EvaluatedNamedFunction),
+        ommx::NamedFunctionLabel,
+    >
 {
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let enf = self.item;
+        let (id, enf) = self.item;
         let m = self.context;
         let dict = PyDict::new(py);
-        dict.set_item("id", enf.id.into_inner())?;
+        dict.set_item("id", id.into_inner())?;
         dict.set_item("value", enf.evaluated_value())?;
         set_used_ids(&dict, enf.used_decision_variable_ids())?;
         set_label_columns(
@@ -1482,15 +1492,15 @@ impl<'a, 'm> ToPandasEntry
 impl<'a, 'm> ToPandasEntry
     for WithModelingContext<
         'm,
-        WithSampleIds<'a, &'a ommx::SampledNamedFunction>,
+        WithSampleIds<'a, (ommx::NamedFunctionID, &'a ommx::SampledNamedFunction)>,
         ommx::NamedFunctionLabel,
     >
 {
     fn to_pandas_entry<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let nf = self.item.item;
+        let (id, nf) = self.item.item;
         let m = self.context;
         let dict = PyDict::new(py);
-        dict.set_item("id", nf.id().into_inner())?;
+        dict.set_item("id", id.into_inner())?;
         set_used_ids(&dict, nf.used_decision_variable_ids())?;
         set_label_columns(
             &dict,

--- a/python/ommx/src/parametric_instance.rs
+++ b/python/ommx/src/parametric_instance.rs
@@ -138,9 +138,9 @@ impl ParametricInstance {
         if let Some(nfs) = named_functions {
             let mut rust_named_functions = BTreeMap::new();
             for nf in nfs {
-                let id = nf.0.id;
-                named_function_labels.insert(id, nf.1);
-                if rust_named_functions.insert(id, nf.0).is_some() {
+                let id = nf.0;
+                named_function_labels.insert(id, nf.2);
+                if rust_named_functions.insert(id, nf.1).is_some() {
                     anyhow::bail!("Duplicate named function ID: {}", id.into_inner());
                 }
             }
@@ -580,7 +580,7 @@ impl ParametricInstance {
         self.inner
             .named_functions()
             .iter()
-            .map(|(id, nf)| NamedFunction(nf.clone(), labels.collect_for(*id)))
+            .map(|(id, nf)| NamedFunction(*id, nf.clone(), labels.collect_for(*id)))
             .collect()
     }
 
@@ -672,6 +672,7 @@ impl ParametricInstance {
             .get(&id)
             .map(|nf| {
                 NamedFunction(
+                    id,
                     nf.clone(),
                     self.inner.named_function_labels().collect_for(id),
                 )
@@ -817,17 +818,21 @@ impl ParametricInstance {
     ) -> PyResult<Bound<'py, PyDataFrame>> {
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let nf_meta_store = self.inner.named_function_labels().clone();
-        let nf_meta_view: Vec<(ommx::NamedFunctionLabel, &ommx::NamedFunction)> = self
+        let nf_meta_view: Vec<(
+            ommx::NamedFunctionLabel,
+            ommx::NamedFunctionID,
+            &ommx::NamedFunction,
+        )> = self
             .inner
             .named_functions()
             .iter()
-            .map(|(id, nf)| (nf_meta_store.collect_for(*id), nf))
+            .map(|(id, nf)| (nf_meta_store.collect_for(*id), *id, nf))
             .collect();
         entries_to_dataframe(
             py,
             nf_meta_view
                 .iter()
-                .map(|(m, nf)| crate::pandas::WithModelingContext::new(*nf, m)),
+                .map(|(m, id, nf)| crate::pandas::WithModelingContext::new((*id, *nf), m)),
             "id",
             flags,
         )

--- a/python/ommx/src/sample_set.rs
+++ b/python/ommx/src/sample_set.rs
@@ -234,7 +234,7 @@ impl SampleSet {
         self.inner
             .named_functions()
             .iter()
-            .map(|(id, nf)| crate::SampledNamedFunction(nf.clone(), labels.collect_for(*id)))
+            .map(|(id, nf)| crate::SampledNamedFunction(*id, nf.clone(), labels.collect_for(*id)))
             .collect()
     }
 
@@ -478,6 +478,7 @@ impl SampleSet {
             .get(&named_function_id)
             .map(|nf| {
                 crate::SampledNamedFunction(
+                    named_function_id,
                     nf.clone(),
                     self.inner
                         .named_function_labels()
@@ -703,18 +704,22 @@ impl SampleSet {
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let sample_ids = sorted_sample_ids(&self.inner);
         let nf_meta_store = self.inner.named_function_labels().clone();
-        let nf_meta_view: Vec<(ommx::NamedFunctionLabel, &ommx::SampledNamedFunction)> = self
+        let nf_meta_view: Vec<(
+            ommx::NamedFunctionLabel,
+            ommx::NamedFunctionID,
+            &ommx::SampledNamedFunction,
+        )> = self
             .inner
             .named_functions()
             .iter()
-            .map(|(id, nf)| (nf_meta_store.collect_for(*id), nf))
+            .map(|(id, nf)| (nf_meta_store.collect_for(*id), *id, nf))
             .collect();
         entries_to_dataframe(
             py,
-            nf_meta_view.iter().map(|(m, nf)| {
+            nf_meta_view.iter().map(|(m, id, nf)| {
                 crate::pandas::WithModelingContext::new(
                     WithSampleIds {
-                        item: *nf,
+                        item: (*id, *nf),
                         sample_ids: &sample_ids,
                     },
                     m,

--- a/python/ommx/src/sampled_named_function.rs
+++ b/python/ommx/src/sampled_named_function.rs
@@ -8,7 +8,11 @@ use std::collections::{BTreeMap, HashSet};
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
 #[derive(Clone)]
-pub struct SampledNamedFunction(pub ommx::SampledNamedFunction, pub ommx::NamedFunctionLabel);
+pub struct SampledNamedFunction(
+    pub ommx::NamedFunctionID,
+    pub ommx::SampledNamedFunction,
+    pub ommx::NamedFunctionLabel,
+);
 
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
@@ -16,31 +20,31 @@ impl SampledNamedFunction {
     /// Get the named function ID
     #[getter]
     pub fn id(&self) -> u64 {
-        self.0.id().into_inner()
+        self.0.into_inner()
     }
 
     /// Get the named function name
     #[getter]
     pub fn name(&self) -> Option<String> {
-        self.1.name.clone()
+        self.2.name.clone()
     }
 
     /// Get the subscripts
     #[getter]
     pub fn subscripts(&self) -> Vec<i64> {
-        self.1.subscripts.clone()
+        self.2.subscripts.clone()
     }
 
     /// Get the description
     #[getter]
     pub fn description(&self) -> Option<String> {
-        self.1.description.clone()
+        self.2.description.clone()
     }
 
     /// Get the parameters
     #[getter]
     pub fn parameters(&self) -> std::collections::HashMap<String, String> {
-        self.1
+        self.2
             .parameters
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
@@ -50,7 +54,7 @@ impl SampledNamedFunction {
     /// Get the sampled values for all samples
     #[getter]
     pub fn evaluated_values(&self) -> BTreeMap<u64, f64> {
-        self.0
+        self.1
             .evaluated_values()
             .iter()
             .map(|(sample_id, value)| (sample_id.into_inner(), *value))
@@ -59,7 +63,7 @@ impl SampledNamedFunction {
 
     #[getter]
     pub fn used_decision_variable_ids(&self) -> HashSet<u64> {
-        self.0
+        self.1
             .used_decision_variable_ids()
             .iter()
             .map(|id| id.into_inner())
@@ -67,7 +71,11 @@ impl SampledNamedFunction {
     }
 
     pub fn __repr__(&self) -> String {
-        self.0.to_string()
+        format!(
+            "SampledNamedFunction(id={}, num_samples={})",
+            self.0.into_inner(),
+            self.1.evaluated_values().num_samples()
+        )
     }
 
     fn __copy__(&self) -> Self {

--- a/python/ommx/src/solution.rs
+++ b/python/ommx/src/solution.rs
@@ -177,7 +177,7 @@ impl Solution {
         self.inner
             .evaluated_named_functions()
             .iter()
-            .map(|(id, nf)| crate::EvaluatedNamedFunction(nf.clone(), labels.collect_for(*id)))
+            .map(|(id, nf)| crate::EvaluatedNamedFunction(*id, nf.clone(), labels.collect_for(*id)))
             .collect()
     }
 
@@ -469,6 +469,7 @@ impl Solution {
             .get(&named_function_id)
             .map(|nf| {
                 crate::EvaluatedNamedFunction(
+                    named_function_id,
                     nf.clone(),
                     self.inner
                         .named_function_labels()
@@ -579,17 +580,21 @@ impl Solution {
     ) -> PyResult<Bound<'py, PyDataFrame>> {
         let flags = crate::pandas::IncludeFlags::from_optional(include)?;
         let nf_meta_store = self.inner.named_function_labels().clone();
-        let nf_meta_view: Vec<(ommx::NamedFunctionLabel, &ommx::EvaluatedNamedFunction)> = self
+        let nf_meta_view: Vec<(
+            ommx::NamedFunctionLabel,
+            ommx::NamedFunctionID,
+            &ommx::EvaluatedNamedFunction,
+        )> = self
             .inner
             .evaluated_named_functions()
             .iter()
-            .map(|(id, nf)| (nf_meta_store.collect_for(*id), nf))
+            .map(|(id, nf)| (nf_meta_store.collect_for(*id), *id, nf))
             .collect();
         entries_to_dataframe(
             py,
             nf_meta_view
                 .iter()
-                .map(|(m, nf)| crate::pandas::WithModelingContext::new(*nf, m)),
+                .map(|(m, id, nf)| crate::pandas::WithModelingContext::new((*id, *nf), m)),
             "id",
             flags,
         )

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -44,6 +44,8 @@ pairs. "Removed" is not itself a stage.
 each lost its inline label/context fields, and the per-host label/context store
 is queried through narrow per-collection accessors on `Instance` /
 `ParametricInstance` (see [Modeling labels and constraint context](#modeling-labels-and-constraint-context)).
+Decision variables and named functions additionally follow the table-owned ID
+rule: the row data no longer stores its own ID.
 
 ## Breaking Changes
 
@@ -620,6 +622,52 @@ individual `DecisionVariable`.
 can still report the table key. The evaluated/sampled row data itself does not
 store the ID; `Solution` and `SampleSet` own it as the map key.
 
+### Named-function table ownership
+
+Named-function IDs and labels no longer live on
+[`NamedFunction`](crate::NamedFunction),
+[`EvaluatedNamedFunction`](crate::EvaluatedNamedFunction), or
+[`SampledNamedFunction`](crate::SampledNamedFunction). The row structs carry
+only intrinsic data:
+
+- `NamedFunction`: the [`Function`](crate::Function)
+- `EvaluatedNamedFunction`: the evaluated value and used decision-variable IDs
+- `SampledNamedFunction`: sampled values and used decision-variable IDs
+
+The [`NamedFunctionID`](crate::NamedFunctionID) is owned by the enclosing
+`BTreeMap` key on [`Instance`](crate::Instance) /
+[`ParametricInstance`](crate::ParametricInstance), and by the corresponding
+evaluated/sampled maps on [`Solution`](crate::Solution) and
+[`SampleSet`](crate::SampleSet). Modeling labels are owned by
+[`NamedFunctionLabelStore`](crate::NamedFunctionLabelStore).
+
+Construction changes mirror constraints and decision variables:
+
+```rust,ignore
+// Before
+let nf = NamedFunction {
+    id,
+    function,
+};
+let evaluated = named_function.evaluate(&state, atol)?;
+let evaluated_id = evaluated.id();
+
+// After
+let nf = NamedFunction { function };
+let instance = Instance::builder()
+    .named_functions(BTreeMap::from([(id, nf.clone())]))
+    .build()?;
+
+let evaluated = nf.evaluate(&state, atol)?;
+let solution = Solution::builder()
+    .evaluated_named_functions(BTreeMap::from([(id, evaluated)]))
+    .build()?;
+```
+
+Legacy `ommx.v1` protobuf messages still carry an inline `id` field. Rust parse
+drains that field into the owning map key, and Rust serialization fills it from
+the map key; the domain row remains ID-less on both sides of the conversion.
+
 ### ConstraintContext
 
 Owned struct used as the I/O type for constraint context (insertion via
@@ -657,6 +705,8 @@ pub struct ConstraintContext {
 - [ ] Replace `DecisionVariable::binary(id)` / `integer(id)` / `continuous(id)` / etc. with the no-argument row factories, and keep the ID on the enclosing map key
 - [ ] Replace `DecisionVariable::substituted_value()` and `DecisionVariable::substitute(...)` with host-owned fixed values: `InstanceBuilder::fixed_decision_variable_values(...)`, `Instance::fixed_decision_variable_value(id)`, or `Instance::fixed_decision_variable_values()`
 - [ ] Update `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`: drop the `atol` argument, pass the `VariableID` separately for diagnostics, and keep using the enclosing `Solution` / `SampleSet` map key as the source of truth
+- [ ] Remove `NamedFunction.id`, `EvaluatedNamedFunction::id()`, and `SampledNamedFunction::id()` reads in Rust. Use the enclosing `BTreeMap<NamedFunctionID, _>` key instead
+- [ ] Construct `NamedFunction { function }` rows and insert them under the desired `NamedFunctionID` key; keep labels in `NamedFunctionLabelStore`
 
 ---
 

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -645,6 +645,13 @@ stores `NamedFunctionTable<EvaluatedNamedFunction>`, and `SampleSet` stores
 cannot be attached to unknown named-function IDs at validated construction
 boundaries.
 
+Host accessors expose shared table views only. They intentionally do not expose
+mutable row views because changing a named-function body after host validation
+could introduce undefined variable IDs. Add named functions through
+[`Instance::new_named_function`](crate::Instance::new_named_function) or the
+validated builders; `new_named_function` returns the allocated
+[`NamedFunctionID`](crate::NamedFunctionID), not a mutable row reference.
+
 Construction changes mirror constraints and decision variables:
 
 ```rust,ignore
@@ -711,6 +718,7 @@ pub struct ConstraintContext {
 - [ ] Update `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`: drop the `atol` argument, pass the `VariableID` separately for diagnostics, and keep using the enclosing `Solution` / `SampleSet` map key as the source of truth
 - [ ] Remove `NamedFunction.id`, `EvaluatedNamedFunction::id()`, and `SampledNamedFunction::id()` reads in Rust. Use the enclosing `NamedFunctionTable<_>` key instead
 - [ ] Construct `NamedFunction { function }` rows and insert them under the desired `NamedFunctionID` key; keep row maps and labels together with `NamedFunctionTable`
+- [ ] Update `Instance::new_named_function(...)` callers to use the returned `NamedFunctionID`; it no longer returns `&mut NamedFunction`
 
 ---
 

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -505,12 +505,14 @@ instance.sos1_constraint_context()
 instance.set_sos1_constraint_context(id, context)?
 instance.variable_labels()                // &VariableLabelStore
 instance.set_variable_label(id, label)?
+instance.named_function_table()           // &NamedFunctionTable<NamedFunction>
 instance.named_function_labels()          // &NamedFunctionLabelStore
 instance.set_named_function_label(id, label)?
 ```
 
 `Solution` and `SampleSet` expose the variable / named-function stores
 the same way (`solution.variable_labels()`,
+`solution.evaluated_named_function_table()`,
 `solution.named_function_labels()`, same on `SampleSet`), but
 constraint context is reached through the evaluated / sampled
 collection getter then `.context()` on the collection — there are no
@@ -634,12 +636,14 @@ only intrinsic data:
 - `EvaluatedNamedFunction`: the evaluated value and used decision-variable IDs
 - `SampledNamedFunction`: sampled values and used decision-variable IDs
 
-The [`NamedFunctionID`](crate::NamedFunctionID) is owned by the enclosing
-`BTreeMap` key on [`Instance`](crate::Instance) /
-[`ParametricInstance`](crate::ParametricInstance), and by the corresponding
-evaluated/sampled maps on [`Solution`](crate::Solution) and
-[`SampleSet`](crate::SampleSet). Modeling labels are owned by
-[`NamedFunctionLabelStore`](crate::NamedFunctionLabelStore).
+The [`NamedFunctionID`](crate::NamedFunctionID) and modeling labels are owned by
+[`NamedFunctionTable`](crate::NamedFunctionTable). `Instance` and
+`ParametricInstance` store `NamedFunctionTable<NamedFunction>`, `Solution`
+stores `NamedFunctionTable<EvaluatedNamedFunction>`, and `SampleSet` stores
+`NamedFunctionTable<SampledNamedFunction>`. The table keeps row payloads and
+[`NamedFunctionLabelStore`](crate::NamedFunctionLabelStore) together so labels
+cannot be attached to unknown named-function IDs at validated construction
+boundaries.
 
 Construction changes mirror constraints and decision variables:
 
@@ -705,8 +709,8 @@ pub struct ConstraintContext {
 - [ ] Replace `DecisionVariable::binary(id)` / `integer(id)` / `continuous(id)` / etc. with the no-argument row factories, and keep the ID on the enclosing map key
 - [ ] Replace `DecisionVariable::substituted_value()` and `DecisionVariable::substitute(...)` with host-owned fixed values: `InstanceBuilder::fixed_decision_variable_values(...)`, `Instance::fixed_decision_variable_value(id)`, or `Instance::fixed_decision_variable_values()`
 - [ ] Update `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`: drop the `atol` argument, pass the `VariableID` separately for diagnostics, and keep using the enclosing `Solution` / `SampleSet` map key as the source of truth
-- [ ] Remove `NamedFunction.id`, `EvaluatedNamedFunction::id()`, and `SampledNamedFunction::id()` reads in Rust. Use the enclosing `BTreeMap<NamedFunctionID, _>` key instead
-- [ ] Construct `NamedFunction { function }` rows and insert them under the desired `NamedFunctionID` key; keep labels in `NamedFunctionLabelStore`
+- [ ] Remove `NamedFunction.id`, `EvaluatedNamedFunction::id()`, and `SampledNamedFunction::id()` reads in Rust. Use the enclosing `NamedFunctionTable<_>` key instead
+- [ ] Construct `NamedFunction { function }` rows and insert them under the desired `NamedFunctionID` key; keep row maps and labels together with `NamedFunctionTable`
 
 ---
 

--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -163,8 +163,9 @@ available at every stage),
 [`VariableLabelStore`](crate::VariableLabelStore) as a sibling
 field on `Instance` / `ParametricInstance` / `Solution` / `SampleSet`
 (no separate `DecisionVariableCollection` was introduced), and
-[`NamedFunctionLabelStore`](crate::NamedFunctionLabelStore) the
-same way for named functions.
+[`NamedFunctionLabelStore`](crate::NamedFunctionLabelStore) inside
+[`NamedFunctionTable`](crate::NamedFunctionTable), which owns named-function
+rows and labels together.
 
 The split lets the type system enforce invariants more tightly. The
 raw active/removed map mutators on `ConstraintCollection<T>` are
@@ -227,13 +228,13 @@ decision variables. The Rust SDK row structs no longer carry their own
 - [`SampledNamedFunction`](crate::SampledNamedFunction) stores sampled values
   and used decision-variable IDs.
 
-The ID lives on the enclosing maps of [`Instance`](crate::Instance),
-[`ParametricInstance`](crate::ParametricInstance),
-[`Solution`](crate::Solution), and [`SampleSet`](crate::SampleSet), while
-modeling labels live in
-[`NamedFunctionLabelStore`](crate::NamedFunctionLabelStore). Legacy
-`ommx.v1` protobuf messages still carry inline IDs; Rust parse drains them into
-map keys and Rust serialization fills them from map keys.
+The ID, row map, and modeling labels now live together in
+[`NamedFunctionTable`](crate::NamedFunctionTable). `Instance` and
+`ParametricInstance` store `NamedFunctionTable<NamedFunction>`, `Solution`
+stores `NamedFunctionTable<EvaluatedNamedFunction>`, and `SampleSet` stores
+`NamedFunctionTable<SampledNamedFunction>`. Legacy `ommx.v1` protobuf messages
+still carry inline IDs; Rust parse drains them into table keys and Rust
+serialization fills them from table keys.
 
 ## Capability model ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#805](https://github.com/Jij-Inc/ommx/pull/805), [#810](https://github.com/Jij-Inc/ommx/pull/810), [#811](https://github.com/Jij-Inc/ommx/pull/811), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 

--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -31,11 +31,14 @@ The 3.0.0 line is a major revision of the Rust SDK:
   `instance.named_function_labels()`, …). One canonical store per
   collection, two views on top: per-id wrapper getters for one-off
   reads and `*_df` for bulk analysis.
-- Decision variables now follow the same table ownership rule:
+- Decision variables and named functions now follow the same table ownership rule:
   [`DecisionVariable`](crate::DecisionVariable) is row data containing
   only `kind` and `bound`; the [`VariableID`](crate::VariableID) and
   fixed values live on the enclosing `Instance` /
   `ParametricInstance` / `Solution` / `SampleSet` tables.
+  [`NamedFunction`](crate::NamedFunction) likewise stores only the
+  [`Function`](crate::Function); [`NamedFunctionID`](crate::NamedFunctionID)
+  lives on the enclosing named-function maps.
 - A **capability model** lets adapters declare what they natively
   support and auto-converts unsupported kinds at the boundary, so a
   valid OMMX instance can be fed to any adapter (the conversion path
@@ -210,6 +213,27 @@ caller-provided `ATol`. `EvaluatedDecisionVariable::new`
 and `SampledDecisionVariable::new` still take the ID as a separate argument so
 non-finite value errors can report the table key, but the resulting row data
 does not store that ID.
+
+## Named-function table ownership ([#964](https://github.com/Jij-Inc/ommx/pull/964))
+
+Named functions now follow the same table-owned ID model as constraints and
+decision variables. The Rust SDK row structs no longer carry their own
+[`NamedFunctionID`](crate::NamedFunctionID):
+
+- [`NamedFunction`](crate::NamedFunction) stores only the intrinsic
+  [`Function`](crate::Function).
+- [`EvaluatedNamedFunction`](crate::EvaluatedNamedFunction) stores the
+  evaluated value and used decision-variable IDs.
+- [`SampledNamedFunction`](crate::SampledNamedFunction) stores sampled values
+  and used decision-variable IDs.
+
+The ID lives on the enclosing maps of [`Instance`](crate::Instance),
+[`ParametricInstance`](crate::ParametricInstance),
+[`Solution`](crate::Solution), and [`SampleSet`](crate::SampleSet), while
+modeling labels live in
+[`NamedFunctionLabelStore`](crate::NamedFunctionLabelStore). Legacy
+`ommx.v1` protobuf messages still carry inline IDs; Rust parse drains them into
+map keys and Rust serialization fills them from map keys.
 
 ## Capability model ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#805](https://github.com/Jij-Inc/ommx/pull/805), [#810](https://github.com/Jij-Inc/ommx/pull/810), [#811](https://github.com/Jij-Inc/ommx/pull/811), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 

--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -236,6 +236,12 @@ stores `NamedFunctionTable<EvaluatedNamedFunction>`, and `SampleSet` stores
 still carry inline IDs; Rust parse drains them into table keys and Rust
 serialization fills them from table keys.
 
+Mutable named-function row views are not exposed from host objects. In
+particular, [`Instance::new_named_function`](crate::Instance::new_named_function)
+now returns the allocated [`NamedFunctionID`](crate::NamedFunctionID) rather
+than `&mut NamedFunction`, so callers cannot invalidate a checked `Instance` by
+editing the function body after insertion.
+
 ## Capability model ([#790](https://github.com/Jij-Inc/ommx/pull/790), [#805](https://github.com/Jij-Inc/ommx/pull/805), [#810](https://github.com/Jij-Inc/ommx/pull/810), [#811](https://github.com/Jij-Inc/ommx/pull/811), [#814](https://github.com/Jij-Inc/ommx/pull/814))
 
 First-class special constraints raise a deployment question: not every

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -184,6 +184,9 @@ pub trait SampledConstraintBehavior {
     /// Returns the first offending sample ID set when a side map is out of sync.
     fn validate_sample_ids(&self, expected: &SampleIDSet) -> std::result::Result<(), SampleIDSet>;
 
+    /// Decision variable IDs recorded as used by this sampled constraint.
+    fn used_decision_variable_ids(&self) -> &VariableIDSet;
+
     /// Extract an evaluated constraint for a specific sample.
     ///
     /// Returns [`None`] if `sample_id` is not present in the sampled data.
@@ -223,6 +226,10 @@ impl SampledConstraintBehavior for SampledConstraint {
             }
         }
         Ok(())
+    }
+
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
     }
 
     fn get(&self, sample_id: SampleID) -> Option<Self::Evaluated> {
@@ -770,6 +777,21 @@ impl<T: ConstraintType> SampledCollection<T> {
     ) -> std::result::Result<(), SampleIDSet> {
         for constraint in self.constraints.values() {
             constraint.validate_sample_ids(expected)?;
+        }
+        Ok(())
+    }
+
+    /// Validate that every sampled constraint only references known decision variables.
+    pub fn validate_used_decision_variable_ids(
+        &self,
+        decision_variable_ids: &BTreeSet<crate::VariableID>,
+    ) -> std::result::Result<(), (T::ID, crate::VariableID)> {
+        for (constraint_id, constraint) in &self.constraints {
+            for var_id in constraint.used_decision_variable_ids() {
+                if !decision_variable_ids.contains(var_id) {
+                    return Err((*constraint_id, *var_id));
+                }
+            }
         }
         Ok(())
     }

--- a/rust/ommx/src/function/div.rs
+++ b/rust/ommx/src/function/div.rs
@@ -61,9 +61,10 @@ mod tests {
         #[test]
         fn div_ref(a in any::<Function>(), c in any::<Coefficient>()) {
             if let Ok(expected) = a.clone() / c {
+                let c_ref = &c;
                 assert_abs_diff_eq!((&a / c).unwrap(), expected);
-                assert_abs_diff_eq!((a.clone() / &c).unwrap(), expected);
-                assert_abs_diff_eq!((&a / &c).unwrap(), expected);
+                assert_abs_diff_eq!((a.clone() / c_ref).unwrap(), expected);
+                assert_abs_diff_eq!((&a / c_ref).unwrap(), expected);
             }
         }
 

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -148,6 +148,10 @@ impl SampledConstraintBehavior for SampledIndicatorConstraint {
         Ok(())
     }
 
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
+    }
+
     fn get(&self, sample_id: SampleID) -> Option<Self::Evaluated> {
         let evaluated_value = *self.stage.evaluated_values.get(sample_id)?;
         let feasible = *self.stage.feasible.get(&sample_id)?;

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -139,7 +139,8 @@ pub enum Sense {
 /// - [`DecisionVariableUsage`] is the reverse-usage index for used decision variables only.
 /// - [`Self::removed_constraints`] may contain fixed or dependent variable IDs.
 ///   These are substituted when the constraint is restored via [`Self::restore_constraint`].
-/// - The keys of [`Self::named_functions`] match the `id()` of their values.
+/// - [`Self::named_functions`] is keyed by the table-owned
+///   [`NamedFunctionID`]; named-function rows do not carry IDs.
 /// - [`Self::named_functions`] may contain fixed or dependent variable IDs (like `removed_constraints`).
 ///   Variable IDs in `named_functions` must be registered in [`Self::decision_variables`],
 ///   but are NOT included in the "used" set calculation.
@@ -585,7 +586,8 @@ impl Instance {
 ///   - **fixed**: Variable IDs present in [`Self::fixed_decision_variable_values`] and not used
 ///   - **dependent**: Keys of `decision_variable_dependency` that are not used or fixed
 /// - [`DecisionVariableUsage`] is the reverse-usage index for used decision variables only.
-/// - The keys of [`Self::named_functions`] match the `id()` of their values.
+/// - [`Self::named_functions`] is keyed by the table-owned
+///   [`NamedFunctionID`]; named-function rows do not carry IDs.
 /// - [`Self::named_functions`] may contain fixed or dependent variable IDs (like `removed_constraints`).
 ///   Variable IDs in `named_functions` must be registered in [`Self::decision_variables`],
 ///   but are NOT included in the "used" set calculation.

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -143,7 +143,7 @@ pub enum Sense {
 /// - [`Self::named_functions`] is keyed by the table-owned
 ///   [`NamedFunctionID`]; named-function rows do not carry IDs.
 /// - [`Self::named_functions`] may contain fixed or dependent variable IDs (like `removed_constraints`).
-///   Variable IDs in `named_functions` must be registered in [`Self::decision_variables`],
+///   Variable IDs referenced by named functions must be registered in [`Self::decision_variables`],
 ///   but are NOT included in the "used" set calculation.
 /// - Modeling-label and constraint-context sidecars are owned by their
 ///   corresponding top-level collection; every label/context ID must refer to an
@@ -583,9 +583,12 @@ impl Instance {
 /// - [`DecisionVariableUsage`] is the reverse-usage index for used decision variables only.
 /// - [`Self::named_functions`] is keyed by the table-owned
 ///   [`NamedFunctionID`]; named-function rows do not carry IDs.
-/// - [`Self::named_functions`] may contain fixed or dependent variable IDs (like `removed_constraints`).
-///   Variable IDs in `named_functions` must be registered in [`Self::decision_variables`],
-///   but are NOT included in the "used" set calculation.
+/// - [`Self::named_functions`] may contain fixed or dependent decision-variable
+///   IDs (like `removed_constraints`) and may also reference parameter IDs.
+///   Every referenced ID must be registered in either
+///   [`Self::decision_variables`] or [`Self::parameters`], but decision-variable
+///   IDs appearing only in named functions are NOT included in the "used" set
+///   calculation.
 /// - Modeling-label and constraint-context sidecars are owned by their
 ///   corresponding top-level collection; every label/context ID must refer to an
 ///   existing decision variable, named function, or active/removed constraint

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -40,7 +40,8 @@ use crate::{
     one_hot_constraint::OneHotConstraint,
     sos1_constraint::Sos1Constraint,
     v1, AcyclicAssignments, Constraint, ConstraintContext, ConstraintID, DecisionVariable,
-    Evaluate, Function, ModelingLabel, NamedFunction, VariableID, VariableIDSet,
+    Evaluate, Function, ModelingLabel, NamedFunction, NamedFunctionTable, VariableID,
+    VariableIDSet,
 };
 use std::collections::{BTreeMap, HashMap};
 
@@ -225,13 +226,8 @@ pub struct Instance {
 
     #[getset(get = "pub")]
     decision_variable_dependency: AcyclicAssignments,
-    #[getset(get = "pub")]
-    named_functions: BTreeMap<NamedFunctionID, NamedFunction>,
-
-    /// Per-named-function modeling labels. Sibling field of
-    /// [`Self::named_functions`]; together they form the canonical
-    /// named-function storage.
-    named_function_labels: crate::named_function::NamedFunctionLabelStore,
+    /// Named-function rows plus their modeling labels.
+    named_functions: NamedFunctionTable<NamedFunction>,
 
     // Optional fields for additional metadata.
     // These fields are public since arbitrary values can be set without validation.
@@ -284,18 +280,19 @@ impl Instance {
         self.fixed_decision_variable_values.get(&id).copied()
     }
 
-    /// Access the per-named-function modeling-label store.
-    pub fn named_function_labels(&self) -> &crate::named_function::NamedFunctionLabelStore {
-        &self.named_function_labels
+    /// Access named-function rows plus their modeling labels.
+    pub fn named_function_table(&self) -> &NamedFunctionTable<NamedFunction> {
+        &self.named_functions
     }
 
-    /// Mutable access to the per-named-function modeling-label store, limited
-    /// to the `instance` module tree.
-    ///
-    /// Public callers should use [`Self::set_named_function_label`], which
-    /// checks that the label ID belongs to this instance.
-    fn named_function_labels_mut(&mut self) -> &mut crate::named_function::NamedFunctionLabelStore {
-        &mut self.named_function_labels
+    /// Access named-function row payloads keyed by table-owned IDs.
+    pub fn named_functions(&self) -> &BTreeMap<NamedFunctionID, NamedFunction> {
+        self.named_functions.entries()
+    }
+
+    /// Access the per-named-function modeling-label store.
+    pub fn named_function_labels(&self) -> &crate::named_function::NamedFunctionLabelStore {
+        self.named_functions.labels()
     }
 
     /// Replace the modeling label for a named function owned by this instance.
@@ -304,9 +301,7 @@ impl Instance {
         id: NamedFunctionID,
         label: ModelingLabel,
     ) -> crate::Result<()> {
-        ensure_modeling_label_target(self.named_functions.contains_key(&id), "named function", id)?;
-        self.named_function_labels.insert(id, label);
-        Ok(())
+        self.named_functions.set_label(id, label)
     }
 
     /// Active constraints.
@@ -672,13 +667,8 @@ pub struct ParametricInstance {
 
     #[getset(get = "pub")]
     decision_variable_dependency: AcyclicAssignments,
-    #[getset(get = "pub")]
-    named_functions: BTreeMap<NamedFunctionID, NamedFunction>,
-
-    /// Per-named-function modeling labels. Sibling field of
-    /// [`Self::named_functions`]; together they form the canonical
-    /// named-function storage.
-    named_function_labels: crate::named_function::NamedFunctionLabelStore,
+    /// Named-function rows plus their modeling labels.
+    named_functions: NamedFunctionTable<NamedFunction>,
 
     // Optional fields for additional metadata.
     // These fields are public since arbitrary values can be set without validation.
@@ -722,9 +712,19 @@ impl ParametricInstance {
         self.fixed_decision_variable_values.get(&id).copied()
     }
 
+    /// Access named-function rows plus their modeling labels.
+    pub fn named_function_table(&self) -> &NamedFunctionTable<NamedFunction> {
+        &self.named_functions
+    }
+
+    /// Access named-function row payloads keyed by table-owned IDs.
+    pub fn named_functions(&self) -> &BTreeMap<NamedFunctionID, NamedFunction> {
+        self.named_functions.entries()
+    }
+
     /// Access the per-named-function modeling-label store.
     pub fn named_function_labels(&self) -> &crate::named_function::NamedFunctionLabelStore {
-        &self.named_function_labels
+        self.named_functions.labels()
     }
 
     /// Replace the modeling label for a named function owned by this parametric
@@ -734,9 +734,7 @@ impl ParametricInstance {
         id: NamedFunctionID,
         label: ModelingLabel,
     ) -> crate::Result<()> {
-        ensure_modeling_label_target(self.named_functions.contains_key(&id), "named function", id)?;
-        self.named_function_labels.insert(id, label);
-        Ok(())
+        self.named_functions.set_label(id, label)
     }
 
     /// Active constraints.

--- a/rust/ommx/src/instance/analysis.rs
+++ b/rust/ommx/src/instance/analysis.rs
@@ -620,7 +620,6 @@ mod tests {
             VariableID::from(2) => DecisionVariable::continuous(),
         };
         let named_function = NamedFunction {
-            id: NamedFunctionID::from(7),
             function: linear!(2).into(),
         };
         let instance = Instance::builder()

--- a/rust/ommx/src/instance/arbitrary.rs
+++ b/rust/ommx/src/instance/arbitrary.rs
@@ -234,8 +234,9 @@ impl Arbitrary for Instance {
                                         Default::default(),
                                     )
                                     .expect("empty removed constraints cannot overlap active constraints"),
-                                    named_functions,
-                                    named_function_labels: Default::default(),
+                                    named_functions: crate::NamedFunctionTable::from_entries(
+                                        named_functions,
+                                    ),
                                     sense,
                                     decision_variables,
                                     variable_labels: Default::default(),

--- a/rust/ommx/src/instance/builder.rs
+++ b/rust/ommx/src/instance/builder.rs
@@ -223,7 +223,7 @@ impl InstanceBuilder {
     /// Returns an error if:
     /// - Required fields (`sense`, `objective`, `decision_variables`, `constraints`) are not set
     /// - Named-function labels reference IDs not present in the named-function table
-    /// - The objective function or constraints reference undefined variable IDs
+    /// - The objective function, constraints, or named functions reference undefined variable IDs
     /// - The keys of `constraints` and `removed_constraints` are not disjoint
     /// - Label/context stores contain IDs that are not owned by the
     ///   corresponding decision-variable, named-function, or constraint collection

--- a/rust/ommx/src/instance/builder.rs
+++ b/rust/ommx/src/instance/builder.rs
@@ -222,7 +222,7 @@ impl InstanceBuilder {
     /// # Errors
     /// Returns an error if:
     /// - Required fields (`sense`, `objective`, `decision_variables`, `constraints`) are not set
-    /// - Named-function map keys don't match their value's ID
+    /// - Named-function labels reference IDs not present in the named-function table
     /// - The objective function or constraints reference undefined variable IDs
     /// - The keys of `constraints` and `removed_constraints` are not disjoint
     /// - Label/context stores contain IDs that are not owned by the
@@ -293,16 +293,8 @@ impl InstanceBuilder {
                 }
             }
         }
-        let named_function_ids = self
-            .named_functions
-            .keys()
-            .copied()
-            .collect::<std::collections::BTreeSet<_>>();
-        crate::modeling_label::validate_modeling_label_ids(
-            &self.named_function_labels,
-            &named_function_ids,
-            "named function",
-        )?;
+        let named_functions =
+            NamedFunctionTable::new(self.named_functions, self.named_function_labels)?;
 
         // Validate indicator constraints
         for value in self.indicator_constraints.values() {
@@ -488,8 +480,7 @@ impl InstanceBuilder {
                 BTreeMap::new(),
                 self.sos1_constraint_context,
             )?,
-            named_functions: self.named_functions,
-            named_function_labels: self.named_function_labels,
+            named_functions,
             decision_variable_dependency: self.decision_variable_dependency,
             parameters: self.parameters,
             description: self.description,
@@ -676,6 +667,27 @@ mod tests {
         assert!(
             err.to_string().contains("unknown decision variable ID")
                 && err.to_string().contains("VariableID(99)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_builder_rejects_orphan_named_function_labels() {
+        let mut named_function_labels = crate::named_function::NamedFunctionLabelStore::default();
+        named_function_labels.set_name(NamedFunctionID::from(99), "orphan");
+
+        let err = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::new())
+            .constraints(BTreeMap::new())
+            .named_function_labels(named_function_labels)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("unknown named function ID")
+                && err.to_string().contains("NamedFunctionID(99)"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/instance/builder.rs
+++ b/rust/ommx/src/instance/builder.rs
@@ -285,15 +285,8 @@ impl InstanceBuilder {
             }
         }
 
-        // Validate named_functions: key must match value's id, and all variable IDs must exist
-        for (key, nf) in &self.named_functions {
-            if *key != nf.id {
-                let id = nf.id;
-                crate::bail!(
-                    { ?key, ?id },
-                    "Named function map key {key:?} does not match value's id {id:?}",
-                );
-            }
+        // Validate named_functions: map keys own IDs, and all referenced variable IDs must exist.
+        for nf in self.named_functions.values() {
             for id in nf.function.required_ids() {
                 if !variable_ids.contains(&id) {
                     crate::bail!({ ?id }, "Undefined variable ID is used: {id:?}");
@@ -1098,44 +1091,12 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_inconsistent_named_function_id() {
-        use crate::{NamedFunction, NamedFunctionID};
-        use maplit::btreemap;
-
-        // Create a named function with id=1 but use key=2 in the map
-        let named_function = NamedFunction {
-            id: NamedFunctionID::from(1),
-            function: Function::Zero,
-        };
-
-        let err = Instance::builder()
-            .sense(Sense::Minimize)
-            .objective(Function::Zero)
-            .decision_variables(BTreeMap::new())
-            .constraints(BTreeMap::new())
-            .named_functions(btreemap! {
-                NamedFunctionID::from(2) => named_function,  // key=2 but id=1
-            })
-            .build()
-            .unwrap_err();
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Named function map key")
-                && msg.contains("NamedFunctionID(2)")
-                && msg.contains("NamedFunctionID(1)"),
-            "unexpected error: {msg}"
-        );
-    }
-
-    #[test]
     fn test_builder_undefined_variable_in_named_function() {
         use crate::{NamedFunction, NamedFunctionID};
         use maplit::btreemap;
 
         // Create a named function that references undefined variable ID 999
         let named_function = NamedFunction {
-            id: NamedFunctionID::from(1),
             function: Function::from(linear!(999) + coeff!(1.0)),
         };
 

--- a/rust/ommx/src/instance/convert.rs
+++ b/rust/ommx/src/instance/convert.rs
@@ -52,7 +52,6 @@ impl From<Instance> for ParametricInstance {
             description,
             annotations,
             named_functions,
-            named_function_labels,
             ..
         }: Instance,
     ) -> Self {
@@ -71,7 +70,6 @@ impl From<Instance> for ParametricInstance {
             description,
             annotations,
             named_functions,
-            named_function_labels,
         }
     }
 }
@@ -172,7 +170,6 @@ impl ParametricInstance {
             one_hot_constraint_collection: self.one_hot_constraint_collection,
             sos1_constraint_collection: self.sos1_constraint_collection,
             named_functions,
-            named_function_labels: self.named_function_labels,
             decision_variable_dependency,
             parameters: Some(parameters),
             description: self.description,

--- a/rust/ommx/src/instance/convert.rs
+++ b/rust/ommx/src/instance/convert.rs
@@ -135,9 +135,7 @@ impl ParametricInstance {
         }
 
         let mut named_functions = self.named_functions;
-        for (_, named_function) in named_functions.iter_mut() {
-            named_function.partial_evaluate(&state, atol)?;
-        }
+        named_functions.partial_evaluate(&state, atol)?;
 
         // Decision-variable dependency RHS expressions can also reference
         // parameter IDs. Without substitution, dependent-variable

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -272,11 +272,8 @@ impl Evaluate for Instance {
             decision_variables.insert(*id, evaluated_dv);
         }
 
-        let mut evaluated_named_functions = BTreeMap::default();
-        for (id, named_function) in self.named_functions.iter() {
-            let evaluated_named_function = named_function.evaluate(&state, atol)?;
-            evaluated_named_functions.insert(*id, evaluated_named_function);
-        }
+        let (evaluated_named_functions, evaluated_named_function_labels) =
+            self.named_functions.evaluate(&state, atol)?.into_parts();
 
         let sense = self.sense();
 
@@ -291,7 +288,7 @@ impl Evaluate for Instance {
                 .evaluated_named_functions(evaluated_named_functions)
                 .decision_variables(decision_variables)
                 .variable_labels(self.variable_labels.clone())
-                .named_function_labels(self.named_function_labels().clone())
+                .named_function_labels(evaluated_named_function_labels)
                 .sense(sense)
                 .build_unchecked()?
         };
@@ -345,12 +342,10 @@ impl Evaluate for Instance {
             decision_variables.insert(*id, sampled_dv);
         }
 
-        // Reconstruct named function values
-        let mut named_functions = std::collections::BTreeMap::new();
-        for (id, named_function) in self.named_functions.iter() {
-            let sampled_named_function = named_function.evaluate_samples(&samples, atol)?;
-            named_functions.insert(*id, sampled_named_function);
-        }
+        let (named_functions, named_function_labels) = self
+            .named_functions
+            .evaluate_samples(&samples, atol)?
+            .into_parts();
 
         Ok(crate::SampleSet::builder()
             .decision_variables(decision_variables)
@@ -361,7 +356,7 @@ impl Evaluate for Instance {
             .one_hot_constraints_collection(sampled_one_hot_constraints)
             .sos1_constraints_collection(sampled_sos1_constraints)
             .named_functions(named_functions)
-            .named_function_labels(self.named_function_labels().clone())
+            .named_function_labels(named_function_labels)
             .sense(self.sense)
             .build()?)
     }

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -291,7 +291,7 @@ impl Evaluate for Instance {
                 .evaluated_named_functions(evaluated_named_functions)
                 .decision_variables(decision_variables)
                 .variable_labels(self.variable_labels.clone())
-                .named_function_labels(self.named_function_labels.clone())
+                .named_function_labels(self.named_function_labels().clone())
                 .sense(sense)
                 .build_unchecked()?
         };
@@ -361,7 +361,7 @@ impl Evaluate for Instance {
             .one_hot_constraints_collection(sampled_one_hot_constraints)
             .sos1_constraints_collection(sampled_sos1_constraints)
             .named_functions(named_functions)
-            .named_function_labels(self.named_function_labels.clone())
+            .named_function_labels(self.named_function_labels().clone())
             .sense(self.sense)
             .build()?)
     }
@@ -820,10 +820,10 @@ mod tests {
                 VariableID::from(2) => 3.0,
             })
             .constraints(BTreeMap::new()) // No constraints
+            .named_functions(named_functions)
             .build()
             .unwrap();
         instance.decision_variable_dependency = decision_variable_dependency;
-        instance.named_functions = named_functions;
 
         // Verify the usage: x1 is used, x2 is fixed, x3 is dependent,
         // x4 and x5 should be irrelevant (named_functions don't contribute to "used")

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -803,7 +803,6 @@ mod tests {
         // - x4: irrelevant variable
         // - x5: only used in named function
         let named_function = NamedFunction {
-            id: NamedFunctionID::from(1),
             function: Function::from(
                 (((linear!(2) + linear!(3)).unwrap() + linear!(4)).unwrap() + linear!(5)).unwrap(),
             ),

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -413,9 +413,9 @@ impl Evaluate for Instance {
         working
             .constraint_collection
             .partial_evaluate(&expanded_state, atol)?;
-        for named_function in working.named_functions.values_mut() {
-            named_function.partial_evaluate(&expanded_state, atol)?;
-        }
+        working
+            .named_functions
+            .partial_evaluate(&expanded_state, atol)?;
         working
             .decision_variable_dependency
             .partial_evaluate(&expanded_state, atol)?;

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -178,11 +178,11 @@ mod tests {
         Instance.indicator_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
         Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[stack] 24
         Instance.indicator_constraint_collection;removed_indicator_constraints;BTreeMap[stack] 24
-        Instance.named_function_labels;ModelingLabelStore.description;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.name;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
-        Instance.named_functions;BTreeMap[stack] 24
+        Instance.named_functions;entries;BTreeMap[stack] 24
+        Instance.named_functions;labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
         Instance.objective;Zero 40
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
@@ -254,11 +254,11 @@ mod tests {
         Instance.indicator_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
         Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[stack] 24
         Instance.indicator_constraint_collection;removed_indicator_constraints;BTreeMap[stack] 24
-        Instance.named_function_labels;ModelingLabelStore.description;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.name;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
-        Instance.named_functions;BTreeMap[stack] 24
+        Instance.named_functions;entries;BTreeMap[stack] 24
+        Instance.named_functions;labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
         Instance.objective;Linear;PolynomialBase.terms 80
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
@@ -343,11 +343,11 @@ mod tests {
         Instance.indicator_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
         Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[stack] 24
         Instance.indicator_constraint_collection;removed_indicator_constraints;BTreeMap[stack] 24
-        Instance.named_function_labels;ModelingLabelStore.description;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.name;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
-        Instance.named_functions;BTreeMap[stack] 24
+        Instance.named_functions;entries;BTreeMap[stack] 24
+        Instance.named_functions;labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
         Instance.objective;Linear;PolynomialBase.terms 80
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
@@ -424,11 +424,11 @@ mod tests {
         Instance.indicator_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
         Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[stack] 24
         Instance.indicator_constraint_collection;removed_indicator_constraints;BTreeMap[stack] 24
-        Instance.named_function_labels;ModelingLabelStore.description;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.name;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
-        Instance.named_functions;BTreeMap[stack] 24
+        Instance.named_functions;entries;BTreeMap[stack] 24
+        Instance.named_functions;labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
         Instance.objective;Zero 40
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
@@ -519,11 +519,11 @@ mod tests {
         Instance.indicator_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
         Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[stack] 24
         Instance.indicator_constraint_collection;removed_indicator_constraints;BTreeMap[stack] 24
-        Instance.named_function_labels;ModelingLabelStore.description;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.name;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
-        Instance.named_function_labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
-        Instance.named_functions;BTreeMap[stack] 24
+        Instance.named_functions;entries;BTreeMap[stack] 24
+        Instance.named_functions;labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.named_functions;labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
         Instance.objective;Zero 40
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32

--- a/rust/ommx/src/instance/named_function.rs
+++ b/rust/ommx/src/instance/named_function.rs
@@ -71,7 +71,7 @@ impl Instance {
         subscripts: Vec<i64>,
         parameters: FnvHashMap<String, String>,
         description: Option<String>,
-    ) -> crate::Result<(NamedFunctionID, &mut NamedFunction)> {
+    ) -> crate::Result<NamedFunctionID> {
         let variable_ids: VariableIDSet = self.decision_variables.keys().cloned().collect();
 
         for id in function.required_ids() {
@@ -89,7 +89,7 @@ impl Instance {
             description,
         };
         self.named_functions.insert(id, named_function, label);
-        Ok((id, self.named_functions.get_mut(&id).unwrap()))
+        Ok(id)
     }
 }
 

--- a/rust/ommx/src/instance/named_function.rs
+++ b/rust/ommx/src/instance/named_function.rs
@@ -21,7 +21,8 @@ impl Instance {
     /// * `subscripts` - The subscripts of the named function (can be empty)
     ///
     /// # Returns
-    /// * `Some(&NamedFunction)` if a named function with the given name and subscripts is found
+    /// * `Some((NamedFunctionID, &NamedFunction))` if a named function with
+    ///   the given name and subscripts is found
     /// * `None` if no matching named function is found
     ///
     /// # Example
@@ -38,11 +39,11 @@ impl Instance {
         &self,
         name: &str,
         subscripts: Vec<i64>,
-    ) -> Option<&NamedFunction> {
+    ) -> Option<(NamedFunctionID, &NamedFunction)> {
         self.named_functions.iter().find_map(|(id, nf)| {
             let store = self.named_function_labels();
             if store.name(*id) == Some(name) && store.subscripts(*id) == subscripts.as_slice() {
-                Some(nf)
+                Some((*id, nf))
             } else {
                 None
             }
@@ -70,7 +71,7 @@ impl Instance {
         subscripts: Vec<i64>,
         parameters: FnvHashMap<String, String>,
         description: Option<String>,
-    ) -> crate::Result<&mut NamedFunction> {
+    ) -> crate::Result<(NamedFunctionID, &mut NamedFunction)> {
         let variable_ids: VariableIDSet = self.decision_variables.keys().cloned().collect();
 
         for id in function.required_ids() {
@@ -81,15 +82,14 @@ impl Instance {
         let id = self.next_named_function_id();
 
         let named_function = NamedFunction { function };
-        self.named_functions.insert(id, named_function);
         let label = crate::named_function::NamedFunctionLabel {
             name,
             subscripts,
             parameters,
             description,
         };
-        self.named_function_labels_mut().insert(id, label);
-        Ok(self.named_functions.get_mut(&id).unwrap())
+        self.named_functions.insert(id, named_function, label);
+        Ok((id, self.named_functions.get_mut(&id).unwrap()))
     }
 }
 
@@ -167,9 +167,10 @@ mod tests {
         // Lookup by correct name and subscripts
         let found = instance.get_named_function_by_name("f", vec![1, 2]);
         assert!(found.is_some());
-        let found_id = NamedFunctionID::from(0);
+        let (found_id, found) = found.unwrap();
+        assert_eq!(found_id, NamedFunctionID::from(0));
         assert_eq!(
-            found.unwrap().function,
+            found.function,
             Function::Constant(Coefficient::try_from(1.0).unwrap())
         );
         assert_eq!(instance.named_function_labels().name(found_id), Some("f"));

--- a/rust/ommx/src/instance/named_function.rs
+++ b/rust/ommx/src/instance/named_function.rs
@@ -80,7 +80,7 @@ impl Instance {
         }
         let id = self.next_named_function_id();
 
-        let named_function = NamedFunction { id, function };
+        let named_function = NamedFunction { function };
         self.named_functions.insert(id, named_function);
         let label = crate::named_function::NamedFunctionLabel {
             name,
@@ -167,7 +167,11 @@ mod tests {
         // Lookup by correct name and subscripts
         let found = instance.get_named_function_by_name("f", vec![1, 2]);
         assert!(found.is_some());
-        let found_id = found.unwrap().id;
+        let found_id = NamedFunctionID::from(0);
+        assert_eq!(
+            found.unwrap().function,
+            Function::Constant(Coefficient::try_from(1.0).unwrap())
+        );
         assert_eq!(instance.named_function_labels().name(found_id), Some("f"));
         assert_eq!(
             instance.named_function_labels().subscripts(found_id),
@@ -227,7 +231,7 @@ mod tests {
         instance.new_continuous();
 
         // Add a named function that references variable 0
-        let nf = instance
+        instance
             .new_named_function(
                 Function::Linear((coeff!(2.0) * linear!(0)).unwrap()),
                 Some("obj".to_string()),
@@ -237,7 +241,8 @@ mod tests {
             )
             .unwrap();
 
-        let nf_id = nf.id;
+        let nf_id = NamedFunctionID::from(0);
+        assert!(instance.named_functions().contains_key(&nf_id));
         assert_eq!(nf_id, NamedFunctionID::from(0));
         let store = instance.named_function_labels();
         assert_eq!(store.name(nf_id), Some("obj"));

--- a/rust/ommx/src/instance/named_function.rs
+++ b/rust/ommx/src/instance/named_function.rs
@@ -154,7 +154,7 @@ mod tests {
     fn test_get_named_function_by_name() {
         let mut instance = Instance::default();
 
-        instance
+        let inserted_id = instance
             .new_named_function(
                 Function::Constant(Coefficient::try_from(1.0).unwrap()),
                 Some("f".to_string()),
@@ -168,7 +168,7 @@ mod tests {
         let found = instance.get_named_function_by_name("f", vec![1, 2]);
         assert!(found.is_some());
         let (found_id, found) = found.unwrap();
-        assert_eq!(found_id, NamedFunctionID::from(0));
+        assert_eq!(found_id, inserted_id);
         assert_eq!(
             found.function,
             Function::Constant(Coefficient::try_from(1.0).unwrap())
@@ -232,7 +232,7 @@ mod tests {
         instance.new_continuous();
 
         // Add a named function that references variable 0
-        instance
+        let nf_id = instance
             .new_named_function(
                 Function::Linear((coeff!(2.0) * linear!(0)).unwrap()),
                 Some("obj".to_string()),
@@ -242,9 +242,7 @@ mod tests {
             )
             .unwrap();
 
-        let nf_id = NamedFunctionID::from(0);
         assert!(instance.named_functions().contains_key(&nf_id));
-        assert_eq!(nf_id, NamedFunctionID::from(0));
         let store = instance.named_function_labels();
         assert_eq!(store.name(nf_id), Some("obj"));
         assert_eq!(store.subscripts(nf_id), &[0]);

--- a/rust/ommx/src/instance/parametric_builder.rs
+++ b/rust/ommx/src/instance/parametric_builder.rs
@@ -318,15 +318,8 @@ impl ParametricInstanceBuilder {
             }
         }
 
-        // Validate named_functions: key must match value's id, and all variable IDs must exist
-        for (key, nf) in &self.named_functions {
-            if *key != nf.id {
-                let id = nf.id;
-                crate::bail!(
-                    { ?key, ?id },
-                    "Named function map key {key:?} does not match value's id {id:?}",
-                );
-            }
+        // Validate named_functions: map keys own IDs, and all referenced variable IDs must exist.
+        for nf in self.named_functions.values() {
             for id in nf.function.required_ids() {
                 if !all_variable_ids.contains(&id) {
                     crate::bail!({ ?id }, "Undefined variable ID is used: {id:?}");
@@ -848,45 +841,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parametric_builder_inconsistent_named_function_id() {
-        use crate::{NamedFunction, NamedFunctionID};
-        use maplit::btreemap;
-
-        // Create a named function with id=1 but use key=2 in the map
-        let named_function = NamedFunction {
-            id: NamedFunctionID::from(1),
-            function: Function::Zero,
-        };
-
-        let err = ParametricInstance::builder()
-            .sense(Sense::Minimize)
-            .objective(Function::Zero)
-            .decision_variables(BTreeMap::new())
-            .parameters(BTreeMap::new())
-            .constraints(BTreeMap::new())
-            .named_functions(btreemap! {
-                NamedFunctionID::from(2) => named_function,  // key=2 but id=1
-            })
-            .build()
-            .unwrap_err();
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Named function map key")
-                && msg.contains("NamedFunctionID(2)")
-                && msg.contains("NamedFunctionID(1)"),
-            "unexpected error: {msg}"
-        );
-    }
-
-    #[test]
     fn test_parametric_builder_undefined_variable_in_named_function() {
         use crate::{coeff, linear, NamedFunction, NamedFunctionID};
         use maplit::btreemap;
 
         // Create a named function that references undefined variable ID 999
         let named_function = NamedFunction {
-            id: NamedFunctionID::from(1),
             function: Function::from(linear!(999) + coeff!(1.0)),
         };
 
@@ -1147,7 +1107,6 @@ mod tests {
         let param_id = VariableID::from(2);
 
         let named_function = NamedFunction {
-            id: NamedFunctionID::from(1),
             function: Function::from(linear!(1) + linear!(2)), // uses both decision var and param
         };
 

--- a/rust/ommx/src/instance/parametric_builder.rs
+++ b/rust/ommx/src/instance/parametric_builder.rs
@@ -326,16 +326,8 @@ impl ParametricInstanceBuilder {
                 }
             }
         }
-        let named_function_ids = self
-            .named_functions
-            .keys()
-            .copied()
-            .collect::<std::collections::BTreeSet<_>>();
-        crate::modeling_label::validate_modeling_label_ids(
-            &self.named_function_labels,
-            &named_function_ids,
-            "named function",
-        )?;
+        let named_functions =
+            NamedFunctionTable::new(self.named_functions, self.named_function_labels)?;
 
         // Validate indicator constraints. Function bodies may reference
         // parameters; the indicator variable is a *structural* position and
@@ -539,8 +531,7 @@ impl ParametricInstanceBuilder {
                 BTreeMap::new(),
                 self.sos1_constraint_context,
             )?,
-            named_functions: self.named_functions,
-            named_function_labels: self.named_function_labels,
+            named_functions,
             decision_variable_dependency: self.decision_variable_dependency,
             description: self.description,
             annotations: Default::default(),
@@ -688,6 +679,28 @@ mod tests {
         assert!(
             err.to_string().contains("unknown decision variable ID")
                 && err.to_string().contains("VariableID(99)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parametric_builder_rejects_orphan_named_function_labels() {
+        let mut named_function_labels = crate::named_function::NamedFunctionLabelStore::default();
+        named_function_labels.set_name(NamedFunctionID::from(99), "orphan");
+
+        let err = ParametricInstance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::new())
+            .parameters(BTreeMap::new())
+            .constraints(BTreeMap::new())
+            .named_function_labels(named_function_labels)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("unknown named function ID")
+                && err.to_string().contains("NamedFunctionID(99)"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/instance/parametric_builder.rs
+++ b/rust/ommx/src/instance/parametric_builder.rs
@@ -221,7 +221,7 @@ impl ParametricInstanceBuilder {
     /// Returns an error if:
     /// - Required fields (`sense`, `objective`, `decision_variables`, `parameters`, `constraints`) are not set
     /// - Decision variable IDs and parameter IDs overlap
-    /// - The objective function or constraints reference undefined variable IDs
+    /// - The objective function, constraints, or named functions reference undefined variable IDs
     /// - The keys of `constraints` and `removed_constraints` are not disjoint
     /// - Label/context stores contain IDs that are not owned by the
     ///   corresponding decision-variable, named-function, or constraint collection

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -409,7 +409,7 @@ impl From<Instance> for v1::Instance {
             .into_iter()
             .map(|(id, nf)| {
                 let label = named_function_labels.remove(id);
-                crate::named_function::parse::named_function_to_v1(nf, label)
+                crate::named_function::parse::named_function_to_v1(id, nf, label)
             })
             .collect();
         let removed_constraints = removed
@@ -710,7 +710,7 @@ impl From<ParametricInstance> for v1::ParametricInstance {
             .into_iter()
             .map(|(id, nf)| {
                 let label = named_function_labels.remove(id);
-                crate::named_function::parse::named_function_to_v1(nf, label)
+                crate::named_function::parse::named_function_to_v1(id, nf, label)
             })
             .collect();
         Self {

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -367,8 +367,11 @@ impl Parse for v1::Instance {
             parameters: self.parameters,
             description: self.description,
             annotations: self.annotations,
-            named_functions,
-            named_function_labels,
+            named_functions: crate::NamedFunctionTable::new(named_functions, named_function_labels)
+                .map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string())
+                        .context(message, "named_functions")
+                })?,
         })
     }
 }
@@ -403,9 +406,8 @@ impl From<Instance> for v1::Instance {
             .into_iter()
             .map(|(id, c)| constraint_to_v1(id, c, constraint_context.remove(id)))
             .collect();
-        let mut named_function_labels = value.named_function_labels;
-        let named_functions = value
-            .named_functions
+        let (named_functions, mut named_function_labels) = value.named_functions.into_parts();
+        let named_functions = named_functions
             .into_iter()
             .map(|(id, nf)| {
                 let label = named_function_labels.remove(id);
@@ -636,8 +638,11 @@ impl Parse for v1::ParametricInstance {
             .map_err(|e| {
                 RawParseError::InvalidInstance(e.to_string()).context(message, "constraint_hints")
             })?,
-            named_functions,
-            named_function_labels,
+            named_functions: crate::NamedFunctionTable::new(named_functions, named_function_labels)
+                .map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string())
+                        .context(message, "named_functions")
+                })?,
             decision_variable_dependency,
             description: self.description,
             annotations: self.annotations,
@@ -661,7 +666,6 @@ impl From<ParametricInstance> for v1::ParametricInstance {
             decision_variable_dependency,
             description,
             named_functions,
-            named_function_labels,
             annotations,
         }: ParametricInstance,
     ) -> Self {
@@ -705,7 +709,7 @@ impl From<ParametricInstance> for v1::ParametricInstance {
             .into_iter()
             .map(|(id, (c, r))| removed_constraint_to_v1(id, c, constraint_context.remove(id), r))
             .collect();
-        let mut named_function_labels = named_function_labels;
+        let (named_functions, mut named_function_labels) = named_functions.into_parts();
         let v1_named_functions = named_functions
             .into_iter()
             .map(|(id, nf)| {

--- a/rust/ommx/src/instance/penalty.rs
+++ b/rust/ommx/src/instance/penalty.rs
@@ -127,7 +127,6 @@ impl Instance {
             decision_variable_dependency: self.decision_variable_dependency,
             description: self.description,
             named_functions: self.named_functions,
-            named_function_labels: self.named_function_labels,
             annotations: self.annotations,
         })
     }
@@ -205,7 +204,6 @@ impl Instance {
                 decision_variable_dependency: self.decision_variable_dependency,
                 description: self.description,
                 named_functions: self.named_functions,
-                named_function_labels: self.named_function_labels,
                 annotations: self.annotations,
             });
         }
@@ -277,7 +275,6 @@ impl Instance {
             decision_variable_dependency: self.decision_variable_dependency,
             description: self.description,
             named_functions: self.named_functions,
-            named_function_labels: self.named_function_labels,
             annotations: self.annotations,
         })
     }

--- a/rust/ommx/src/instance/substitute.rs
+++ b/rust/ommx/src/instance/substitute.rs
@@ -97,7 +97,8 @@ impl Substitute for Instance {
             }
         }
 
-        // Apply substitution to the existing decision_variable_dependency
+        // Apply substitution to named functions and existing dependencies.
+        self.named_functions.substitute_acyclic(acyclic)?;
         substitute_acyclic(&mut self.decision_variable_dependency, acyclic)?;
 
         Ok(self)
@@ -204,6 +205,8 @@ impl Substitute for ParametricInstance {
             }
         }
 
+        // Apply substitution to named functions and existing dependencies.
+        self.named_functions.substitute_acyclic(acyclic)?;
         substitute_acyclic(&mut self.decision_variable_dependency, acyclic)?;
 
         Ok(self)
@@ -221,7 +224,7 @@ impl Substitute for ParametricInstance {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{coeff, constraint::Equality, linear, DecisionVariable, Sense};
+    use crate::{coeff, constraint::Equality, linear, DecisionVariable, Evaluate, Sense};
     use std::collections::BTreeMap;
 
     #[test]
@@ -245,8 +248,17 @@ mod tests {
         };
         constraints.insert(ConstraintID::from(1), constraint);
 
-        let instance =
+        let mut instance =
             Instance::new(Sense::Minimize, objective, decision_variables, constraints).unwrap();
+        let named_function_id = instance
+            .new_named_function(
+                Function::from((linear!(1) + linear!(2)).unwrap()),
+                Some("tracked".to_string()),
+                vec![],
+                Default::default(),
+                None,
+            )
+            .unwrap();
 
         // Substitute x1 with x3 + 1
         let substitution = Function::from(linear!(3) + coeff!(1.0));
@@ -260,6 +272,13 @@ mod tests {
             .decision_variable_dependency
             .get(&VariableID::from(1))
             .is_some());
+
+        let named_function = result.named_functions().get(&named_function_id).unwrap();
+        let expected_ids: std::collections::BTreeSet<_> =
+            [VariableID::from(2), VariableID::from(3)]
+                .into_iter()
+                .collect();
+        assert_eq!(named_function.required_ids(), expected_ids);
     }
 
     #[test]

--- a/rust/ommx/src/instance/substitute.rs
+++ b/rust/ommx/src/instance/substitute.rs
@@ -98,7 +98,7 @@ impl Substitute for Instance {
         }
 
         // Apply substitution to named functions and existing dependencies.
-        self.named_functions.substitute_acyclic(acyclic)?;
+        substitute_acyclic(&mut self.named_functions, acyclic)?;
         substitute_acyclic(&mut self.decision_variable_dependency, acyclic)?;
 
         Ok(self)
@@ -206,7 +206,7 @@ impl Substitute for ParametricInstance {
         }
 
         // Apply substitution to named functions and existing dependencies.
-        self.named_functions.substitute_acyclic(acyclic)?;
+        substitute_acyclic(&mut self.named_functions, acyclic)?;
         substitute_acyclic(&mut self.decision_variable_dependency, acyclic)?;
 
         Ok(self)

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -5,6 +5,7 @@ pub(crate) mod parse;
 
 use derive_more::{Deref, From};
 use getset::*;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
 use crate::{Function, SampleID, Sampled, VariableIDSet};
@@ -96,6 +97,162 @@ impl std::fmt::Display for NamedFunction {
 /// Modeling label for named functions.
 pub type NamedFunctionLabel = crate::ModelingLabel;
 
+/// Owner of named-function rows and their modeling labels.
+///
+/// The table key owns [`NamedFunctionID`], the row value owns intrinsic data
+/// (`NamedFunction`, `EvaluatedNamedFunction`, or `SampledNamedFunction`), and
+/// [`NamedFunctionLabelStore`] owns `name`, `subscripts`, `parameters`, and
+/// `description`. This mirrors `ConstraintCollection` for named functions,
+/// without active/removed state.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NamedFunctionTable<T> {
+    entries: BTreeMap<NamedFunctionID, T>,
+    labels: NamedFunctionLabelStore,
+}
+
+impl<T> Default for NamedFunctionTable<T> {
+    fn default() -> Self {
+        Self {
+            entries: BTreeMap::default(),
+            labels: NamedFunctionLabelStore::default(),
+        }
+    }
+}
+
+impl<T> NamedFunctionTable<T> {
+    /// Construct a named-function table, rejecting labels for unknown IDs.
+    pub fn new(
+        entries: BTreeMap<NamedFunctionID, T>,
+        labels: NamedFunctionLabelStore,
+    ) -> crate::Result<Self> {
+        let owned_ids = entries.keys().copied().collect::<BTreeSet<_>>();
+        crate::modeling_label::validate_modeling_label_ids(&labels, &owned_ids, "named function")?;
+        Ok(Self { entries, labels })
+    }
+
+    /// Construct a table with no labels.
+    pub fn from_entries(entries: BTreeMap<NamedFunctionID, T>) -> Self {
+        Self {
+            entries,
+            labels: NamedFunctionLabelStore::default(),
+        }
+    }
+
+    /// Construct a table without validating that labels refer to existing rows.
+    ///
+    /// This is for host-level unchecked constructors whose caller already owns
+    /// the invariant. Prefer [`Self::new`] at external input boundaries.
+    pub(crate) fn from_parts_unchecked(
+        entries: BTreeMap<NamedFunctionID, T>,
+        labels: NamedFunctionLabelStore,
+    ) -> Self {
+        Self { entries, labels }
+    }
+
+    /// Split the table into its row map and label store.
+    ///
+    /// Use this at serialization or conversion boundaries that must join
+    /// labels back onto row payloads. Iterating by value is intentionally not
+    /// provided, so consuming code cannot silently drop labels.
+    pub fn into_parts(self) -> (BTreeMap<NamedFunctionID, T>, NamedFunctionLabelStore) {
+        (self.entries, self.labels)
+    }
+
+    /// Intrinsic row map, keyed by table-owned [`NamedFunctionID`].
+    pub fn entries(&self) -> &BTreeMap<NamedFunctionID, T> {
+        &self.entries
+    }
+
+    /// Per-row modeling label store.
+    pub fn labels(&self) -> &NamedFunctionLabelStore {
+        &self.labels
+    }
+
+    /// Replace the modeling label for an existing named-function row.
+    pub fn set_label(
+        &mut self,
+        id: NamedFunctionID,
+        label: NamedFunctionLabel,
+    ) -> crate::Result<()> {
+        if !self.entries.contains_key(&id) {
+            crate::bail!(
+                { ?id },
+                "Modeling label references unknown named function ID {id:?}",
+            );
+        }
+        self.labels.insert(id, label);
+        Ok(())
+    }
+
+    /// Insert or replace one row and its modeling label.
+    pub fn insert(&mut self, id: NamedFunctionID, row: T, label: NamedFunctionLabel) -> Option<T> {
+        self.labels.insert(id, label);
+        self.entries.insert(id, row)
+    }
+
+    pub fn contains_key(&self, id: &NamedFunctionID) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    pub fn get(&self, id: &NamedFunctionID) -> Option<&T> {
+        self.entries.get(id)
+    }
+
+    pub fn get_mut(&mut self, id: &NamedFunctionID) -> Option<&mut T> {
+        self.entries.get_mut(id)
+    }
+
+    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, NamedFunctionID, T> {
+        self.entries.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::collections::btree_map::IterMut<'_, NamedFunctionID, T> {
+        self.entries.iter_mut()
+    }
+
+    pub fn keys(&self) -> std::collections::btree_map::Keys<'_, NamedFunctionID, T> {
+        self.entries.keys()
+    }
+
+    pub fn values(&self) -> std::collections::btree_map::Values<'_, NamedFunctionID, T> {
+        self.entries.values()
+    }
+
+    pub fn values_mut(&mut self) -> std::collections::btree_map::ValuesMut<'_, NamedFunctionID, T> {
+        self.entries.values_mut()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn last_key_value(&self) -> Option<(&NamedFunctionID, &T)> {
+        self.entries.last_key_value()
+    }
+}
+
+impl<T: LogicalMemoryProfile> LogicalMemoryProfile for NamedFunctionTable<T> {
+    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
+        self.entries
+            .visit_logical_memory(path.with("entries").as_mut(), visitor);
+        self.labels
+            .visit_logical_memory(path.with("labels").as_mut(), visitor);
+    }
+}
+
+impl<'a, T> IntoIterator for &'a NamedFunctionTable<T> {
+    type Item = (&'a NamedFunctionID, &'a T);
+    type IntoIter = std::collections::btree_map::Iter<'a, NamedFunctionID, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.iter()
+    }
+}
+
 /// `ommx.v1.EvaluatedNamedFunction` with validated, typed fields.
 ///
 /// Modeling labels moved to a per-collection
@@ -151,5 +308,39 @@ impl SampledNamedFunction {
             evaluated_value,
             used_decision_variable_ids: self.used_decision_variable_ids.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod table_tests {
+    use super::*;
+
+    #[test]
+    fn rejects_label_for_unknown_id() {
+        let mut labels = NamedFunctionLabelStore::default();
+        labels.set_name(NamedFunctionID::from(1), "unknown");
+
+        let err = NamedFunctionTable::<NamedFunction>::new(BTreeMap::new(), labels).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Modeling label references unknown named function ID"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn preserves_rows_and_labels() {
+        let id = NamedFunctionID::from(0);
+        let row = NamedFunction {
+            function: Function::Zero,
+        };
+        let mut labels = NamedFunctionLabelStore::default();
+        labels.set_name(id, "cost");
+
+        let table = NamedFunctionTable::new(BTreeMap::from([(id, row.clone())]), labels).unwrap();
+
+        assert_eq!(table.get(&id), Some(&row));
+        assert_eq!(table.labels().name(id), Some("cost"));
     }
 }

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -198,16 +198,8 @@ impl<T> NamedFunctionTable<T> {
         self.entries.get(id)
     }
 
-    pub fn get_mut(&mut self, id: &NamedFunctionID) -> Option<&mut T> {
-        self.entries.get_mut(id)
-    }
-
     pub fn iter(&self) -> std::collections::btree_map::Iter<'_, NamedFunctionID, T> {
         self.entries.iter()
-    }
-
-    pub fn iter_mut(&mut self) -> std::collections::btree_map::IterMut<'_, NamedFunctionID, T> {
-        self.entries.iter_mut()
     }
 
     pub fn keys(&self) -> std::collections::btree_map::Keys<'_, NamedFunctionID, T> {
@@ -216,10 +208,6 @@ impl<T> NamedFunctionTable<T> {
 
     pub fn values(&self) -> std::collections::btree_map::Values<'_, NamedFunctionID, T> {
         self.entries.values()
-    }
-
-    pub fn values_mut(&mut self) -> std::collections::btree_map::ValuesMut<'_, NamedFunctionID, T> {
-        self.entries.values_mut()
     }
 
     pub fn len(&self) -> usize {

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -71,23 +71,25 @@ impl LogicalMemoryProfile for NamedFunctionID {
 /// - `name`: A human-readable identifier (e.g., "f")
 /// - `subscripts`: The index values (e.g., `[1, 5]` for `f[1, 5]`)
 ///
-/// Named function IDs are managed separately from decision variable IDs and constraint IDs,
-/// so the same ID value can be used across these different namespaces.
+/// Named function IDs are managed by the enclosing named-function table key,
+/// separately from decision variable IDs and constraint IDs, so the same ID
+/// value can be used across these different namespaces.
 ///
 /// The modeling label (`name`, `subscripts`, `parameters`, `description`) is stored in a
 /// per-collection [`NamedFunctionLabelStore`] keyed by [`NamedFunctionID`];
-/// the per-element struct no longer carries it.
+/// the per-element struct no longer carries it or the ID.
 ///
-/// Corresponds to `ommx.v1.NamedFunction`.
+/// Corresponds to `ommx.v1.NamedFunction`, but the legacy protobuf inline `id`
+/// is drained into / filled from the enclosing map key at the parse/serialize
+/// boundary.
 #[derive(Debug, Clone, PartialEq, LogicalMemoryProfile)]
 pub struct NamedFunction {
-    pub id: NamedFunctionID,
     pub function: Function,
 }
 
 impl std::fmt::Display for NamedFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "NamedFunction(id={}, {})", self.id, self.function)
+        write!(f, "NamedFunction({})", self.function)
     }
 }
 
@@ -98,11 +100,10 @@ pub type NamedFunctionLabel = crate::ModelingLabel;
 ///
 /// Modeling labels moved to a per-collection
 /// [`NamedFunctionLabelStore`] on `Solution`; the struct only carries
-/// intrinsic evaluated data.
+/// intrinsic evaluated data. The legacy protobuf inline `id` is owned by the
+/// enclosing `Solution` map key in the Rust domain model.
 #[derive(Debug, Clone, PartialEq, CopyGetters, Getters)]
 pub struct EvaluatedNamedFunction {
-    #[getset(get_copy = "pub")]
-    pub id: NamedFunctionID,
     #[getset(get_copy = "pub")]
     pub evaluated_value: f64,
     #[getset(get = "pub")]
@@ -111,11 +112,7 @@ pub struct EvaluatedNamedFunction {
 
 impl std::fmt::Display for EvaluatedNamedFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "EvaluatedNamedFunction(id={}, value={})",
-            self.id, self.evaluated_value
-        )
+        write!(f, "EvaluatedNamedFunction(value={})", self.evaluated_value)
     }
 }
 
@@ -123,11 +120,10 @@ impl std::fmt::Display for EvaluatedNamedFunction {
 ///
 /// Modeling labels moved to a per-collection
 /// [`NamedFunctionLabelStore`] on `SampleSet`; the struct only carries
-/// intrinsic sampled data.
+/// intrinsic sampled data. The legacy protobuf inline `id` is owned by the
+/// enclosing `SampleSet` map key in the Rust domain model.
 #[derive(Debug, Clone, PartialEq, Getters)]
 pub struct SampledNamedFunction {
-    #[getset(get = "pub")]
-    id: NamedFunctionID,
     #[getset(get = "pub")]
     evaluated_values: Sampled<f64>,
     #[getset(get = "pub")]
@@ -138,8 +134,7 @@ impl std::fmt::Display for SampledNamedFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "SampledNamedFunction(id={}, num_samples={})",
-            self.id,
+            "SampledNamedFunction(num_samples={})",
             self.evaluated_values.num_samples()
         )
     }
@@ -153,7 +148,6 @@ impl SampledNamedFunction {
         let evaluated_value = *self.evaluated_values.get(sample_id)?;
 
         Some(EvaluatedNamedFunction {
-            id: *self.id(),
             evaluated_value,
             used_decision_variable_ids: self.used_decision_variable_ids.clone(),
         })

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -105,6 +105,25 @@ pub type NamedFunctionLabel = crate::ModelingLabel;
 /// [`NamedFunctionLabelStore`] owns `name`, `subscripts`, `parameters`, and
 /// `description`. This mirrors `ConstraintCollection` for named functions,
 /// without active/removed state.
+///
+/// # Invariants
+///
+/// - Every modeling-label ID is owned by this table; labels for unknown
+///   [`NamedFunctionID`] values are rejected by [`Self::new`] and
+///   [`Self::set_label`].
+/// - Public mutation preserves the row/label ownership boundary. Rows can be
+///   inserted or replaced only together with the corresponding label via
+///   [`Self::insert`]; mutable row iteration is not exposed.
+///
+/// # Host-level invariants
+///
+/// This table intentionally does not validate row semantics that require a
+/// surrounding top-level object. For example, whether a created
+/// [`NamedFunction`] references defined decision variables, or whether an
+/// evaluated/sampled named function's `used_decision_variable_ids` exist in the
+/// evaluated/sampled decision-variable table, is validated by host builders such
+/// as [`crate::Instance::builder`], [`crate::Solution::builder`], and
+/// [`crate::SampleSet::builder`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct NamedFunctionTable<T> {
     entries: BTreeMap<NamedFunctionID, T>,

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -2,6 +2,7 @@ mod arbitrary;
 mod evaluate;
 mod label_store;
 pub(crate) mod parse;
+mod substitute;
 
 use derive_more::{Deref, From};
 use getset::*;

--- a/rust/ommx/src/named_function/arbitrary.rs
+++ b/rust/ommx/src/named_function/arbitrary.rs
@@ -10,10 +10,7 @@ impl Arbitrary for NamedFunction {
     type Strategy = BoxedStrategy<Self>;
     fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
         Function::arbitrary_with(params)
-            .prop_map(|function| NamedFunction {
-                id: NamedFunctionID(0), // Should be replaced with a unique ID, but cannot be generated here
-                function,
-            })
+            .prop_map(|function| NamedFunction { function })
             .boxed()
     }
 }
@@ -60,10 +57,7 @@ pub fn arbitrary_named_functions(
             ids.into_iter()
                 .map(NamedFunctionID::from)
                 .zip(named_functions)
-                .map(|(id, mut named_function)| {
-                    named_function.id = id;
-                    (id, named_function)
-                })
+                .map(|(id, named_function)| (id, named_function))
                 .collect()
         })
         .boxed()

--- a/rust/ommx/src/named_function/arbitrary.rs
+++ b/rust/ommx/src/named_function/arbitrary.rs
@@ -57,7 +57,6 @@ pub fn arbitrary_named_functions(
             ids.into_iter()
                 .map(NamedFunctionID::from)
                 .zip(named_functions)
-                .map(|(id, named_function)| (id, named_function))
                 .collect()
         })
         .boxed()

--- a/rust/ommx/src/named_function/evaluate.rs
+++ b/rust/ommx/src/named_function/evaluate.rs
@@ -44,20 +44,6 @@ impl Evaluate for NamedFunction {
     }
 }
 
-impl NamedFunctionTable<NamedFunction> {
-    pub(crate) fn substitute_acyclic(
-        &mut self,
-        acyclic: &crate::AcyclicAssignments,
-    ) -> Result<(), crate::SubstitutionError> {
-        let mut updated = self.clone();
-        for named_function in updated.entries.values_mut() {
-            crate::substitute_acyclic(&mut named_function.function, acyclic)?;
-        }
-        *self = updated;
-        Ok(())
-    }
-}
-
 impl Evaluate for NamedFunctionTable<NamedFunction> {
     type Output = NamedFunctionTable<EvaluatedNamedFunction>;
     type SampledOutput = NamedFunctionTable<SampledNamedFunction>;

--- a/rust/ommx/src/named_function/evaluate.rs
+++ b/rust/ommx/src/named_function/evaluate.rs
@@ -13,7 +13,6 @@ impl Evaluate for NamedFunction {
         let evaluated_value = self.function.evaluate(solution, atol)?;
         let used_decision_variable_ids = self.function.required_ids();
         Ok(EvaluatedNamedFunction {
-            id: self.id,
             evaluated_value,
             used_decision_variable_ids,
         })
@@ -39,7 +38,6 @@ impl Evaluate for NamedFunction {
         let evaluated_values = self.function.evaluate_samples(samples, atol)?;
         let used_decision_variable_ids = self.function.required_ids();
         Ok(SampledNamedFunction {
-            id: self.id,
             evaluated_values,
             used_decision_variable_ids,
         })
@@ -56,14 +54,12 @@ mod tests {
     fn test_evaluate_constant_function() {
         // NamedFunction with a constant function
         let nf = NamedFunction {
-            id: NamedFunctionID::from(1),
             function: Function::Constant(Coefficient::try_from(42.0).unwrap()),
         };
 
         let state = crate::v1::State::default();
         let result = nf.evaluate(&state, crate::ATol::default()).unwrap();
 
-        assert_eq!(result.id(), NamedFunctionID::from(1));
         assert_eq!(result.evaluated_value(), 42.0);
         assert!(result.used_decision_variable_ids().is_empty());
     }
@@ -72,7 +68,6 @@ mod tests {
     fn test_evaluate_linear_function() {
         // NamedFunction with 2*x1 + 3*x2
         let nf = NamedFunction {
-            id: NamedFunctionID::from(2),
             function: Function::Linear(
                 ((coeff!(2.0) * linear!(1)).unwrap() + (coeff!(3.0) * linear!(2)).unwrap())
                     .unwrap(),
@@ -96,7 +91,6 @@ mod tests {
     fn test_required_ids() {
         // NamedFunction with a linear function referencing variables 1 and 2
         let nf = NamedFunction {
-            id: NamedFunctionID::from(3),
             function: Function::Linear(
                 ((coeff!(2.0) * linear!(1)).unwrap() + (coeff!(3.0) * linear!(2)).unwrap())
                     .unwrap(),

--- a/rust/ommx/src/named_function/evaluate.rs
+++ b/rust/ommx/src/named_function/evaluate.rs
@@ -56,18 +56,62 @@ impl NamedFunctionTable<NamedFunction> {
         *self = updated;
         Ok(())
     }
+}
 
-    pub(crate) fn partial_evaluate(
+impl Evaluate for NamedFunctionTable<NamedFunction> {
+    type Output = NamedFunctionTable<EvaluatedNamedFunction>;
+    type SampledOutput = NamedFunctionTable<SampledNamedFunction>;
+
+    fn evaluate(&self, state: &crate::v1::State, atol: crate::ATol) -> crate::Result<Self::Output> {
+        let mut results = std::collections::BTreeMap::new();
+        for (id, named_function) in &self.entries {
+            let evaluated = named_function.evaluate(state, atol).inspect_err(|e| {
+                tracing::error!(?id, error = %e, "failed to evaluate named function");
+            })?;
+            results.insert(*id, evaluated);
+        }
+        NamedFunctionTable::new(results, self.labels.clone())
+    }
+
+    fn partial_evaluate(
         &mut self,
         state: &crate::v1::State,
         atol: crate::ATol,
     ) -> crate::Result<()> {
         let mut updated = self.clone();
-        for named_function in updated.entries.values_mut() {
-            named_function.partial_evaluate(state, atol)?;
+        for (id, named_function) in updated.entries.iter_mut() {
+            named_function
+                .partial_evaluate(state, atol)
+                .inspect_err(|e| {
+                    tracing::error!(?id, error = %e, "failed to partial_evaluate named function");
+                })?;
         }
         *self = updated;
         Ok(())
+    }
+
+    fn required_ids(&self) -> VariableIDSet {
+        self.entries
+            .values()
+            .flat_map(Evaluate::required_ids)
+            .collect()
+    }
+
+    fn evaluate_samples(
+        &self,
+        samples: &crate::Sampled<crate::v1::State>,
+        atol: crate::ATol,
+    ) -> crate::Result<Self::SampledOutput> {
+        let mut results = std::collections::BTreeMap::new();
+        for (id, named_function) in &self.entries {
+            let sampled = named_function
+                .evaluate_samples(samples, atol)
+                .inspect_err(|e| {
+                    tracing::error!(?id, error = %e, "failed to evaluate_samples named function");
+                })?;
+            results.insert(*id, sampled);
+        }
+        NamedFunctionTable::new(results, self.labels.clone())
     }
 }
 
@@ -126,5 +170,80 @@ mod tests {
 
         let ids = nf.required_ids();
         assert_eq!(ids, btreeset! { VariableID::from(1), VariableID::from(2) });
+    }
+
+    #[test]
+    fn test_table_evaluate_preserves_labels() {
+        let id = NamedFunctionID::from(7);
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            id,
+            NamedFunction {
+                function: Function::Linear(linear!(1).into()),
+            },
+        );
+        let mut labels = NamedFunctionLabelStore::new();
+        labels.set_name(id, "cost");
+        labels.set_subscripts(id, vec![3]);
+        let table = NamedFunctionTable::new(entries, labels).unwrap();
+
+        let state = crate::v1::State {
+            entries: [(1, 4.0)].into_iter().collect(),
+        };
+        let evaluated = table.evaluate(&state, crate::ATol::default()).unwrap();
+
+        assert_eq!(evaluated.labels().name(id), Some("cost"));
+        assert_eq!(evaluated.labels().subscripts(id), &[3]);
+        let row = evaluated.get(&id).unwrap();
+        assert_eq!(row.evaluated_value(), 4.0);
+        assert_eq!(
+            *row.used_decision_variable_ids(),
+            btreeset! { VariableID::from(1) }
+        );
+    }
+
+    #[test]
+    fn test_table_evaluate_samples_preserves_labels() {
+        let id = NamedFunctionID::from(8);
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            id,
+            NamedFunction {
+                function: Function::Linear(linear!(1).into()),
+            },
+        );
+        let mut labels = NamedFunctionLabelStore::new();
+        labels.set_name(id, "load");
+        let table = NamedFunctionTable::new(entries, labels).unwrap();
+
+        let samples = crate::Sampled::new(
+            vec![
+                vec![crate::SampleID::from(0)],
+                vec![crate::SampleID::from(1)],
+            ],
+            [
+                crate::v1::State {
+                    entries: [(1, 2.0)].into_iter().collect(),
+                },
+                crate::v1::State {
+                    entries: [(1, 5.0)].into_iter().collect(),
+                },
+            ],
+        )
+        .unwrap();
+        let sampled = table
+            .evaluate_samples(&samples, crate::ATol::default())
+            .unwrap();
+
+        assert_eq!(sampled.labels().name(id), Some("load"));
+        let row = sampled.get(&id).unwrap();
+        assert_eq!(
+            row.get(crate::SampleID::from(0)).unwrap().evaluated_value(),
+            2.0
+        );
+        assert_eq!(
+            row.get(crate::SampleID::from(1)).unwrap().evaluated_value(),
+            5.0
+        );
     }
 }

--- a/rust/ommx/src/named_function/evaluate.rs
+++ b/rust/ommx/src/named_function/evaluate.rs
@@ -44,6 +44,33 @@ impl Evaluate for NamedFunction {
     }
 }
 
+impl NamedFunctionTable<NamedFunction> {
+    pub(crate) fn substitute_acyclic(
+        &mut self,
+        acyclic: &crate::AcyclicAssignments,
+    ) -> Result<(), crate::SubstitutionError> {
+        let mut updated = self.clone();
+        for named_function in updated.entries.values_mut() {
+            crate::substitute_acyclic(&mut named_function.function, acyclic)?;
+        }
+        *self = updated;
+        Ok(())
+    }
+
+    pub(crate) fn partial_evaluate(
+        &mut self,
+        state: &crate::v1::State,
+        atol: crate::ATol,
+    ) -> crate::Result<()> {
+        let mut updated = self.clone();
+        for named_function in updated.entries.values_mut() {
+            named_function.partial_evaluate(state, atol)?;
+        }
+        *self = updated;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/ommx/src/named_function/parse.rs
+++ b/rust/ommx/src/named_function/parse.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 /// parse can drain it into the [`NamedFunctionLabelStore`].
 #[derive(Debug)]
 pub struct ParsedNamedFunction {
+    pub id: NamedFunctionID,
     pub named_function: NamedFunction,
     pub label: NamedFunctionLabel,
 }
@@ -31,10 +32,8 @@ impl Parse for v1::NamedFunction {
                 field: "function",
             })?
             .parse_as(&(), message, "function")?;
-        let named_function = NamedFunction {
-            id: NamedFunctionID(self.id),
-            function,
-        };
+        let id = NamedFunctionID(self.id);
+        let named_function = NamedFunction { function };
         let label = NamedFunctionLabel {
             name: self.name,
             subscripts: self.subscripts,
@@ -42,6 +41,7 @@ impl Parse for v1::NamedFunction {
             description: self.description,
         };
         Ok(ParsedNamedFunction {
+            id,
             named_function,
             label,
         })
@@ -60,7 +60,7 @@ impl Parse for Vec<v1::NamedFunction> {
         let mut label_store = NamedFunctionLabelStore::default();
         for v in self {
             let parsed: ParsedNamedFunction = v.parse(&())?;
-            let id = parsed.named_function.id;
+            let id = parsed.id;
             if named_functions.insert(id, parsed.named_function).is_some() {
                 return Err(RawParseError::InvalidInstance(format!(
                     "Duplicated named function ID is found in definition: {id:?}"
@@ -75,7 +75,8 @@ impl Parse for Vec<v1::NamedFunction> {
 
 /// Build a v1 `NamedFunction` from its intrinsic data plus drained modeling label.
 pub(crate) fn named_function_to_v1(
-    NamedFunction { id, function }: NamedFunction,
+    id: NamedFunctionID,
+    NamedFunction { function }: NamedFunction,
     label: NamedFunctionLabel,
 ) -> v1::NamedFunction {
     v1::NamedFunction {
@@ -91,6 +92,7 @@ pub(crate) fn named_function_to_v1(
 /// Parsed v1 `EvaluatedNamedFunction` together with its drained modeling label.
 #[derive(Debug)]
 pub struct ParsedEvaluatedNamedFunction {
+    pub id: NamedFunctionID,
     pub evaluated_named_function: EvaluatedNamedFunction,
     pub label: NamedFunctionLabel,
 }
@@ -100,8 +102,8 @@ impl Parse for v1::EvaluatedNamedFunction {
     type Context = ();
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let id = NamedFunctionID(self.id);
         let evaluated_named_function = EvaluatedNamedFunction {
-            id: NamedFunctionID(self.id),
             evaluated_value: self.evaluated_value,
             used_decision_variable_ids: self
                 .used_decision_variable_ids
@@ -116,6 +118,7 @@ impl Parse for v1::EvaluatedNamedFunction {
             description: self.description,
         };
         Ok(ParsedEvaluatedNamedFunction {
+            id,
             evaluated_named_function,
             label,
         })
@@ -124,8 +127,8 @@ impl Parse for v1::EvaluatedNamedFunction {
 
 /// Build a v1 `EvaluatedNamedFunction` from its intrinsic data plus drained modeling label.
 pub(crate) fn evaluated_named_function_to_v1(
+    id: NamedFunctionID,
     EvaluatedNamedFunction {
-        id,
         evaluated_value,
         used_decision_variable_ids,
     }: EvaluatedNamedFunction,
@@ -148,6 +151,7 @@ pub(crate) fn evaluated_named_function_to_v1(
 /// Parsed v1 `SampledNamedFunction` together with its drained modeling label.
 #[derive(Debug)]
 pub struct ParsedSampledNamedFunction {
+    pub id: NamedFunctionID,
     pub sampled_named_function: SampledNamedFunction,
     pub label: NamedFunctionLabel,
 }
@@ -165,8 +169,8 @@ impl Parse for v1::SampledNamedFunction {
                 field: "evaluated_values",
             })?
             .parse_as(&(), message, "evaluated_values")?;
+        let id = NamedFunctionID(self.id);
         let sampled_named_function = SampledNamedFunction {
-            id: NamedFunctionID(self.id),
             evaluated_values,
             used_decision_variable_ids: self
                 .used_decision_variable_ids
@@ -181,6 +185,7 @@ impl Parse for v1::SampledNamedFunction {
             description: self.description,
         };
         Ok(ParsedSampledNamedFunction {
+            id,
             sampled_named_function,
             label,
         })
@@ -189,11 +194,11 @@ impl Parse for v1::SampledNamedFunction {
 
 /// Build a v1 `SampledNamedFunction` from its intrinsic data plus drained modeling label.
 pub(crate) fn sampled_named_function_to_v1(
+    id: NamedFunctionID,
     sampled: SampledNamedFunction,
     label: NamedFunctionLabel,
 ) -> v1::SampledNamedFunction {
     let SampledNamedFunction {
-        id,
         evaluated_values,
         used_decision_variable_ids,
     } = sampled;
@@ -281,10 +286,11 @@ mod tests {
         };
 
         let parsed: ParsedEvaluatedNamedFunction = v1_enf.parse(&()).unwrap();
+        let id = parsed.id;
         let enf = parsed.evaluated_named_function;
         let label = parsed.label;
 
-        assert_eq!(enf.id(), NamedFunctionID::from(42));
+        assert_eq!(id, NamedFunctionID::from(42));
         assert_eq!(enf.evaluated_value(), 3.14);
         assert_eq!(
             *enf.used_decision_variable_ids(),
@@ -325,10 +331,11 @@ mod tests {
         };
 
         let parsed: ParsedSampledNamedFunction = v1_snf.parse(&()).unwrap();
+        let id = parsed.id;
         let snf = parsed.sampled_named_function;
         let label = parsed.label;
 
-        assert_eq!(*snf.id(), NamedFunctionID::from(7));
+        assert_eq!(id, NamedFunctionID::from(7));
         assert_eq!(label.name, Some("cost".to_string()));
         assert_eq!(label.subscripts, vec![1, 2]);
         assert_eq!(label.description, Some("A sampled function".to_string()));
@@ -339,7 +346,7 @@ mod tests {
         );
 
         // Round-trip: SampledNamedFunction + label -> v1::SampledNamedFunction
-        let v1_converted = sampled_named_function_to_v1(snf, label);
+        let v1_converted = sampled_named_function_to_v1(id, snf, label);
         assert_eq!(v1_converted.id, 7);
         assert_eq!(v1_converted.name, Some("cost".to_string()));
         assert!(v1_converted.evaluated_values.is_some());

--- a/rust/ommx/src/named_function/substitute.rs
+++ b/rust/ommx/src/named_function/substitute.rs
@@ -1,0 +1,89 @@
+use super::*;
+use crate::{substitute_one_via_acyclic, Function, Substitute, SubstitutionError, VariableID};
+
+impl Substitute for NamedFunction {
+    type Output = Self;
+
+    fn substitute_acyclic(
+        mut self,
+        acyclic: &crate::AcyclicAssignments,
+    ) -> Result<Self::Output, SubstitutionError> {
+        self.function = self.function.substitute_acyclic(acyclic)?;
+        Ok(self)
+    }
+
+    fn substitute_one(
+        self,
+        assigned: VariableID,
+        f: &Function,
+    ) -> Result<Self::Output, SubstitutionError> {
+        substitute_one_via_acyclic(self, assigned, f)
+    }
+}
+
+impl Substitute for NamedFunctionTable<NamedFunction> {
+    type Output = Self;
+
+    fn substitute_acyclic(
+        self,
+        acyclic: &crate::AcyclicAssignments,
+    ) -> Result<Self::Output, SubstitutionError> {
+        let NamedFunctionTable { entries, labels } = self;
+        let mut substituted_entries = std::collections::BTreeMap::new();
+        for (id, named_function) in entries {
+            let substituted = named_function
+                .substitute_acyclic(acyclic)
+                .inspect_err(|e| {
+                    tracing::error!(?id, error = %e, "failed to substitute named function");
+                })?;
+            substituted_entries.insert(id, substituted);
+        }
+        Ok(NamedFunctionTable {
+            entries: substituted_entries,
+            labels,
+        })
+    }
+
+    fn substitute_one(
+        self,
+        assigned: VariableID,
+        f: &Function,
+    ) -> Result<Self::Output, SubstitutionError> {
+        substitute_one_via_acyclic(self, assigned, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coeff, linear, Evaluate};
+    use maplit::btreeset;
+
+    #[test]
+    fn test_named_function_table_substitute_preserves_labels() {
+        let id = NamedFunctionID::from(1);
+        let mut entries = std::collections::BTreeMap::new();
+        entries.insert(
+            id,
+            NamedFunction {
+                function: Function::from((linear!(1) + linear!(2)).unwrap()),
+            },
+        );
+        let mut labels = NamedFunctionLabelStore::new();
+        labels.set_name(id, "tracked");
+        let table = NamedFunctionTable::new(entries, labels).unwrap();
+
+        let substituted = table
+            .substitute_one(
+                VariableID::from(1),
+                &Function::from((linear!(3) + coeff!(1.0)).unwrap()),
+            )
+            .unwrap();
+
+        assert_eq!(substituted.labels().name(id), Some("tracked"));
+        assert_eq!(
+            substituted.get(&id).unwrap().required_ids(),
+            btreeset! { VariableID::from(2), VariableID::from(3) }
+        );
+    }
+}

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -142,6 +142,10 @@ impl SampledConstraintBehavior for SampledOneHotConstraint {
         Ok(())
     }
 
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
+    }
+
     fn get(&self, sample_id: SampleID) -> Option<Self::Evaluated> {
         let feasible = *self.stage.feasible.get(&sample_id)?;
         let active_variable = *self.stage.active_variable.get(&sample_id)?;

--- a/rust/ommx/src/polynomial_base/convert.rs
+++ b/rust/ommx/src/polynomial_base/convert.rs
@@ -47,37 +47,6 @@ impl<M: Monomial> IntoIterator for PolynomialBase<M> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{coeff, linear, Linear};
-
-    #[test]
-    fn try_from_terms_combines_duplicate_terms() {
-        let polynomial =
-            Linear::try_from_terms([(linear!(1), coeff!(2.0)), (linear!(1), coeff!(3.0))]).unwrap();
-
-        assert_eq!(polynomial.terms[&linear!(1)], coeff!(5.0));
-    }
-
-    #[test]
-    fn try_from_terms_removes_cancelled_terms() {
-        let polynomial =
-            Linear::try_from_terms([(linear!(1), coeff!(1.0)), (linear!(1), coeff!(-1.0))])
-                .unwrap();
-
-        assert!(polynomial.is_zero());
-    }
-
-    #[test]
-    fn try_from_terms_returns_error_on_overflow() {
-        let huge = Coefficient::try_from(f64::MAX).unwrap();
-        let err = Linear::try_from_terms([(linear!(1), huge), (linear!(1), huge)]).unwrap_err();
-
-        assert_eq!(err, CoefficientError::Infinite);
-    }
-}
-
 impl<'a, M: Monomial> IntoIterator for &'a PolynomialBase<M> {
     type Item = (&'a M, &'a Coefficient);
     type IntoIter = std::collections::hash_map::Iter<'a, M, Coefficient>;
@@ -124,5 +93,36 @@ impl<M: Monomial> TryFrom<f64> for PolynomialBase<M> {
             Err(CoefficientError::Zero) => Ok(Self::default()),
             Err(e) => Err(e),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coeff, linear, Linear};
+
+    #[test]
+    fn try_from_terms_combines_duplicate_terms() {
+        let polynomial =
+            Linear::try_from_terms([(linear!(1), coeff!(2.0)), (linear!(1), coeff!(3.0))]).unwrap();
+
+        assert_eq!(polynomial.terms[&linear!(1)], coeff!(5.0));
+    }
+
+    #[test]
+    fn try_from_terms_removes_cancelled_terms() {
+        let polynomial =
+            Linear::try_from_terms([(linear!(1), coeff!(1.0)), (linear!(1), coeff!(-1.0))])
+                .unwrap();
+
+        assert!(polynomial.is_zero());
+    }
+
+    #[test]
+    fn try_from_terms_returns_error_on_overflow() {
+        let huge = Coefficient::try_from(f64::MAX).unwrap();
+        let err = Linear::try_from_terms([(linear!(1), huge), (linear!(1), huge)]).unwrap_err();
+
+        assert_eq!(err, CoefficientError::Infinite);
     }
 }

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -3,7 +3,9 @@ mod parse;
 mod serialize;
 
 use crate::{
-    constraint_type::{EvaluatedCollection, SampledCollection, SampledConstraintBehavior},
+    constraint_type::{
+        ConstraintType, EvaluatedCollection, SampledCollection, SampledConstraintBehavior,
+    },
     indicator_constraint::IndicatorConstraint,
     Constraint, ConstraintID, EvaluatedConstraint, EvaluatedDecisionVariable,
     EvaluatedNamedFunction, NamedFunctionID, NamedFunctionTable, SampleID, SampleIDSet, Sampled,
@@ -78,6 +80,23 @@ pub enum SampleSetError {
     #[error("Required field is missing: {field}")]
     MissingRequiredField { field: &'static str },
 
+    #[error(
+        "Variable ID {id:?} used in {constraint_family} constraint {constraint_id} is not in decision_variables"
+    )]
+    UndefinedVariableInConstraint {
+        id: VariableID,
+        constraint_family: &'static str,
+        constraint_id: String,
+    },
+
+    #[error(
+        "Variable ID {id:?} used in named function {named_function_id:?} is not in decision_variables"
+    )]
+    UndefinedVariableInNamedFunction {
+        id: VariableID,
+        named_function_id: NamedFunctionID,
+    },
+
     #[error("{message}")]
     InvalidSidecar { message: String },
 }
@@ -92,6 +111,9 @@ pub enum SampleSetError {
 ///   [`NamedFunctionID`]; sampled named-function rows do not carry IDs.
 /// - All [`Self::decision_variables`], [`Self::objectives`], sampled constraint
 ///   collections, and [`Self::named_functions`] have the same sample ID set.
+/// - [`Self::decision_variables`] contains all variable IDs referenced in
+///   `used_decision_variable_ids` of each sampled constraint and sampled named
+///   function.
 /// - [`Self::feasible`] and [`Self::feasible_relaxed`] are computed from all
 ///   sampled constraint collections:
 ///   - `feasible`: true if all constraints are satisfied for that sample.
@@ -125,6 +147,22 @@ pub struct SampleSet {
     pub metadata: Option<crate::v1::ProcessMetadata>,
     /// User-defined or third-party extension annotations.
     pub annotations: HashMap<String, String>,
+}
+
+fn validate_sampled_constraint_used_ids<T: ConstraintType>(
+    constraint_family: &'static str,
+    constraints: &SampledCollection<T>,
+    decision_variable_ids: &BTreeSet<VariableID>,
+) -> Result<(), SampleSetError> {
+    constraints
+        .validate_used_decision_variable_ids(decision_variable_ids)
+        .map_err(
+            |(constraint_id, var_id)| SampleSetError::UndefinedVariableInConstraint {
+                id: var_id,
+                constraint_family,
+                constraint_id: format!("{constraint_id:?}"),
+            },
+        )
 }
 
 impl SampleSet {
@@ -532,6 +570,8 @@ impl SampleSetBuilder {
     /// Returns an error if:
     /// - Required fields (`decision_variables`, `objectives`, `constraints`, `sense`) are not set
     /// - Sample IDs are inconsistent across decision variables, objectives, constraints, and named functions
+    /// - Variables referenced in constraints' or named functions'
+    ///   `used_decision_variable_ids` are not in `decision_variables`
     pub fn build(self) -> Result<SampleSet, SampleSetError> {
         let decision_variables =
             self.decision_variables
@@ -625,7 +665,24 @@ impl SampleSetBuilder {
                 found,
             })?;
 
-        for sampled_named_function in named_functions.values() {
+        validate_sampled_constraint_used_ids("regular", &constraints, &decision_variable_ids)?;
+        validate_sampled_constraint_used_ids(
+            "indicator",
+            &self.indicator_constraints,
+            &decision_variable_ids,
+        )?;
+        validate_sampled_constraint_used_ids(
+            "one-hot",
+            &self.one_hot_constraints,
+            &decision_variable_ids,
+        )?;
+        validate_sampled_constraint_used_ids(
+            "SOS1",
+            &self.sos1_constraints,
+            &decision_variable_ids,
+        )?;
+
+        for (named_function_id, sampled_named_function) in named_functions.iter() {
             if !sampled_named_function
                 .evaluated_values()
                 .has_same_ids(&objective_sample_ids)
@@ -634,6 +691,14 @@ impl SampleSetBuilder {
                     expected: objective_sample_ids.clone(),
                     found: sampled_named_function.evaluated_values().ids(),
                 });
+            }
+            for var_id in sampled_named_function.used_decision_variable_ids() {
+                if !decision_variables.contains_key(var_id) {
+                    return Err(SampleSetError::UndefinedVariableInNamedFunction {
+                        id: *var_id,
+                        named_function_id: *named_function_id,
+                    });
+                }
             }
         }
 
@@ -671,6 +736,8 @@ impl SampleSetBuilder {
     /// - `decision_variables` is keyed by the intended [`VariableID`] for each row
     /// - Sampled constraint collection keys and sidecars are internally consistent
     /// - Sampled named-function table keys and labels are internally consistent
+    /// - All `used_decision_variable_ids` in sampled constraints and sampled
+    ///   named functions exist in `decision_variables`
     /// - Sample IDs are consistent across all components
     ///
     /// Use [`Self::build`] for validated construction.
@@ -851,6 +918,84 @@ mod tests {
                 && err.to_string().contains("NamedFunctionID(99)"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn builder_rejects_undefined_variable_in_sampled_named_function() {
+        use crate::parse::Parse as _;
+
+        let var_id = VariableID::from(1);
+        let nf_id = NamedFunctionID::from(7);
+        let sample_id = SampleID::from(0);
+        let parsed: crate::named_function::parse::ParsedSampledNamedFunction =
+            crate::v1::SampledNamedFunction {
+                id: nf_id.into_inner(),
+                evaluated_values: Some(crate::v1::SampledValues {
+                    entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                        ids: vec![sample_id.into_inner()],
+                        value: 1.0,
+                    }],
+                }),
+                used_decision_variable_ids: vec![var_id.into_inner()],
+                ..Default::default()
+            }
+            .parse(&())
+            .unwrap();
+        let mut objectives = crate::Sampled::default();
+        objectives.append([sample_id], 0.0).unwrap();
+
+        let err = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(objectives)
+            .constraints(BTreeMap::new())
+            .named_functions(BTreeMap::from([(nf_id, parsed.sampled_named_function)]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SampleSetError::UndefinedVariableInNamedFunction { id, named_function_id }
+                if id == var_id && named_function_id == nf_id
+        ));
+    }
+
+    #[test]
+    fn builder_rejects_undefined_variable_in_sampled_constraint() {
+        let var_id = VariableID::from(1);
+        let constraint_id = ConstraintID::from(2);
+        let sample_id = SampleID::from(0);
+
+        let mut evaluated_values = crate::Sampled::default();
+        evaluated_values.append([sample_id], 0.0).unwrap();
+        let sampled_constraint = crate::Constraint {
+            equality: Equality::EqualToZero,
+            stage: crate::constraint::SampledData {
+                evaluated_values,
+                dual_variables: None,
+                feasible: BTreeMap::from([(sample_id, true)]),
+                used_decision_variable_ids: [var_id].into_iter().collect(),
+            },
+        };
+        let mut objectives = crate::Sampled::default();
+        objectives.append([sample_id], 0.0).unwrap();
+
+        let err = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(objectives)
+            .constraints(BTreeMap::from([(constraint_id, sampled_constraint)]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SampleSetError::UndefinedVariableInConstraint {
+                id,
+                constraint_family: "regular",
+                constraint_id: ref found_constraint_id,
+            } if id == var_id && found_constraint_id == &format!("{constraint_id:?}")
+        ));
     }
 
     /// Regression: `SampleSet::get(sid)` must propagate variable modeling

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -41,6 +41,9 @@ pub enum SampleSetError {
     #[error("Duplicated variable ID is found in definition: {id:?}")]
     DuplicatedVariableID { id: VariableID },
 
+    #[error("Duplicated named function ID is found in definition: {id:?}")]
+    DuplicatedNamedFunctionID { id: NamedFunctionID },
+
     #[error("Duplicate subscripts for {name}: {subscripts:?}")]
     DuplicateSubscripts { name: String, subscripts: Vec<i64> },
 

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -6,8 +6,8 @@ use crate::{
     constraint_type::{EvaluatedCollection, SampledCollection, SampledConstraintBehavior},
     indicator_constraint::IndicatorConstraint,
     Constraint, ConstraintID, EvaluatedConstraint, EvaluatedDecisionVariable,
-    EvaluatedNamedFunction, NamedFunctionID, SampleID, SampleIDSet, Sampled, SampledConstraint,
-    SampledDecisionVariable, SampledNamedFunction, Sense, Solution, VariableID,
+    EvaluatedNamedFunction, NamedFunctionID, NamedFunctionTable, SampleID, SampleIDSet, Sampled,
+    SampledConstraint, SampledDecisionVariable, SampledNamedFunction, Sense, Solution, VariableID,
 };
 use getset::Getters;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -113,11 +113,8 @@ pub struct SampleSet {
     one_hot_constraints: SampledCollection<crate::OneHotConstraint>,
     #[getset(get = "pub")]
     sos1_constraints: SampledCollection<crate::Sos1Constraint>,
-    #[getset(get = "pub")]
-    named_functions: BTreeMap<NamedFunctionID, SampledNamedFunction>,
-    /// Per-named-function modeling labels (sibling of [`Self::named_functions`]).
-    #[getset(get = "pub")]
-    named_function_labels: crate::named_function::NamedFunctionLabelStore,
+    /// Sampled named-function rows plus their modeling labels.
+    named_functions: NamedFunctionTable<SampledNamedFunction>,
     #[getset(get = "pub")]
     sense: Sense,
     #[getset(get = "pub")]
@@ -152,6 +149,21 @@ impl SampleSet {
             .constraints(constraints)
             .sense(sense)
             .build()
+    }
+
+    /// Access sampled named-function rows plus their modeling labels.
+    pub fn named_function_table(&self) -> &NamedFunctionTable<SampledNamedFunction> {
+        &self.named_functions
+    }
+
+    /// Access sampled named-function row payloads keyed by table-owned IDs.
+    pub fn named_functions(&self) -> &BTreeMap<NamedFunctionID, SampledNamedFunction> {
+        self.named_functions.entries()
+    }
+
+    /// Access the per-named-function modeling-label store.
+    pub fn named_function_labels(&self) -> &crate::named_function::NamedFunctionLabelStore {
+        self.named_functions.labels()
     }
 
     /// Get sample IDs available in this sample set
@@ -241,7 +253,7 @@ impl SampleSet {
         // Get evaluated named functions
         let mut evaluated_named_functions: BTreeMap<NamedFunctionID, EvaluatedNamedFunction> =
             BTreeMap::default();
-        for (named_function_id, named_function) in &self.named_functions {
+        for (named_function_id, named_function) in self.named_functions.iter() {
             let evaluated_named_function = named_function.get(sample_id)?;
             evaluated_named_functions.insert(*named_function_id, evaluated_named_function);
         }
@@ -290,7 +302,7 @@ impl SampleSet {
                 .evaluated_named_functions(evaluated_named_functions)
                 .decision_variables(decision_variables)
                 .variable_labels(self.variable_labels.clone())
-                .named_function_labels(self.named_function_labels.clone())
+                .named_function_labels(self.named_functions.labels().clone())
                 .sense(sense)
                 .build_unchecked()
                 .expect("SampleSet invariants guarantee Solution invariants")
@@ -549,19 +561,12 @@ impl SampleSetBuilder {
         .map_err(|e| SampleSetError::InvalidSidecar {
             message: e.to_string(),
         })?;
-        let named_function_ids = self
-            .named_functions
-            .keys()
-            .copied()
-            .collect::<BTreeSet<_>>();
-        crate::modeling_label::validate_modeling_label_ids(
-            &self.named_function_labels,
-            &named_function_ids,
-            "named function",
-        )
-        .map_err(|e| SampleSetError::InvalidSidecar {
-            message: e.to_string(),
-        })?;
+        let named_functions =
+            NamedFunctionTable::new(self.named_functions, self.named_function_labels).map_err(
+                |e| SampleSetError::InvalidSidecar {
+                    message: e.to_string(),
+                },
+            )?;
         constraints
             .validate_context_ids()
             .map_err(|e| SampleSetError::InvalidSidecar {
@@ -620,7 +625,7 @@ impl SampleSetBuilder {
                 found,
             })?;
 
-        for sampled_named_function in self.named_functions.values() {
+        for sampled_named_function in named_functions.values() {
             if !sampled_named_function
                 .evaluated_values()
                 .has_same_ids(&objective_sample_ids)
@@ -649,8 +654,7 @@ impl SampleSetBuilder {
             indicator_constraints: self.indicator_constraints,
             one_hot_constraints: self.one_hot_constraints,
             sos1_constraints: self.sos1_constraints,
-            named_functions: self.named_functions,
-            named_function_labels: self.named_function_labels.clone(),
+            named_functions,
             sense,
             feasible,
             feasible_relaxed,
@@ -666,7 +670,7 @@ impl SampleSetBuilder {
     /// The caller must ensure:
     /// - `decision_variables` is keyed by the intended [`VariableID`] for each row
     /// - Sampled constraint collection keys and sidecars are internally consistent
-    /// - Named function keys match their value's `id()`
+    /// - Sampled named-function table keys and labels are internally consistent
     /// - Sample IDs are consistent across all components
     ///
     /// Use [`Self::build`] for validated construction.
@@ -712,8 +716,10 @@ impl SampleSetBuilder {
             indicator_constraints: self.indicator_constraints,
             one_hot_constraints: self.one_hot_constraints,
             sos1_constraints: self.sos1_constraints,
-            named_functions: self.named_functions,
-            named_function_labels: self.named_function_labels.clone(),
+            named_functions: NamedFunctionTable::from_parts_unchecked(
+                self.named_functions,
+                self.named_function_labels,
+            ),
             sense,
             feasible,
             feasible_relaxed,
@@ -822,6 +828,27 @@ mod tests {
         assert!(
             err.to_string().contains("unknown decision variable ID")
                 && err.to_string().contains("VariableID(99)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn builder_rejects_orphan_named_function_label_id() {
+        let mut named_function_labels = crate::named_function::NamedFunctionLabelStore::default();
+        named_function_labels.set_name(NamedFunctionID::from(99), "orphan");
+
+        let err = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(crate::Sampled::default())
+            .constraints(BTreeMap::new())
+            .named_function_labels(named_function_labels)
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("unknown named function ID")
+                && err.to_string().contains("NamedFunctionID(99)"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -78,12 +78,6 @@ pub enum SampleSetError {
     #[error("Required field is missing: {field}")]
     MissingRequiredField { field: &'static str },
 
-    #[error("Named function key {key:?} does not match value's id {value_id:?}")]
-    InconsistentNamedFunctionID {
-        key: NamedFunctionID,
-        value_id: NamedFunctionID,
-    },
-
     #[error("{message}")]
     InvalidSidecar { message: String },
 }
@@ -94,7 +88,8 @@ pub enum SampleSetError {
 /// -----------
 /// - [`Self::decision_variables`] is keyed by the table-owned
 ///   [`VariableID`]; sampled decision-variable rows do not carry IDs.
-/// - The keys of [`Self::named_functions`] match the `id()` of their values.
+/// - [`Self::named_functions`] is keyed by the table-owned
+///   [`NamedFunctionID`]; sampled named-function rows do not carry IDs.
 /// - All [`Self::decision_variables`], [`Self::objectives`], sampled constraint
 ///   collections, and [`Self::named_functions`] have the same sample ID set.
 /// - [`Self::feasible`] and [`Self::feasible_relaxed`] are computed from all
@@ -545,14 +540,6 @@ impl SampleSetBuilder {
             .sense
             .ok_or(SampleSetError::MissingRequiredField { field: "sense" })?;
 
-        for (key, value) in &self.named_functions {
-            if key != value.id() {
-                return Err(SampleSetError::InconsistentNamedFunctionID {
-                    key: *key,
-                    value_id: *value.id(),
-                });
-            }
-        }
         let decision_variable_ids = decision_variables.keys().copied().collect::<BTreeSet<_>>();
         crate::modeling_label::validate_modeling_label_ids(
             &self.variable_labels,

--- a/rust/ommx/src/sample_set/extract.rs
+++ b/rust/ommx/src/sample_set/extract.rs
@@ -21,7 +21,7 @@ impl SampleSet {
     pub fn named_function_names(&self) -> std::collections::BTreeSet<String> {
         self.named_functions
             .keys()
-            .filter_map(|id| self.named_function_labels.name(*id).map(str::to_owned))
+            .filter_map(|id| self.named_function_labels().name(*id).map(str::to_owned))
             .collect()
     }
 
@@ -176,12 +176,12 @@ impl SampleSet {
         let mut result: BTreeMap<String, BTreeMap<Vec<i64>, f64>> = BTreeMap::new();
 
         for (id, nf) in &self.named_functions {
-            let name = match self.named_function_labels.name(*id) {
+            let name = match self.named_function_labels().name(*id) {
                 Some(n) => n.to_string(),
                 None => continue, // Skip functions without names
             };
 
-            let subscripts = self.named_function_labels.subscripts(*id).to_vec();
+            let subscripts = self.named_function_labels().subscripts(*id).to_vec();
             let value = *nf
                 .evaluated_values()
                 .get(sample_id)
@@ -218,7 +218,7 @@ impl SampleSet {
         let named_functions_with_name: Vec<(NamedFunctionID, &SampledNamedFunction)> = self
             .named_functions
             .iter()
-            .filter(|(id, _)| self.named_function_labels.name(**id) == Some(name))
+            .filter(|(id, _)| self.named_function_labels().name(**id) == Some(name))
             .map(|(id, nf)| (*id, nf))
             .collect();
         if named_functions_with_name.is_empty() {
@@ -228,7 +228,7 @@ impl SampleSet {
         }
         let mut result = BTreeMap::new();
         for (id, nf) in &named_functions_with_name {
-            let subscripts = self.named_function_labels.subscripts(*id).to_vec();
+            let subscripts = self.named_function_labels().subscripts(*id).to_vec();
             let value = *nf
                 .evaluated_values()
                 .get(sample_id)

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -64,7 +64,7 @@ impl Parse for crate::v1::SampleSet {
         for v1_named_function in self.named_functions {
             let parsed: crate::named_function::parse::ParsedSampledNamedFunction =
                 v1_named_function.parse_as(&(), message, "named_functions")?;
-            let id = *parsed.sampled_named_function.id();
+            let id = parsed.id;
             named_functions.insert(id, parsed.sampled_named_function);
             named_function_labels.insert(id, parsed.label);
         }
@@ -189,7 +189,7 @@ impl From<SampleSet> for crate::v1::SampleSet {
             .iter()
             .map(|(id, nf)| {
                 let label = named_function_labels_store.collect_for(*id);
-                crate::named_function::parse::sampled_named_function_to_v1(nf.clone(), label)
+                crate::named_function::parse::sampled_named_function_to_v1(*id, nf.clone(), label)
             })
             .collect();
         let sense = (*sample_set.sense()).into();

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -65,7 +65,15 @@ impl Parse for crate::v1::SampleSet {
             let parsed: crate::named_function::parse::ParsedSampledNamedFunction =
                 v1_named_function.parse_as(&(), message, "named_functions")?;
             let id = parsed.id;
-            named_functions.insert(id, parsed.sampled_named_function);
+            if named_functions
+                .insert(id, parsed.sampled_named_function)
+                .is_some()
+            {
+                return Err(crate::RawParseError::SampleSetError(
+                    crate::SampleSetError::DuplicatedNamedFunctionID { id },
+                )
+                .context(message, "named_functions"));
+            }
             named_function_labels.insert(id, parsed.label);
         }
 
@@ -480,6 +488,53 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.SampleSet[decision_variables]
         Duplicated variable ID is found in definition: VariableID(1)
+        "###);
+    }
+
+    #[test]
+    fn test_sample_set_parse_fails_with_duplicated_named_function_id() {
+        let sample_id = crate::SampleID::from(0);
+        let sampled_values = crate::v1::SampledValues {
+            entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                ids: vec![sample_id.into_inner()],
+                value: 1.0,
+            }],
+        };
+        let v1_sample_set = crate::v1::SampleSet {
+            objectives: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![sample_id.into_inner()],
+                    value: 0.0,
+                }],
+            }),
+            named_functions: vec![
+                crate::v1::SampledNamedFunction {
+                    id: 7,
+                    evaluated_values: Some(sampled_values.clone()),
+                    ..Default::default()
+                },
+                crate::v1::SampledNamedFunction {
+                    id: 7,
+                    evaluated_values: Some(sampled_values),
+                    ..Default::default()
+                },
+            ],
+            sense: crate::v1::instance::Sense::Minimize as i32,
+            ..Default::default()
+        };
+
+        let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error.error,
+            crate::RawParseError::SampleSetError(
+                crate::SampleSetError::DuplicatedNamedFunctionID { id }
+            ) if id == crate::NamedFunctionID::from(7)
+        ));
+        insta::assert_snapshot!(error.to_string(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.SampleSet[named_functions]
+        Duplicated named function ID is found in definition: NamedFunctionID(7)
         "###);
     }
 

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -39,6 +39,9 @@ pub enum SolutionError {
     #[error("Duplicated variable ID is found in definition: {id:?}")]
     DuplicatedVariableID { id: VariableID },
 
+    #[error("Duplicated named function ID is found in definition: {id:?}")]
+    DuplicatedNamedFunctionID { id: NamedFunctionID },
+
     #[deprecated(
         note = "Parameters are now ignored in extract_decision_variables and extract_all_decision_variables"
     )]

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -81,12 +81,6 @@ pub enum SolutionError {
         id: VariableID,
         constraint_id: ConstraintID,
     },
-
-    #[error("Named function key {key:?} does not match value's id {value_id:?}")]
-    InconsistentNamedFunctionID {
-        key: NamedFunctionID,
-        value_id: NamedFunctionID,
-    },
 }
 
 /// Single solution result with data integrity guarantees
@@ -97,7 +91,8 @@ pub enum SolutionError {
 ///   [`VariableID`]; evaluated decision-variable rows do not carry IDs.
 /// - The keys of the evaluated constraint collections are the table-owned
 ///   constraint IDs for each constraint family.
-/// - The keys of [`Self::evaluated_named_functions`] match the `id()` of their values.
+/// - [`Self::evaluated_named_functions`] is keyed by the table-owned
+///   [`NamedFunctionID`]; evaluated named-function rows do not carry IDs.
 /// - [`Self::decision_variables`] contains all variable IDs referenced in `used_decision_variable_ids` of each constraint.
 ///
 /// Note
@@ -474,11 +469,11 @@ impl Solution {
         name: &str,
     ) -> Result<BTreeMap<Vec<i64>, f64>, SolutionError> {
         // Collect all named functions with the given name
-        let functions_with_name: Vec<&EvaluatedNamedFunction> = self
+        let functions_with_name: Vec<(NamedFunctionID, &EvaluatedNamedFunction)> = self
             .evaluated_named_functions
             .iter()
             .filter(|(id, _)| self.named_function_labels.name(**id) == Some(name))
-            .map(|(_, nf)| nf)
+            .map(|(id, nf)| (*id, nf))
             .collect();
         if functions_with_name.is_empty() {
             return Err(SolutionError::UnknownNamedFunctionName {
@@ -487,8 +482,8 @@ impl Solution {
         }
 
         let mut result = BTreeMap::new();
-        for nf in &functions_with_name {
-            let key = self.named_function_labels.subscripts(nf.id()).to_vec();
+        for (id, nf) in &functions_with_name {
+            let key = self.named_function_labels.subscripts(*id).to_vec();
             if result.contains_key(&key) {
                 return Err(SolutionError::DuplicateSubscript { subscripts: key });
             }
@@ -723,16 +718,6 @@ impl SolutionBuilder {
             .sense
             .ok_or(SolutionError::MissingRequiredField { field: "sense" })?;
 
-        // Validate named function keys match their id
-        for (key, value) in &self.evaluated_named_functions {
-            if *key != value.id() {
-                return Err(SolutionError::InconsistentNamedFunctionID {
-                    key: *key,
-                    value_id: value.id(),
-                }
-                .into());
-            }
-        }
         let decision_variable_ids = decision_variables.keys().copied().collect::<BTreeSet<_>>();
         crate::modeling_label::validate_modeling_label_ids(
             &self.variable_labels,

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -4,7 +4,8 @@ mod serialize;
 use crate::{
     constraint_type::EvaluatedCollection, decision_variable::VariableLabelStore,
     indicator_constraint::IndicatorConstraint, Constraint, ConstraintID, EvaluatedConstraint,
-    EvaluatedDecisionVariable, EvaluatedNamedFunction, NamedFunctionID, Sense, VariableID,
+    EvaluatedDecisionVariable, EvaluatedNamedFunction, NamedFunctionID, NamedFunctionTable, Sense,
+    VariableID,
 };
 use getset::Getters;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -81,6 +82,9 @@ pub enum SolutionError {
         id: VariableID,
         constraint_id: ConstraintID,
     },
+
+    #[error("{message}")]
+    InvalidSidecar { message: String },
 }
 
 /// Single solution result with data integrity guarantees
@@ -111,16 +115,13 @@ pub struct Solution {
     evaluated_one_hot_constraints: EvaluatedCollection<crate::OneHotConstraint>,
     #[getset(get = "pub")]
     evaluated_sos1_constraints: EvaluatedCollection<crate::Sos1Constraint>,
-    #[getset(get = "pub")]
-    evaluated_named_functions: BTreeMap<NamedFunctionID, EvaluatedNamedFunction>,
+    /// Evaluated named-function rows plus their modeling labels.
+    evaluated_named_functions: NamedFunctionTable<EvaluatedNamedFunction>,
     #[getset(get = "pub")]
     decision_variables: BTreeMap<VariableID, EvaluatedDecisionVariable>,
     /// Per-variable modeling labels (sibling of [`Self::decision_variables`]).
     #[getset(get = "pub")]
     variable_labels: VariableLabelStore,
-    /// Per-named-function modeling labels (sibling of [`Self::evaluated_named_functions`]).
-    #[getset(get = "pub")]
-    named_function_labels: crate::named_function::NamedFunctionLabelStore,
     /// Optimality status - not guaranteed by Solution itself
     pub optimality: crate::v1::Optimality,
     /// Relaxation status - not guaranteed by Solution itself
@@ -161,6 +162,21 @@ impl Solution {
                 .build_unchecked()
                 .expect("All required fields are provided")
         }
+    }
+
+    /// Access evaluated named-function rows plus their modeling labels.
+    pub fn evaluated_named_function_table(&self) -> &NamedFunctionTable<EvaluatedNamedFunction> {
+        &self.evaluated_named_functions
+    }
+
+    /// Access evaluated named-function row payloads keyed by table-owned IDs.
+    pub fn evaluated_named_functions(&self) -> &BTreeMap<NamedFunctionID, EvaluatedNamedFunction> {
+        self.evaluated_named_functions.entries()
+    }
+
+    /// Access the per-named-function modeling-label store.
+    pub fn named_function_labels(&self) -> &crate::named_function::NamedFunctionLabelStore {
+        self.evaluated_named_functions.labels()
     }
 
     /// Get decision variable IDs used in this solution
@@ -448,7 +464,7 @@ impl Solution {
     pub fn named_function_names(&self) -> BTreeSet<String> {
         self.evaluated_named_functions
             .keys()
-            .filter_map(|id| self.named_function_labels.name(*id).map(str::to_owned))
+            .filter_map(|id| self.named_function_labels().name(*id).map(str::to_owned))
             .collect()
     }
 
@@ -472,7 +488,7 @@ impl Solution {
         let functions_with_name: Vec<(NamedFunctionID, &EvaluatedNamedFunction)> = self
             .evaluated_named_functions
             .iter()
-            .filter(|(id, _)| self.named_function_labels.name(**id) == Some(name))
+            .filter(|(id, _)| self.named_function_labels().name(**id) == Some(name))
             .map(|(id, nf)| (*id, nf))
             .collect();
         if functions_with_name.is_empty() {
@@ -483,7 +499,7 @@ impl Solution {
 
         let mut result = BTreeMap::new();
         for (id, nf) in &functions_with_name {
-            let key = self.named_function_labels.subscripts(*id).to_vec();
+            let key = self.named_function_labels().subscripts(*id).to_vec();
             if result.contains_key(&key) {
                 return Err(SolutionError::DuplicateSubscript { subscripts: key });
             }
@@ -508,12 +524,12 @@ impl Solution {
         let mut result: BTreeMap<String, BTreeMap<Vec<i64>, f64>> = BTreeMap::new();
 
         for (id, nf) in &self.evaluated_named_functions {
-            let name = match self.named_function_labels.name(*id) {
+            let name = match self.named_function_labels().name(*id) {
                 Some(n) => n.to_string(),
                 None => continue, // Skip named functions without names
             };
 
-            let subscripts = self.named_function_labels.subscripts(*id).to_vec();
+            let subscripts = self.named_function_labels().subscripts(*id).to_vec();
             let value = nf.evaluated_value();
 
             let funcs_map = result.entry(name).or_default();
@@ -698,7 +714,7 @@ impl SolutionBuilder {
     /// Returns an error if:
     /// - Required fields (`objective`, `evaluated_constraints`, `decision_variables`, `sense`) are not set
     /// - Constraint collection sidecars contain invalid keys
-    /// - Named function keys don't match their value's `id()`
+    /// - Named-function labels reference IDs not present in the evaluated named-function table
     /// - Variables referenced in constraints' `used_decision_variable_ids` are not in `decision_variables`
     pub fn build(self) -> crate::Result<Solution> {
         let objective = self
@@ -724,16 +740,8 @@ impl SolutionBuilder {
             &decision_variable_ids,
             "decision variable",
         )?;
-        let named_function_ids = self
-            .evaluated_named_functions
-            .keys()
-            .copied()
-            .collect::<BTreeSet<_>>();
-        crate::modeling_label::validate_modeling_label_ids(
-            &self.named_function_labels,
-            &named_function_ids,
-            "named function",
-        )?;
+        let evaluated_named_functions =
+            NamedFunctionTable::new(self.evaluated_named_functions, self.named_function_labels)?;
         evaluated_constraints.validate_context_ids()?;
         self.evaluated_indicator_constraints
             .validate_context_ids()?;
@@ -795,10 +803,9 @@ impl SolutionBuilder {
             evaluated_indicator_constraints: self.evaluated_indicator_constraints,
             evaluated_one_hot_constraints: self.evaluated_one_hot_constraints,
             evaluated_sos1_constraints: self.evaluated_sos1_constraints,
-            evaluated_named_functions: self.evaluated_named_functions,
+            evaluated_named_functions,
             decision_variables,
             variable_labels: self.variable_labels.clone(),
-            named_function_labels: self.named_function_labels.clone(),
             optimality: self.optimality,
             relaxation: self.relaxation,
             sense: Some(sense),
@@ -814,7 +821,7 @@ impl SolutionBuilder {
     /// The caller must ensure:
     /// - `decision_variables` is keyed by the intended [`VariableID`] for each row
     /// - Evaluated constraint collection keys and sidecars are internally consistent
-    /// - Named function keys match their value's `id()`
+    /// - Evaluated named-function table keys and labels are internally consistent
     /// - All `used_decision_variable_ids` in constraints exist in `decision_variables`
     ///
     /// Use [`Self::build`] for validated construction.
@@ -847,10 +854,12 @@ impl SolutionBuilder {
             evaluated_indicator_constraints: self.evaluated_indicator_constraints,
             evaluated_one_hot_constraints: self.evaluated_one_hot_constraints,
             evaluated_sos1_constraints: self.evaluated_sos1_constraints,
-            evaluated_named_functions: self.evaluated_named_functions,
+            evaluated_named_functions: NamedFunctionTable::from_parts_unchecked(
+                self.evaluated_named_functions,
+                self.named_function_labels,
+            ),
             decision_variables,
             variable_labels: self.variable_labels.clone(),
-            named_function_labels: self.named_function_labels.clone(),
             optimality: self.optimality,
             relaxation: self.relaxation,
             sense: Some(sense),
@@ -1229,6 +1238,27 @@ mod tests {
         assert!(
             err.to_string().contains("unknown decision variable ID")
                 && err.to_string().contains("VariableID(99)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn builder_rejects_orphan_named_function_label_id() {
+        let mut named_function_labels = crate::named_function::NamedFunctionLabelStore::default();
+        named_function_labels.set_name(NamedFunctionID::from(99), "orphan");
+
+        let err = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .decision_variables(BTreeMap::new())
+            .named_function_labels(named_function_labels)
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("unknown named function ID")
+                && err.to_string().contains("NamedFunctionID(99)"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -83,6 +83,14 @@ pub enum SolutionError {
         constraint_id: ConstraintID,
     },
 
+    #[error(
+        "Variable ID {id:?} used in named function {named_function_id:?} is not in decision_variables"
+    )]
+    UndefinedVariableInNamedFunction {
+        id: VariableID,
+        named_function_id: NamedFunctionID,
+    },
+
     #[error("{message}")]
     InvalidSidecar { message: String },
 }
@@ -97,7 +105,9 @@ pub enum SolutionError {
 ///   constraint IDs for each constraint family.
 /// - [`Self::evaluated_named_functions`] is keyed by the table-owned
 ///   [`NamedFunctionID`]; evaluated named-function rows do not carry IDs.
-/// - [`Self::decision_variables`] contains all variable IDs referenced in `used_decision_variable_ids` of each constraint.
+/// - [`Self::decision_variables`] contains all variable IDs referenced in
+///   `used_decision_variable_ids` of each evaluated constraint and evaluated
+///   named function.
 ///
 /// Note
 /// -----
@@ -132,6 +142,23 @@ pub struct Solution {
     pub metadata: Option<crate::v1::ProcessMetadata>,
     /// User-defined or third-party extension annotations.
     pub annotations: HashMap<String, String>,
+}
+
+fn validate_evaluated_named_function_used_ids(
+    decision_variables: &BTreeMap<VariableID, EvaluatedDecisionVariable>,
+    evaluated_named_functions: &NamedFunctionTable<EvaluatedNamedFunction>,
+) -> Result<(), SolutionError> {
+    for (named_function_id, named_function) in evaluated_named_functions.iter() {
+        for var_id in named_function.used_decision_variable_ids() {
+            if !decision_variables.contains_key(var_id) {
+                return Err(SolutionError::UndefinedVariableInNamedFunction {
+                    id: *var_id,
+                    named_function_id: *named_function_id,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 impl Solution {
@@ -715,7 +742,8 @@ impl SolutionBuilder {
     /// - Required fields (`objective`, `evaluated_constraints`, `decision_variables`, `sense`) are not set
     /// - Constraint collection sidecars contain invalid keys
     /// - Named-function labels reference IDs not present in the evaluated named-function table
-    /// - Variables referenced in constraints' `used_decision_variable_ids` are not in `decision_variables`
+    /// - Variables referenced in constraints' or named functions'
+    ///   `used_decision_variable_ids` are not in `decision_variables`
     pub fn build(self) -> crate::Result<Solution> {
         let objective = self
             .objective
@@ -796,6 +824,10 @@ impl SolutionBuilder {
                 }
             }
         }
+        validate_evaluated_named_function_used_ids(
+            &decision_variables,
+            &evaluated_named_functions,
+        )?;
 
         Ok(Solution {
             objective,
@@ -822,7 +854,8 @@ impl SolutionBuilder {
     /// - `decision_variables` is keyed by the intended [`VariableID`] for each row
     /// - Evaluated constraint collection keys and sidecars are internally consistent
     /// - Evaluated named-function table keys and labels are internally consistent
-    /// - All `used_decision_variable_ids` in constraints exist in `decision_variables`
+    /// - All `used_decision_variable_ids` in constraints and evaluated named
+    ///   functions exist in `decision_variables`
     ///
     /// Use [`Self::build`] for validated construction.
     /// This method is useful when invariants are guaranteed by construction,
@@ -1261,6 +1294,38 @@ mod tests {
                 && err.to_string().contains("NamedFunctionID(99)"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn builder_rejects_undefined_variable_in_evaluated_named_function() {
+        use crate::parse::Parse as _;
+
+        let var_id = VariableID::from(1);
+        let nf_id = NamedFunctionID::from(7);
+        let parsed: crate::named_function::parse::ParsedEvaluatedNamedFunction =
+            crate::v1::EvaluatedNamedFunction {
+                id: nf_id.into_inner(),
+                evaluated_value: 1.0,
+                used_decision_variable_ids: vec![var_id.into_inner()],
+                ..Default::default()
+            }
+            .parse(&())
+            .unwrap();
+
+        let err = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_named_functions(BTreeMap::from([(nf_id, parsed.evaluated_named_function)]))
+            .decision_variables(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+        let solution_err = err.downcast_ref::<SolutionError>().unwrap();
+        assert!(matches!(
+            solution_err,
+            SolutionError::UndefinedVariableInNamedFunction { id, named_function_id }
+                if *id == var_id && *named_function_id == nf_id
+        ));
     }
 
     #[test]

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -59,7 +59,15 @@ impl Parse for crate::v1::Solution {
             let parsed: crate::named_function::parse::ParsedEvaluatedNamedFunction =
                 enf.parse_as(&(), message, "evaluated_named_functions")?;
             let id = parsed.id;
-            evaluated_named_functions.insert(id, parsed.evaluated_named_function);
+            if evaluated_named_functions
+                .insert(id, parsed.evaluated_named_function)
+                .is_some()
+            {
+                return Err(crate::RawParseError::SolutionError(
+                    SolutionError::DuplicatedNamedFunctionID { id },
+                )
+                .context(message, "evaluated_named_functions"));
+            }
             named_function_labels.insert(id, parsed.label);
         }
 
@@ -632,6 +640,44 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
         Duplicated variable ID is found in definition: VariableID(1)
+        "###);
+    }
+
+    #[test]
+    fn test_solution_parse_fails_with_duplicated_named_function_id() {
+        use crate::v1;
+
+        let v1_solution = v1::Solution {
+            objective: 0.0,
+            evaluated_named_functions: vec![
+                v1::EvaluatedNamedFunction {
+                    id: 7,
+                    evaluated_value: 1.0,
+                    ..Default::default()
+                },
+                v1::EvaluatedNamedFunction {
+                    id: 7,
+                    evaluated_value: 2.0,
+                    ..Default::default()
+                },
+            ],
+            feasible: true,
+            feasible_relaxed: Some(true),
+            ..Default::default()
+        };
+
+        let result: Result<Solution, ParseError> = v1_solution.parse(&());
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error.error,
+            crate::RawParseError::SolutionError(
+                SolutionError::DuplicatedNamedFunctionID { id }
+            ) if id == crate::NamedFunctionID::from(7)
+        ));
+        insta::assert_snapshot!(error.to_string(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.Solution[evaluated_named_functions]
+        Duplicated named function ID is found in definition: NamedFunctionID(7)
         "###);
     }
 

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -58,7 +58,7 @@ impl Parse for crate::v1::Solution {
         for enf in self.evaluated_named_functions {
             let parsed: crate::named_function::parse::ParsedEvaluatedNamedFunction =
                 enf.parse_as(&(), message, "evaluated_named_functions")?;
-            let id = parsed.evaluated_named_function.id();
+            let id = parsed.id;
             evaluated_named_functions.insert(id, parsed.evaluated_named_function);
             named_function_labels.insert(id, parsed.label);
         }
@@ -223,7 +223,11 @@ impl From<Solution> for crate::v1::Solution {
             .iter()
             .map(|(id, enf)| {
                 let label = named_function_labels_store.collect_for(*id);
-                crate::named_function::parse::evaluated_named_function_to_v1(enf.clone(), label)
+                crate::named_function::parse::evaluated_named_function_to_v1(
+                    *id,
+                    enf.clone(),
+                    label,
+                )
             })
             .collect();
         let variable_labels_store = solution.variable_labels().clone();

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -130,6 +130,19 @@ impl Parse for crate::v1::Solution {
             })
             .map_err(|e| ParseError::from(e).context(message, "relaxation"))?;
 
+        let evaluated_named_functions =
+            crate::NamedFunctionTable::new(evaluated_named_functions, named_function_labels)
+                .map_err(|e| {
+                    crate::RawParseError::SolutionError(crate::SolutionError::InvalidSidecar {
+                        message: e.to_string(),
+                    })
+                    .context(message, "evaluated_named_functions")
+                })?;
+        validate_evaluated_named_function_used_ids(&decision_variables, &evaluated_named_functions)
+            .map_err(|e| {
+                crate::RawParseError::SolutionError(e).context(message, "evaluated_named_functions")
+            })?;
+
         let solution = Solution {
             objective,
             evaluated_constraints: crate::constraint_type::EvaluatedCollection::with_context(
@@ -144,16 +157,7 @@ impl Parse for crate::v1::Solution {
             evaluated_indicator_constraints: Default::default(),
             evaluated_one_hot_constraints: Default::default(),
             evaluated_sos1_constraints: Default::default(),
-            evaluated_named_functions: crate::NamedFunctionTable::new(
-                evaluated_named_functions,
-                named_function_labels,
-            )
-            .map_err(|e| {
-                crate::RawParseError::SolutionError(crate::SolutionError::InvalidSidecar {
-                    message: e.to_string(),
-                })
-                .context(message, "evaluated_named_functions")
-            })?,
+            evaluated_named_functions,
             decision_variables,
             variable_labels,
             optimality,
@@ -628,6 +632,42 @@ mod tests {
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
         Duplicated variable ID is found in definition: VariableID(1)
+        "###);
+    }
+
+    #[test]
+    fn test_solution_parse_rejects_undefined_variable_in_named_function() {
+        use crate::v1;
+
+        let v1_solution = v1::Solution {
+            objective: 42.5,
+            evaluated_named_functions: vec![v1::EvaluatedNamedFunction {
+                id: 7,
+                evaluated_value: 1.0,
+                used_decision_variable_ids: vec![1],
+                ..Default::default()
+            }],
+            feasible: true,
+            feasible_relaxed: Some(true),
+            ..Default::default()
+        };
+
+        let result: Result<Solution, ParseError> = v1_solution.parse(&());
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error.error,
+            crate::RawParseError::SolutionError(
+                SolutionError::UndefinedVariableInNamedFunction {
+                    id,
+                    named_function_id,
+                }
+            ) if id == crate::VariableID::from(1)
+                && named_function_id == crate::NamedFunctionID::from(7)
+        ));
+        insta::assert_snapshot!(error.to_string(), @r###"
+        Traceback for OMMX Message parse error:
+        └─ommx.v1.Solution[evaluated_named_functions]
+        Variable ID VariableID(1) used in named function NamedFunctionID(7) is not in decision_variables
         "###);
     }
 

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -144,10 +144,18 @@ impl Parse for crate::v1::Solution {
             evaluated_indicator_constraints: Default::default(),
             evaluated_one_hot_constraints: Default::default(),
             evaluated_sos1_constraints: Default::default(),
-            evaluated_named_functions,
+            evaluated_named_functions: crate::NamedFunctionTable::new(
+                evaluated_named_functions,
+                named_function_labels,
+            )
+            .map_err(|e| {
+                crate::RawParseError::SolutionError(crate::SolutionError::InvalidSidecar {
+                    message: e.to_string(),
+                })
+                .context(message, "evaluated_named_functions")
+            })?,
             decision_variables,
             variable_labels,
-            named_function_labels,
             optimality,
             relaxation,
             sense,

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -142,6 +142,10 @@ impl SampledConstraintBehavior for SampledSos1Constraint {
         Ok(())
     }
 
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
+    }
+
     fn get(&self, sample_id: SampleID) -> Option<Self::Evaluated> {
         let feasible = *self.stage.feasible.get(&sample_id)?;
         let active_variable = *self.stage.active_variable.get(&sample_id)?;


### PR DESCRIPTION
## Summary

Part of #958.

This PR normalizes Rust SDK named-function ownership so `NamedFunctionID` is owned by the enclosing top-level table, not by each row.

- Remove inline IDs from Rust `NamedFunction`, `EvaluatedNamedFunction`, and `SampledNamedFunction` row data.
- Introduce `NamedFunctionTable<T>` as the owner of named-function rows and their `NamedFunctionLabelStore`, analogous to `ConstraintCollection` without removed state.
- Store `NamedFunctionTable<NamedFunction>` on `Instance` / `ParametricInstance`, `NamedFunctionTable<EvaluatedNamedFunction>` on `Solution`, and `NamedFunctionTable<SampledNamedFunction>` on `SampleSet`.
- Thread table keys through v1 protobuf parse/write paths for `Instance`, `ParametricInstance`, `Solution`, and `SampleSet`.
- Reject duplicate named-function IDs while parsing legacy v1 `Solution` and `SampleSet` repeated named-function fields instead of silently overwriting table rows.
- Keep mutable named-function row operations table-owned: host accessors expose shared table views, `Instance::new_named_function` returns the allocated `NamedFunctionID`, parameter substitution follows the existing substitution pattern through `Substitute for NamedFunctionTable<NamedFunction>`, and partial evaluation follows the existing collection pattern through `Evaluate for NamedFunctionTable<NamedFunction>`.
- Document and enforce the invariant split: `NamedFunctionTable<T>` owns row keys and modeling-label sidecars, while `Instance` / `ParametricInstance` / `Solution` / `SampleSet` validate variable-universe invariants that a table cannot know by itself.
- Keep Python SDK `NamedFunction` wrappers exposing `.id` as a snapshot/wrapper field while the Rust domain row remains ID-less, and cover Python host construction boundaries for duplicate named-function IDs, unknown variable IDs, and parametric named functions that reference parameters.
- Update logical-memory snapshots, pandas conversion, the Rust migration guide, and Rust release notes to describe table-owned named-function IDs.
- Update the domain-responsibility review skill so future reviews explicitly check which invariant layer can enforce each rule.
- Clean up small Rust clippy findings required by the Rust lint gate.

## Design impact

Named functions now match the same ownership model already used for constraints and decision variables in the v3 Rust SDK normalization work: the table key is the source of truth for the ID, the row stores intrinsic data, and `NamedFunctionTable<T>` keeps the row map and modeling labels together so orphan named-function labels are rejected at validated construction boundaries.

`NamedFunctionTable<NamedFunction>` is also the mutation boundary for row bodies. `Substitute` and `Evaluate::partial_evaluate` are table-owned operations instead of exposed mutable row iteration, so callers cannot invalidate a checked host object by editing a named-function body outside the owner. The table `Evaluate` implementation returns evaluated / sampled named-function tables, preserving the same IDs and modeling labels.

The table-level invariant is intentionally narrow: labels must reference table-owned named-function IDs, and rows/labels move together. Host-level builders validate the broader semantic invariants: created named functions may only reference IDs defined by the enclosing instance, evaluated/sampled named functions may only report `used_decision_variable_ids` present in the enclosing result object, and sampled constraints now receive the same used-variable validation before `SampleSet::get` creates unchecked per-sample `Solution` values.
