### PR TITLE
Add ommx.v2 serialization conversions

### DIFF
--- a/rust/ommx/doc/release_note.md
+++ b/rust/ommx/doc/release_note.md
@@ -151,6 +151,27 @@ The migration guide's [ConstraintCollection](crate::doc::migration_guide#constra
 and [EvaluatedCollection / SampledCollection](crate::doc::migration_guide#evaluatedcollection--sampledcollection)
 reference cards list the public methods on each.
 
+## Write-only `ommx.v2` serialization ([#983](https://github.com/Jij-Inc/ommx/pull/983))
+
+The Rust SDK can now serialize normalized top-level root objects to the new
+`ommx.v2` protobuf roots. Use
+[`Instance::to_v2_bytes`](crate::Instance::to_v2_bytes),
+[`ParametricInstance::to_v2_bytes`](crate::ParametricInstance::to_v2_bytes),
+[`Solution::to_v2_bytes`](crate::Solution::to_v2_bytes), or
+[`SampleSet::to_v2_bytes`](crate::SampleSet::to_v2_bytes) for write-only v2
+serialization.
+
+The v2 writer preserves the normalized ownership model: table keys own IDs,
+modeling labels and fixed values serialize as sidecar columns, constraint
+contexts carry modeling labels plus provenance, and active/removed constraint
+membership stays on the constraint collection. First-class indicator, one-hot,
+and SOS1 collections are serialized directly and top-level roots populate
+`required_features` so older readers can reject unsupported semantic features
+instead of silently interpreting a weaker model.
+
+`to_bytes` / `from_bytes` remain on the existing v1 path until v2
+deserialization lands in a follow-up PR.
+
 ## Modeling labels and constraint context on the enclosing collection ([#843](https://github.com/Jij-Inc/ommx/pull/843), [#848](https://github.com/Jij-Inc/ommx/pull/848), [#850](https://github.com/Jij-Inc/ommx/pull/850), [#853](https://github.com/Jij-Inc/ommx/pull/853))
 
 Constraints, decision variables, and named functions used to carry their

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -7,6 +7,7 @@ mod parse;
 mod reduce_binary_power;
 pub(crate) mod stage;
 
+pub(crate) use context_store::constraint_context_store_to_v2_map;
 pub use context_store::ConstraintContextStore;
 
 use crate::logical_memory::LogicalMemoryProfile;
@@ -102,6 +103,30 @@ pub struct ConstraintContext {
     pub provenance: Vec<Provenance>,
 }
 
+impl From<Provenance> for crate::v2::Provenance {
+    fn from(provenance: Provenance) -> Self {
+        use crate::v2::provenance::Source;
+
+        let source = match provenance {
+            Provenance::IndicatorConstraint(id) => Source::IndicatorConstraintId(id.into_inner()),
+            Provenance::OneHotConstraint(id) => Source::OneHotConstraintId(id.into_inner()),
+            Provenance::Sos1Constraint(id) => Source::Sos1ConstraintId(id.into_inner()),
+        };
+        Self {
+            source: Some(source),
+        }
+    }
+}
+
+impl From<ConstraintContext> for crate::v2::ConstraintContext {
+    fn from(context: ConstraintContext) -> Self {
+        Self {
+            label: Some(context.label.into()),
+            provenance: context.provenance.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
 /// A constraint parameterized by its lifecycle stage.
 ///
 /// Holds only the constraint's intrinsic data (`equality` plus stage-specific
@@ -150,6 +175,15 @@ impl Constraint<Created> {
     }
 }
 
+impl From<Constraint<Created>> for crate::v2::RegularConstraint {
+    fn from(constraint: Constraint<Created>) -> Self {
+        Self {
+            equality: constraint.equality.into(),
+            function: Some(constraint.stage.function.into()),
+        }
+    }
+}
+
 impl std::fmt::Display for Constraint<Created> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let equality_symbol = match self.equality {
@@ -168,6 +202,23 @@ impl std::fmt::Display for Constraint<Created> {
 
 /// Type alias for an evaluated constraint.
 pub type EvaluatedConstraint = Constraint<Evaluated>;
+
+impl From<EvaluatedConstraint> for crate::v2::EvaluatedRegularConstraint {
+    fn from(constraint: EvaluatedConstraint) -> Self {
+        Self {
+            equality: constraint.equality.into(),
+            evaluated_value: constraint.stage.evaluated_value,
+            feasible: constraint.stage.feasible,
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+            dual_variable: constraint.stage.dual_variable,
+        }
+    }
+}
 
 impl EvaluatedConstraint {
     /// Check if this constraint is feasible given a specific tolerance
@@ -197,6 +248,28 @@ impl EvaluatedConstraint {
 
 /// Type alias for a sampled constraint.
 pub type SampledConstraint = Constraint<SampledStage>;
+
+impl From<SampledConstraint> for crate::v2::SampledRegularConstraint {
+    fn from(constraint: SampledConstraint) -> Self {
+        Self {
+            equality: constraint.equality.into(),
+            evaluated_values: Some(constraint.stage.evaluated_values.into()),
+            feasible: constraint
+                .stage
+                .feasible
+                .into_iter()
+                .map(|(id, value)| (id.into_inner(), value))
+                .collect(),
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+            dual_variables: constraint.stage.dual_variables.map(Into::into),
+        }
+    }
+}
 
 impl SampledConstraint {
     /// Check feasibility for a specific sample.

--- a/rust/ommx/src/constraint/context_store.rs
+++ b/rust/ommx/src/constraint/context_store.rs
@@ -3,7 +3,7 @@ use crate::constraint_type::IDType;
 use crate::logical_memory::LogicalMemoryProfile;
 use crate::ModelingLabelStore;
 use fnv::FnvHashMap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 /// ID-keyed storage for constraint labels and transformation provenance.
 ///
@@ -141,6 +141,16 @@ impl<ID: IDType> ConstraintContextStore<ID> {
             .chain(self.provenance.keys().copied())
             .collect()
     }
+}
+
+pub(crate) fn constraint_context_store_to_v2_map<ID: IDType>(
+    store: &ConstraintContextStore<ID>,
+) -> HashMap<u64, crate::v2::ConstraintContext> {
+    store
+        .ids()
+        .into_iter()
+        .map(|id| (id.into(), store.collect_for(id).into()))
+        .collect()
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/constraint/context_store.rs
+++ b/rust/ommx/src/constraint/context_store.rs
@@ -3,7 +3,7 @@ use crate::constraint_type::IDType;
 use crate::logical_memory::LogicalMemoryProfile;
 use crate::ModelingLabelStore;
 use fnv::FnvHashMap;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// ID-keyed storage for constraint labels and transformation provenance.
 ///
@@ -145,7 +145,7 @@ impl<ID: IDType> ConstraintContextStore<ID> {
 
 pub(crate) fn constraint_context_store_to_v2_map<ID: IDType>(
     store: &ConstraintContextStore<ID>,
-) -> HashMap<u64, crate::v2::ConstraintContext> {
+) -> BTreeMap<u64, crate::v2::ConstraintContext> {
     store
         .ids()
         .into_iter()

--- a/rust/ommx/src/constraint/stage.rs
+++ b/rust/ommx/src/constraint/stage.rs
@@ -40,6 +40,15 @@ pub struct RemovedReason {
     pub parameters: FnvHashMap<String, String>,
 }
 
+impl From<RemovedReason> for crate::v2::RemovedReason {
+    fn from(reason: RemovedReason) -> Self {
+        Self {
+            reason: reason.reason,
+            parameters: reason.parameters.into_iter().collect(),
+        }
+    }
+}
+
 // ===== Stage data types for regular Constraint =====
 
 /// Data carried by a regular constraint in the Created stage.

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -32,12 +32,12 @@
 use crate::Result;
 use crate::{
     constraint::{
-        ConstraintContext, ConstraintContextStore, ConstraintID, EvaluatedConstraint,
-        RemovedReason, SampledConstraint,
+        constraint_context_store_to_v2_map, ConstraintContext, ConstraintContextStore,
+        ConstraintID, EvaluatedConstraint, RemovedReason, SampledConstraint,
     },
     v1, ATol, Constraint, Evaluate, SampleID, SampleIDSet, VariableIDSet,
 };
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap};
 
 fn validate_no_key_overlap<ID, L, R>(
     left: &BTreeMap<ID, L>,
@@ -713,6 +713,117 @@ fn removed_constraint_to_v1(
         removed_reason: removed_reason.reason,
         removed_reason_parameters: removed_reason.parameters.into_iter().collect(),
     }
+}
+
+macro_rules! impl_v2_created_collection {
+    ($source:ty => $target:ty) => {
+        impl From<ConstraintCollection<$source>> for $target {
+            fn from(value: ConstraintCollection<$source>) -> Self {
+                let ConstraintCollection {
+                    active,
+                    removed,
+                    context,
+                } = value;
+                let (removed, removed_reasons) = removed_entries_to_v2_maps(removed);
+                Self {
+                    active: entries_to_v2_map(active),
+                    removed,
+                    removed_reasons,
+                    contexts: constraint_context_store_to_v2_map(&context),
+                }
+            }
+        }
+    };
+}
+
+impl_v2_created_collection!(Constraint => crate::v2::RegularConstraintCollection);
+impl_v2_created_collection!(crate::IndicatorConstraint => crate::v2::IndicatorConstraintCollection);
+impl_v2_created_collection!(crate::OneHotConstraint => crate::v2::OneHotConstraintCollection);
+impl_v2_created_collection!(crate::Sos1Constraint => crate::v2::Sos1ConstraintCollection);
+
+macro_rules! impl_v2_evaluated_collection {
+    ($source:ty => $target:ty) => {
+        impl From<EvaluatedCollection<$source>> for $target {
+            fn from(value: EvaluatedCollection<$source>) -> Self {
+                let EvaluatedCollection {
+                    constraints,
+                    removed_reasons,
+                    context,
+                } = value;
+                Self {
+                    entries: entries_to_v2_map(constraints),
+                    removed_reasons: removed_reasons_to_v2_map(removed_reasons),
+                    contexts: constraint_context_store_to_v2_map(&context),
+                }
+            }
+        }
+    };
+}
+
+impl_v2_evaluated_collection!(Constraint => crate::v2::EvaluatedRegularConstraintCollection);
+impl_v2_evaluated_collection!(crate::IndicatorConstraint => crate::v2::EvaluatedIndicatorConstraintCollection);
+impl_v2_evaluated_collection!(crate::OneHotConstraint => crate::v2::EvaluatedOneHotConstraintCollection);
+impl_v2_evaluated_collection!(crate::Sos1Constraint => crate::v2::EvaluatedSos1ConstraintCollection);
+
+macro_rules! impl_v2_sampled_collection {
+    ($source:ty => $target:ty) => {
+        impl From<SampledCollection<$source>> for $target {
+            fn from(value: SampledCollection<$source>) -> Self {
+                let SampledCollection {
+                    constraints,
+                    removed_reasons,
+                    context,
+                } = value;
+                Self {
+                    entries: entries_to_v2_map(constraints),
+                    removed_reasons: removed_reasons_to_v2_map(removed_reasons),
+                    contexts: constraint_context_store_to_v2_map(&context),
+                }
+            }
+        }
+    };
+}
+
+impl_v2_sampled_collection!(Constraint => crate::v2::SampledRegularConstraintCollection);
+impl_v2_sampled_collection!(crate::IndicatorConstraint => crate::v2::SampledIndicatorConstraintCollection);
+impl_v2_sampled_collection!(crate::OneHotConstraint => crate::v2::SampledOneHotConstraintCollection);
+impl_v2_sampled_collection!(crate::Sos1Constraint => crate::v2::SampledSos1ConstraintCollection);
+
+fn entries_to_v2_map<ID, Row, V2Row>(entries: BTreeMap<ID, Row>) -> HashMap<u64, V2Row>
+where
+    ID: IDType,
+    Row: Into<V2Row>,
+{
+    entries
+        .into_iter()
+        .map(|(id, row)| (id.into(), row.into()))
+        .collect()
+}
+
+fn removed_entries_to_v2_maps<ID, Row, V2Row>(
+    removed: BTreeMap<ID, (Row, RemovedReason)>,
+) -> (HashMap<u64, V2Row>, HashMap<u64, crate::v2::RemovedReason>)
+where
+    ID: IDType,
+    Row: Into<V2Row>,
+{
+    let mut rows = HashMap::new();
+    let mut reasons = HashMap::new();
+    for (id, (row, reason)) in removed {
+        let id = id.into();
+        rows.insert(id, row.into());
+        reasons.insert(id, reason.into());
+    }
+    (rows, reasons)
+}
+
+fn removed_reasons_to_v2_map<ID: IDType>(
+    removed_reasons: BTreeMap<ID, RemovedReason>,
+) -> HashMap<u64, crate::v2::RemovedReason> {
+    removed_reasons
+        .into_iter()
+        .map(|(id, reason)| (id.into(), reason.into()))
+        .collect()
 }
 
 impl<T: ConstraintType> Evaluate for ConstraintCollection<T> {

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     v1, ATol, Constraint, Evaluate, SampleID, SampleIDSet, VariableIDSet,
 };
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap};
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 fn validate_no_key_overlap<ID, L, R>(
     left: &BTreeMap<ID, L>,
@@ -789,7 +789,7 @@ impl_v2_sampled_collection!(crate::IndicatorConstraint => crate::v2::SampledIndi
 impl_v2_sampled_collection!(crate::OneHotConstraint => crate::v2::SampledOneHotConstraintCollection);
 impl_v2_sampled_collection!(crate::Sos1Constraint => crate::v2::SampledSos1ConstraintCollection);
 
-fn entries_to_v2_map<ID, Row, V2Row>(entries: BTreeMap<ID, Row>) -> HashMap<u64, V2Row>
+fn entries_to_v2_map<ID, Row, V2Row>(entries: BTreeMap<ID, Row>) -> BTreeMap<u64, V2Row>
 where
     ID: IDType,
     Row: Into<V2Row>,
@@ -802,13 +802,16 @@ where
 
 fn removed_entries_to_v2_maps<ID, Row, V2Row>(
     removed: BTreeMap<ID, (Row, RemovedReason)>,
-) -> (HashMap<u64, V2Row>, HashMap<u64, crate::v2::RemovedReason>)
+) -> (
+    BTreeMap<u64, V2Row>,
+    BTreeMap<u64, crate::v2::RemovedReason>,
+)
 where
     ID: IDType,
     Row: Into<V2Row>,
 {
-    let mut rows = HashMap::new();
-    let mut reasons = HashMap::new();
+    let mut rows = BTreeMap::new();
+    let mut reasons = BTreeMap::new();
     for (id, (row, reason)) in removed {
         let id = id.into();
         rows.insert(id, row.into());
@@ -819,7 +822,7 @@ where
 
 fn removed_reasons_to_v2_map<ID: IDType>(
     removed_reasons: BTreeMap<ID, RemovedReason>,
-) -> HashMap<u64, crate::v2::RemovedReason> {
+) -> BTreeMap<u64, crate::v2::RemovedReason> {
     removed_reasons
         .into_iter()
         .map(|(id, reason)| (id.into(), reason.into()))

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::logical_memory::LogicalMemoryProfile;
 use crate::{ATol, Bound, Created, Evaluated, ModelingLabel, SampledStage};
@@ -540,6 +540,85 @@ fn sampled_decision_variable_to_v1(
         )),
         samples: Some(samples.into()),
     }
+}
+
+impl From<DecisionVariable> for crate::v2::DecisionVariable {
+    fn from(value: DecisionVariable) -> Self {
+        let DecisionVariable { kind, bound } = value;
+        Self {
+            kind: kind.into(),
+            bound: Some(bound.into()),
+        }
+    }
+}
+
+impl From<EvaluatedDecisionVariable> for crate::v2::EvaluatedDecisionVariable {
+    fn from(value: EvaluatedDecisionVariable) -> Self {
+        let EvaluatedDecisionVariable { kind, bound, value } = value;
+        Self {
+            kind: kind.into(),
+            bound: Some(bound.into()),
+            value,
+        }
+    }
+}
+
+impl From<SampledDecisionVariable> for crate::v2::SampledDecisionVariable {
+    fn from(value: SampledDecisionVariable) -> Self {
+        let SampledDecisionVariable {
+            kind,
+            bound,
+            samples,
+        } = value;
+        Self {
+            kind: kind.into(),
+            bound: Some(bound.into()),
+            samples: Some(samples.into()),
+        }
+    }
+}
+
+impl From<DecisionVariableTable<Created>> for crate::v2::DecisionVariableTable {
+    fn from(table: DecisionVariableTable<Created>) -> Self {
+        Self {
+            entries: table_entries_to_v2_map(table.entries),
+            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            fixed_values: table
+                .columns
+                .fixed_values
+                .into_iter()
+                .map(|(id, value)| (id.into_inner(), value))
+                .collect(),
+        }
+    }
+}
+
+impl From<EvaluatedDecisionVariableTable> for crate::v2::EvaluatedDecisionVariableTable {
+    fn from(table: EvaluatedDecisionVariableTable) -> Self {
+        Self {
+            entries: table_entries_to_v2_map(table.entries),
+            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+        }
+    }
+}
+
+impl From<SampledDecisionVariableTable> for crate::v2::SampledDecisionVariableTable {
+    fn from(table: SampledDecisionVariableTable) -> Self {
+        Self {
+            entries: table_entries_to_v2_map(table.entries),
+            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+        }
+    }
+}
+
+fn table_entries_to_v2_map<T, V2>(entries: BTreeMap<VariableID, T>) -> HashMap<u64, V2>
+where
+    T: Into<V2>,
+{
+    entries
+        .into_iter()
+        .map(|(id, row)| (id.into_inner(), row.into()))
+        .collect()
 }
 
 impl<'a, S: DecisionVariableTableStage> IntoIterator for &'a DecisionVariableTable<S> {

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::logical_memory::LogicalMemoryProfile;
 use crate::{ATol, Bound, Created, Evaluated, ModelingLabel, SampledStage};
@@ -611,7 +611,7 @@ impl From<SampledDecisionVariableTable> for crate::v2::SampledDecisionVariableTa
     }
 }
 
-fn table_entries_to_v2_map<T, V2>(entries: BTreeMap<VariableID, T>) -> HashMap<u64, V2>
+fn table_entries_to_v2_map<T, V2>(entries: BTreeMap<VariableID, T>) -> BTreeMap<u64, V2>
 where
     T: Into<V2>,
 {

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -203,6 +203,62 @@ impl IndicatorConstraint<Created> {
     }
 }
 
+impl From<IndicatorConstraint<Created>> for crate::v2::IndicatorConstraint {
+    fn from(constraint: IndicatorConstraint<Created>) -> Self {
+        Self {
+            indicator_variable: constraint.indicator_variable.into_inner(),
+            equality: constraint.equality.into(),
+            function: Some(constraint.stage.function.into()),
+        }
+    }
+}
+
+impl From<EvaluatedIndicatorConstraint> for crate::v2::EvaluatedIndicatorConstraint {
+    fn from(constraint: EvaluatedIndicatorConstraint) -> Self {
+        Self {
+            indicator_variable: constraint.indicator_variable.into_inner(),
+            equality: constraint.equality.into(),
+            evaluated_value: constraint.stage.evaluated_value,
+            feasible: constraint.stage.feasible,
+            indicator_active: constraint.stage.indicator_active,
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
+impl From<SampledIndicatorConstraint> for crate::v2::SampledIndicatorConstraint {
+    fn from(constraint: SampledIndicatorConstraint) -> Self {
+        Self {
+            indicator_variable: constraint.indicator_variable.into_inner(),
+            equality: constraint.equality.into(),
+            evaluated_values: Some(constraint.stage.evaluated_values.into()),
+            feasible: constraint
+                .stage
+                .feasible
+                .into_iter()
+                .map(|(id, value)| (id.into_inner(), value))
+                .collect(),
+            indicator_active: constraint
+                .stage
+                .indicator_active
+                .into_iter()
+                .map(|(id, value)| (id.into_inner(), value))
+                .collect(),
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
 impl std::fmt::Display for IndicatorConstraint<Created> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let equality_symbol = match self.equality {

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -74,7 +74,7 @@ impl From<Instance> for v2::Instance {
                 &decision_variable_dependency,
             ),
             named_functions: Some(named_functions.into()),
-            annotations: crate::protobuf_extension_annotations(annotations),
+            annotations: crate::v2_io::extension_annotations_to_v2_map(annotations),
         }
     }
 }
@@ -117,7 +117,7 @@ impl From<ParametricInstance> for v2::ParametricInstance {
                 &decision_variable_dependency,
             ),
             named_functions: Some(named_functions.into()),
-            annotations: crate::protobuf_extension_annotations(annotations),
+            annotations: crate::v2_io::extension_annotations_to_v2_map(annotations),
         }
     }
 }
@@ -128,7 +128,7 @@ fn created_collection_has_payload<T: ConstraintType>(collection: &ConstraintColl
 
 fn decision_variable_dependency_to_v2_map(
     dependency: &AcyclicAssignments,
-) -> std::collections::HashMap<u64, v1::Function> {
+) -> std::collections::BTreeMap<u64, v1::Function> {
     dependency
         .iter()
         .map(|(id, function)| (id.into_inner(), function.clone().into()))
@@ -198,6 +198,8 @@ mod tests {
             v2::Feature::ConstraintSos1 as i32,
         ]
     }
+
+    fn assert_btree_map<K: Ord, V>(_: &BTreeMap<K, V>) {}
 
     #[test]
     fn v2_instance_serializes_special_constraint_collections() {
@@ -296,6 +298,19 @@ mod tests {
         let proto = v2::Instance::decode(bytes.as_slice()).unwrap();
 
         assert_eq!(proto.required_features, expected_special_features());
+    }
+
+    #[test]
+    fn v2_generated_maps_are_ordered_for_deterministic_encoding() {
+        let proto = v2::Instance::from(instance_with_special_constraints());
+
+        assert_btree_map(&proto.annotations);
+        let decision_variables = proto.decision_variables.as_ref().unwrap();
+        assert_btree_map(&decision_variables.entries);
+        assert_btree_map(&decision_variables.labels);
+        let indicator_constraints = proto.indicator_constraints.as_ref().unwrap();
+        assert_btree_map(&indicator_constraints.active);
+        assert_btree_map(&indicator_constraints.contexts);
     }
 
     #[test]

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -1,11 +1,16 @@
 use super::*;
-use crate::{v1, Message, Parse};
+use crate::{v1, v2, ConstraintType, Message, Parse};
 use anyhow::Result;
 
 impl Instance {
     pub fn to_bytes(&self) -> Vec<u8> {
         let v1_instance = v1::Instance::from(self.clone());
         v1_instance.encode_to_vec()
+    }
+
+    pub fn to_v2_bytes(&self) -> Vec<u8> {
+        let v2_instance = v2::Instance::from(self.clone());
+        v2_instance.encode_to_vec()
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
@@ -20,8 +25,310 @@ impl ParametricInstance {
         v1_instance.encode_to_vec()
     }
 
+    pub fn to_v2_bytes(&self) -> Vec<u8> {
+        let v2_instance = v2::ParametricInstance::from(self.clone());
+        v2_instance.encode_to_vec()
+    }
+
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let inner = v1::ParametricInstance::decode(bytes)?;
         Ok(Parse::parse(inner, &())?)
+    }
+}
+
+impl From<Instance> for v2::Instance {
+    fn from(value: Instance) -> Self {
+        let required_features = crate::v2_io::required_features(
+            created_collection_has_payload(&value.indicator_constraint_collection),
+            created_collection_has_payload(&value.one_hot_constraint_collection),
+            created_collection_has_payload(&value.sos1_constraint_collection),
+        );
+
+        let Instance {
+            sense,
+            objective,
+            decision_variables,
+            constraint_collection,
+            indicator_constraint_collection,
+            one_hot_constraint_collection,
+            sos1_constraint_collection,
+            decision_variable_dependency,
+            named_functions,
+            parameters,
+            description,
+            annotations,
+        } = value;
+
+        Self {
+            required_features,
+            description,
+            decision_variables: Some(decision_variables.into()),
+            objective: Some(objective.into()),
+            regular_constraints: Some(constraint_collection.into()),
+            sense: sense.into(),
+            parameters,
+            indicator_constraints: Some(indicator_constraint_collection.into()),
+            one_hot_constraints: Some(one_hot_constraint_collection.into()),
+            sos1_constraints: Some(sos1_constraint_collection.into()),
+            decision_variable_dependency: decision_variable_dependency_to_v2_map(
+                &decision_variable_dependency,
+            ),
+            named_functions: Some(named_functions.into()),
+            annotations: crate::protobuf_extension_annotations(annotations),
+        }
+    }
+}
+
+impl From<ParametricInstance> for v2::ParametricInstance {
+    fn from(value: ParametricInstance) -> Self {
+        let required_features = crate::v2_io::required_features(
+            created_collection_has_payload(&value.indicator_constraint_collection),
+            created_collection_has_payload(&value.one_hot_constraint_collection),
+            created_collection_has_payload(&value.sos1_constraint_collection),
+        );
+
+        let ParametricInstance {
+            sense,
+            objective,
+            decision_variables,
+            parameters,
+            constraint_collection,
+            indicator_constraint_collection,
+            one_hot_constraint_collection,
+            sos1_constraint_collection,
+            decision_variable_dependency,
+            named_functions,
+            description,
+            annotations,
+        } = value;
+
+        Self {
+            required_features,
+            description,
+            decision_variables: Some(decision_variables.into()),
+            parameters: Some(parameters.into()),
+            objective: Some(objective.into()),
+            regular_constraints: Some(constraint_collection.into()),
+            sense: sense.into(),
+            indicator_constraints: Some(indicator_constraint_collection.into()),
+            one_hot_constraints: Some(one_hot_constraint_collection.into()),
+            sos1_constraints: Some(sos1_constraint_collection.into()),
+            decision_variable_dependency: decision_variable_dependency_to_v2_map(
+                &decision_variable_dependency,
+            ),
+            named_functions: Some(named_functions.into()),
+            annotations: crate::protobuf_extension_annotations(annotations),
+        }
+    }
+}
+
+fn created_collection_has_payload<T: ConstraintType>(collection: &ConstraintCollection<T>) -> bool {
+    !collection.active().is_empty() || !collection.removed().is_empty()
+}
+
+fn decision_variable_dependency_to_v2_map(
+    dependency: &AcyclicAssignments,
+) -> std::collections::HashMap<u64, v1::Function> {
+    dependency
+        .iter()
+        .map(|(id, function)| (id.into_inner(), function.clone().into()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        v2, ATol, DecisionVariable, Equality, Evaluate, Function, IndicatorConstraint,
+        IndicatorConstraintID, OneHotConstraint, OneHotConstraintID, ParameterLabelStore,
+        ParameterTable, Sampled, Sos1Constraint, Sos1ConstraintID, VariableID,
+    };
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+    fn instance_with_special_constraints() -> Instance {
+        let variable_1 = VariableID::from(1);
+        let variable_2 = VariableID::from(2);
+
+        let indicator_id = IndicatorConstraintID::from(10);
+        let one_hot_id = OneHotConstraintID::from(20);
+        let sos1_id = Sos1ConstraintID::from(30);
+
+        let mut indicator_context = ConstraintContextStore::default();
+        indicator_context.set_name(indicator_id, "indicator");
+        let mut one_hot_context = ConstraintContextStore::default();
+        one_hot_context.set_name(one_hot_id, "one_hot");
+        let mut sos1_context = ConstraintContextStore::default();
+        sos1_context.set_name(sos1_id, "sos1");
+
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::from([
+                (variable_1, DecisionVariable::binary()),
+                (variable_2, DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                indicator_id,
+                IndicatorConstraint::new(
+                    variable_1,
+                    Equality::LessThanOrEqualToZero,
+                    Function::Zero,
+                ),
+            )]))
+            .indicator_constraint_context(indicator_context)
+            .one_hot_constraints(BTreeMap::from([(
+                one_hot_id,
+                OneHotConstraint::new(BTreeSet::from([variable_1, variable_2])).unwrap(),
+            )]))
+            .one_hot_constraint_context(one_hot_context)
+            .sos1_constraints(BTreeMap::from([(
+                sos1_id,
+                Sos1Constraint::new(BTreeSet::from([variable_1, variable_2])).unwrap(),
+            )]))
+            .sos1_constraint_context(sos1_context)
+            .build()
+            .unwrap()
+    }
+
+    fn expected_special_features() -> Vec<i32> {
+        vec![
+            v2::Feature::ConstraintIndicator as i32,
+            v2::Feature::ConstraintOneHot as i32,
+            v2::Feature::ConstraintSos1 as i32,
+        ]
+    }
+
+    #[test]
+    fn v2_instance_serializes_special_constraint_collections() {
+        let proto = v2::Instance::from(instance_with_special_constraints());
+
+        assert_eq!(proto.required_features, expected_special_features());
+        let indicator_constraints = proto.indicator_constraints.unwrap();
+        assert!(indicator_constraints.active.contains_key(&10));
+        assert_eq!(
+            indicator_constraints
+                .contexts
+                .get(&10)
+                .and_then(|context| context.label.as_ref())
+                .and_then(|label| label.name.as_deref()),
+            Some("indicator")
+        );
+
+        let one_hot_constraints = proto.one_hot_constraints.unwrap();
+        assert_eq!(
+            one_hot_constraints.active.get(&20).unwrap().variables,
+            vec![1, 2]
+        );
+
+        let sos1_constraints = proto.sos1_constraints.unwrap();
+        assert_eq!(
+            sos1_constraints.active.get(&30).unwrap().variables,
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn v2_solution_serializes_evaluated_special_constraint_collections() {
+        let instance = instance_with_special_constraints();
+        let solution = instance
+            .evaluate(
+                &v1::State {
+                    entries: HashMap::from([(1, 1.0), (2, 0.0)]),
+                },
+                ATol::default(),
+            )
+            .unwrap();
+
+        let proto = v2::Solution::from(solution);
+
+        assert_eq!(proto.required_features, expected_special_features());
+        assert!(proto
+            .evaluated_indicator_constraints
+            .unwrap()
+            .entries
+            .contains_key(&10));
+        assert!(proto
+            .evaluated_one_hot_constraints
+            .unwrap()
+            .entries
+            .contains_key(&20));
+        assert!(proto
+            .evaluated_sos1_constraints
+            .unwrap()
+            .entries
+            .contains_key(&30));
+    }
+
+    #[test]
+    fn v2_sample_set_serializes_sampled_special_constraint_collections() {
+        let instance = instance_with_special_constraints();
+        let samples = Sampled::from(v1::State {
+            entries: HashMap::from([(1, 1.0), (2, 0.0)]),
+        });
+        let sample_set = instance
+            .evaluate_samples(&samples, ATol::default())
+            .unwrap();
+
+        let proto = v2::SampleSet::from(sample_set);
+
+        assert_eq!(proto.required_features, expected_special_features());
+        assert!(proto
+            .sampled_indicator_constraints
+            .unwrap()
+            .entries
+            .contains_key(&10));
+        assert!(proto
+            .sampled_one_hot_constraints
+            .unwrap()
+            .entries
+            .contains_key(&20));
+        assert!(proto
+            .sampled_sos1_constraints
+            .unwrap()
+            .entries
+            .contains_key(&30));
+    }
+
+    #[test]
+    fn to_v2_bytes_encodes_v2_instance() {
+        let bytes = instance_with_special_constraints().to_v2_bytes();
+        let proto = v2::Instance::decode(bytes.as_slice()).unwrap();
+
+        assert_eq!(proto.required_features, expected_special_features());
+    }
+
+    #[test]
+    fn v2_parametric_instance_serializes_parameter_table() {
+        let decision_variable_id = VariableID::from(1);
+        let parameter_id = VariableID::from(100);
+        let mut parameter_labels = ParameterLabelStore::default();
+        parameter_labels.set_name(parameter_id, "p");
+
+        let instance = ParametricInstance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::from([(
+                decision_variable_id,
+                DecisionVariable::binary(),
+            )]))
+            .parameters(
+                ParameterTable::new(BTreeSet::from([parameter_id]), parameter_labels).unwrap(),
+            )
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap();
+
+        let proto = v2::ParametricInstance::from(instance);
+        let parameters = proto.parameters.unwrap();
+
+        assert_eq!(parameters.ids, vec![100]);
+        assert_eq!(
+            parameters
+                .labels
+                .get(&100)
+                .and_then(|label| label.name.as_deref()),
+            Some("p")
+        );
     }
 }

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -71,7 +71,7 @@ impl From<Instance> for v2::Instance {
             one_hot_constraints: Some(one_hot_constraint_collection.into()),
             sos1_constraints: Some(sos1_constraint_collection.into()),
             decision_variable_dependency: decision_variable_dependency_to_v2_map(
-                &decision_variable_dependency,
+                decision_variable_dependency,
             ),
             named_functions: Some(named_functions.into()),
             annotations: crate::v2_io::extension_annotations_to_v2_map(annotations),
@@ -114,7 +114,7 @@ impl From<ParametricInstance> for v2::ParametricInstance {
             one_hot_constraints: Some(one_hot_constraint_collection.into()),
             sos1_constraints: Some(sos1_constraint_collection.into()),
             decision_variable_dependency: decision_variable_dependency_to_v2_map(
-                &decision_variable_dependency,
+                decision_variable_dependency,
             ),
             named_functions: Some(named_functions.into()),
             annotations: crate::v2_io::extension_annotations_to_v2_map(annotations),
@@ -127,11 +127,11 @@ fn created_collection_has_payload<T: ConstraintType>(collection: &ConstraintColl
 }
 
 fn decision_variable_dependency_to_v2_map(
-    dependency: &AcyclicAssignments,
+    dependency: AcyclicAssignments,
 ) -> std::collections::BTreeMap<u64, v1::Function> {
     dependency
-        .iter()
-        .map(|(id, function)| (id.into_inner(), function.clone().into()))
+        .into_iter()
+        .map(|(id, function)| (id.into_inner(), function.into()))
         .collect()
 }
 

--- a/rust/ommx/src/lib.rs
+++ b/rust/ommx/src/lib.rs
@@ -108,6 +108,7 @@ pub mod v2 {
 }
 
 mod v1_io;
+mod v2_io;
 
 /// Supplementary documentation bundled with the crate.
 ///

--- a/rust/ommx/src/modeling_label.rs
+++ b/rust/ommx/src/modeling_label.rs
@@ -1,7 +1,7 @@
 use crate::constraint_type::IDType;
 use crate::logical_memory::LogicalMemoryProfile;
 use fnv::FnvHashMap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::OnceLock;
 
 fn empty_parameters() -> &'static FnvHashMap<String, String> {
@@ -195,6 +195,27 @@ pub(crate) fn validate_modeling_label_ids<ID: IDType>(
         );
     }
     Ok(())
+}
+
+impl From<ModelingLabel> for crate::v2::ModelingLabel {
+    fn from(label: ModelingLabel) -> Self {
+        Self {
+            name: label.name,
+            subscripts: label.subscripts,
+            parameters: label.parameters.into_iter().collect(),
+            description: label.description,
+        }
+    }
+}
+
+pub(crate) fn modeling_label_store_to_v2_map<ID: IDType>(
+    store: &ModelingLabelStore<ID>,
+) -> HashMap<u64, crate::v2::ModelingLabel> {
+    store
+        .ids()
+        .into_iter()
+        .map(|id| (id.into(), store.collect_for(id).into()))
+        .collect()
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/modeling_label.rs
+++ b/rust/ommx/src/modeling_label.rs
@@ -1,7 +1,7 @@
 use crate::constraint_type::IDType;
 use crate::logical_memory::LogicalMemoryProfile;
 use fnv::FnvHashMap;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
 
 fn empty_parameters() -> &'static FnvHashMap<String, String> {
@@ -210,7 +210,7 @@ impl From<ModelingLabel> for crate::v2::ModelingLabel {
 
 pub(crate) fn modeling_label_store_to_v2_map<ID: IDType>(
     store: &ModelingLabelStore<ID>,
-) -> HashMap<u64, crate::v2::ModelingLabel> {
+) -> BTreeMap<u64, crate::v2::ModelingLabel> {
     store
         .ids()
         .into_iter()

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -6,7 +6,7 @@ mod substitute;
 
 use derive_more::{Deref, From};
 use getset::*;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::logical_memory::LogicalMemoryProfile;
 use crate::{Function, SampleID, Sampled, VariableIDSet};
@@ -474,7 +474,7 @@ impl From<NamedFunctionTable<SampledNamedFunction>> for crate::v2::SampledNamedF
 
 fn named_function_entries_to_v2_map<T, V2>(
     entries: BTreeMap<NamedFunctionID, T>,
-) -> HashMap<u64, V2>
+) -> BTreeMap<u64, V2>
 where
     T: Into<V2>,
 {

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -6,7 +6,7 @@ mod substitute;
 
 use derive_more::{Deref, From};
 use getset::*;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::logical_memory::LogicalMemoryProfile;
 use crate::{Function, SampleID, Sampled, VariableIDSet};
@@ -409,6 +409,79 @@ fn sampled_named_function_to_v1(
             .map(|id| id.into_inner())
             .collect(),
     }
+}
+
+impl From<NamedFunction> for crate::v2::NamedFunction {
+    fn from(value: NamedFunction) -> Self {
+        Self {
+            function: Some(value.function.into()),
+        }
+    }
+}
+
+impl From<EvaluatedNamedFunction> for crate::v2::EvaluatedNamedFunction {
+    fn from(value: EvaluatedNamedFunction) -> Self {
+        Self {
+            evaluated_value: value.evaluated_value,
+            used_decision_variable_ids: value
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
+impl From<SampledNamedFunction> for crate::v2::SampledNamedFunction {
+    fn from(value: SampledNamedFunction) -> Self {
+        Self {
+            evaluated_values: Some(value.evaluated_values.into()),
+            used_decision_variable_ids: value
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
+impl From<NamedFunctionTable<NamedFunction>> for crate::v2::NamedFunctionTable {
+    fn from(table: NamedFunctionTable<NamedFunction>) -> Self {
+        Self {
+            entries: named_function_entries_to_v2_map(table.entries),
+            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+        }
+    }
+}
+
+impl From<NamedFunctionTable<EvaluatedNamedFunction>> for crate::v2::EvaluatedNamedFunctionTable {
+    fn from(table: NamedFunctionTable<EvaluatedNamedFunction>) -> Self {
+        Self {
+            entries: named_function_entries_to_v2_map(table.entries),
+            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+        }
+    }
+}
+
+impl From<NamedFunctionTable<SampledNamedFunction>> for crate::v2::SampledNamedFunctionTable {
+    fn from(table: NamedFunctionTable<SampledNamedFunction>) -> Self {
+        Self {
+            entries: named_function_entries_to_v2_map(table.entries),
+            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+        }
+    }
+}
+
+fn named_function_entries_to_v2_map<T, V2>(
+    entries: BTreeMap<NamedFunctionID, T>,
+) -> HashMap<u64, V2>
+where
+    T: Into<V2>,
+{
+    entries
+        .into_iter()
+        .map(|(id, row)| (id.into_inner(), row.into()))
+        .collect()
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/ommx.v2.rs
+++ b/rust/ommx/src/ommx.v2.rs
@@ -12,9 +12,11 @@ pub struct ModelingLabel {
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(int64, repeated, tag = "2")]
     pub subscripts: ::prost::alloc::vec::Vec<i64>,
-    #[prost(map = "string, string", tag = "3")]
-    pub parameters:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(btree_map = "string, string", tag = "3")]
+    pub parameters: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     #[prost(string, optional, tag = "4")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
 }
@@ -110,9 +112,11 @@ pub struct ConstraintContext {
 pub struct RemovedReason {
     #[prost(string, tag = "1")]
     pub reason: ::prost::alloc::string::String,
-    #[prost(map = "string, string", tag = "2")]
-    pub parameters:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(btree_map = "string, string", tag = "2")]
+    pub parameters: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 /// Regular scalar constraint row.
 ///
@@ -160,56 +164,56 @@ pub struct Sos1Constraint {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegularConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub active: ::std::collections::HashMap<u64, RegularConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed: ::std::collections::HashMap<u64, RegularConstraint>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "4")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub active: ::prost::alloc::collections::BTreeMap<u64, RegularConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed: ::prost::alloc::collections::BTreeMap<u64, RegularConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "4")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Indicator constraint collection at the definition stage.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IndicatorConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub active: ::std::collections::HashMap<u64, IndicatorConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed: ::std::collections::HashMap<u64, IndicatorConstraint>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "4")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub active: ::prost::alloc::collections::BTreeMap<u64, IndicatorConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed: ::prost::alloc::collections::BTreeMap<u64, IndicatorConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "4")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// One-hot constraint collection at the definition stage.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneHotConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub active: ::std::collections::HashMap<u64, OneHotConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed: ::std::collections::HashMap<u64, OneHotConstraint>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "4")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub active: ::prost::alloc::collections::BTreeMap<u64, OneHotConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed: ::prost::alloc::collections::BTreeMap<u64, OneHotConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "4")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// SOS1 constraint collection at the definition stage.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Sos1ConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub active: ::std::collections::HashMap<u64, Sos1Constraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed: ::std::collections::HashMap<u64, Sos1Constraint>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "4")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub active: ::prost::alloc::collections::BTreeMap<u64, Sos1Constraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed: ::prost::alloc::collections::BTreeMap<u64, Sos1Constraint>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "4")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Evaluated regular constraint row.
 #[non_exhaustive]
@@ -278,48 +282,48 @@ pub struct EvaluatedSos1Constraint {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvaluatedRegularConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, EvaluatedRegularConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, EvaluatedRegularConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Evaluated indicator constraint collection.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvaluatedIndicatorConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, EvaluatedIndicatorConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, EvaluatedIndicatorConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Evaluated one-hot constraint collection.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvaluatedOneHotConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, EvaluatedOneHotConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, EvaluatedOneHotConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Evaluated SOS1 constraint collection.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvaluatedSos1ConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, EvaluatedSos1Constraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, EvaluatedSos1Constraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Map value used when a present sample can have no active variable.
 #[non_exhaustive]
@@ -338,8 +342,8 @@ pub struct SampledRegularConstraint {
     pub equality: i32,
     #[prost(message, optional, tag = "2")]
     pub evaluated_values: ::core::option::Option<super::v1::SampledValues>,
-    #[prost(map = "uint64, bool", tag = "3")]
-    pub feasible: ::std::collections::HashMap<u64, bool>,
+    #[prost(btree_map = "uint64, bool", tag = "3")]
+    pub feasible: ::prost::alloc::collections::BTreeMap<u64, bool>,
     #[prost(uint64, repeated, tag = "4")]
     pub used_decision_variable_ids: ::prost::alloc::vec::Vec<u64>,
     #[prost(message, optional, tag = "5")]
@@ -356,10 +360,10 @@ pub struct SampledIndicatorConstraint {
     pub equality: i32,
     #[prost(message, optional, tag = "3")]
     pub evaluated_values: ::core::option::Option<super::v1::SampledValues>,
-    #[prost(map = "uint64, bool", tag = "4")]
-    pub feasible: ::std::collections::HashMap<u64, bool>,
-    #[prost(map = "uint64, bool", tag = "5")]
-    pub indicator_active: ::std::collections::HashMap<u64, bool>,
+    #[prost(btree_map = "uint64, bool", tag = "4")]
+    pub feasible: ::prost::alloc::collections::BTreeMap<u64, bool>,
+    #[prost(btree_map = "uint64, bool", tag = "5")]
+    pub indicator_active: ::prost::alloc::collections::BTreeMap<u64, bool>,
     #[prost(uint64, repeated, tag = "6")]
     pub used_decision_variable_ids: ::prost::alloc::vec::Vec<u64>,
 }
@@ -370,10 +374,10 @@ pub struct SampledIndicatorConstraint {
 pub struct SampledOneHotConstraint {
     #[prost(uint64, repeated, tag = "1")]
     pub variables: ::prost::alloc::vec::Vec<u64>,
-    #[prost(map = "uint64, bool", tag = "2")]
-    pub feasible: ::std::collections::HashMap<u64, bool>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub active_variable: ::std::collections::HashMap<u64, SampledActiveVariable>,
+    #[prost(btree_map = "uint64, bool", tag = "2")]
+    pub feasible: ::prost::alloc::collections::BTreeMap<u64, bool>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub active_variable: ::prost::alloc::collections::BTreeMap<u64, SampledActiveVariable>,
     #[prost(uint64, repeated, tag = "4")]
     pub used_decision_variable_ids: ::prost::alloc::vec::Vec<u64>,
 }
@@ -384,10 +388,10 @@ pub struct SampledOneHotConstraint {
 pub struct SampledSos1Constraint {
     #[prost(uint64, repeated, tag = "1")]
     pub variables: ::prost::alloc::vec::Vec<u64>,
-    #[prost(map = "uint64, bool", tag = "2")]
-    pub feasible: ::std::collections::HashMap<u64, bool>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub active_variable: ::std::collections::HashMap<u64, SampledActiveVariable>,
+    #[prost(btree_map = "uint64, bool", tag = "2")]
+    pub feasible: ::prost::alloc::collections::BTreeMap<u64, bool>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub active_variable: ::prost::alloc::collections::BTreeMap<u64, SampledActiveVariable>,
     #[prost(uint64, repeated, tag = "4")]
     pub used_decision_variable_ids: ::prost::alloc::vec::Vec<u64>,
 }
@@ -396,48 +400,48 @@ pub struct SampledSos1Constraint {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SampledRegularConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, SampledRegularConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, SampledRegularConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Sampled indicator constraint collection.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SampledIndicatorConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, SampledIndicatorConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, SampledIndicatorConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Sampled one-hot constraint collection.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SampledOneHotConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, SampledOneHotConstraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, SampledOneHotConstraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Sampled SOS1 constraint collection.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SampledSos1ConstraintCollection {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, SampledSos1Constraint>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub removed_reasons: ::std::collections::HashMap<u64, RemovedReason>,
-    #[prost(map = "uint64, message", tag = "3")]
-    pub contexts: ::std::collections::HashMap<u64, ConstraintContext>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, SampledSos1Constraint>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub removed_reasons: ::prost::alloc::collections::BTreeMap<u64, RemovedReason>,
+    #[prost(btree_map = "uint64, message", tag = "3")]
+    pub contexts: ::prost::alloc::collections::BTreeMap<u64, ConstraintContext>,
 }
 /// Definition-stage decision-variable row.
 ///
@@ -483,32 +487,32 @@ pub struct SampledDecisionVariable {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DecisionVariableTable {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, DecisionVariable>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub labels: ::std::collections::HashMap<u64, ModelingLabel>,
-    #[prost(map = "uint64, double", tag = "3")]
-    pub fixed_values: ::std::collections::HashMap<u64, f64>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, DecisionVariable>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub labels: ::prost::alloc::collections::BTreeMap<u64, ModelingLabel>,
+    #[prost(btree_map = "uint64, double", tag = "3")]
+    pub fixed_values: ::prost::alloc::collections::BTreeMap<u64, f64>,
 }
 /// Evaluated-stage decision-variable table.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvaluatedDecisionVariableTable {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, EvaluatedDecisionVariable>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub labels: ::std::collections::HashMap<u64, ModelingLabel>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, EvaluatedDecisionVariable>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub labels: ::prost::alloc::collections::BTreeMap<u64, ModelingLabel>,
 }
 /// Sampled-stage decision-variable table.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SampledDecisionVariableTable {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, SampledDecisionVariable>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub labels: ::std::collections::HashMap<u64, ModelingLabel>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, SampledDecisionVariable>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub labels: ::prost::alloc::collections::BTreeMap<u64, ModelingLabel>,
 }
 /// Named function row used by v2 top-level table owners.
 ///
@@ -549,30 +553,30 @@ pub struct SampledNamedFunction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NamedFunctionTable {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, NamedFunction>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub labels: ::std::collections::HashMap<u64, ModelingLabel>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, NamedFunction>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub labels: ::prost::alloc::collections::BTreeMap<u64, ModelingLabel>,
 }
 /// Evaluated-stage named-function table.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EvaluatedNamedFunctionTable {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, EvaluatedNamedFunction>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub labels: ::std::collections::HashMap<u64, ModelingLabel>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, EvaluatedNamedFunction>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub labels: ::prost::alloc::collections::BTreeMap<u64, ModelingLabel>,
 }
 /// Sampled-stage named-function table.
 #[non_exhaustive]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SampledNamedFunctionTable {
-    #[prost(map = "uint64, message", tag = "1")]
-    pub entries: ::std::collections::HashMap<u64, SampledNamedFunction>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub labels: ::std::collections::HashMap<u64, ModelingLabel>,
+    #[prost(btree_map = "uint64, message", tag = "1")]
+    pub entries: ::prost::alloc::collections::BTreeMap<u64, SampledNamedFunction>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub labels: ::prost::alloc::collections::BTreeMap<u64, ModelingLabel>,
 }
 /// Validated optimization problem serialization root.
 #[non_exhaustive]
@@ -599,13 +603,16 @@ pub struct Instance {
     pub one_hot_constraints: ::core::option::Option<OneHotConstraintCollection>,
     #[prost(message, optional, tag = "10")]
     pub sos1_constraints: ::core::option::Option<Sos1ConstraintCollection>,
-    #[prost(map = "uint64, message", tag = "11")]
-    pub decision_variable_dependency: ::std::collections::HashMap<u64, super::v1::Function>,
+    #[prost(btree_map = "uint64, message", tag = "11")]
+    pub decision_variable_dependency:
+        ::prost::alloc::collections::BTreeMap<u64, super::v1::Function>,
     #[prost(message, optional, tag = "12")]
     pub named_functions: ::core::option::Option<NamedFunctionTable>,
-    #[prost(map = "string, string", tag = "13")]
-    pub annotations:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(btree_map = "string, string", tag = "13")]
+    pub annotations: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 /// Parameter IDs and labels owned by ParametricInstance.
 ///
@@ -620,8 +627,8 @@ pub struct Instance {
 pub struct ParameterTable {
     #[prost(uint64, repeated, tag = "1")]
     pub ids: ::prost::alloc::vec::Vec<u64>,
-    #[prost(map = "uint64, message", tag = "2")]
-    pub labels: ::std::collections::HashMap<u64, ModelingLabel>,
+    #[prost(btree_map = "uint64, message", tag = "2")]
+    pub labels: ::prost::alloc::collections::BTreeMap<u64, ModelingLabel>,
 }
 /// Validated parametric optimization problem serialization root.
 #[non_exhaustive]
@@ -648,13 +655,16 @@ pub struct ParametricInstance {
     pub one_hot_constraints: ::core::option::Option<OneHotConstraintCollection>,
     #[prost(message, optional, tag = "10")]
     pub sos1_constraints: ::core::option::Option<Sos1ConstraintCollection>,
-    #[prost(map = "uint64, message", tag = "11")]
-    pub decision_variable_dependency: ::std::collections::HashMap<u64, super::v1::Function>,
+    #[prost(btree_map = "uint64, message", tag = "11")]
+    pub decision_variable_dependency:
+        ::prost::alloc::collections::BTreeMap<u64, super::v1::Function>,
     #[prost(message, optional, tag = "12")]
     pub named_functions: ::core::option::Option<NamedFunctionTable>,
-    #[prost(map = "string, string", tag = "13")]
-    pub annotations:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(btree_map = "string, string", tag = "13")]
+    pub annotations: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 /// Validated multi-sample solver or sampler output serialization root.
 #[non_exhaustive]
@@ -669,19 +679,21 @@ pub struct SampleSet {
     pub decision_variables: ::core::option::Option<SampledDecisionVariableTable>,
     #[prost(message, optional, tag = "4")]
     pub sampled_regular_constraints: ::core::option::Option<SampledRegularConstraintCollection>,
-    #[prost(map = "uint64, bool", tag = "5")]
-    pub feasible: ::std::collections::HashMap<u64, bool>,
+    #[prost(btree_map = "uint64, bool", tag = "5")]
+    pub feasible: ::prost::alloc::collections::BTreeMap<u64, bool>,
     #[prost(enumeration = "super::v1::instance::Sense", tag = "6")]
     pub sense: i32,
-    #[prost(map = "uint64, bool", tag = "7")]
-    pub feasible_relaxed: ::std::collections::HashMap<u64, bool>,
+    #[prost(btree_map = "uint64, bool", tag = "7")]
+    pub feasible_relaxed: ::prost::alloc::collections::BTreeMap<u64, bool>,
     #[prost(message, optional, tag = "8")]
     pub sampled_named_functions: ::core::option::Option<SampledNamedFunctionTable>,
     #[prost(message, optional, tag = "9")]
     pub metadata: ::core::option::Option<super::v1::ProcessMetadata>,
-    #[prost(map = "string, string", tag = "10")]
-    pub annotations:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(btree_map = "string, string", tag = "10")]
+    pub annotations: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     #[prost(message, optional, tag = "11")]
     pub sampled_indicator_constraints: ::core::option::Option<SampledIndicatorConstraintCollection>,
     #[prost(message, optional, tag = "12")]
@@ -716,9 +728,11 @@ pub struct Solution {
     pub evaluated_named_functions: ::core::option::Option<EvaluatedNamedFunctionTable>,
     #[prost(message, optional, tag = "11")]
     pub metadata: ::core::option::Option<super::v1::ProcessMetadata>,
-    #[prost(map = "string, string", tag = "12")]
-    pub annotations:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(btree_map = "string, string", tag = "12")]
+    pub annotations: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     #[prost(message, optional, tag = "13")]
     pub evaluated_indicator_constraints:
         ::core::option::Option<EvaluatedIndicatorConstraintCollection>,

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -190,6 +190,75 @@ impl OneHotConstraint<Created> {
     }
 }
 
+impl From<OneHotConstraint<Created>> for crate::v2::OneHotConstraint {
+    fn from(constraint: OneHotConstraint<Created>) -> Self {
+        Self {
+            variables: constraint
+                .variables
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
+impl From<EvaluatedOneHotConstraint> for crate::v2::EvaluatedOneHotConstraint {
+    fn from(constraint: EvaluatedOneHotConstraint) -> Self {
+        Self {
+            variables: constraint
+                .variables
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+            feasible: constraint.stage.feasible,
+            active_variable: constraint.stage.active_variable.map(|id| id.into_inner()),
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
+impl From<SampledOneHotConstraint> for crate::v2::SampledOneHotConstraint {
+    fn from(constraint: SampledOneHotConstraint) -> Self {
+        Self {
+            variables: constraint
+                .variables
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+            feasible: constraint
+                .stage
+                .feasible
+                .into_iter()
+                .map(|(id, value)| (id.into_inner(), value))
+                .collect(),
+            active_variable: constraint
+                .stage
+                .active_variable
+                .into_iter()
+                .map(|(id, variable_id)| {
+                    (
+                        id.into_inner(),
+                        crate::v2::SampledActiveVariable {
+                            variable_id: variable_id.map(|id| id.into_inner()),
+                        },
+                    )
+                })
+                .collect(),
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
 impl std::fmt::Display for OneHotConstraint<Created> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let vars: Vec<String> = self

--- a/rust/ommx/src/parameter.rs
+++ b/rust/ommx/src/parameter.rs
@@ -182,6 +182,15 @@ impl ParameterTable {
     }
 }
 
+impl From<ParameterTable> for crate::v2::ParameterTable {
+    fn from(table: ParameterTable) -> Self {
+        Self {
+            ids: table.ids.into_iter().map(|id| id.into_inner()).collect(),
+            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+        }
+    }
+}
+
 impl LogicalMemoryProfile for ParameterTable {
     fn visit_logical_memory<V: LogicalMemoryVisitor>(&self, path: &mut Path, visitor: &mut V) {
         self.ids

--- a/rust/ommx/src/sample_set/serialize.rs
+++ b/rust/ommx/src/sample_set/serialize.rs
@@ -52,7 +52,7 @@ impl From<SampleSet> for v2::SampleSet {
             feasible_relaxed: sample_bool_map_to_v2(feasible_relaxed),
             sampled_named_functions: Some(named_functions.into()),
             metadata,
-            annotations: crate::protobuf_extension_annotations(annotations),
+            annotations: crate::v2_io::extension_annotations_to_v2_map(annotations),
             sampled_indicator_constraints: Some(indicator_constraints.into()),
             sampled_one_hot_constraints: Some(one_hot_constraints.into()),
             sampled_sos1_constraints: Some(sos1_constraints.into()),
@@ -62,7 +62,7 @@ impl From<SampleSet> for v2::SampleSet {
 
 fn sample_bool_map_to_v2(
     map: std::collections::BTreeMap<SampleID, bool>,
-) -> std::collections::HashMap<u64, bool> {
+) -> std::collections::BTreeMap<u64, bool> {
     map.into_iter()
         .map(|(sample_id, value)| (sample_id.into_inner(), value))
         .collect()

--- a/rust/ommx/src/sample_set/serialize.rs
+++ b/rust/ommx/src/sample_set/serialize.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{v1, Message, Parse};
+use crate::{v1, v2, Message, Parse};
 use anyhow::Result;
 
 impl SampleSet {
@@ -8,8 +8,62 @@ impl SampleSet {
         v1_sample_set.encode_to_vec()
     }
 
+    pub fn to_v2_bytes(&self) -> Vec<u8> {
+        let v2_sample_set = v2::SampleSet::from(self.clone());
+        v2_sample_set.encode_to_vec()
+    }
+
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let inner = v1::SampleSet::decode(bytes)?;
         Ok(Parse::parse(inner, &())?)
     }
+}
+
+impl From<SampleSet> for v2::SampleSet {
+    fn from(value: SampleSet) -> Self {
+        let required_features = crate::v2_io::required_features(
+            !value.indicator_constraints.is_empty(),
+            !value.one_hot_constraints.is_empty(),
+            !value.sos1_constraints.is_empty(),
+        );
+
+        let SampleSet {
+            decision_variables,
+            objectives,
+            constraints,
+            indicator_constraints,
+            one_hot_constraints,
+            sos1_constraints,
+            named_functions,
+            sense,
+            feasible,
+            feasible_relaxed,
+            metadata,
+            annotations,
+        } = value;
+
+        Self {
+            required_features,
+            objectives: Some(objectives.into()),
+            decision_variables: Some(decision_variables.into()),
+            sampled_regular_constraints: Some(constraints.into()),
+            feasible: sample_bool_map_to_v2(feasible),
+            sense: sense.into(),
+            feasible_relaxed: sample_bool_map_to_v2(feasible_relaxed),
+            sampled_named_functions: Some(named_functions.into()),
+            metadata,
+            annotations: crate::protobuf_extension_annotations(annotations),
+            sampled_indicator_constraints: Some(indicator_constraints.into()),
+            sampled_one_hot_constraints: Some(one_hot_constraints.into()),
+            sampled_sos1_constraints: Some(sos1_constraints.into()),
+        }
+    }
+}
+
+fn sample_bool_map_to_v2(
+    map: std::collections::BTreeMap<SampleID, bool>,
+) -> std::collections::HashMap<u64, bool> {
+    map.into_iter()
+        .map(|(sample_id, value)| (sample_id.into_inner(), value))
+        .collect()
 }

--- a/rust/ommx/src/solution/serialize.rs
+++ b/rust/ommx/src/solution/serialize.rs
@@ -56,7 +56,7 @@ impl From<Solution> for v2::Solution {
             sense: sense.map(Into::into).unwrap_or_default(),
             evaluated_named_functions: Some(evaluated_named_functions.into()),
             metadata,
-            annotations: crate::protobuf_extension_annotations(annotations),
+            annotations: crate::v2_io::extension_annotations_to_v2_map(annotations),
             evaluated_indicator_constraints: Some(evaluated_indicator_constraints.into()),
             evaluated_one_hot_constraints: Some(evaluated_one_hot_constraints.into()),
             evaluated_sos1_constraints: Some(evaluated_sos1_constraints.into()),

--- a/rust/ommx/src/solution/serialize.rs
+++ b/rust/ommx/src/solution/serialize.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{v1, Message, Parse};
+use crate::{v1, v2, Message, Parse};
 use anyhow::Result;
 
 impl Solution {
@@ -8,8 +8,58 @@ impl Solution {
         v1_solution.encode_to_vec()
     }
 
+    pub fn to_v2_bytes(&self) -> Vec<u8> {
+        let v2_solution = v2::Solution::from(self.clone());
+        v2_solution.encode_to_vec()
+    }
+
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let inner = v1::Solution::decode(bytes)?;
         Ok(Parse::parse(inner, &())?)
+    }
+}
+
+impl From<Solution> for v2::Solution {
+    fn from(value: Solution) -> Self {
+        let required_features = crate::v2_io::required_features(
+            !value.evaluated_indicator_constraints.is_empty(),
+            !value.evaluated_one_hot_constraints.is_empty(),
+            !value.evaluated_sos1_constraints.is_empty(),
+        );
+        let feasible = value.feasible();
+        let feasible_relaxed = value.feasible_relaxed();
+
+        let Solution {
+            objective,
+            evaluated_constraints,
+            evaluated_indicator_constraints,
+            evaluated_one_hot_constraints,
+            evaluated_sos1_constraints,
+            evaluated_named_functions,
+            decision_variables,
+            optimality,
+            relaxation,
+            sense,
+            metadata,
+            annotations,
+        } = value;
+
+        Self {
+            required_features,
+            objective,
+            decision_variables: Some(decision_variables.into()),
+            evaluated_regular_constraints: Some(evaluated_constraints.into()),
+            feasible,
+            optimality: optimality.into(),
+            relaxation: relaxation.into(),
+            feasible_relaxed: Some(feasible_relaxed),
+            sense: sense.map(Into::into).unwrap_or_default(),
+            evaluated_named_functions: Some(evaluated_named_functions.into()),
+            metadata,
+            annotations: crate::protobuf_extension_annotations(annotations),
+            evaluated_indicator_constraints: Some(evaluated_indicator_constraints.into()),
+            evaluated_one_hot_constraints: Some(evaluated_one_hot_constraints.into()),
+            evaluated_sos1_constraints: Some(evaluated_sos1_constraints.into()),
+        }
     }
 }

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -190,6 +190,75 @@ impl Sos1Constraint<Created> {
     }
 }
 
+impl From<Sos1Constraint<Created>> for crate::v2::Sos1Constraint {
+    fn from(constraint: Sos1Constraint<Created>) -> Self {
+        Self {
+            variables: constraint
+                .variables
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
+impl From<EvaluatedSos1Constraint> for crate::v2::EvaluatedSos1Constraint {
+    fn from(constraint: EvaluatedSos1Constraint) -> Self {
+        Self {
+            variables: constraint
+                .variables
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+            feasible: constraint.stage.feasible,
+            active_variable: constraint.stage.active_variable.map(|id| id.into_inner()),
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
+impl From<SampledSos1Constraint> for crate::v2::SampledSos1Constraint {
+    fn from(constraint: SampledSos1Constraint) -> Self {
+        Self {
+            variables: constraint
+                .variables
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+            feasible: constraint
+                .stage
+                .feasible
+                .into_iter()
+                .map(|(id, value)| (id.into_inner(), value))
+                .collect(),
+            active_variable: constraint
+                .stage
+                .active_variable
+                .into_iter()
+                .map(|(id, variable_id)| {
+                    (
+                        id.into_inner(),
+                        crate::v2::SampledActiveVariable {
+                            variable_id: variable_id.map(|id| id.into_inner()),
+                        },
+                    )
+                })
+                .collect(),
+            used_decision_variable_ids: constraint
+                .stage
+                .used_decision_variable_ids
+                .into_iter()
+                .map(|id| id.into_inner())
+                .collect(),
+        }
+    }
+}
+
 impl std::fmt::Display for Sos1Constraint<Created> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let vars: Vec<String> = self

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -1,0 +1,21 @@
+//! IO-adjacent helpers for protobuf-generated `v2::*` roots.
+
+use crate::v2::Feature;
+
+pub(crate) fn required_features(
+    has_indicator_constraints: bool,
+    has_one_hot_constraints: bool,
+    has_sos1_constraints: bool,
+) -> Vec<i32> {
+    let mut features = Vec::new();
+    if has_indicator_constraints {
+        features.push(Feature::ConstraintIndicator as i32);
+    }
+    if has_one_hot_constraints {
+        features.push(Feature::ConstraintOneHot as i32);
+    }
+    if has_sos1_constraints {
+        features.push(Feature::ConstraintSos1 as i32);
+    }
+    features
+}

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -1,5 +1,7 @@
 //! IO-adjacent helpers for protobuf-generated `v2::*` roots.
 
+use std::collections::{BTreeMap, HashMap};
+
 use crate::v2::Feature;
 
 pub(crate) fn required_features(
@@ -18,4 +20,12 @@ pub(crate) fn required_features(
         features.push(Feature::ConstraintSos1 as i32);
     }
     features
+}
+
+pub(crate) fn extension_annotations_to_v2_map(
+    annotations: HashMap<String, String>,
+) -> BTreeMap<String, String> {
+    crate::protobuf_extension_annotations(annotations)
+        .into_iter()
+        .collect()
 }

--- a/rust/protogen/src/main.rs
+++ b/rust/protogen/src/main.rs
@@ -38,6 +38,7 @@ fn main() -> Result<()> {
     let mut cfg = Config::new();
     cfg.type_attribute(".", "#[non_exhaustive]");
     cfg.field_attribute("SampleSet.feasible_unrelaxed", "#[deprecated]");
+    cfg.btree_map([".ommx.v2"]);
     cfg.out_dir(&out).compile_protos(&protos, &[proto_root])?;
 
     let mut generated = glob(&format!("{}/ommx.*.rs", out.display()))?


### PR DESCRIPTION
Part of #958.

## Summary

This PR adds write-only Rust SDK serialization support for the new `ommx.v2` top-level roots.

It implements `From` conversions from the normalized Rust SDK domain objects into generated `crate::v2::*` protobuf messages for:

- `Instance`
- `ParametricInstance`
- `Solution`
- `SampleSet`

The conversion keeps the existing normalized ownership model intact:

- table keys own decision-variable, parameter, named-function, and constraint IDs;
- modeling labels, constraint contexts, removed reasons, provenance, and fixed values serialize as sidecar columns;
- special constraint families serialize as first-class v2 collections instead of being dropped or translated through legacy hints;
- top-level roots populate `required_features` when the payload contains indicator, one-hot, or SOS1 constraints.

`to_bytes()` remains on the existing v1 path because v2 deserialization is intentionally left for the follow-up PR. This PR adds `to_v2_bytes()` for the four top-level root objects as the write-only v2 serialization entry point.

## Follow-up

The next PR should implement v2 deserialization and then decide when the default `to_bytes()` / `from_bytes()` path should move from v1 to v2.
