### PR TITLE
Broaden LogicalMemoryProfile derive coverage

### DIFF
--- a/.agents/skills/domain-responsibility-review/SKILL.md
+++ b/.agents/skills/domain-responsibility-review/SKILL.md
@@ -62,11 +62,13 @@ Treat this as a review pre-pass, not as the required final response order. When 
   constraints. Review both the lower-level table API and every top-level
   builder/parser/unchecked path.
 - For `LogicalMemoryProfile`, prefer `#[derive(LogicalMemoryProfile)]` for
-  composite structs. Hand-written impls on composite types are a review risk
-  because new fields can be forgotten. Reserve manual impls for leaf types
-  only. Do not hand-write a composite impl to skip, rename, or collapse fields;
-  if a composite type cannot derive cleanly, fix the derive macro rather than
-  treating the type as an exception.
+  local Rust data types, including newtypes, tuple structs, and fieldless enums.
+  Hand-written impls on ordinary data shapes are a review risk because new
+  fields can be forgotten or collapsed. If a type cannot derive cleanly, first
+  add the missing standard-library impl or extend the derive macro rather than
+  treating the type as an exception. Reserve manual impls for semantically
+  special profiling shapes such as foreign/generated types, data-carrying enums,
+  stage-specific owner wrappers, or shared ownership types like `Rc`/`Arc`.
 - For new builder/setter/attachment APIs, add focused tests for both preservation and rejection paths, such as sidecar round-trips and orphan-ID validation.
 - For derived analysis or table-building code, avoid recomputing whole-instance partitions inside per-variable or per-row loops; compute the owner-side role/set partition once when the operation needs it repeatedly.
 

--- a/rust/ommx-derive/src/lib.rs
+++ b/rust/ommx-derive/src/lib.rs
@@ -31,9 +31,9 @@
 //!
 //! - Structs with named fields, tuple fields, or no fields.
 //!   - All fields must implement `LogicalMemoryProfile`. Primitives,
-//!     `String`, `Option<T>`, `Vec<T>`, `BTreeMap`, `HashMap`,
-//!     `FnvHashMap`, and `BTreeSet` all have blanket impls in
-//!     `ommx::logical_memory::collections`.
+//!     `String`, `Option<T>`, arrays, `Box<T>`, `Vec<T>`,
+//!     `VecDeque<T>`, maps, sets, `PhantomData<T>`, and tuples all have
+//!     reusable impls in `ommx::logical_memory::collections`.
 //! - Generic structs: when a field type depends on a type parameter, the
 //!   generated impl adds a `FieldType: LogicalMemoryProfile` where-clause.
 //!   This keeps composite structs derivable without hand-written impls.

--- a/rust/ommx-derive/src/lib.rs
+++ b/rust/ommx-derive/src/lib.rs
@@ -21,11 +21,16 @@
 //!
 //! # `#[derive(LogicalMemoryProfile)]`
 //!
-//! Generates a `LogicalMemoryProfile` impl that delegates to each field
-//! of a named-field struct. Each field is emitted under the path frame
-//! `"TypeName.field_name"`. The `ommx` crate uses this derive at every
-//! struct definition that participates in memory profiling, so that
-//! adding or removing a field automatically adjusts the profile.
+//! Generates a `LogicalMemoryProfile` impl. By default this delegates to
+//! each field of a named-field struct, with each field emitted under the
+//! path frame `"TypeName.field_name"`. The `ommx` crate uses this derive
+//! at every struct definition that participates in memory profiling, so
+//! that adding or removing a field automatically adjusts the profile.
+//!
+//! Leaf-like types can instead opt in to `#[logical_memory(leaf)]`, which
+//! emits a single leaf of `std::mem::size_of::<Self>()` at the current path.
+//! This is intended for POD structs, tuple newtypes, and small enums whose
+//! logical memory is their inline representation.
 //!
 //! ## Supported
 //!
@@ -37,13 +42,15 @@
 //! - Generic structs: when a field type depends on a type parameter, the
 //!   generated impl adds a `FieldType: LogicalMemoryProfile` where-clause.
 //!   This keeps composite structs derivable without hand-written impls.
+//! - `#[logical_memory(leaf)]` on structs, tuple structs, unit structs, and
+//!   enums. Leaf mode does not add field bounds because it does not inspect
+//!   fields.
 //!
 //! ## Not supported
 //!
-//! - Tuple structs and unit structs → emit a `compile_error!`. Use a
-//!   hand-written impl only for leaf-like wrappers; otherwise extend this
-//!   derive.
-//! - Enums → emit a `compile_error!`.
+//! - Tuple structs and unit structs without `#[logical_memory(leaf)]` → emit
+//!   a `compile_error!`.
+//! - Enums without `#[logical_memory(leaf)]` → emit a `compile_error!`.
 //! - Field skipping → there is no `#[logical_memory(skip)]` attribute.
 //!   Composite structs should not skip fields; extend this derive if a
 //!   composite profiling use case needs more macro support.
@@ -66,11 +73,12 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{parse_quote, Data, DeriveInput, Fields, GenericArgument, PathArguments, Type};
 
-/// Derive `LogicalMemoryProfile` for a struct by delegating to each field.
+/// Derive `LogicalMemoryProfile` for a type.
 ///
-/// Only structs with named fields are supported. Each field's profile is
-/// emitted under the path frame `"TypeName.field_name"`.
-#[proc_macro_derive(LogicalMemoryProfile)]
+/// By default, only structs with named fields are supported, and each field's
+/// profile is emitted under the path frame `"TypeName.field_name"`. With
+/// `#[logical_memory(leaf)]`, the type emits one `size_of::<Self>()` leaf.
+#[proc_macro_derive(LogicalMemoryProfile, attributes(logical_memory))]
 pub fn derive_logical_memory_profile(input: TokenStream) -> TokenStream {
     derive_logical_memory_profile_impl(input.into()).into()
 }
@@ -86,6 +94,14 @@ fn derive_logical_memory_profile_impl(input: TokenStream2) -> TokenStream2 {
     };
     let name = &input.ident;
     let name_str = name.to_string();
+
+    let attrs = match parse_logical_memory_attrs(&input.attrs) {
+        Ok(attrs) => attrs,
+        Err(err) => return err.to_compile_error(),
+    };
+    if attrs.leaf {
+        return derive_leaf_impl(&input);
+    }
 
     let fields = match &input.data {
         Data::Struct(data) => match &data.fields {
@@ -143,6 +159,55 @@ fn derive_logical_memory_profile_impl(input: TokenStream2) -> TokenStream2 {
                 visitor: &mut __V,
             ) {
                 #( #field_visits )*
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct LogicalMemoryAttrs {
+    leaf: bool,
+}
+
+fn parse_logical_memory_attrs(attrs: &[syn::Attribute]) -> syn::Result<LogicalMemoryAttrs> {
+    let mut parsed = LogicalMemoryAttrs::default();
+
+    for attr in attrs {
+        if !attr.path().is_ident("logical_memory") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("leaf") {
+                if parsed.leaf {
+                    return Err(meta.error("duplicate `leaf` logical_memory attribute"));
+                }
+                parsed.leaf = true;
+                Ok(())
+            } else {
+                Err(meta.error("unsupported logical_memory attribute; expected `leaf`"))
+            }
+        })?;
+    }
+
+    Ok(parsed)
+}
+
+fn derive_leaf_impl(input: &DeriveInput) -> TokenStream2 {
+    let name = &input.ident;
+    let generics = input.generics.clone();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ::ommx::logical_memory::LogicalMemoryProfile
+            for #name #ty_generics #where_clause
+        {
+            fn visit_logical_memory<__V: ::ommx::logical_memory::LogicalMemoryVisitor>(
+                &self,
+                path: &mut ::ommx::logical_memory::Path,
+                visitor: &mut __V,
+            ) {
+                visitor.visit_leaf(path, ::std::mem::size_of::<Self>());
             }
         }
     }
@@ -393,6 +458,62 @@ mod tests {
         insta::assert_snapshot!(render(input), @r###"
         ::core::compile_error! {
             "LogicalMemoryProfile derive only supports structs with named fields"
+        }
+        "###);
+    }
+
+    #[test]
+    fn snapshot_leaf_tuple_struct() {
+        let input = quote! {
+            #[logical_memory(leaf)]
+            struct VariableID(u64);
+        };
+        insta::assert_snapshot!(render(input), @r###"
+        impl ::ommx::logical_memory::LogicalMemoryProfile for VariableID {
+            fn visit_logical_memory<__V: ::ommx::logical_memory::LogicalMemoryVisitor>(
+                &self,
+                path: &mut ::ommx::logical_memory::Path,
+                visitor: &mut __V,
+            ) {
+                visitor.visit_leaf(path, ::std::mem::size_of::<Self>());
+            }
+        }
+        "###);
+    }
+
+    #[test]
+    fn snapshot_leaf_enum() {
+        let input = quote! {
+            #[logical_memory(leaf)]
+            enum Equality {
+                EqualToZero,
+                LessThanOrEqualToZero,
+            }
+        };
+        insta::assert_snapshot!(render(input), @r###"
+        impl ::ommx::logical_memory::LogicalMemoryProfile for Equality {
+            fn visit_logical_memory<__V: ::ommx::logical_memory::LogicalMemoryVisitor>(
+                &self,
+                path: &mut ::ommx::logical_memory::Path,
+                visitor: &mut __V,
+            ) {
+                visitor.visit_leaf(path, ::std::mem::size_of::<Self>());
+            }
+        }
+        "###);
+    }
+
+    #[test]
+    fn snapshot_rejects_unknown_attribute() {
+        let input = quote! {
+            #[logical_memory(skip)]
+            struct Foo {
+                value: u64,
+            }
+        };
+        insta::assert_snapshot!(render(input), @r###"
+        ::core::compile_error! {
+            "unsupported logical_memory attribute; expected `leaf`"
         }
         "###);
     }

--- a/rust/ommx-derive/src/lib.rs
+++ b/rust/ommx-derive/src/lib.rs
@@ -21,20 +21,15 @@
 //!
 //! # `#[derive(LogicalMemoryProfile)]`
 //!
-//! Generates a `LogicalMemoryProfile` impl. By default this delegates to
-//! each field of a named-field struct, with each field emitted under the
-//! path frame `"TypeName.field_name"`. The `ommx` crate uses this derive
-//! at every struct definition that participates in memory profiling, so
-//! that adding or removing a field automatically adjusts the profile.
-//!
-//! Leaf-like types can instead opt in to `#[logical_memory(leaf)]`, which
-//! emits a single leaf of `std::mem::size_of::<Self>()` at the current path.
-//! This is intended for POD structs, tuple newtypes, and small enums whose
-//! logical memory is their inline representation.
+//! Generates a `LogicalMemoryProfile` impl by following the type structure.
+//! Named-field structs delegate to each field under `"TypeName.field_name"`;
+//! tuple structs delegate under `"TypeName.0"`, `"TypeName.1"`, and so on.
+//! Unit structs emit no leaves. Fieldless enums emit one inline leaf of
+//! `std::mem::size_of::<Self>()`.
 //!
 //! ## Supported
 //!
-//! - Structs with named fields.
+//! - Structs with named fields, tuple fields, or no fields.
 //!   - All fields must implement `LogicalMemoryProfile`. Primitives,
 //!     `String`, `Option<T>`, `Vec<T>`, `BTreeMap`, `HashMap`,
 //!     `FnvHashMap`, and `BTreeSet` all have blanket impls in
@@ -42,15 +37,12 @@
 //! - Generic structs: when a field type depends on a type parameter, the
 //!   generated impl adds a `FieldType: LogicalMemoryProfile` where-clause.
 //!   This keeps composite structs derivable without hand-written impls.
-//! - `#[logical_memory(leaf)]` on structs, tuple structs, unit structs, and
-//!   enums. Leaf mode does not add field bounds because it does not inspect
-//!   fields.
+//! - Fieldless enums. Data-carrying enums should keep a hand-written impl
+//!   until variant-aware enum decomposition is introduced.
 //!
 //! ## Not supported
 //!
-//! - Tuple structs and unit structs without `#[logical_memory(leaf)]` → emit
-//!   a `compile_error!`.
-//! - Enums without `#[logical_memory(leaf)]` → emit a `compile_error!`.
+//! - Data-carrying enum variants → emit a `compile_error!`.
 //! - Field skipping → there is no `#[logical_memory(skip)]` attribute.
 //!   Composite structs should not skip fields; extend this derive if a
 //!   composite profiling use case needs more macro support.
@@ -75,10 +67,9 @@ use syn::{parse_quote, Data, DeriveInput, Fields, GenericArgument, PathArguments
 
 /// Derive `LogicalMemoryProfile` for a type.
 ///
-/// By default, only structs with named fields are supported, and each field's
-/// profile is emitted under the path frame `"TypeName.field_name"`. With
-/// `#[logical_memory(leaf)]`, the type emits one `size_of::<Self>()` leaf.
-#[proc_macro_derive(LogicalMemoryProfile, attributes(logical_memory))]
+/// Struct fields are delegated structurally. Fieldless enums emit one
+/// `size_of::<Self>()` leaf.
+#[proc_macro_derive(LogicalMemoryProfile)]
 pub fn derive_logical_memory_profile(input: TokenStream) -> TokenStream {
     derive_logical_memory_profile_impl(input.into()).into()
 }
@@ -93,60 +84,50 @@ fn derive_logical_memory_profile_impl(input: TokenStream2) -> TokenStream2 {
         Err(err) => return err.to_compile_error(),
     };
     let name = &input.ident;
-    let name_str = name.to_string();
 
-    let attrs = match parse_logical_memory_attrs(&input.attrs) {
-        Ok(attrs) => attrs,
-        Err(err) => return err.to_compile_error(),
-    };
-    if attrs.leaf {
-        return derive_leaf_impl(&input);
-    }
-
-    let fields = match &input.data {
-        Data::Struct(data) => match &data.fields {
-            Fields::Named(fields) => &fields.named,
-            _ => {
+    let mut generics = input.generics.clone();
+    let body = match &input.data {
+        Data::Struct(data) => {
+            let field_visits = struct_field_visits(name, &data.fields);
+            if has_type_params(&generics) {
+                for field in data.fields.iter() {
+                    if type_uses_type_param(&field.ty, &generics) {
+                        let ty = &field.ty;
+                        generics
+                            .make_where_clause()
+                            .predicates
+                            .push(parse_quote!(#ty: ::ommx::logical_memory::LogicalMemoryProfile));
+                    }
+                }
+            }
+            quote! {
+                #( #field_visits )*
+            }
+        }
+        Data::Enum(data) => {
+            if let Some(variant) = data
+                .variants
+                .iter()
+                .find(|variant| !matches!(variant.fields, Fields::Unit))
+            {
                 return syn::Error::new_spanned(
-                    name,
-                    "LogicalMemoryProfile derive only supports structs with named fields",
+                    variant,
+                    "LogicalMemoryProfile derive only supports fieldless enums",
                 )
                 .to_compile_error();
             }
-        },
+            quote! {
+                visitor.visit_leaf(path, ::std::mem::size_of::<Self>());
+            }
+        }
         _ => {
             return syn::Error::new_spanned(
                 name,
-                "LogicalMemoryProfile derive only supports structs",
+                "LogicalMemoryProfile derive only supports structs and fieldless enums",
             )
             .to_compile_error();
         }
     };
-
-    let field_visits = fields.iter().map(|field| {
-        let field_name = field.ident.as_ref().expect("named field");
-        let frame = format!("{name_str}.{field_name}");
-        quote! {
-            ::ommx::logical_memory::LogicalMemoryProfile::visit_logical_memory(
-                &self.#field_name,
-                path.with(#frame).as_mut(),
-                visitor,
-            );
-        }
-    });
-
-    let mut generics = input.generics.clone();
-    if has_type_params(&generics) {
-        for field in fields {
-            if type_uses_type_param(&field.ty, &generics) {
-                let ty = &field.ty;
-                generics
-                    .make_where_clause()
-                    .predicates
-                    .push(parse_quote!(#ty: ::ommx::logical_memory::LogicalMemoryProfile));
-            }
-        }
-    }
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
@@ -158,59 +139,41 @@ fn derive_logical_memory_profile_impl(input: TokenStream2) -> TokenStream2 {
                 path: &mut ::ommx::logical_memory::Path,
                 visitor: &mut __V,
             ) {
-                #( #field_visits )*
+                #body
             }
         }
     }
 }
 
-#[derive(Default)]
-struct LogicalMemoryAttrs {
-    leaf: bool,
-}
-
-fn parse_logical_memory_attrs(attrs: &[syn::Attribute]) -> syn::Result<LogicalMemoryAttrs> {
-    let mut parsed = LogicalMemoryAttrs::default();
-
-    for attr in attrs {
-        if !attr.path().is_ident("logical_memory") {
-            continue;
-        }
-
-        attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("leaf") {
-                if parsed.leaf {
-                    return Err(meta.error("duplicate `leaf` logical_memory attribute"));
-                }
-                parsed.leaf = true;
-                Ok(())
-            } else {
-                Err(meta.error("unsupported logical_memory attribute; expected `leaf`"))
+fn struct_field_visits(name: &syn::Ident, fields: &Fields) -> Vec<TokenStream2> {
+    let name_str = name.to_string();
+    fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            let access = field
+                .ident
+                .as_ref()
+                .map(|ident| quote!(#ident))
+                .unwrap_or_else(|| {
+                    let index = syn::Index::from(index);
+                    quote!(#index)
+                });
+            let field_name = field
+                .ident
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| index.to_string());
+            let frame = format!("{name_str}.{field_name}");
+            quote! {
+                ::ommx::logical_memory::LogicalMemoryProfile::visit_logical_memory(
+                    &self.#access,
+                    path.with(#frame).as_mut(),
+                    visitor,
+                );
             }
-        })?;
-    }
-
-    Ok(parsed)
-}
-
-fn derive_leaf_impl(input: &DeriveInput) -> TokenStream2 {
-    let name = &input.ident;
-    let generics = input.generics.clone();
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    quote! {
-        impl #impl_generics ::ommx::logical_memory::LogicalMemoryProfile
-            for #name #ty_generics #where_clause
-        {
-            fn visit_logical_memory<__V: ::ommx::logical_memory::LogicalMemoryVisitor>(
-                &self,
-                path: &mut ::ommx::logical_memory::Path,
-                visitor: &mut __V,
-            ) {
-                visitor.visit_leaf(path, ::std::mem::size_of::<Self>());
-            }
-        }
-    }
+        })
+        .collect()
 }
 
 fn has_type_params(generics: &syn::Generics) -> bool {
@@ -436,55 +399,8 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_rejects_enum() {
-        // Error output is also snapshot-tested to lock in the diagnostic
-        // message surface. The generated compile_error! invocation is the
-        // contract for non-struct inputs.
+    fn snapshot_fieldless_enum() {
         let input = quote! {
-            enum NotSupported { A, B }
-        };
-        insta::assert_snapshot!(render(input), @r###"
-        ::core::compile_error! {
-            "LogicalMemoryProfile derive only supports structs"
-        }
-        "###);
-    }
-
-    #[test]
-    fn snapshot_rejects_tuple_struct() {
-        let input = quote! {
-            struct Tuple(u64, String);
-        };
-        insta::assert_snapshot!(render(input), @r###"
-        ::core::compile_error! {
-            "LogicalMemoryProfile derive only supports structs with named fields"
-        }
-        "###);
-    }
-
-    #[test]
-    fn snapshot_leaf_tuple_struct() {
-        let input = quote! {
-            #[logical_memory(leaf)]
-            struct VariableID(u64);
-        };
-        insta::assert_snapshot!(render(input), @r###"
-        impl ::ommx::logical_memory::LogicalMemoryProfile for VariableID {
-            fn visit_logical_memory<__V: ::ommx::logical_memory::LogicalMemoryVisitor>(
-                &self,
-                path: &mut ::ommx::logical_memory::Path,
-                visitor: &mut __V,
-            ) {
-                visitor.visit_leaf(path, ::std::mem::size_of::<Self>());
-            }
-        }
-        "###);
-    }
-
-    #[test]
-    fn snapshot_leaf_enum() {
-        let input = quote! {
-            #[logical_memory(leaf)]
             enum Equality {
                 EqualToZero,
                 LessThanOrEqualToZero,
@@ -504,16 +420,72 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_rejects_unknown_attribute() {
+    fn snapshot_tuple_struct() {
         let input = quote! {
-            #[logical_memory(skip)]
-            struct Foo {
+            struct Tuple(u64, String);
+        };
+        insta::assert_snapshot!(render(input), @r###"
+        impl ::ommx::logical_memory::LogicalMemoryProfile for Tuple {
+            fn visit_logical_memory<__V: ::ommx::logical_memory::LogicalMemoryVisitor>(
+                &self,
+                path: &mut ::ommx::logical_memory::Path,
+                visitor: &mut __V,
+            ) {
+                ::ommx::logical_memory::LogicalMemoryProfile::visit_logical_memory(
+                    &self.0,
+                    path.with("Tuple.0").as_mut(),
+                    visitor,
+                );
+                ::ommx::logical_memory::LogicalMemoryProfile::visit_logical_memory(
+                    &self.1,
+                    path.with("Tuple.1").as_mut(),
+                    visitor,
+                );
+            }
+        }
+        "###);
+    }
+
+    #[test]
+    fn snapshot_unit_struct() {
+        let input = quote! {
+            struct Unit;
+        };
+        insta::assert_snapshot!(render(input), @r###"
+        impl ::ommx::logical_memory::LogicalMemoryProfile for Unit {
+            fn visit_logical_memory<__V: ::ommx::logical_memory::LogicalMemoryVisitor>(
+                &self,
+                path: &mut ::ommx::logical_memory::Path,
+                visitor: &mut __V,
+            ) {}
+        }
+        "###);
+    }
+
+    #[test]
+    fn snapshot_rejects_data_enum() {
+        let input = quote! {
+            enum Provenance {
+                IndicatorConstraint(IndicatorConstraintID),
+            }
+        };
+        insta::assert_snapshot!(render(input), @r###"
+        ::core::compile_error! {
+            "LogicalMemoryProfile derive only supports fieldless enums"
+        }
+        "###);
+    }
+
+    #[test]
+    fn snapshot_rejects_union() {
+        let input = quote! {
+            union Foo {
                 value: u64,
             }
         };
         insta::assert_snapshot!(render(input), @r###"
         ::core::compile_error! {
-            "unsupported logical_memory attribute; expected `leaf`"
+            "LogicalMemoryProfile derive only supports structs and fieldless enums"
         }
         "###);
     }

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -68,7 +68,15 @@ pub type Bounds = BTreeMap<VariableID, Bound>;
 /// // Default is `(-inf, inf)`
 /// assert_eq!(Bound::default(), Bound::try_from([f64::NEG_INFINITY, f64::INFINITY]).unwrap());
 /// ```
-#[derive(Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    crate::logical_memory::LogicalMemoryProfile,
+)]
+#[logical_memory(leaf)]
 pub struct Bound {
     lower: f64,
     upper: f64,
@@ -526,8 +534,6 @@ impl Arbitrary for Bound {
             .boxed()
     }
 }
-
-mod logical_memory;
 
 #[cfg(test)]
 mod tests {

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -76,7 +76,6 @@ pub type Bounds = BTreeMap<VariableID, Bound>;
     serde::Deserialize,
     crate::logical_memory::LogicalMemoryProfile,
 )]
-#[logical_memory(leaf)]
 pub struct Bound {
     lower: f64,
     upper: f64,

--- a/rust/ommx/src/bound/logical_memory.rs
+++ b/rust/ommx/src/bound/logical_memory.rs
@@ -1,9 +1,0 @@
-use crate::bound::Bound;
-use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
-use std::mem::size_of;
-
-impl LogicalMemoryProfile for Bound {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, size_of::<Bound>());
-    }
-}

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -23,7 +23,6 @@ pub use stage::{
 
 /// Constraint equality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, LogicalMemoryProfile)]
-#[logical_memory(leaf)]
 pub enum Equality {
     /// $f(x) = 0$ type constraint.
     EqualToZero,
@@ -47,7 +46,6 @@ pub enum Equality {
     LogicalMemoryProfile,
 )]
 #[serde(transparent)]
-#[logical_memory(leaf)]
 pub struct ConstraintID(u64);
 
 impl std::fmt::Debug for ConstraintID {
@@ -79,8 +77,7 @@ impl From<ConstraintID> for u64 {
 /// For example, when an indicator constraint with indicator=1 is propagated,
 /// it is promoted to a regular `Constraint` with a provenance step recording
 /// the original indicator constraint ID.
-#[derive(Debug, Clone, PartialEq, Eq, LogicalMemoryProfile)]
-#[logical_memory(leaf)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Provenance {
     IndicatorConstraint(crate::IndicatorConstraintID),
     OneHotConstraint(crate::OneHotConstraintID),

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -22,7 +22,8 @@ pub use stage::{
 // name collision with `crate::Sampled<T>` (the sampled-values container).
 
 /// Constraint equality.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, LogicalMemoryProfile)]
+#[logical_memory(leaf)]
 pub enum Equality {
     /// $f(x) = 0$ type constraint.
     EqualToZero,
@@ -43,8 +44,10 @@ pub enum Equality {
     Deref,
     serde::Serialize,
     serde::Deserialize,
+    LogicalMemoryProfile,
 )]
 #[serde(transparent)]
+#[logical_memory(leaf)]
 pub struct ConstraintID(u64);
 
 impl std::fmt::Debug for ConstraintID {
@@ -76,7 +79,8 @@ impl From<ConstraintID> for u64 {
 /// For example, when an indicator constraint with indicator=1 is propagated,
 /// it is promoted to a regular `Constraint` with a provenance step recording
 /// the original indicator constraint ID.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, LogicalMemoryProfile)]
+#[logical_memory(leaf)]
 pub enum Provenance {
     IndicatorConstraint(crate::IndicatorConstraintID),
     OneHotConstraint(crate::OneHotConstraintID),

--- a/rust/ommx/src/constraint/logical_memory.rs
+++ b/rust/ommx/src/constraint/logical_memory.rs
@@ -1,24 +1,5 @@
-use crate::constraint::{Constraint, ConstraintID, Created, Equality, Provenance, RemovedReason};
+use crate::constraint::{Constraint, Created};
 use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
-use std::mem::size_of;
-
-impl LogicalMemoryProfile for ConstraintID {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, size_of::<ConstraintID>());
-    }
-}
-
-impl LogicalMemoryProfile for Equality {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, size_of::<Equality>());
-    }
-}
-
-impl LogicalMemoryProfile for Provenance {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, size_of::<Provenance>());
-    }
-}
 
 // ConstraintContext, CreatedData, and RemovedReason use
 // `#[derive(LogicalMemoryProfile)]` on their definition sites.
@@ -35,17 +16,6 @@ impl LogicalMemoryProfile for Constraint<Created> {
             .visit_logical_memory(path.with("Constraint.equality").as_mut(), visitor);
         self.stage
             .visit_logical_memory(path.with("Constraint.stage").as_mut(), visitor);
-    }
-}
-
-impl LogicalMemoryProfile for (Constraint<Created>, RemovedReason) {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        self.0
-            .visit_logical_memory(path.with("RemovedConstraint").as_mut(), visitor);
-        self.1.visit_logical_memory(
-            path.with("RemovedConstraint.removed_reason").as_mut(),
-            visitor,
-        );
     }
 }
 

--- a/rust/ommx/src/constraint/logical_memory.rs
+++ b/rust/ommx/src/constraint/logical_memory.rs
@@ -1,8 +1,19 @@
-use crate::constraint::{Constraint, Created};
+use crate::constraint::{Constraint, Created, Provenance};
 use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
+use std::mem::size_of;
 
 // ConstraintContext, CreatedData, and RemovedReason use
 // `#[derive(LogicalMemoryProfile)]` on their definition sites.
+//
+// Provenance is a data-carrying enum whose current variants contain only
+// inline ID payloads. Count the enum layout as one inline value until the derive
+// supports variant-aware enum decomposition without double-counting payload
+// stack bytes.
+impl LogicalMemoryProfile for Provenance {
+    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
+        visitor.visit_leaf(path, size_of::<Provenance>());
+    }
+}
 
 // Constraint<Created> - manually implemented because generic types
 // cannot be used with the simple ident-based macro form.

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -32,8 +32,10 @@ use std::collections::BTreeSet;
     Deref,
     serde::Serialize,
     serde::Deserialize,
+    LogicalMemoryProfile,
 )]
 #[serde(transparent)]
+#[logical_memory(leaf)]
 pub struct VariableID(u64);
 pub type VariableIDSet = BTreeSet<VariableID>;
 
@@ -62,8 +64,19 @@ impl std::fmt::Display for VariableID {
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    LogicalMemoryProfile,
 )]
+#[logical_memory(leaf)]
 pub enum Kind {
     Continuous,
     Integer,

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -35,7 +35,6 @@ use std::collections::BTreeSet;
     LogicalMemoryProfile,
 )]
 #[serde(transparent)]
-#[logical_memory(leaf)]
 pub struct VariableID(u64);
 pub type VariableIDSet = BTreeSet<VariableID>;
 
@@ -76,7 +75,6 @@ impl std::fmt::Display for VariableID {
     serde::Deserialize,
     LogicalMemoryProfile,
 )]
-#[logical_memory(leaf)]
 pub enum Kind {
     Continuous,
     Integer,

--- a/rust/ommx/src/decision_variable/logical_memory.rs
+++ b/rust/ommx/src/decision_variable/logical_memory.rs
@@ -15,7 +15,8 @@ mod tests {
         // intrinsic fields appear here; per-variable modeling labels live at
         // `Instance::variable_labels` (see `instance/logical_memory.rs`).
         insta::assert_snapshot!(folded, @r###"
-        DecisionVariable.bound 16
+        DecisionVariable.bound;Bound.lower 8
+        DecisionVariable.bound;Bound.upper 8
         DecisionVariable.kind 1
         "###);
     }
@@ -35,7 +36,8 @@ mod tests {
 
         let folded = logical_memory_to_folded(&dv);
         insta::assert_snapshot!(folded, @r###"
-        DecisionVariable.bound 16
+        DecisionVariable.bound;Bound.lower 8
+        DecisionVariable.bound;Bound.upper 8
         DecisionVariable.kind 1
         "###);
     }

--- a/rust/ommx/src/decision_variable/logical_memory.rs
+++ b/rust/ommx/src/decision_variable/logical_memory.rs
@@ -1,19 +1,3 @@
-use crate::decision_variable::{Kind, VariableID};
-use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
-use std::mem::size_of;
-
-impl LogicalMemoryProfile for VariableID {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, size_of::<VariableID>());
-    }
-}
-
-impl LogicalMemoryProfile for Kind {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, size_of::<Kind>());
-    }
-}
-
 // DecisionVariable and DecisionVariableLabel use
 // `#[derive(LogicalMemoryProfile)]` on their definition sites.
 

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -26,7 +26,6 @@ use std::collections::BTreeMap;
     crate::logical_memory::LogicalMemoryProfile,
 )]
 #[serde(transparent)]
-#[logical_memory(leaf)]
 pub struct IndicatorConstraintID(u64);
 
 impl std::fmt::Debug for IndicatorConstraintID {

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -23,8 +23,10 @@ use std::collections::BTreeMap;
     Deref,
     serde::Serialize,
     serde::Deserialize,
+    crate::logical_memory::LogicalMemoryProfile,
 )]
 #[serde(transparent)]
+#[logical_memory(leaf)]
 pub struct IndicatorConstraintID(u64);
 
 impl std::fmt::Debug for IndicatorConstraintID {

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -97,7 +97,6 @@ pub type Capabilities = std::collections::BTreeSet<AdditionalCapability>;
     Default,
     crate::logical_memory::LogicalMemoryProfile,
 )]
-#[logical_memory(leaf)]
 pub enum Sense {
     #[default]
     Minimize,

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -85,7 +85,19 @@ pub enum AdditionalCapability {
 /// formatting, and comparison are deterministic and sorted by variant order.
 pub type Capabilities = std::collections::BTreeSet<AdditionalCapability>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    crate::logical_memory::LogicalMemoryProfile,
+)]
+#[logical_memory(leaf)]
 pub enum Sense {
     #[default]
     Minimize,

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -202,9 +202,10 @@ mod tests {
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
         Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;DecisionVariableTable.columns;CreatedDecisionVariableColumns.fixed_values;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key] 16
+        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key];VariableID.0 16
         Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound 32
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.lower 16
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.upper 16
         Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.kind 2
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
@@ -277,7 +278,7 @@ mod tests {
         let folded = logical_memory_to_folded(&instance);
         insta::assert_snapshot!(folded, @r###"
         Instance.annotations;HashMap[stack] 48
-        Instance.constraint_collection;constraints;BTreeMap[key] 8
+        Instance.constraint_collection;constraints;BTreeMap[key];ConstraintID.0 8
         Instance.constraint_collection;constraints;BTreeMap[stack] 24
         Instance.constraint_collection;constraints;Constraint.equality 1
         Instance.constraint_collection;constraints;Constraint.stage;CreatedData.function;Linear;PolynomialBase.terms 80
@@ -291,9 +292,10 @@ mod tests {
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
         Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;DecisionVariableTable.columns;CreatedDecisionVariableColumns.fixed_values;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key] 16
+        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key];VariableID.0 16
         Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound 32
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.lower 16
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.upper 16
         Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.kind 2
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
@@ -394,13 +396,14 @@ mod tests {
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
         Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;DecisionVariableTable.columns;CreatedDecisionVariableColumns.fixed_values;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key] 24
+        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key];VariableID.0 24
         Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound 48
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.lower 24
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.upper 24
         Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.kind 3
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name 95
-        Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name;FnvHashMap[key] 24
+        Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name;FnvHashMap[key];VariableID.0 24
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
@@ -485,9 +488,10 @@ mod tests {
         Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
         Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
         Instance.decision_variables;DecisionVariableTable.columns;CreatedDecisionVariableColumns.fixed_values;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key] 8
+        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key];VariableID.0 8
         Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[stack] 24
-        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound 16
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.lower 8
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.upper 8
         Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.kind 1
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
         Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name;FnvHashMap[stack] 32

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -1,13 +1,6 @@
-use crate::instance::{Instance, Sense};
+use crate::instance::Instance;
 use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
 use crate::v1;
-use std::mem::size_of;
-
-impl LogicalMemoryProfile for Sense {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, size_of::<Sense>());
-    }
-}
 
 // Implementations for protobuf types
 
@@ -26,24 +19,6 @@ crate::impl_logical_memory_profile! {
     }
 }
 
-// Leaf impls for special constraint ID types
-macro_rules! impl_id_logical_memory {
-    ($id_type:ty) => {
-        impl LogicalMemoryProfile for $id_type {
-            fn visit_logical_memory<V: LogicalMemoryVisitor>(
-                &self,
-                path: &mut Path,
-                visitor: &mut V,
-            ) {
-                visitor.visit_leaf(path, std::mem::size_of::<$id_type>());
-            }
-        }
-    };
-}
-impl_id_logical_memory!(crate::IndicatorConstraintID);
-impl_id_logical_memory!(crate::OneHotConstraintID);
-impl_id_logical_memory!(crate::Sos1ConstraintID);
-
 // LogicalMemoryProfile for special constraint Created types
 // These are simpler than Constraint since they have no function.
 macro_rules! impl_special_constraint_profile {
@@ -56,21 +31,6 @@ macro_rules! impl_special_constraint_profile {
             ) {
                 // Count the whole constraint as a single leaf for simplicity
                 visitor.visit_leaf(path, std::mem::size_of_val(self));
-            }
-        }
-
-        impl LogicalMemoryProfile for ($constraint_type, crate::constraint::RemovedReason) {
-            fn visit_logical_memory<V: LogicalMemoryVisitor>(
-                &self,
-                path: &mut Path,
-                visitor: &mut V,
-            ) {
-                self.0
-                    .visit_logical_memory(path.with($name).as_mut(), visitor);
-                self.1.visit_logical_memory(
-                    path.with(concat!($name, ".removed_reason")).as_mut(),
-                    visitor,
-                );
             }
         }
     };

--- a/rust/ommx/src/instance/logical_memory.rs
+++ b/rust/ommx/src/instance/logical_memory.rs
@@ -19,25 +19,51 @@ crate::impl_logical_memory_profile! {
     }
 }
 
-// LogicalMemoryProfile for special constraint Created types
-// These are simpler than Constraint since they have no function.
+// LogicalMemoryProfile for special constraint Created types.
+//
+// These generic stage wrappers cannot currently use the derive macro cleanly,
+// but they still follow the same field-by-field accounting policy as derived
+// composite structs.
 macro_rules! impl_special_constraint_profile {
-    ($constraint_type:ty, $name:expr) => {
+    ($constraint_type:ty, $name:literal { $($field:ident),+ $(,)? }) => {
         impl LogicalMemoryProfile for $constraint_type {
             fn visit_logical_memory<V: LogicalMemoryVisitor>(
                 &self,
                 path: &mut Path,
                 visitor: &mut V,
             ) {
-                // Count the whole constraint as a single leaf for simplicity
-                visitor.visit_leaf(path, std::mem::size_of_val(self));
+                $(
+                    self.$field.visit_logical_memory(
+                        path.with(concat!($name, ".", stringify!($field))).as_mut(),
+                        visitor,
+                    );
+                )+
             }
         }
     };
 }
-impl_special_constraint_profile!(crate::IndicatorConstraint, "IndicatorConstraint");
-impl_special_constraint_profile!(crate::OneHotConstraint, "OneHotConstraint");
-impl_special_constraint_profile!(crate::Sos1Constraint, "Sos1Constraint");
+impl_special_constraint_profile!(
+    crate::IndicatorConstraint,
+    "IndicatorConstraint" {
+        indicator_variable,
+        equality,
+        stage,
+    }
+);
+impl_special_constraint_profile!(
+    crate::OneHotConstraint,
+    "OneHotConstraint" {
+        variables,
+        stage,
+    }
+);
+impl_special_constraint_profile!(
+    crate::Sos1Constraint,
+    "Sos1Constraint" {
+        variables,
+        stage,
+    }
+);
 
 macro_rules! impl_constraint_collection_profile {
     ($constraint_type:ty, $active_name:expr, $removed_name:expr) => {
@@ -109,7 +135,7 @@ mod tests {
     use crate::{
         coeff, linear, Constraint, ConstraintID, DecisionVariable, Equality, Function, VariableID,
     };
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     #[test]
     fn test_instance_empty_snapshot() {
@@ -331,6 +357,122 @@ mod tests {
         Instance.sos1_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
         Instance.sos1_constraint_collection;removed_sos1_constraints;BTreeMap[stack] 24
         Instance.sos1_constraint_collection;sos1_constraints;BTreeMap[stack] 24
+        "###);
+    }
+
+    #[test]
+    fn test_instance_with_special_constraints_snapshot() {
+        let mut decision_variables = BTreeMap::new();
+        decision_variables.insert(VariableID::from(1), DecisionVariable::binary());
+        decision_variables.insert(VariableID::from(2), DecisionVariable::binary());
+        decision_variables.insert(VariableID::from(3), DecisionVariable::continuous());
+
+        let mut instance = Instance::new(
+            crate::instance::Sense::Minimize,
+            Function::Zero,
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        instance
+            .add_indicator_constraint(
+                crate::IndicatorConstraint::new(
+                    VariableID::from(1),
+                    Equality::LessThanOrEqualToZero,
+                    Function::Linear((linear!(2) + coeff!(-1.0)).unwrap()),
+                ),
+                crate::ConstraintContext::default(),
+            )
+            .unwrap();
+        instance
+            .add_one_hot_constraint(
+                crate::OneHotConstraint::new(
+                    [1, 2]
+                        .into_iter()
+                        .map(VariableID::from)
+                        .collect::<BTreeSet<_>>(),
+                )
+                .unwrap(),
+                crate::ConstraintContext::default(),
+            )
+            .unwrap();
+        instance
+            .add_sos1_constraint(
+                crate::Sos1Constraint::new(
+                    [2, 3]
+                        .into_iter()
+                        .map(VariableID::from)
+                        .collect::<BTreeSet<_>>(),
+                )
+                .unwrap(),
+                crate::ConstraintContext::default(),
+            )
+            .unwrap();
+
+        let folded = logical_memory_to_folded(&instance);
+        insta::assert_snapshot!(folded, @r###"
+        Instance.annotations;HashMap[stack] 48
+        Instance.constraint_collection;constraints;BTreeMap[stack] 24
+        Instance.constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
+        Instance.constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
+        Instance.constraint_collection;removed_constraints;BTreeMap[stack] 24
+        Instance.decision_variable_dependency;AcyclicAssignments.assignments;FnvHashMap[stack] 32
+        Instance.decision_variable_dependency;AcyclicAssignments.dependency 144
+        Instance.decision_variable_dependency;AcyclicAssignments.topological_order;Vec[stack] 24
+        Instance.decision_variables;DecisionVariableTable.columns;CreatedDecisionVariableColumns.fixed_values;BTreeMap[stack] 24
+        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[key];VariableID.0 24
+        Instance.decision_variables;DecisionVariableTable.entries;BTreeMap[stack] 24
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.lower 24
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.bound;Bound.upper 24
+        Instance.decision_variables;DecisionVariableTable.entries;DecisionVariable.kind 3
+        Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.decision_variables;DecisionVariableTable.labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
+        Instance.description;Option[stack] 168
+        Instance.indicator_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.indicator_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.indicator_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.indicator_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
+        Instance.indicator_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
+        Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[key];IndicatorConstraintID.0 8
+        Instance.indicator_constraint_collection;indicator_constraints;BTreeMap[stack] 24
+        Instance.indicator_constraint_collection;indicator_constraints;IndicatorConstraint.equality 1
+        Instance.indicator_constraint_collection;indicator_constraints;IndicatorConstraint.indicator_variable;VariableID.0 8
+        Instance.indicator_constraint_collection;indicator_constraints;IndicatorConstraint.stage;CreatedData.function;Linear;PolynomialBase.terms 80
+        Instance.indicator_constraint_collection;removed_indicator_constraints;BTreeMap[stack] 24
+        Instance.named_functions;NamedFunctionTable.entries;BTreeMap[stack] 24
+        Instance.named_functions;NamedFunctionTable.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.named_functions;NamedFunctionTable.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.named_functions;NamedFunctionTable.labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.named_functions;NamedFunctionTable.labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
+        Instance.objective;Zero 40
+        Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.one_hot_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
+        Instance.one_hot_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
+        Instance.one_hot_constraint_collection;one_hot_constraints;BTreeMap[key];OneHotConstraintID.0 8
+        Instance.one_hot_constraint_collection;one_hot_constraints;BTreeMap[stack] 24
+        Instance.one_hot_constraint_collection;one_hot_constraints;OneHotConstraint.variables;BTreeSet[stack] 24
+        Instance.one_hot_constraint_collection;one_hot_constraints;OneHotConstraint.variables;VariableID.0 16
+        Instance.one_hot_constraint_collection;removed_one_hot_constraints;BTreeMap[stack] 24
+        Instance.parameters;Option[stack] 48
+        Instance.sense 1
+        Instance.sos1_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.description;FnvHashMap[stack] 32
+        Instance.sos1_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.name;FnvHashMap[stack] 32
+        Instance.sos1_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.parameters;FnvHashMap[stack] 32
+        Instance.sos1_constraint_collection;context;ConstraintContextStore.labels;ModelingLabelStore.subscripts;FnvHashMap[stack] 32
+        Instance.sos1_constraint_collection;context;ConstraintContextStore.provenance;FnvHashMap[stack] 32
+        Instance.sos1_constraint_collection;removed_sos1_constraints;BTreeMap[stack] 24
+        Instance.sos1_constraint_collection;sos1_constraints;BTreeMap[key];Sos1ConstraintID.0 8
+        Instance.sos1_constraint_collection;sos1_constraints;BTreeMap[stack] 24
+        Instance.sos1_constraint_collection;sos1_constraints;Sos1Constraint.variables;BTreeSet[stack] 24
+        Instance.sos1_constraint_collection;sos1_constraints;Sos1Constraint.variables;VariableID.0 16
         "###);
     }
 

--- a/rust/ommx/src/logical_memory.rs
+++ b/rust/ommx/src/logical_memory.rs
@@ -39,17 +39,20 @@
 //!   owning type and the field name, which makes the hierarchy
 //!   easy to read at a glance.
 //!
-//! - **Never write `size_of::<Self>()` at a struct leaf.** That would
-//!   double-count: the struct's stack slot already includes every field
-//!   by layout. Delegate to each field instead. Padding between fields
-//!   is the only thing missed — an acceptable trade-off.
+//! - **Do not collapse composite owners to `size_of::<Self>()`.** That would
+//!   double-count if the fields are also visited, and would hide child
+//!   structure if they are not. Delegate to each field instead. Padding
+//!   between fields is the only thing missed — an acceptable trade-off.
+//!   Use `#[logical_memory(leaf)]` only for inline POD wrappers/enums whose
+//!   fields should not be semantically decomposed.
 //!
 //! - **Stack vs heap.** Primitives and POD structs (`Bound`, `Kind`, ...)
-//!   emit a single leaf of `size_of::<T>()`. Collections emit a
-//!   `Type[stack]` leaf for their header (`size_of::<Vec<T>>()` etc.)
-//!   and then delegate to their elements; unused capacity is deliberately
-//!   ignored. `String` emits `size_of::<String>() + len()` (heap
-//!   bytes actually present).
+//!   emit a single leaf of `size_of::<T>()`. Owning containers (`Vec`,
+//!   `VecDeque`, maps, sets, `Box`) emit a `Type[stack]` leaf for their
+//!   handle/header and then delegate to their live contents; unused capacity
+//!   is deliberately ignored. `String` emits `size_of::<String>() + len()`
+//!   (heap bytes actually present). Arrays and tuples delegate to their
+//!   elements under `Array[element]` / `Tuple.0`, `Tuple.1`, ... frames.
 //!
 //! - **Aggregation.** Multiple visits to the same path accumulate in
 //!   [`MemoryProfile`]. So profiling a `BTreeMap<Id, T>` with 1000
@@ -239,9 +242,10 @@ pub(crate) fn logical_total_bytes<T: LogicalMemoryProfile>(value: &T) -> usize {
 // Macro to implement LogicalMemoryProfile for structs with fields
 /// Generates a LogicalMemoryProfile implementation that delegates to each field.
 ///
-/// Kept for leaf-like wrappers and foreign types where we need an explicit
-/// type-name override. Prefer `#[derive(LogicalMemoryProfile)]` for composite
-/// structs.
+/// Kept for foreign types where we need an explicit type-name override.
+/// Prefer `#[derive(LogicalMemoryProfile)]` for composite structs and
+/// `#[derive(LogicalMemoryProfile)] #[logical_memory(leaf)]` for leaf-like
+/// local types.
 ///
 /// # Example
 /// ```ignore
@@ -326,7 +330,23 @@ macro_rules! impl_logical_memory_profile_for_primitive {
 }
 
 impl_logical_memory_profile_for_primitive!(
-    u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64
+    (),
+    bool,
+    char,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64
 );
 
 #[cfg(test)]

--- a/rust/ommx/src/logical_memory.rs
+++ b/rust/ommx/src/logical_memory.rs
@@ -44,9 +44,10 @@
 //!   structure if they are not. Delegate to each field instead. Padding
 //!   between fields is the only thing missed — an acceptable trade-off.
 //!
-//! - **Stack vs heap.** Primitives and POD structs (`Bound`, `Kind`, ...)
-//!   emit a single leaf of `size_of::<T>()`. Owning containers (`Vec`,
-//!   `VecDeque`, maps, sets, `Box`) emit a `Type[stack]` leaf for their
+//! - **Stack vs heap.** Primitive scalars and fieldless enums emit a single
+//!   leaf of `size_of::<T>()`. Local composite data types, including POD-like
+//!   wrappers such as `Bound`, delegate to their fields. Owning containers
+//!   (`Vec`, `VecDeque`, maps, sets, `Box`) emit a `Type[stack]` leaf for their
 //!   handle/header and then delegate to their live contents; unused capacity
 //!   is deliberately ignored. `String` emits `size_of::<String>() + len()`
 //!   (heap bytes actually present). Arrays and tuples delegate to their
@@ -241,7 +242,7 @@ pub(crate) fn logical_total_bytes<T: LogicalMemoryProfile>(value: &T) -> usize {
 /// Generates a LogicalMemoryProfile implementation that delegates to each field.
 ///
 /// Kept for foreign types where we need an explicit type-name override.
-/// Prefer `#[derive(LogicalMemoryProfile)]` for local composite types.
+/// Prefer `#[derive(LogicalMemoryProfile)]` for local Rust data types.
 ///
 /// # Example
 /// ```ignore

--- a/rust/ommx/src/logical_memory.rs
+++ b/rust/ommx/src/logical_memory.rs
@@ -43,8 +43,6 @@
 //!   double-count if the fields are also visited, and would hide child
 //!   structure if they are not. Delegate to each field instead. Padding
 //!   between fields is the only thing missed — an acceptable trade-off.
-//!   Use `#[logical_memory(leaf)]` only for inline POD wrappers/enums whose
-//!   fields should not be semantically decomposed.
 //!
 //! - **Stack vs heap.** Primitives and POD structs (`Bound`, `Kind`, ...)
 //!   emit a single leaf of `size_of::<T>()`. Owning containers (`Vec`,
@@ -243,9 +241,7 @@ pub(crate) fn logical_total_bytes<T: LogicalMemoryProfile>(value: &T) -> usize {
 /// Generates a LogicalMemoryProfile implementation that delegates to each field.
 ///
 /// Kept for foreign types where we need an explicit type-name override.
-/// Prefer `#[derive(LogicalMemoryProfile)]` for composite structs and
-/// `#[derive(LogicalMemoryProfile)] #[logical_memory(leaf)]` for leaf-like
-/// local types.
+/// Prefer `#[derive(LogicalMemoryProfile)]` for local composite types.
 ///
 /// # Example
 /// ```ignore

--- a/rust/ommx/src/logical_memory/collections.rs
+++ b/rust/ommx/src/logical_memory/collections.rs
@@ -32,6 +32,34 @@ where
     }
 }
 
+impl<T, const N: usize> LogicalMemoryProfile for [T; N]
+where
+    T: LogicalMemoryProfile,
+{
+    fn visit_logical_memory<Vis: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut Vis) {
+        for element in self {
+            element.visit_logical_memory(path.with("Array[element]").as_mut(), visitor);
+        }
+    }
+}
+
+impl<T> LogicalMemoryProfile for Box<T>
+where
+    T: LogicalMemoryProfile,
+{
+    fn visit_logical_memory<Vis: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut Vis) {
+        visitor.visit_leaf(&path.with("Box[stack]"), size_of::<Box<T>>());
+        self.as_ref()
+            .visit_logical_memory(path.with("Box[value]").as_mut(), visitor);
+    }
+}
+
+impl<T: ?Sized> LogicalMemoryProfile for std::marker::PhantomData<T> {
+    fn visit_logical_memory<Vis: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut Vis) {
+        visitor.visit_leaf(path, size_of::<std::marker::PhantomData<T>>());
+    }
+}
+
 impl<K, V> LogicalMemoryProfile for std::collections::BTreeMap<K, V>
 where
     K: LogicalMemoryProfile,
@@ -76,6 +104,20 @@ where
     }
 }
 
+impl<T> LogicalMemoryProfile for std::collections::HashSet<T>
+where
+    T: LogicalMemoryProfile,
+{
+    fn visit_logical_memory<Vis: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut Vis) {
+        let set_stack = size_of::<std::collections::HashSet<T>>();
+        visitor.visit_leaf(&path.with("HashSet[stack]"), set_stack);
+
+        for element in self {
+            element.visit_logical_memory(path, visitor);
+        }
+    }
+}
+
 impl<K, V> LogicalMemoryProfile for fnv::FnvHashMap<K, V>
 where
     K: LogicalMemoryProfile,
@@ -98,6 +140,20 @@ where
     }
 }
 
+impl<T> LogicalMemoryProfile for fnv::FnvHashSet<T>
+where
+    T: LogicalMemoryProfile,
+{
+    fn visit_logical_memory<Vis: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut Vis) {
+        let set_stack = size_of::<fnv::FnvHashSet<T>>();
+        visitor.visit_leaf(&path.with("FnvHashSet[stack]"), set_stack);
+
+        for element in self {
+            element.visit_logical_memory(path, visitor);
+        }
+    }
+}
+
 impl<T> LogicalMemoryProfile for Vec<T>
 where
     T: LogicalMemoryProfile,
@@ -108,6 +164,20 @@ where
         visitor.visit_leaf(&path.with("Vec[stack]"), vec_stack);
 
         // Delegate to each element
+        for element in self {
+            element.visit_logical_memory(path, visitor);
+        }
+    }
+}
+
+impl<T> LogicalMemoryProfile for std::collections::VecDeque<T>
+where
+    T: LogicalMemoryProfile,
+{
+    fn visit_logical_memory<Vis: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut Vis) {
+        let deque_stack = size_of::<std::collections::VecDeque<T>>();
+        visitor.visit_leaf(&path.with("VecDeque[stack]"), deque_stack);
+
         for element in self {
             element.visit_logical_memory(path, visitor);
         }
@@ -129,3 +199,101 @@ where
         }
     }
 }
+
+macro_rules! impl_tuple_logical_memory_profile {
+    ($(($index:tt, $name:ident)),+ $(,)?) => {
+        impl<$($name),+> LogicalMemoryProfile for ($($name,)+)
+        where
+            $($name: LogicalMemoryProfile),+
+        {
+            fn visit_logical_memory<Vis: LogicalMemoryVisitor>(
+                &self,
+                path: &mut Path,
+                visitor: &mut Vis,
+            ) {
+                $(
+                    self.$index.visit_logical_memory(
+                        path.with(concat!("Tuple.", stringify!($index))).as_mut(),
+                        visitor,
+                    );
+                )+
+            }
+        }
+    };
+}
+
+impl_tuple_logical_memory_profile!((0, T0));
+impl_tuple_logical_memory_profile!((0, T0), (1, T1));
+impl_tuple_logical_memory_profile!((0, T0), (1, T1), (2, T2));
+impl_tuple_logical_memory_profile!((0, T0), (1, T1), (2, T2), (3, T3));
+impl_tuple_logical_memory_profile!((0, T0), (1, T1), (2, T2), (3, T3), (4, T4));
+impl_tuple_logical_memory_profile!((0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5));
+impl_tuple_logical_memory_profile!(
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6)
+);
+impl_tuple_logical_memory_profile!(
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7)
+);
+impl_tuple_logical_memory_profile!(
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8)
+);
+impl_tuple_logical_memory_profile!(
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8),
+    (9, T9)
+);
+impl_tuple_logical_memory_profile!(
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8),
+    (9, T9),
+    (10, T10)
+);
+impl_tuple_logical_memory_profile!(
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8),
+    (9, T9),
+    (10, T10),
+    (11, T11)
+);

--- a/rust/ommx/src/logical_memory/tests.rs
+++ b/rust/ommx/src/logical_memory/tests.rs
@@ -155,7 +155,7 @@ fn test_btreemap_with_linear() {
 
     let folded = logical_memory_to_folded(&map);
     insta::assert_snapshot!(folded, @r###"
-    BTreeMap[key] 16
+    BTreeMap[key];VariableID.0 16
     BTreeMap[stack] 24
     PolynomialBase.terms 112
     "###);
@@ -173,7 +173,7 @@ fn test_hashmap_with_linear() {
     let folded = logical_memory_to_folded(&map);
     // Note: HashMap iteration order is non-deterministic, but snapshots should still be stable
     insta::assert_snapshot!(folded, @r###"
-    HashMap[key] 16
+    HashMap[key];VariableID.0 16
     HashMap[stack] 48
     PolynomialBase.terms 112
     "###);
@@ -338,7 +338,6 @@ struct DeriveTargetNested {
 }
 
 #[derive(LogicalMemoryProfile)]
-#[logical_memory(leaf)]
 #[allow(dead_code)]
 struct DeriveTargetLeaf(u64);
 
@@ -386,12 +385,12 @@ fn test_derive_nested_struct_snapshot() {
 }
 
 #[test]
-fn test_derive_leaf_snapshot() {
+fn test_derive_tuple_struct_snapshot() {
     let value = DeriveLeafHolder {
         leaf: DeriveTargetLeaf(0),
     };
     let folded = logical_memory_to_folded(&value);
-    insta::assert_snapshot!(folded, @"DeriveLeafHolder.leaf 8");
+    insta::assert_snapshot!(folded, @"DeriveLeafHolder.leaf;DeriveTargetLeaf.0 8");
 }
 
 #[test]

--- a/rust/ommx/src/logical_memory/tests.rs
+++ b/rust/ommx/src/logical_memory/tests.rs
@@ -195,6 +195,113 @@ fn test_vec_with_linear() {
 }
 
 #[test]
+fn test_array_snapshot() {
+    let array = [1_u64, 2, 3];
+    let folded = logical_memory_to_folded(&array);
+    insta::assert_snapshot!(folded, @"Array[element] 24");
+}
+
+#[test]
+fn test_box_snapshot() {
+    let value = Box::new("hi".to_string());
+    let folded = logical_memory_to_folded(&value);
+    insta::assert_snapshot!(folded, @r###"
+    Box[stack] 8
+    Box[value] 26
+    "###);
+}
+
+#[test]
+fn test_hashset_snapshot() {
+    use std::collections::HashSet;
+
+    #[derive(LogicalMemoryProfile)]
+    struct HashSetHolder {
+        set: HashSet<u64>,
+    }
+
+    let folded = logical_memory_to_folded(&HashSetHolder {
+        set: HashSet::from([1_u64, 2, 3]),
+    });
+    insta::assert_snapshot!(folded, @r###"
+    HashSetHolder.set 24
+    HashSetHolder.set;HashSet[stack] 48
+    "###);
+}
+
+#[test]
+fn test_fnv_hashset_snapshot() {
+    use fnv::FnvHashSet;
+
+    #[derive(LogicalMemoryProfile)]
+    struct FnvHashSetHolder {
+        set: FnvHashSet<u64>,
+    }
+
+    let folded = logical_memory_to_folded(&FnvHashSetHolder {
+        set: FnvHashSet::from_iter([1_u64, 2, 3]),
+    });
+    insta::assert_snapshot!(folded, @r###"
+    FnvHashSetHolder.set 24
+    FnvHashSetHolder.set;FnvHashSet[stack] 32
+    "###);
+}
+
+#[test]
+fn test_vecdeque_snapshot() {
+    use std::collections::VecDeque;
+
+    #[derive(LogicalMemoryProfile)]
+    struct VecDequeHolder {
+        deque: VecDeque<u64>,
+    }
+
+    let folded = logical_memory_to_folded(&VecDequeHolder {
+        deque: VecDeque::from([1_u64, 2, 3]),
+    });
+    insta::assert_snapshot!(folded, @r###"
+    VecDequeHolder.deque 24
+    VecDequeHolder.deque;VecDeque[stack] 32
+    "###);
+}
+
+#[test]
+fn test_bool_char_unit_and_phantom_data_snapshot() {
+    use std::marker::PhantomData;
+
+    #[derive(LogicalMemoryProfile)]
+    struct MiscStdTypes {
+        enabled: bool,
+        marker: char,
+        unit: (),
+        phantom: PhantomData<u64>,
+    }
+
+    let value = MiscStdTypes {
+        enabled: true,
+        marker: 'x',
+        unit: (),
+        phantom: PhantomData,
+    };
+    let folded = logical_memory_to_folded(&value);
+    insta::assert_snapshot!(folded, @r###"
+    MiscStdTypes.enabled 1
+    MiscStdTypes.marker 4
+    "###);
+}
+
+#[test]
+fn test_tuple_snapshot() {
+    let tuple = (1_u64, "hi".to_string(), 3_u32);
+    let folded = logical_memory_to_folded(&tuple);
+    insta::assert_snapshot!(folded, @r###"
+    Tuple.0 8
+    Tuple.1 26
+    Tuple.2 4
+    "###);
+}
+
+#[test]
 fn test_empty_collections() {
     use crate::Linear;
     use std::collections::BTreeMap;
@@ -228,6 +335,16 @@ struct DeriveTargetFlat {
 struct DeriveTargetNested {
     leaf: u32,
     inner: DeriveTargetFlat,
+}
+
+#[derive(LogicalMemoryProfile)]
+#[logical_memory(leaf)]
+#[allow(dead_code)]
+struct DeriveTargetLeaf(u64);
+
+#[derive(LogicalMemoryProfile)]
+struct DeriveLeafHolder {
+    leaf: DeriveTargetLeaf,
 }
 
 #[test]
@@ -266,6 +383,15 @@ fn test_derive_nested_struct_snapshot() {
     DeriveTargetNested.inner;DeriveTargetFlat.gamma 24
     DeriveTargetNested.leaf 4
     "###);
+}
+
+#[test]
+fn test_derive_leaf_snapshot() {
+    let value = DeriveLeafHolder {
+        leaf: DeriveTargetLeaf(0),
+    };
+    let folded = logical_memory_to_folded(&value);
+    insta::assert_snapshot!(folded, @"DeriveLeafHolder.leaf 8");
 }
 
 #[test]

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -29,7 +29,6 @@ pub use label_store::NamedFunctionLabelStore;
     LogicalMemoryProfile,
 )]
 #[serde(transparent)]
-#[logical_memory(leaf)]
 pub struct NamedFunctionID(u64);
 
 impl std::fmt::Debug for NamedFunctionID {

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -8,7 +8,7 @@ use derive_more::{Deref, From};
 use getset::*;
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
+use crate::logical_memory::LogicalMemoryProfile;
 use crate::{Function, SampleID, Sampled, VariableIDSet};
 pub use arbitrary::*;
 pub use label_store::NamedFunctionLabelStore;
@@ -26,8 +26,10 @@ pub use label_store::NamedFunctionLabelStore;
     Deref,
     serde::Serialize,
     serde::Deserialize,
+    LogicalMemoryProfile,
 )]
 #[serde(transparent)]
+#[logical_memory(leaf)]
 pub struct NamedFunctionID(u64);
 
 impl std::fmt::Debug for NamedFunctionID {
@@ -51,12 +53,6 @@ impl NamedFunctionID {
 impl From<NamedFunctionID> for u64 {
     fn from(id: NamedFunctionID) -> Self {
         id.0
-    }
-}
-
-impl LogicalMemoryProfile for NamedFunctionID {
-    fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
-        visitor.visit_leaf(path, std::mem::size_of::<NamedFunctionID>());
     }
 }
 

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -23,8 +23,10 @@ use std::collections::{BTreeMap, BTreeSet};
     Deref,
     serde::Serialize,
     serde::Deserialize,
+    crate::logical_memory::LogicalMemoryProfile,
 )]
 #[serde(transparent)]
+#[logical_memory(leaf)]
 pub struct OneHotConstraintID(u64);
 
 impl std::fmt::Debug for OneHotConstraintID {

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -26,7 +26,6 @@ use std::collections::{BTreeMap, BTreeSet};
     crate::logical_memory::LogicalMemoryProfile,
 )]
 #[serde(transparent)]
-#[logical_memory(leaf)]
 pub struct OneHotConstraintID(u64);
 
 impl std::fmt::Debug for OneHotConstraintID {

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -74,7 +74,7 @@ pub struct OneHotConstraint<S: Stage<Self> = Created> {
 /// Data carried by a one-hot constraint in the Created stage.
 ///
 /// One-hot constraints are structural — no function is stored.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, crate::logical_memory::LogicalMemoryProfile)]
 pub struct OneHotCreatedData;
 
 /// Data carried by a one-hot constraint in the Evaluated stage.

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -26,7 +26,6 @@ use std::collections::{BTreeMap, BTreeSet};
     crate::logical_memory::LogicalMemoryProfile,
 )]
 #[serde(transparent)]
-#[logical_memory(leaf)]
 pub struct Sos1ConstraintID(u64);
 
 impl std::fmt::Debug for Sos1ConstraintID {

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -23,8 +23,10 @@ use std::collections::{BTreeMap, BTreeSet};
     Deref,
     serde::Serialize,
     serde::Deserialize,
+    crate::logical_memory::LogicalMemoryProfile,
 )]
 #[serde(transparent)]
+#[logical_memory(leaf)]
 pub struct Sos1ConstraintID(u64);
 
 impl std::fmt::Debug for Sos1ConstraintID {

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -74,7 +74,7 @@ pub struct Sos1Constraint<S: Stage<Self> = Created> {
 /// Data carried by a SOS1 constraint in the Created stage.
 ///
 /// SOS1 constraints are structural — no function is stored.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, crate::logical_memory::LogicalMemoryProfile)]
 pub struct Sos1CreatedData;
 
 /// Data carried by a SOS1 constraint in the Evaluated stage.

--- a/rust/ommx/src/substitute/assignments/logical_memory.rs
+++ b/rust/ommx/src/substitute/assignments/logical_memory.rs
@@ -57,11 +57,11 @@ mod tests {
 
         let folded = logical_memory_to_folded(&assignments);
         insta::assert_snapshot!(folded, @r###"
-        AcyclicAssignments.assignments;FnvHashMap[key] 16
+        AcyclicAssignments.assignments;FnvHashMap[key];VariableID.0 16
         AcyclicAssignments.assignments;FnvHashMap[stack] 32
         AcyclicAssignments.assignments;Linear;PolynomialBase.terms 160
         AcyclicAssignments.dependency 224
-        AcyclicAssignments.topological_order 16
+        AcyclicAssignments.topological_order;VariableID.0 16
         AcyclicAssignments.topological_order;Vec[stack] 24
         "###);
     }


### PR DESCRIPTION
## Summary

This PR broadens internal `LogicalMemoryProfile` coverage so ordinary local Rust data shapes can derive profiling instead of carrying bespoke hand-written impls.

The `LogicalMemoryProfile` derive now follows more Rust type structure directly: named structs delegate to `Type.field`, tuple structs delegate to `Type.0`, `Type.1`, and so on, unit structs emit no leaves, and fieldless enums emit their inline enum size. Data-carrying enums remain explicit until variant-aware enum decomposition is designed.

The standard logical-memory library now covers arrays, boxes, hash sets, `VecDeque`, `PhantomData`, boolean/character/unit primitives, and tuples up to arity 12. Removed constraint tuple specializations are replaced by the generic tuple representation, making tuple profiling consistent across the crate.

Local IDs, `Bound`, and small enum-like values now use derive at their definition sites. Special constraint created-stage wrappers remain manual because of their stage-generic shape, but their implementations now delegate field-by-field so indicator functions and structural variable sets remain visible in profiles.

The OMMX domain-review skill is updated to match this policy: ordinary local Rust data shapes should derive or gain missing standard/macro support, while manual impls are reserved for semantically special profile shapes.

## Impact

Logical memory profiles now expose more of the actual OMMX data structure and are less likely to drift when fields are added. Shared-pointer types such as `Rc` and `Arc` are intentionally left without blanket impls because they need explicit ownership and de-duplication semantics.
