### PR TITLE
Add OMMX v2 protobuf round-trip support

### DIFF
--- a/proto/ommx/v2/sample_set.proto
+++ b/proto/ommx/v2/sample_set.proto
@@ -25,4 +25,7 @@ message SampleSet {
   SampledIndicatorConstraintCollection sampled_indicator_constraints = 11;
   SampledOneHotConstraintCollection sampled_one_hot_constraints = 12;
   SampledSos1ConstraintCollection sampled_sos1_constraints = 13;
+  // Absolute tolerance used to compute and validate `feasible`,
+  // `feasible_relaxed`, and per-constraint feasibility columns.
+  optional double feasibility_atol = 14;
 }

--- a/proto/ommx/v2/solution.proto
+++ b/proto/ommx/v2/solution.proto
@@ -26,4 +26,7 @@ message Solution {
   EvaluatedIndicatorConstraintCollection evaluated_indicator_constraints = 13;
   EvaluatedOneHotConstraintCollection evaluated_one_hot_constraints = 14;
   EvaluatedSos1ConstraintCollection evaluated_sos1_constraints = 15;
+  // Absolute tolerance used to compute and validate `feasible`,
+  // `feasible_relaxed`, and per-constraint feasibility columns.
+  optional double feasibility_atol = 16;
 }

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -332,6 +332,10 @@ impl Parse for crate::v2::EvaluatedRegularConstraint {
             })
             .map_err(|e| ParseError::from(e).context(message, "equality"))?
             .parse_as(&(), message, "equality")?;
+        crate::v2_io::validate_finite_f64(self.evaluated_value, message, "evaluated_value")?;
+        if let Some(dual_variable) = self.dual_variable {
+            crate::v2_io::validate_finite_f64(dual_variable, message, "dual_variable")?;
+        }
         validate_feasible_from_evaluated_value(
             equality,
             self.evaluated_value,
@@ -426,6 +430,7 @@ impl Parse for crate::v2::SampledRegularConstraint {
                 field: "evaluated_values",
             })?
             .parse_as(&(), message, "evaluated_values")?;
+        crate::v2_io::validate_sampled_f64_values(&evaluated_values, message, "evaluated_values")?;
         let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
         for (sample_id, evaluated_value) in evaluated_values.iter() {
             if let Some(provided_feasible) = feasible.get(sample_id).copied() {
@@ -442,6 +447,9 @@ impl Parse for crate::v2::SampledRegularConstraint {
             .dual_variables
             .map(|values| values.parse_as(&(), message, "dual_variables"))
             .transpose()?;
+        if let Some(dual_variables) = &dual_variables {
+            crate::v2_io::validate_sampled_f64_values(dual_variables, message, "dual_variables")?;
+        }
         Ok(Constraint {
             equality,
             stage: SampledData {
@@ -570,5 +578,92 @@ mod tests {
         let state = crate::v1::State::default();
         let evaluated = constraint.evaluate(&state, crate::ATol::default()).unwrap();
         assert_eq!(evaluated.violation(), 0.0001);
+    }
+
+    #[test]
+    fn parse_v2_evaluated_rejects_non_finite_value_even_if_marked_infeasible() {
+        let proto = crate::v2::EvaluatedRegularConstraint {
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_value: f64::INFINITY,
+            feasible: false,
+            used_decision_variable_ids: vec![],
+            dual_variable: None,
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("evaluated_value must be finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_evaluated_rejects_non_finite_dual_variable() {
+        let proto = crate::v2::EvaluatedRegularConstraint {
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_value: 0.0,
+            feasible: true,
+            used_decision_variable_ids: vec![],
+            dual_variable: Some(f64::INFINITY),
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("dual_variable must be finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_sampled_rejects_non_finite_evaluated_values() {
+        let proto = crate::v2::SampledRegularConstraint {
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_values: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![0],
+                    value: f64::INFINITY,
+                }],
+            }),
+            feasible: std::collections::BTreeMap::from([(0, false)]),
+            used_decision_variable_ids: vec![],
+            dual_variables: None,
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("evaluated_values must be finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_sampled_rejects_non_finite_dual_variables() {
+        let proto = crate::v2::SampledRegularConstraint {
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_values: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![0],
+                    value: 0.0,
+                }],
+            }),
+            feasible: std::collections::BTreeMap::from([(0, true)]),
+            used_decision_variable_ids: vec![],
+            dual_variables: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![0],
+                    value: f64::INFINITY,
+                }],
+            }),
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("dual_variables must be finite"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -10,7 +10,7 @@ pub(crate) mod stage;
 pub use context_store::ConstraintContextStore;
 
 use crate::logical_memory::LogicalMemoryProfile;
-use crate::{Function, Parse, ParseError, RawParseError, SampleID, VariableID};
+use crate::{ATol, Function, Parse, ParseError, RawParseError, SampleID, VariableID};
 pub use arbitrary::*;
 use derive_more::{Deref, From};
 use fnv::FnvHashSet;
@@ -278,6 +278,30 @@ impl std::fmt::Display for Constraint<Created> {
 /// Type alias for an evaluated constraint.
 pub type EvaluatedConstraint = Constraint<Evaluated>;
 
+fn feasible_from_evaluated_value(equality: Equality, evaluated_value: f64, atol: ATol) -> bool {
+    match equality {
+        Equality::EqualToZero => evaluated_value.abs() < *atol,
+        Equality::LessThanOrEqualToZero => evaluated_value < *atol,
+    }
+}
+
+fn validate_feasible_from_evaluated_value(
+    equality: Equality,
+    evaluated_value: f64,
+    provided_feasible: bool,
+    atol: ATol,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    let computed_feasible = feasible_from_evaluated_value(equality, evaluated_value, atol);
+    if provided_feasible != computed_feasible {
+        return Err(RawParseError::InvalidInstance(format!(
+            "Inconsistent constraint feasibility: provided={provided_feasible}, computed={computed_feasible}",
+        ))
+        .context(message, "feasible"));
+    }
+    Ok(())
+}
+
 impl From<EvaluatedConstraint> for crate::v2::EvaluatedRegularConstraint {
     fn from(constraint: EvaluatedConstraint) -> Self {
         Self {
@@ -297,9 +321,9 @@ impl From<EvaluatedConstraint> for crate::v2::EvaluatedRegularConstraint {
 
 impl Parse for crate::v2::EvaluatedRegularConstraint {
     type Output = EvaluatedConstraint;
-    type Context = ();
+    type Context = ATol;
 
-    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+    fn parse(self, atol: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.EvaluatedRegularConstraint";
         let equality = crate::v1::Equality::try_from(self.equality)
             .map_err(|_| RawParseError::UnknownEnumValue {
@@ -308,6 +332,13 @@ impl Parse for crate::v2::EvaluatedRegularConstraint {
             })
             .map_err(|e| ParseError::from(e).context(message, "equality"))?
             .parse_as(&(), message, "equality")?;
+        validate_feasible_from_evaluated_value(
+            equality,
+            self.evaluated_value,
+            self.feasible,
+            *atol,
+            message,
+        )?;
         Ok(Constraint {
             equality,
             stage: EvaluatedData {
@@ -377,9 +408,9 @@ impl From<SampledConstraint> for crate::v2::SampledRegularConstraint {
 
 impl Parse for crate::v2::SampledRegularConstraint {
     type Output = SampledConstraint;
-    type Context = ();
+    type Context = ATol;
 
-    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+    fn parse(self, atol: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.SampledRegularConstraint";
         let equality = crate::v1::Equality::try_from(self.equality)
             .map_err(|_| RawParseError::UnknownEnumValue {
@@ -395,6 +426,18 @@ impl Parse for crate::v2::SampledRegularConstraint {
                 field: "evaluated_values",
             })?
             .parse_as(&(), message, "evaluated_values")?;
+        let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
+        for (sample_id, evaluated_value) in evaluated_values.iter() {
+            if let Some(provided_feasible) = feasible.get(sample_id).copied() {
+                validate_feasible_from_evaluated_value(
+                    equality,
+                    *evaluated_value,
+                    provided_feasible,
+                    *atol,
+                    message,
+                )?;
+            }
+        }
         let dual_variables = self
             .dual_variables
             .map(|values| values.parse_as(&(), message, "dual_variables"))
@@ -403,7 +446,7 @@ impl Parse for crate::v2::SampledRegularConstraint {
             equality,
             stage: SampledData {
                 evaluated_values,
-                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
+                feasible,
                 used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
                     self.used_decision_variable_ids,
                     message,

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -8,9 +8,6 @@ mod reduce_binary_power;
 pub(crate) mod stage;
 
 pub use context_store::ConstraintContextStore;
-pub(crate) use context_store::{
-    constraint_context_store_from_v2_map, constraint_context_store_to_v2_map,
-};
 
 use crate::logical_memory::LogicalMemoryProfile;
 use crate::{Function, Parse, ParseError, RawParseError, SampleID, VariableID};

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -7,11 +7,13 @@ mod parse;
 mod reduce_binary_power;
 pub(crate) mod stage;
 
-pub(crate) use context_store::constraint_context_store_to_v2_map;
 pub use context_store::ConstraintContextStore;
+pub(crate) use context_store::{
+    constraint_context_store_from_v2_map, constraint_context_store_to_v2_map,
+};
 
 use crate::logical_memory::LogicalMemoryProfile;
-use crate::{Function, SampleID, VariableID};
+use crate::{Function, Parse, ParseError, RawParseError, SampleID, VariableID};
 pub use arbitrary::*;
 use derive_more::{Deref, From};
 use fnv::FnvHashSet;
@@ -118,11 +120,60 @@ impl From<Provenance> for crate::v2::Provenance {
     }
 }
 
+impl Parse for crate::v2::Provenance {
+    type Output = Provenance;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        use crate::v2::provenance::Source;
+
+        match self.source.ok_or(RawParseError::MissingField {
+            message: "ommx.v2.Provenance",
+            field: "source",
+        })? {
+            Source::IndicatorConstraintId(id) => Ok(Provenance::IndicatorConstraint(
+                crate::IndicatorConstraintID::from(id),
+            )),
+            Source::OneHotConstraintId(id) => Ok(Provenance::OneHotConstraint(
+                crate::OneHotConstraintID::from(id),
+            )),
+            Source::Sos1ConstraintId(id) => Ok(Provenance::Sos1Constraint(
+                crate::Sos1ConstraintID::from(id),
+            )),
+        }
+    }
+}
+
 impl From<ConstraintContext> for crate::v2::ConstraintContext {
     fn from(context: ConstraintContext) -> Self {
         Self {
             label: Some(context.label.into()),
             provenance: context.provenance.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl Parse for crate::v2::ConstraintContext {
+    type Output = ConstraintContext;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let mut provenance = Vec::with_capacity(self.provenance.len());
+        for value in self.provenance {
+            provenance.push(value.parse_as(&(), "ommx.v2.ConstraintContext", "provenance")?);
+        }
+        Ok(ConstraintContext {
+            label: self.label.map(Into::into).unwrap_or_default(),
+            provenance,
+        })
+    }
+}
+
+impl From<crate::v2::RemovedReason> for RemovedReason {
+    fn from(reason: crate::v2::RemovedReason) -> Self {
+        Self {
+            reason: reason.reason,
+            parameters: reason.parameters.into_iter().collect(),
         }
     }
 }
@@ -184,6 +235,33 @@ impl From<Constraint<Created>> for crate::v2::RegularConstraint {
     }
 }
 
+impl Parse for crate::v2::RegularConstraint {
+    type Output = Constraint<Created>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.RegularConstraint";
+        let equality = crate::v1::Equality::try_from(self.equality)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Equality",
+                value: self.equality,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "equality"))?
+            .parse_as(&(), message, "equality")?;
+        let function = self
+            .function
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "function",
+            })?
+            .parse_as(&(), message, "function")?;
+        Ok(Constraint {
+            equality,
+            stage: CreatedData { function },
+        })
+    }
+}
+
 impl std::fmt::Display for Constraint<Created> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let equality_symbol = match self.equality {
@@ -217,6 +295,35 @@ impl From<EvaluatedConstraint> for crate::v2::EvaluatedRegularConstraint {
                 .collect(),
             dual_variable: constraint.stage.dual_variable,
         }
+    }
+}
+
+impl Parse for crate::v2::EvaluatedRegularConstraint {
+    type Output = EvaluatedConstraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.EvaluatedRegularConstraint";
+        let equality = crate::v1::Equality::try_from(self.equality)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Equality",
+                value: self.equality,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "equality"))?
+            .parse_as(&(), message, "equality")?;
+        Ok(Constraint {
+            equality,
+            stage: EvaluatedData {
+                evaluated_value: self.evaluated_value,
+                feasible: self.feasible,
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+                dual_variable: self.dual_variable,
+            },
+        })
     }
 }
 
@@ -268,6 +375,46 @@ impl From<SampledConstraint> for crate::v2::SampledRegularConstraint {
                 .collect(),
             dual_variables: constraint.stage.dual_variables.map(Into::into),
         }
+    }
+}
+
+impl Parse for crate::v2::SampledRegularConstraint {
+    type Output = SampledConstraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampledRegularConstraint";
+        let equality = crate::v1::Equality::try_from(self.equality)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Equality",
+                value: self.equality,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "equality"))?
+            .parse_as(&(), message, "equality")?;
+        let evaluated_values = self
+            .evaluated_values
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "evaluated_values",
+            })?
+            .parse_as(&(), message, "evaluated_values")?;
+        let dual_variables = self
+            .dual_variables
+            .map(|values| values.parse_as(&(), message, "dual_variables"))
+            .transpose()?;
+        Ok(Constraint {
+            equality,
+            stage: SampledData {
+                evaluated_values,
+                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+                dual_variables,
+            },
+        })
     }
 }
 

--- a/rust/ommx/src/constraint/context_store.rs
+++ b/rust/ommx/src/constraint/context_store.rs
@@ -1,9 +1,9 @@
 use crate::constraint::{ConstraintContext, Provenance};
 use crate::constraint_type::IDType;
 use crate::logical_memory::LogicalMemoryProfile;
-use crate::{ModelingLabelStore, Parse, ParseError};
+use crate::ModelingLabelStore;
 use fnv::FnvHashMap;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 /// ID-keyed storage for constraint labels and transformation provenance.
 ///
@@ -141,28 +141,6 @@ impl<ID: IDType> ConstraintContextStore<ID> {
             .chain(self.provenance.keys().copied())
             .collect()
     }
-}
-
-pub(crate) fn constraint_context_store_to_v2_map<ID: IDType>(
-    store: &ConstraintContextStore<ID>,
-) -> BTreeMap<u64, crate::v2::ConstraintContext> {
-    store
-        .ids()
-        .into_iter()
-        .map(|id| (id.into(), store.collect_for(id).into()))
-        .collect()
-}
-
-pub(crate) fn constraint_context_store_from_v2_map<ID: IDType>(
-    contexts: BTreeMap<u64, crate::v2::ConstraintContext>,
-    message: &'static str,
-    field: &'static str,
-) -> Result<ConstraintContextStore<ID>, ParseError> {
-    let mut store = ConstraintContextStore::default();
-    for (id, context) in contexts {
-        store.insert(ID::from(id), context.parse_as(&(), message, field)?);
-    }
-    Ok(store)
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/constraint/context_store.rs
+++ b/rust/ommx/src/constraint/context_store.rs
@@ -1,7 +1,7 @@
 use crate::constraint::{ConstraintContext, Provenance};
 use crate::constraint_type::IDType;
 use crate::logical_memory::LogicalMemoryProfile;
-use crate::ModelingLabelStore;
+use crate::{ModelingLabelStore, Parse, ParseError};
 use fnv::FnvHashMap;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -151,6 +151,18 @@ pub(crate) fn constraint_context_store_to_v2_map<ID: IDType>(
         .into_iter()
         .map(|id| (id.into(), store.collect_for(id).into()))
         .collect()
+}
+
+pub(crate) fn constraint_context_store_from_v2_map<ID: IDType>(
+    contexts: BTreeMap<u64, crate::v2::ConstraintContext>,
+    message: &'static str,
+    field: &'static str,
+) -> Result<ConstraintContextStore<ID>, ParseError> {
+    let mut store = ConstraintContextStore::default();
+    for (id, context) in contexts {
+        store.insert(ID::from(id), context.parse_as(&(), message, field)?);
+    }
+    Ok(store)
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -32,7 +32,6 @@
 use crate::Result;
 use crate::{
     constraint::{
-        constraint_context_store_from_v2_map, constraint_context_store_to_v2_map,
         ConstraintContext, ConstraintContextStore, ConstraintID, EvaluatedConstraint,
         RemovedReason, SampledConstraint,
     },
@@ -795,6 +794,28 @@ impl_v2_sampled_collection!(Constraint => crate::v2::SampledRegularConstraintCol
 impl_v2_sampled_collection!(crate::IndicatorConstraint => crate::v2::SampledIndicatorConstraintCollection);
 impl_v2_sampled_collection!(crate::OneHotConstraint => crate::v2::SampledOneHotConstraintCollection);
 impl_v2_sampled_collection!(crate::Sos1Constraint => crate::v2::SampledSos1ConstraintCollection);
+
+fn constraint_context_store_to_v2_map<ID: IDType>(
+    store: &ConstraintContextStore<ID>,
+) -> BTreeMap<u64, crate::v2::ConstraintContext> {
+    store
+        .ids()
+        .into_iter()
+        .map(|id| (id.into(), store.collect_for(id).into()))
+        .collect()
+}
+
+fn constraint_context_store_from_v2_map<ID: IDType>(
+    contexts: BTreeMap<u64, crate::v2::ConstraintContext>,
+    message: &'static str,
+    field: &'static str,
+) -> std::result::Result<ConstraintContextStore<ID>, ParseError> {
+    let mut store = ConstraintContextStore::default();
+    for (id, context) in contexts {
+        store.insert(ID::from(id), context.parse_as(&(), message, field)?);
+    }
+    Ok(store)
+}
 
 macro_rules! impl_parse_v2_created_collection {
     ($source:ty => $target:ty) => {

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -850,11 +850,16 @@ macro_rules! impl_parse_v2_evaluated_collection {
     ($source:ty => $target:ty) => {
         impl Parse for $target {
             type Output = EvaluatedCollection<$source>;
-            type Context = ();
+            type Context = crate::ATol;
 
-            fn parse(self, _: &Self::Context) -> std::result::Result<Self::Output, ParseError> {
+            fn parse(self, atol: &Self::Context) -> std::result::Result<Self::Output, ParseError> {
                 let message = stringify!($target);
-                let entries = parse_v2_constraint_entries(self.entries, message, "entries")?;
+                let entries = parse_v2_constraint_entries_with_context(
+                    self.entries,
+                    message,
+                    "entries",
+                    atol,
+                )?;
                 let removed_reasons =
                     parse_v2_removed_reasons(self.removed_reasons, message, "removed_reasons")?;
                 let context =
@@ -876,11 +881,16 @@ macro_rules! impl_parse_v2_sampled_collection {
     ($source:ty => $target:ty) => {
         impl Parse for $target {
             type Output = SampledCollection<$source>;
-            type Context = ();
+            type Context = crate::ATol;
 
-            fn parse(self, _: &Self::Context) -> std::result::Result<Self::Output, ParseError> {
+            fn parse(self, atol: &Self::Context) -> std::result::Result<Self::Output, ParseError> {
                 let message = stringify!($target);
-                let entries = parse_v2_constraint_entries(self.entries, message, "entries")?;
+                let entries = parse_v2_constraint_entries_with_context(
+                    self.entries,
+                    message,
+                    "entries",
+                    atol,
+                )?;
                 let removed_reasons =
                     parse_v2_removed_reasons(self.removed_reasons, message, "removed_reasons")?;
                 let context =
@@ -921,6 +931,22 @@ where
     entries
         .into_iter()
         .map(|(id, row)| Ok((ID::from(id), row.parse_as(&(), message, field)?)))
+        .collect()
+}
+
+fn parse_v2_constraint_entries_with_context<ID, V2Row, Row, C>(
+    entries: BTreeMap<u64, V2Row>,
+    message: &'static str,
+    field: &'static str,
+    context: &C,
+) -> std::result::Result<BTreeMap<ID, Row>, ParseError>
+where
+    ID: IDType,
+    V2Row: Parse<Output = Row, Context = C>,
+{
+    entries
+        .into_iter()
+        .map(|(id, row)| Ok((ID::from(id), row.parse_as(context, message, field)?)))
         .collect()
 }
 

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -38,6 +38,9 @@ use crate::{
     v1, ATol, Constraint, Evaluate, Parse, ParseError, RawParseError, SampleID, SampleIDSet,
     VariableIDSet,
 };
+use std::sync::LazyLock;
+
+static EMPTY_VARIABLE_ID_SET: LazyLock<VariableIDSet> = LazyLock::new(VariableIDSet::default);
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 fn validate_no_key_overlap<ID, L, R>(
@@ -169,7 +172,9 @@ pub trait ConstraintType {
 pub trait EvaluatedConstraintBehavior {
     type ID;
     fn is_feasible(&self) -> bool;
-    fn used_decision_variable_ids(&self) -> &VariableIDSet;
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &EMPTY_VARIABLE_ID_SET
+    }
 }
 
 /// Common behavior for a sampled constraint (multi-sample evaluation result).
@@ -187,7 +192,9 @@ pub trait SampledConstraintBehavior {
     fn validate_sample_ids(&self, expected: &SampleIDSet) -> std::result::Result<(), SampleIDSet>;
 
     /// Decision variable IDs recorded as used by this sampled constraint.
-    fn used_decision_variable_ids(&self) -> &VariableIDSet;
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &EMPTY_VARIABLE_ID_SET
+    }
 
     /// Extract an evaluated constraint for a specific sample.
     ///

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -32,10 +32,12 @@
 use crate::Result;
 use crate::{
     constraint::{
-        constraint_context_store_to_v2_map, ConstraintContext, ConstraintContextStore,
-        ConstraintID, EvaluatedConstraint, RemovedReason, SampledConstraint,
+        constraint_context_store_from_v2_map, constraint_context_store_to_v2_map,
+        ConstraintContext, ConstraintContextStore, ConstraintID, EvaluatedConstraint,
+        RemovedReason, SampledConstraint,
     },
-    v1, ATol, Constraint, Evaluate, SampleID, SampleIDSet, VariableIDSet,
+    v1, ATol, Constraint, Evaluate, Parse, ParseError, RawParseError, SampleID, SampleIDSet,
+    VariableIDSet,
 };
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
@@ -168,6 +170,7 @@ pub trait ConstraintType {
 pub trait EvaluatedConstraintBehavior {
     type ID;
     fn is_feasible(&self) -> bool;
+    fn used_decision_variable_ids(&self) -> &VariableIDSet;
 }
 
 /// Common behavior for a sampled constraint (multi-sample evaluation result).
@@ -201,6 +204,10 @@ impl EvaluatedConstraintBehavior for EvaluatedConstraint {
     type ID = ConstraintID;
     fn is_feasible(&self) -> bool {
         self.stage.feasible
+    }
+
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
     }
 }
 
@@ -789,6 +796,87 @@ impl_v2_sampled_collection!(crate::IndicatorConstraint => crate::v2::SampledIndi
 impl_v2_sampled_collection!(crate::OneHotConstraint => crate::v2::SampledOneHotConstraintCollection);
 impl_v2_sampled_collection!(crate::Sos1Constraint => crate::v2::SampledSos1ConstraintCollection);
 
+macro_rules! impl_parse_v2_created_collection {
+    ($source:ty => $target:ty) => {
+        impl Parse for $target {
+            type Output = ConstraintCollection<$source>;
+            type Context = ();
+
+            fn parse(self, _: &Self::Context) -> std::result::Result<Self::Output, ParseError> {
+                let message = stringify!($target);
+                let active = parse_v2_constraint_entries(self.active, message, "active")?;
+                let removed = parse_v2_removed_constraint_entries(
+                    self.removed,
+                    self.removed_reasons,
+                    message,
+                )?;
+                let context =
+                    constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
+                ConstraintCollection::with_context(active, removed, context).map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string()).context(message, "active")
+                })
+            }
+        }
+    };
+}
+
+impl_parse_v2_created_collection!(Constraint => crate::v2::RegularConstraintCollection);
+impl_parse_v2_created_collection!(crate::IndicatorConstraint => crate::v2::IndicatorConstraintCollection);
+impl_parse_v2_created_collection!(crate::OneHotConstraint => crate::v2::OneHotConstraintCollection);
+impl_parse_v2_created_collection!(crate::Sos1Constraint => crate::v2::Sos1ConstraintCollection);
+
+macro_rules! impl_parse_v2_evaluated_collection {
+    ($source:ty => $target:ty) => {
+        impl Parse for $target {
+            type Output = EvaluatedCollection<$source>;
+            type Context = ();
+
+            fn parse(self, _: &Self::Context) -> std::result::Result<Self::Output, ParseError> {
+                let message = stringify!($target);
+                let entries = parse_v2_constraint_entries(self.entries, message, "entries")?;
+                let removed_reasons =
+                    parse_v2_removed_reasons(self.removed_reasons, message, "removed_reasons")?;
+                let context =
+                    constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
+                EvaluatedCollection::with_context(entries, removed_reasons, context).map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string()).context(message, "entries")
+                })
+            }
+        }
+    };
+}
+
+impl_parse_v2_evaluated_collection!(Constraint => crate::v2::EvaluatedRegularConstraintCollection);
+impl_parse_v2_evaluated_collection!(crate::IndicatorConstraint => crate::v2::EvaluatedIndicatorConstraintCollection);
+impl_parse_v2_evaluated_collection!(crate::OneHotConstraint => crate::v2::EvaluatedOneHotConstraintCollection);
+impl_parse_v2_evaluated_collection!(crate::Sos1Constraint => crate::v2::EvaluatedSos1ConstraintCollection);
+
+macro_rules! impl_parse_v2_sampled_collection {
+    ($source:ty => $target:ty) => {
+        impl Parse for $target {
+            type Output = SampledCollection<$source>;
+            type Context = ();
+
+            fn parse(self, _: &Self::Context) -> std::result::Result<Self::Output, ParseError> {
+                let message = stringify!($target);
+                let entries = parse_v2_constraint_entries(self.entries, message, "entries")?;
+                let removed_reasons =
+                    parse_v2_removed_reasons(self.removed_reasons, message, "removed_reasons")?;
+                let context =
+                    constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
+                SampledCollection::with_context(entries, removed_reasons, context).map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string()).context(message, "entries")
+                })
+            }
+        }
+    };
+}
+
+impl_parse_v2_sampled_collection!(Constraint => crate::v2::SampledRegularConstraintCollection);
+impl_parse_v2_sampled_collection!(crate::IndicatorConstraint => crate::v2::SampledIndicatorConstraintCollection);
+impl_parse_v2_sampled_collection!(crate::OneHotConstraint => crate::v2::SampledOneHotConstraintCollection);
+impl_parse_v2_sampled_collection!(crate::Sos1Constraint => crate::v2::SampledSos1ConstraintCollection);
+
 fn entries_to_v2_map<ID, Row, V2Row>(entries: BTreeMap<ID, Row>) -> BTreeMap<u64, V2Row>
 where
     ID: IDType,
@@ -797,6 +885,21 @@ where
     entries
         .into_iter()
         .map(|(id, row)| (id.into(), row.into()))
+        .collect()
+}
+
+fn parse_v2_constraint_entries<ID, V2Row, Row>(
+    entries: BTreeMap<u64, V2Row>,
+    message: &'static str,
+    field: &'static str,
+) -> std::result::Result<BTreeMap<ID, Row>, ParseError>
+where
+    ID: IDType,
+    V2Row: Parse<Output = Row, Context = ()>,
+{
+    entries
+        .into_iter()
+        .map(|(id, row)| Ok((ID::from(id), row.parse_as(&(), message, field)?)))
         .collect()
 }
 
@@ -820,6 +923,39 @@ where
     (rows, reasons)
 }
 
+fn parse_v2_removed_constraint_entries<ID, V2Row, Row>(
+    removed: BTreeMap<u64, V2Row>,
+    mut removed_reasons: BTreeMap<u64, crate::v2::RemovedReason>,
+    message: &'static str,
+) -> std::result::Result<BTreeMap<ID, (Row, RemovedReason)>, ParseError>
+where
+    ID: IDType,
+    V2Row: Parse<Output = Row, Context = ()>,
+{
+    let mut out = BTreeMap::new();
+    for (id, row) in removed {
+        let reason = removed_reasons.remove(&id).ok_or_else(|| {
+            RawParseError::InvalidInstance(format!(
+                "Removed constraint ID {:?} has no removed reason",
+                ID::from(id)
+            ))
+            .context(message, "removed_reasons")
+        })?;
+        out.insert(
+            ID::from(id),
+            (row.parse_as(&(), message, "removed")?, reason.into()),
+        );
+    }
+    if let Some(id) = removed_reasons.keys().next().copied() {
+        return Err(RawParseError::InvalidInstance(format!(
+            "Removed reason references unknown constraint ID {:?}",
+            ID::from(id)
+        ))
+        .context(message, "removed_reasons"));
+    }
+    Ok(out)
+}
+
 fn removed_reasons_to_v2_map<ID: IDType>(
     removed_reasons: BTreeMap<ID, RemovedReason>,
 ) -> BTreeMap<u64, crate::v2::RemovedReason> {
@@ -827,6 +963,17 @@ fn removed_reasons_to_v2_map<ID: IDType>(
         .into_iter()
         .map(|(id, reason)| (id.into(), reason.into()))
         .collect()
+}
+
+fn parse_v2_removed_reasons<ID: IDType>(
+    removed_reasons: BTreeMap<u64, crate::v2::RemovedReason>,
+    _message: &'static str,
+    _field: &'static str,
+) -> std::result::Result<BTreeMap<ID, RemovedReason>, ParseError> {
+    Ok(removed_reasons
+        .into_iter()
+        .map(|(id, reason)| (ID::from(id), reason.into()))
+        .collect())
 }
 
 impl<T: ConstraintType> Evaluate for ConstraintCollection<T> {

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -833,6 +833,14 @@ macro_rules! impl_parse_v2_created_collection {
                 )?;
                 let context =
                     constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
+                let owned_ids = active
+                    .keys()
+                    .chain(removed.keys())
+                    .copied()
+                    .collect::<BTreeSet<_>>();
+                validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string()).context(message, "contexts")
+                })?;
                 ConstraintCollection::with_context(active, removed, context).map_err(|e| {
                     RawParseError::InvalidInstance(e.to_string()).context(message, "active")
                 })
@@ -864,8 +872,13 @@ macro_rules! impl_parse_v2_evaluated_collection {
                     parse_v2_removed_reasons(self.removed_reasons, message, "removed_reasons")?;
                 let context =
                     constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
+                let owned_ids = entries.keys().copied().collect::<BTreeSet<_>>();
+                validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string()).context(message, "contexts")
+                })?;
                 EvaluatedCollection::with_context(entries, removed_reasons, context).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string()).context(message, "entries")
+                    RawParseError::InvalidInstance(e.to_string())
+                        .context(message, "removed_reasons")
                 })
             }
         }
@@ -895,8 +908,13 @@ macro_rules! impl_parse_v2_sampled_collection {
                     parse_v2_removed_reasons(self.removed_reasons, message, "removed_reasons")?;
                 let context =
                     constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
+                let owned_ids = entries.keys().copied().collect::<BTreeSet<_>>();
+                validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
+                    RawParseError::InvalidInstance(e.to_string()).context(message, "contexts")
+                })?;
                 SampledCollection::with_context(entries, removed_reasons, context).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string()).context(message, "entries")
+                    RawParseError::InvalidInstance(e.to_string())
+                        .context(message, "removed_reasons")
                 })
             }
         }
@@ -1857,5 +1875,85 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Removed reason references unknown constraint ID"));
+    }
+
+    #[test]
+    fn parse_v2_created_collection_orphan_context_reports_contexts_field() {
+        let err = crate::v2::RegularConstraintCollection {
+            contexts: [(
+                1,
+                crate::v2::ConstraintContext {
+                    label: Some(crate::v2::ModelingLabel {
+                        name: Some("orphan".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("[contexts]"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_evaluated_collection_orphan_context_reports_contexts_field() {
+        let atol = ATol::default();
+        let err = crate::v2::EvaluatedRegularConstraintCollection {
+            contexts: [(
+                1,
+                crate::v2::ConstraintContext {
+                    label: Some(crate::v2::ModelingLabel {
+                        name: Some("orphan".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        }
+        .parse(&atol)
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("[contexts]"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_sampled_collection_orphan_context_reports_contexts_field() {
+        let atol = ATol::default();
+        let err = crate::v2::SampledRegularConstraintCollection {
+            contexts: [(
+                1,
+                crate::v2::ConstraintContext {
+                    label: Some(crate::v2::ModelingLabel {
+                        name: Some("orphan".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        }
+        .parse(&atol)
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("[contexts]"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::logical_memory::LogicalMemoryProfile;
-use crate::{ATol, Bound, Created, Evaluated, ModelingLabel, SampledStage};
+use crate::{
+    ATol, Bound, Created, Evaluated, ModelingLabel, Parse, ParseError, RawParseError, SampledStage,
+};
 
 use super::{
     DecisionVariable, DecisionVariableError, DecisionVariableLabel, EvaluatedDecisionVariable,
@@ -552,6 +554,36 @@ impl From<DecisionVariable> for crate::v2::DecisionVariable {
     }
 }
 
+impl Parse for crate::v2::DecisionVariable {
+    type Output = DecisionVariable;
+    type Context = VariableID;
+
+    fn parse(self, id: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.DecisionVariable";
+        let kind = crate::v1::decision_variable::Kind::try_from(self.kind)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.decision_variable.Kind",
+                value: self.kind,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "kind"))?
+            .parse_as(&(), message, "kind")?;
+        let bound = self
+            .bound
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "bound",
+            })?
+            .parse_as(&(), message, "bound")?;
+        DecisionVariable::new(kind, bound, ATol::default()).map_err(|source| {
+            RawParseError::InvalidDecisionVariable(DecisionVariableError::InvalidDefinition {
+                id: *id,
+                source: Box::new(source),
+            })
+            .context(message, "bound")
+        })
+    }
+}
+
 impl From<EvaluatedDecisionVariable> for crate::v2::EvaluatedDecisionVariable {
     fn from(value: EvaluatedDecisionVariable) -> Self {
         let EvaluatedDecisionVariable { kind, bound, value } = value;
@@ -560,6 +592,22 @@ impl From<EvaluatedDecisionVariable> for crate::v2::EvaluatedDecisionVariable {
             bound: Some(bound.into()),
             value,
         }
+    }
+}
+
+impl Parse for crate::v2::EvaluatedDecisionVariable {
+    type Output = EvaluatedDecisionVariable;
+    type Context = VariableID;
+
+    fn parse(self, id: &Self::Context) -> Result<Self::Output, ParseError> {
+        let decision_variable = crate::v2::DecisionVariable {
+            kind: self.kind,
+            bound: self.bound,
+        }
+        .parse(id)?;
+        EvaluatedDecisionVariable::new(*id, decision_variable, self.value)
+            .map_err(RawParseError::InvalidDecisionVariable)
+            .map_err(|e| ParseError::from(e).context("ommx.v2.EvaluatedDecisionVariable", "value"))
     }
 }
 
@@ -578,6 +626,30 @@ impl From<SampledDecisionVariable> for crate::v2::SampledDecisionVariable {
     }
 }
 
+impl Parse for crate::v2::SampledDecisionVariable {
+    type Output = SampledDecisionVariable;
+    type Context = VariableID;
+
+    fn parse(self, id: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampledDecisionVariable";
+        let decision_variable = crate::v2::DecisionVariable {
+            kind: self.kind,
+            bound: self.bound,
+        }
+        .parse_as(id, message, "decision_variable")?;
+        let samples = self
+            .samples
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "samples",
+            })?
+            .parse_as(&(), message, "samples")?;
+        SampledDecisionVariable::new(*id, decision_variable, samples)
+            .map_err(RawParseError::InvalidDecisionVariable)
+            .map_err(|e| ParseError::from(e).context(message, "samples"))
+    }
+}
+
 impl From<DecisionVariableTable<Created>> for crate::v2::DecisionVariableTable {
     fn from(table: DecisionVariableTable<Created>) -> Self {
         Self {
@@ -593,6 +665,28 @@ impl From<DecisionVariableTable<Created>> for crate::v2::DecisionVariableTable {
     }
 }
 
+impl Parse for crate::v2::DecisionVariableTable {
+    type Output = DecisionVariableTable<Created>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.DecisionVariableTable";
+        let mut entries = BTreeMap::new();
+        for (id, row) in self.entries {
+            let id = VariableID::from(id);
+            entries.insert(id, row.parse_as(&id, message, "entries")?);
+        }
+        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        let fixed_values = self
+            .fixed_values
+            .into_iter()
+            .map(|(id, value)| (VariableID::from(id), value))
+            .collect();
+        DecisionVariableTable::with_fixed_values(entries, labels, fixed_values, ATol::default())
+            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
+    }
+}
+
 impl From<EvaluatedDecisionVariableTable> for crate::v2::EvaluatedDecisionVariableTable {
     fn from(table: EvaluatedDecisionVariableTable) -> Self {
         Self {
@@ -602,12 +696,46 @@ impl From<EvaluatedDecisionVariableTable> for crate::v2::EvaluatedDecisionVariab
     }
 }
 
+impl Parse for crate::v2::EvaluatedDecisionVariableTable {
+    type Output = EvaluatedDecisionVariableTable;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.EvaluatedDecisionVariableTable";
+        let mut entries = BTreeMap::new();
+        for (id, row) in self.entries {
+            let id = VariableID::from(id);
+            entries.insert(id, row.parse_as(&id, message, "entries")?);
+        }
+        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        EvaluatedDecisionVariableTable::new(entries, labels)
+            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
+    }
+}
+
 impl From<SampledDecisionVariableTable> for crate::v2::SampledDecisionVariableTable {
     fn from(table: SampledDecisionVariableTable) -> Self {
         Self {
             entries: table_entries_to_v2_map(table.entries),
             labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
         }
+    }
+}
+
+impl Parse for crate::v2::SampledDecisionVariableTable {
+    type Output = SampledDecisionVariableTable;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampledDecisionVariableTable";
+        let mut entries = BTreeMap::new();
+        for (id, row) in self.entries {
+            let id = VariableID::from(id);
+            entries.insert(id, row.parse_as(&id, message, "entries")?);
+        }
+        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        SampledDecisionVariableTable::new(entries, labels)
+            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
     }
 }
 

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -654,7 +654,7 @@ impl From<DecisionVariableTable<Created>> for crate::v2::DecisionVariableTable {
     fn from(table: DecisionVariableTable<Created>) -> Self {
         Self {
             entries: table_entries_to_v2_map(table.entries),
-            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            labels: crate::v2_io::modeling_label_store_to_v2_map(&table.labels),
             fixed_values: table
                 .columns
                 .fixed_values
@@ -676,7 +676,7 @@ impl Parse for crate::v2::DecisionVariableTable {
             let id = VariableID::from(id);
             entries.insert(id, row.parse_as(&id, message, "entries")?);
         }
-        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         let fixed_values = self
             .fixed_values
             .into_iter()
@@ -691,7 +691,7 @@ impl From<EvaluatedDecisionVariableTable> for crate::v2::EvaluatedDecisionVariab
     fn from(table: EvaluatedDecisionVariableTable) -> Self {
         Self {
             entries: table_entries_to_v2_map(table.entries),
-            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            labels: crate::v2_io::modeling_label_store_to_v2_map(&table.labels),
         }
     }
 }
@@ -707,7 +707,7 @@ impl Parse for crate::v2::EvaluatedDecisionVariableTable {
             let id = VariableID::from(id);
             entries.insert(id, row.parse_as(&id, message, "entries")?);
         }
-        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         EvaluatedDecisionVariableTable::new(entries, labels)
             .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
     }
@@ -717,7 +717,7 @@ impl From<SampledDecisionVariableTable> for crate::v2::SampledDecisionVariableTa
     fn from(table: SampledDecisionVariableTable) -> Self {
         Self {
             entries: table_entries_to_v2_map(table.entries),
-            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            labels: crate::v2_io::modeling_label_store_to_v2_map(&table.labels),
         }
     }
 }
@@ -733,7 +733,7 @@ impl Parse for crate::v2::SampledDecisionVariableTable {
             let id = VariableID::from(id);
             entries.insert(id, row.parse_as(&id, message, "entries")?);
         }
-        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         SampledDecisionVariableTable::new(entries, labels)
             .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
     }

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -68,17 +68,25 @@ impl DecisionVariableTableStage for Created {
         columns: &Self::Columns,
         atol: Self::TableValidationContext,
     ) -> crate::Result<()> {
-        for (id, value) in &columns.fixed_values {
-            let Some(row) = entries.get(id) else {
-                crate::bail!(
-                    { ?id },
-                    "Fixed decision-variable value references unknown decision variable ID {id:?}",
-                );
-            };
-            row.check_value_consistency(*id, *value, atol)?;
-        }
-        Ok(())
+        validate_created_fixed_values(entries, &columns.fixed_values, atol)
     }
+}
+
+fn validate_created_fixed_values(
+    entries: &BTreeMap<VariableID, DecisionVariable>,
+    fixed_values: &BTreeMap<VariableID, f64>,
+    atol: ATol,
+) -> crate::Result<()> {
+    for (id, value) in fixed_values {
+        let Some(row) = entries.get(id) else {
+            crate::bail!(
+                { ?id },
+                "Fixed decision-variable value references unknown decision variable ID {id:?}",
+            );
+        };
+        row.check_value_consistency(*id, *value, atol)?;
+    }
+    Ok(())
 }
 
 impl DecisionVariableTableStage for Evaluated {
@@ -682,8 +690,17 @@ impl Parse for crate::v2::DecisionVariableTable {
             .into_iter()
             .map(|(id, value)| (VariableID::from(id), value))
             .collect();
-        DecisionVariableTable::with_fixed_values(entries, labels, fixed_values, ATol::default())
-            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
+        DecisionVariableTable::<Created>::validate_labels(&entries, &labels).map_err(|e| {
+            RawParseError::InvalidInstance(e.to_string()).context(message, "labels")
+        })?;
+        validate_created_fixed_values(&entries, &fixed_values, ATol::default()).map_err(|e| {
+            RawParseError::InvalidInstance(e.to_string()).context(message, "fixed_values")
+        })?;
+        Ok(DecisionVariableTable {
+            entries,
+            labels,
+            columns: CreatedDecisionVariableColumns { fixed_values },
+        })
     }
 }
 
@@ -709,7 +726,7 @@ impl Parse for crate::v2::EvaluatedDecisionVariableTable {
         }
         let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         EvaluatedDecisionVariableTable::new(entries, labels)
-            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
+            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
     }
 }
 
@@ -735,7 +752,7 @@ impl Parse for crate::v2::SampledDecisionVariableTable {
         }
         let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         SampledDecisionVariableTable::new(entries, labels)
-            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "entries"))
+            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
     }
 }
 
@@ -1029,5 +1046,95 @@ mod tests {
         assert_eq!(variable.id, 1);
         assert_eq!(variable.name.as_deref(), Some("x"));
         assert!(rows[0].samples.is_some());
+    }
+
+    #[test]
+    fn parse_v2_definition_table_orphan_label_reports_labels_field() {
+        let err = crate::v2::DecisionVariableTable {
+            entries: BTreeMap::new(),
+            labels: [(
+                1,
+                crate::v2::ModelingLabel {
+                    name: Some("orphan".to_string()),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            fixed_values: BTreeMap::new(),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("ommx.v2.DecisionVariableTable[labels]"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_definition_table_orphan_fixed_value_reports_fixed_values_field() {
+        let err = crate::v2::DecisionVariableTable {
+            entries: BTreeMap::new(),
+            labels: BTreeMap::new(),
+            fixed_values: [(1, 0.0)].into_iter().collect(),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("ommx.v2.DecisionVariableTable[fixed_values]"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_evaluated_table_orphan_label_reports_labels_field() {
+        let err = crate::v2::EvaluatedDecisionVariableTable {
+            entries: BTreeMap::new(),
+            labels: [(
+                1,
+                crate::v2::ModelingLabel {
+                    name: Some("orphan".to_string()),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("ommx.v2.EvaluatedDecisionVariableTable[labels]"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_sampled_table_orphan_label_reports_labels_field() {
+        let err = crate::v2::SampledDecisionVariableTable {
+            entries: BTreeMap::new(),
+            labels: [(
+                1,
+                crate::v2::ModelingLabel {
+                    name: Some("orphan".to_string()),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("ommx.v2.SampledDecisionVariableTable[labels]"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     constraint_type::{
         sample_ids_from_map, ConstraintType, EvaluatedConstraintBehavior, SampledConstraintBehavior,
     },
-    Function, SampleID, SampleIDSet, VariableID, VariableIDSet,
+    Function, Parse, ParseError, RawParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
 };
 use derive_more::{Deref, From};
 use std::collections::BTreeMap;
@@ -124,6 +124,10 @@ impl EvaluatedConstraintBehavior for EvaluatedIndicatorConstraint {
     fn is_feasible(&self) -> bool {
         self.stage.feasible
     }
+
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
+    }
 }
 
 impl SampledConstraintBehavior for SampledIndicatorConstraint {
@@ -213,6 +217,34 @@ impl From<IndicatorConstraint<Created>> for crate::v2::IndicatorConstraint {
     }
 }
 
+impl Parse for crate::v2::IndicatorConstraint {
+    type Output = IndicatorConstraint<Created>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.IndicatorConstraint";
+        let equality = crate::v1::Equality::try_from(self.equality)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Equality",
+                value: self.equality,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "equality"))?
+            .parse_as(&(), message, "equality")?;
+        let function = self
+            .function
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "function",
+            })?
+            .parse_as(&(), message, "function")?;
+        Ok(IndicatorConstraint {
+            indicator_variable: VariableID::from(self.indicator_variable),
+            equality,
+            stage: CreatedData { function },
+        })
+    }
+}
+
 impl From<EvaluatedIndicatorConstraint> for crate::v2::EvaluatedIndicatorConstraint {
     fn from(constraint: EvaluatedIndicatorConstraint) -> Self {
         Self {
@@ -228,6 +260,36 @@ impl From<EvaluatedIndicatorConstraint> for crate::v2::EvaluatedIndicatorConstra
                 .map(|id| id.into_inner())
                 .collect(),
         }
+    }
+}
+
+impl Parse for crate::v2::EvaluatedIndicatorConstraint {
+    type Output = EvaluatedIndicatorConstraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.EvaluatedIndicatorConstraint";
+        let equality = crate::v1::Equality::try_from(self.equality)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Equality",
+                value: self.equality,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "equality"))?
+            .parse_as(&(), message, "equality")?;
+        Ok(IndicatorConstraint {
+            indicator_variable: VariableID::from(self.indicator_variable),
+            equality,
+            stage: IndicatorEvaluatedData {
+                evaluated_value: self.evaluated_value,
+                feasible: self.feasible,
+                indicator_active: self.indicator_active,
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+            },
+        })
     }
 }
 
@@ -256,6 +318,43 @@ impl From<SampledIndicatorConstraint> for crate::v2::SampledIndicatorConstraint 
                 .map(|id| id.into_inner())
                 .collect(),
         }
+    }
+}
+
+impl Parse for crate::v2::SampledIndicatorConstraint {
+    type Output = SampledIndicatorConstraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampledIndicatorConstraint";
+        let equality = crate::v1::Equality::try_from(self.equality)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Equality",
+                value: self.equality,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "equality"))?
+            .parse_as(&(), message, "equality")?;
+        let evaluated_values = self
+            .evaluated_values
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "evaluated_values",
+            })?
+            .parse_as(&(), message, "evaluated_values")?;
+        Ok(IndicatorConstraint {
+            indicator_variable: VariableID::from(self.indicator_variable),
+            equality,
+            stage: IndicatorSampledData {
+                evaluated_values,
+                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
+                indicator_active: crate::v2_io::sample_bool_map_from_v2(self.indicator_active),
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+            },
+        })
     }
 }
 

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -5,7 +5,8 @@ use crate::{
     constraint_type::{
         sample_ids_from_map, ConstraintType, EvaluatedConstraintBehavior, SampledConstraintBehavior,
     },
-    Function, Parse, ParseError, RawParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
+    ATol, Function, Parse, ParseError, RawParseError, SampleID, SampleIDSet, VariableID,
+    VariableIDSet,
 };
 use derive_more::{Deref, From};
 use std::collections::BTreeMap;
@@ -263,11 +264,45 @@ impl From<EvaluatedIndicatorConstraint> for crate::v2::EvaluatedIndicatorConstra
     }
 }
 
+fn indicator_feasible_from_evaluated_value(
+    equality: Equality,
+    evaluated_value: f64,
+    indicator_active: bool,
+    atol: ATol,
+) -> bool {
+    if !indicator_active {
+        return true;
+    }
+    match equality {
+        Equality::EqualToZero => evaluated_value.abs() < *atol,
+        Equality::LessThanOrEqualToZero => evaluated_value < *atol,
+    }
+}
+
+fn validate_indicator_feasible_from_evaluated_value(
+    equality: Equality,
+    evaluated_value: f64,
+    indicator_active: bool,
+    provided_feasible: bool,
+    atol: ATol,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    let computed_feasible =
+        indicator_feasible_from_evaluated_value(equality, evaluated_value, indicator_active, atol);
+    if provided_feasible != computed_feasible {
+        return Err(RawParseError::InvalidInstance(format!(
+            "Inconsistent indicator constraint feasibility: provided={provided_feasible}, computed={computed_feasible}",
+        ))
+        .context(message, "feasible"));
+    }
+    Ok(())
+}
+
 impl Parse for crate::v2::EvaluatedIndicatorConstraint {
     type Output = EvaluatedIndicatorConstraint;
-    type Context = ();
+    type Context = ATol;
 
-    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+    fn parse(self, atol: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.EvaluatedIndicatorConstraint";
         let equality = crate::v1::Equality::try_from(self.equality)
             .map_err(|_| RawParseError::UnknownEnumValue {
@@ -276,6 +311,14 @@ impl Parse for crate::v2::EvaluatedIndicatorConstraint {
             })
             .map_err(|e| ParseError::from(e).context(message, "equality"))?
             .parse_as(&(), message, "equality")?;
+        validate_indicator_feasible_from_evaluated_value(
+            equality,
+            self.evaluated_value,
+            self.indicator_active,
+            self.feasible,
+            *atol,
+            message,
+        )?;
         Ok(IndicatorConstraint {
             indicator_variable: VariableID::from(self.indicator_variable),
             equality,
@@ -323,9 +366,9 @@ impl From<SampledIndicatorConstraint> for crate::v2::SampledIndicatorConstraint 
 
 impl Parse for crate::v2::SampledIndicatorConstraint {
     type Output = SampledIndicatorConstraint;
-    type Context = ();
+    type Context = ATol;
 
-    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+    fn parse(self, atol: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.SampledIndicatorConstraint";
         let equality = crate::v1::Equality::try_from(self.equality)
             .map_err(|_| RawParseError::UnknownEnumValue {
@@ -341,13 +384,30 @@ impl Parse for crate::v2::SampledIndicatorConstraint {
                 field: "evaluated_values",
             })?
             .parse_as(&(), message, "evaluated_values")?;
+        let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
+        let indicator_active = crate::v2_io::sample_bool_map_from_v2(self.indicator_active);
+        for (sample_id, evaluated_value) in evaluated_values.iter() {
+            if let (Some(provided_feasible), Some(indicator_active)) = (
+                feasible.get(sample_id).copied(),
+                indicator_active.get(sample_id).copied(),
+            ) {
+                validate_indicator_feasible_from_evaluated_value(
+                    equality,
+                    *evaluated_value,
+                    indicator_active,
+                    provided_feasible,
+                    *atol,
+                    message,
+                )?;
+            }
+        }
         Ok(IndicatorConstraint {
             indicator_variable: VariableID::from(self.indicator_variable),
             equality,
             stage: IndicatorSampledData {
                 evaluated_values,
-                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
-                indicator_active: crate::v2_io::sample_bool_map_from_v2(self.indicator_active),
+                feasible,
+                indicator_active,
                 used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
                     self.used_decision_variable_ids,
                     message,

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -311,6 +311,7 @@ impl Parse for crate::v2::EvaluatedIndicatorConstraint {
             })
             .map_err(|e| ParseError::from(e).context(message, "equality"))?
             .parse_as(&(), message, "equality")?;
+        crate::v2_io::validate_finite_f64(self.evaluated_value, message, "evaluated_value")?;
         validate_indicator_feasible_from_evaluated_value(
             equality,
             self.evaluated_value,
@@ -384,6 +385,7 @@ impl Parse for crate::v2::SampledIndicatorConstraint {
                 field: "evaluated_values",
             })?
             .parse_as(&(), message, "evaluated_values")?;
+        crate::v2_io::validate_sampled_f64_values(&evaluated_values, message, "evaluated_values")?;
         let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
         let indicator_active = crate::v2_io::sample_bool_map_from_v2(self.indicator_active);
         for (sample_id, evaluated_value) in evaluated_values.iter() {
@@ -468,5 +470,48 @@ mod tests {
         let ic =
             IndicatorConstraint::new(VariableID::from(10), Equality::EqualToZero, Function::Zero);
         let _: <IndicatorConstraint as ConstraintType>::Created = ic;
+    }
+
+    #[test]
+    fn parse_v2_evaluated_rejects_non_finite_value_even_when_inactive() {
+        let proto = crate::v2::EvaluatedIndicatorConstraint {
+            indicator_variable: 1,
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_value: f64::INFINITY,
+            feasible: true,
+            indicator_active: false,
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("evaluated_value must be finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_sampled_rejects_non_finite_values_even_when_inactive() {
+        let proto = crate::v2::SampledIndicatorConstraint {
+            indicator_variable: 1,
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_values: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![0],
+                    value: f64::INFINITY,
+                }],
+            }),
+            feasible: std::collections::BTreeMap::from([(0, true)]),
+            indicator_active: std::collections::BTreeMap::from([(0, false)]),
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("evaluated_values must be finite"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -350,6 +350,7 @@ impl Evaluate for Instance {
                 .decision_variables(decision_variables)
                 .variable_labels(self.variable_labels().clone())
                 .sense(sense)
+                .feasibility_atol(atol)
                 .build_unchecked()?
         };
 
@@ -414,6 +415,7 @@ impl Evaluate for Instance {
             .sos1_constraints_collection(sampled_sos1_constraints)
             .named_function_table(named_functions)
             .sense(self.sense)
+            .feasibility_atol(atol)
             .build()?)
     }
 

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -5,7 +5,7 @@ use crate::{
     constraint_type::ConstraintCollection,
     parse::{as_variable_id, Parse, ParseError, RawParseError},
     v1::{self},
-    Constraint, ConstraintID, VariableID,
+    v2, Constraint, ConstraintID, VariableID,
 };
 
 type ConvertedConstraintHints = (
@@ -108,6 +108,228 @@ fn validate_fixed_decision_variable_partition(
             "Variable {id:?} cannot be both fixed and dependent"
         ))
         .context(message, "decision_variables"));
+    }
+
+    Ok(())
+}
+
+fn parse_v2_required_sense(value: i32, message: &'static str) -> Result<Sense, ParseError> {
+    let sense = v1::instance::Sense::try_from(value)
+        .map_err(|_| RawParseError::UnknownEnumValue {
+            enum_name: "ommx.v1.Sense",
+            value,
+        })
+        .map_err(|e| ParseError::from(e).context(message, "sense"))?;
+    match sense {
+        v1::instance::Sense::Minimize => Ok(Sense::Minimize),
+        v1::instance::Sense::Maximize => Ok(Sense::Maximize),
+        v1::instance::Sense::Unspecified => Err(RawParseError::UnknownEnumValue {
+            enum_name: "ommx.v1.Sense",
+            value,
+        }
+        .context(message, "sense")),
+    }
+}
+
+fn parse_v2_decision_variable_dependency(
+    dependency: BTreeMap<u64, v1::Function>,
+    message: &'static str,
+) -> Result<AcyclicAssignments, ParseError> {
+    let dependency = dependency
+        .into_iter()
+        .map(|(id, function)| {
+            Ok((
+                VariableID::from(id),
+                function.parse_as(&(), message, "decision_variable_dependency")?,
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, ParseError>>()?;
+    AcyclicAssignments::new(dependency)
+        .map_err(|e| RawParseError::from(e).context(message, "decision_variable_dependency"))
+}
+
+fn created_collection_has_payload<T: crate::ConstraintType>(
+    collection: &ConstraintCollection<T>,
+) -> bool {
+    !collection.active().is_empty() || !collection.removed().is_empty()
+}
+
+fn validate_instance_special_features(
+    required_features: &std::collections::BTreeSet<v2::Feature>,
+    indicator_constraints: &ConstraintCollection<crate::IndicatorConstraint>,
+    one_hot_constraints: &ConstraintCollection<crate::OneHotConstraint>,
+    sos1_constraints: &ConstraintCollection<crate::Sos1Constraint>,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    crate::v2_io::validate_feature_payload(
+        required_features,
+        v2::Feature::ConstraintIndicator,
+        created_collection_has_payload(indicator_constraints),
+        message,
+        "indicator_constraints",
+    )?;
+    crate::v2_io::validate_feature_payload(
+        required_features,
+        v2::Feature::ConstraintOneHot,
+        created_collection_has_payload(one_hot_constraints),
+        message,
+        "one_hot_constraints",
+    )?;
+    crate::v2_io::validate_feature_payload(
+        required_features,
+        v2::Feature::ConstraintSos1,
+        created_collection_has_payload(sos1_constraints),
+        message,
+        "sos1_constraints",
+    )?;
+    Ok(())
+}
+
+fn validate_created_constraint_references<T: crate::ConstraintType>(
+    collection: &ConstraintCollection<T>,
+    valid_ids: &VariableIDSet,
+    message: &'static str,
+    field: &'static str,
+) -> Result<(), ParseError> {
+    for constraint in collection.active().values().chain(
+        collection
+            .removed()
+            .values()
+            .map(|(constraint, _)| constraint),
+    ) {
+        for id in constraint.required_ids() {
+            if !valid_ids.contains(&id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Undefined variable ID is used: {id:?}"
+                ))
+                .context(message, field));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn active_used_ids_from_created_collection<T: crate::ConstraintType>(
+    collection: &ConstraintCollection<T>,
+) -> VariableIDSet {
+    collection
+        .active()
+        .values()
+        .flat_map(|constraint| constraint.required_ids())
+        .collect()
+}
+
+fn validate_fixed_dependent_partition_from_sets(
+    used: &VariableIDSet,
+    fixed_values: &BTreeMap<VariableID, f64>,
+    decision_variable_dependency: &AcyclicAssignments,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    let fixed: VariableIDSet = fixed_values.keys().copied().collect();
+    let dependent: VariableIDSet = decision_variable_dependency.keys().collect();
+
+    if let Some(id) = used.intersection(&dependent).next() {
+        return Err(RawParseError::InvalidInstance(format!(
+            "Dependent variable cannot be used in objectives or constraints: {id:?}"
+        ))
+        .context(message, "decision_variables"));
+    }
+    if let Some(id) = used.intersection(&fixed).next() {
+        return Err(RawParseError::InvalidInstance(format!(
+            "Fixed variable {id:?} cannot be used in objectives or constraints"
+        ))
+        .context(message, "decision_variables"));
+    }
+    if let Some(id) = fixed.intersection(&dependent).next() {
+        return Err(RawParseError::InvalidInstance(format!(
+            "Variable {id:?} cannot be both fixed and dependent"
+        ))
+        .context(message, "decision_variables"));
+    }
+
+    Ok(())
+}
+
+fn validate_structural_special_constraints(
+    decision_variables: &DecisionVariableTable,
+    parameter_ids: Option<&VariableIDSet>,
+    indicator_constraints: &ConstraintCollection<crate::IndicatorConstraint>,
+    one_hot_constraints: &ConstraintCollection<crate::OneHotConstraint>,
+    sos1_constraints: &ConstraintCollection<crate::Sos1Constraint>,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    for indicator in indicator_constraints
+        .active()
+        .values()
+        .chain(indicator_constraints.removed().values().map(|(row, _)| row))
+    {
+        let id = indicator.indicator_variable;
+        let Some(variable) = decision_variables.get(&id) else {
+            let detail = if parameter_ids.is_some_and(|ids| ids.contains(&id)) {
+                format!(
+                    "Parameter id {id:?} cannot occupy the structural indicator-variable position; it must be a binary decision variable"
+                )
+            } else {
+                format!("Indicator variable {id:?} is not defined in decision_variables")
+            };
+            return Err(
+                RawParseError::InvalidInstance(detail).context(message, "indicator_constraints")
+            );
+        };
+        if variable.kind() != crate::decision_variable::Kind::Binary {
+            return Err(RawParseError::InvalidInstance(format!(
+                "Indicator variable {id:?} must be binary"
+            ))
+            .context(message, "indicator_constraints"));
+        }
+    }
+
+    for one_hot in one_hot_constraints
+        .active()
+        .values()
+        .chain(one_hot_constraints.removed().values().map(|(row, _)| row))
+    {
+        for id in &one_hot.variables {
+            let Some(variable) = decision_variables.get(id) else {
+                let detail = if parameter_ids.is_some_and(|ids| ids.contains(id)) {
+                    format!(
+                        "Parameter id {id:?} cannot occupy a structural one-hot variable position; it must be a binary decision variable"
+                    )
+                } else {
+                    format!("One-hot variable {id:?} is not defined in decision_variables")
+                };
+                return Err(
+                    RawParseError::InvalidInstance(detail).context(message, "one_hot_constraints")
+                );
+            };
+            if variable.kind() != crate::decision_variable::Kind::Binary {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "One-hot variable {id:?} must be binary"
+                ))
+                .context(message, "one_hot_constraints"));
+            }
+        }
+    }
+
+    for sos1 in sos1_constraints
+        .active()
+        .values()
+        .chain(sos1_constraints.removed().values().map(|(row, _)| row))
+    {
+        for id in &sos1.variables {
+            if !decision_variables.contains_key(id) {
+                let detail = if parameter_ids.is_some_and(|ids| ids.contains(id)) {
+                    format!(
+                        "Parameter id {id:?} cannot occupy a structural SOS1 variable position; it must be a decision variable"
+                    )
+                } else {
+                    format!("SOS1 variable {id:?} is not defined in decision_variables")
+                };
+                return Err(
+                    RawParseError::InvalidInstance(detail).context(message, "sos1_constraints")
+                );
+            }
+        }
     }
 
     Ok(())
@@ -341,6 +563,175 @@ impl Parse for v1::Instance {
 impl TryFrom<v1::Instance> for Instance {
     type Error = ParseError;
     fn try_from(value: v1::Instance) -> Result<Self, Self::Error> {
+        value.parse(&())
+    }
+}
+
+impl Parse for v2::Instance {
+    type Output = Instance;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.Instance";
+        let required_features =
+            crate::v2_io::parse_required_features(self.required_features, message)?;
+        let annotations =
+            crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
+        let sense = parse_v2_required_sense(self.sense, message)?;
+        let decision_variables = self
+            .decision_variables
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "decision_variables",
+            })?
+            .parse_as(&(), message, "decision_variables")?;
+        let decision_variable_ids: VariableIDSet = decision_variables.keys().copied().collect();
+        let objective = self
+            .objective
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "objective",
+            })?
+            .parse_as(&(), message, "objective")?;
+        for id in objective.required_ids() {
+            if !decision_variable_ids.contains(&id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Undefined variable ID is used: {id:?}"
+                ))
+                .context(message, "objective"));
+            }
+        }
+
+        let constraint_collection = self
+            .regular_constraints
+            .map(|value| value.parse_as(&(), message, "regular_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let indicator_constraint_collection = self
+            .indicator_constraints
+            .map(|value| value.parse_as(&(), message, "indicator_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let one_hot_constraint_collection = self
+            .one_hot_constraints
+            .map(|value| value.parse_as(&(), message, "one_hot_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let sos1_constraint_collection = self
+            .sos1_constraints
+            .map(|value| value.parse_as(&(), message, "sos1_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        validate_instance_special_features(
+            &required_features,
+            &indicator_constraint_collection,
+            &one_hot_constraint_collection,
+            &sos1_constraint_collection,
+            message,
+        )?;
+
+        validate_created_constraint_references(
+            &constraint_collection,
+            &decision_variable_ids,
+            message,
+            "regular_constraints",
+        )?;
+        validate_created_constraint_references(
+            &indicator_constraint_collection,
+            &decision_variable_ids,
+            message,
+            "indicator_constraints",
+        )?;
+        validate_created_constraint_references(
+            &one_hot_constraint_collection,
+            &decision_variable_ids,
+            message,
+            "one_hot_constraints",
+        )?;
+        validate_created_constraint_references(
+            &sos1_constraint_collection,
+            &decision_variable_ids,
+            message,
+            "sos1_constraints",
+        )?;
+
+        validate_structural_special_constraints(
+            &decision_variables,
+            None,
+            &indicator_constraint_collection,
+            &one_hot_constraint_collection,
+            &sos1_constraint_collection,
+            message,
+        )?;
+
+        let named_functions = self
+            .named_functions
+            .map(|value| value.parse_as(&(), message, "named_functions"))
+            .transpose()?
+            .unwrap_or_default();
+        for named_function in named_functions.values() {
+            for id in named_function.function.required_ids() {
+                if !decision_variable_ids.contains(&id) {
+                    return Err(RawParseError::InvalidInstance(format!(
+                        "Undefined variable ID is used: {id:?}"
+                    ))
+                    .context(message, "named_functions"));
+                }
+            }
+        }
+
+        let decision_variable_dependency =
+            parse_v2_decision_variable_dependency(self.decision_variable_dependency, message)?;
+        for id in decision_variable_dependency.keys() {
+            if !decision_variable_ids.contains(&id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Variable ID {id:?} in decision_variable_dependency is not in decision_variables"
+                ))
+                .context(message, "decision_variable_dependency"));
+            }
+        }
+
+        let mut used = objective.required_ids();
+        used.extend(active_used_ids_from_created_collection(
+            &constraint_collection,
+        ));
+        used.extend(active_used_ids_from_created_collection(
+            &indicator_constraint_collection,
+        ));
+        used.extend(active_used_ids_from_created_collection(
+            &one_hot_constraint_collection,
+        ));
+        used.extend(active_used_ids_from_created_collection(
+            &sos1_constraint_collection,
+        ));
+        validate_fixed_dependent_partition_from_sets(
+            &used,
+            decision_variables.fixed_values(),
+            &decision_variable_dependency,
+            message,
+        )?;
+
+        Ok(Instance {
+            sense,
+            objective,
+            decision_variables,
+            constraint_collection,
+            indicator_constraint_collection,
+            one_hot_constraint_collection,
+            sos1_constraint_collection,
+            decision_variable_dependency,
+            parameters: self.parameters,
+            description: self.description,
+            annotations,
+            named_functions,
+        })
+    }
+}
+
+impl TryFrom<v2::Instance> for Instance {
+    type Error = ParseError;
+
+    fn try_from(value: v2::Instance) -> Result<Self, Self::Error> {
         value.parse(&())
     }
 }
@@ -585,6 +976,201 @@ impl Parse for v1::ParametricInstance {
             description: self.description,
             annotations: self.annotations,
         })
+    }
+}
+
+impl Parse for v2::ParametricInstance {
+    type Output = ParametricInstance;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.ParametricInstance";
+        let required_features =
+            crate::v2_io::parse_required_features(self.required_features, message)?;
+        let annotations =
+            crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
+        let sense = parse_v2_required_sense(self.sense, message)?;
+        let decision_variables = self
+            .decision_variables
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "decision_variables",
+            })?
+            .parse_as(&(), message, "decision_variables")?;
+        let parameters = self
+            .parameters
+            .map(|value| value.parse_as(&(), message, "parameters"))
+            .transpose()?
+            .unwrap_or_default();
+
+        let decision_variable_ids: VariableIDSet = decision_variables.keys().copied().collect();
+        let parameter_ids: VariableIDSet = parameters.keys().copied().collect();
+        if let Some(id) = decision_variable_ids.intersection(&parameter_ids).next() {
+            return Err(RawParseError::InvalidInstance(format!(
+                "Duplicated variable ID is found in definition: {id:?}"
+            ))
+            .context(message, "parameters"));
+        }
+        let all_variable_ids: VariableIDSet = decision_variable_ids
+            .union(&parameter_ids)
+            .copied()
+            .collect();
+
+        let objective = self
+            .objective
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "objective",
+            })?
+            .parse_as(&(), message, "objective")?;
+        for id in objective.required_ids() {
+            if !all_variable_ids.contains(&id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Undefined variable ID is used: {id:?}"
+                ))
+                .context(message, "objective"));
+            }
+        }
+
+        let constraint_collection = self
+            .regular_constraints
+            .map(|value| value.parse_as(&(), message, "regular_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let indicator_constraint_collection = self
+            .indicator_constraints
+            .map(|value| value.parse_as(&(), message, "indicator_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let one_hot_constraint_collection = self
+            .one_hot_constraints
+            .map(|value| value.parse_as(&(), message, "one_hot_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let sos1_constraint_collection = self
+            .sos1_constraints
+            .map(|value| value.parse_as(&(), message, "sos1_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        validate_instance_special_features(
+            &required_features,
+            &indicator_constraint_collection,
+            &one_hot_constraint_collection,
+            &sos1_constraint_collection,
+            message,
+        )?;
+
+        validate_created_constraint_references(
+            &constraint_collection,
+            &all_variable_ids,
+            message,
+            "regular_constraints",
+        )?;
+        validate_created_constraint_references(
+            &indicator_constraint_collection,
+            &all_variable_ids,
+            message,
+            "indicator_constraints",
+        )?;
+        validate_created_constraint_references(
+            &one_hot_constraint_collection,
+            &all_variable_ids,
+            message,
+            "one_hot_constraints",
+        )?;
+        validate_created_constraint_references(
+            &sos1_constraint_collection,
+            &all_variable_ids,
+            message,
+            "sos1_constraints",
+        )?;
+
+        validate_structural_special_constraints(
+            &decision_variables,
+            Some(&parameter_ids),
+            &indicator_constraint_collection,
+            &one_hot_constraint_collection,
+            &sos1_constraint_collection,
+            message,
+        )?;
+
+        let named_functions = self
+            .named_functions
+            .map(|value| value.parse_as(&(), message, "named_functions"))
+            .transpose()?
+            .unwrap_or_default();
+        for named_function in named_functions.values() {
+            for id in named_function.function.required_ids() {
+                if !all_variable_ids.contains(&id) {
+                    return Err(RawParseError::InvalidInstance(format!(
+                        "Undefined variable ID is used: {id:?}"
+                    ))
+                    .context(message, "named_functions"));
+                }
+            }
+        }
+
+        let decision_variable_dependency =
+            parse_v2_decision_variable_dependency(self.decision_variable_dependency, message)?;
+        for id in decision_variable_dependency.keys() {
+            if !decision_variable_ids.contains(&id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Variable ID {id:?} in decision_variable_dependency is not in decision_variables"
+                ))
+                .context(message, "decision_variable_dependency"));
+            }
+        }
+        for id in decision_variable_dependency.required_ids() {
+            if !all_variable_ids.contains(&id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Undefined variable ID is used in decision_variable_dependency: {id:?}"
+                ))
+                .context(message, "decision_variable_dependency"));
+            }
+        }
+
+        let mut used = objective.required_ids();
+        used.extend(active_used_ids_from_created_collection(
+            &constraint_collection,
+        ));
+        used.extend(active_used_ids_from_created_collection(
+            &indicator_constraint_collection,
+        ));
+        used.extend(active_used_ids_from_created_collection(
+            &one_hot_constraint_collection,
+        ));
+        used.extend(active_used_ids_from_created_collection(
+            &sos1_constraint_collection,
+        ));
+        validate_fixed_dependent_partition_from_sets(
+            &used,
+            decision_variables.fixed_values(),
+            &decision_variable_dependency,
+            message,
+        )?;
+
+        Ok(ParametricInstance {
+            sense,
+            objective,
+            decision_variables,
+            parameters,
+            constraint_collection,
+            indicator_constraint_collection,
+            one_hot_constraint_collection,
+            sos1_constraint_collection,
+            named_functions,
+            decision_variable_dependency,
+            description: self.description,
+            annotations,
+        })
+    }
+}
+
+impl TryFrom<v2::ParametricInstance> for ParametricInstance {
+    type Error = ParseError;
+
+    fn try_from(value: v2::ParametricInstance) -> Result<Self, Self::Error> {
+        value.parse(&())
     }
 }
 

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -113,24 +113,6 @@ fn validate_fixed_decision_variable_partition(
     Ok(())
 }
 
-fn parse_v2_required_sense(value: i32, message: &'static str) -> Result<Sense, ParseError> {
-    let sense = v1::instance::Sense::try_from(value)
-        .map_err(|_| RawParseError::UnknownEnumValue {
-            enum_name: "ommx.v1.Sense",
-            value,
-        })
-        .map_err(|e| ParseError::from(e).context(message, "sense"))?;
-    match sense {
-        v1::instance::Sense::Minimize => Ok(Sense::Minimize),
-        v1::instance::Sense::Maximize => Ok(Sense::Maximize),
-        v1::instance::Sense::Unspecified => Err(RawParseError::UnknownEnumValue {
-            enum_name: "ommx.v1.Sense",
-            value,
-        }
-        .context(message, "sense")),
-    }
-}
-
 fn parse_v2_decision_variable_dependency(
     dependency: BTreeMap<u64, v1::Function>,
     message: &'static str,
@@ -577,7 +559,7 @@ impl Parse for v2::Instance {
             crate::v2_io::parse_required_features(self.required_features, message)?;
         let annotations =
             crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
-        let sense = parse_v2_required_sense(self.sense, message)?;
+        let sense = crate::v2_io::parse_v2_required_sense(self.sense, message)?;
         let decision_variables = self
             .decision_variables
             .ok_or(RawParseError::MissingField {
@@ -997,7 +979,7 @@ impl Parse for v2::ParametricInstance {
             crate::v2_io::parse_required_features(self.required_features, message)?;
         let annotations =
             crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
-        let sense = parse_v2_required_sense(self.sense, message)?;
+        let sense = crate::v2_io::parse_v2_required_sense(self.sense, message)?;
         let decision_variables = self
             .decision_variables
             .ok_or(RawParseError::MissingField {

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -690,6 +690,14 @@ impl Parse for v2::Instance {
                 .context(message, "decision_variable_dependency"));
             }
         }
+        for id in decision_variable_dependency.required_ids() {
+            if !decision_variable_ids.contains(&id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Undefined variable ID is used in decision_variable_dependency: {id:?}"
+                ))
+                .context(message, "decision_variable_dependency"));
+            }
+        }
 
         let mut used = objective.required_ids();
         used.extend(active_used_ids_from_created_collection(
@@ -1236,6 +1244,7 @@ impl From<ParametricInstance> for v1::ParametricInstance {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::coeff;
     use crate::instance::Instance;
     use proptest::prelude::*;
     use std::collections::HashMap;
@@ -1791,7 +1800,7 @@ mod tests {
 
     #[test]
     fn test_parametric_instance_parse_with_invalid_sense_uses_default() {
-        use crate::{coeff, linear, DecisionVariable, Function, Sense, VariableID};
+        use crate::{linear, DecisionVariable, Function, Sense, VariableID};
         use std::collections::HashMap;
 
         // Create a v1::ParametricInstance with invalid sense value
@@ -1826,7 +1835,7 @@ mod tests {
 
     #[test]
     fn test_instance_parse_with_invalid_sense_uses_default() {
-        use crate::{coeff, linear, DecisionVariable, Function, Sense, VariableID};
+        use crate::{linear, DecisionVariable, Function, Sense, VariableID};
         use std::collections::HashMap;
 
         // Create a v1::Instance with invalid sense value
@@ -2106,6 +2115,33 @@ mod tests {
         └─ommx.v1.Instance[format_version]
         Unsupported ommx format version: data has format_version=1, but this SDK supports up to 0. Please upgrade the OMMX SDK.
         "###);
+    }
+
+    #[test]
+    fn test_v2_instance_parse_rejects_undefined_dependency_rhs() {
+        use crate::{linear, DecisionVariable, Function, Sense, VariableID};
+
+        let instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(linear!(1)))
+            .decision_variables(maplit::btreemap! {
+                VariableID::from(1) => DecisionVariable::binary(),
+            })
+            .constraints(Default::default())
+            .build()
+            .unwrap();
+        let mut proto = crate::v2::Instance::from(instance);
+        proto
+            .decision_variable_dependency
+            .insert(1, Function::from(linear!(999)).into());
+
+        let err = Instance::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains(
+                "Undefined variable ID is used in decision_variable_dependency: VariableID(999)"
+            ),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -17,6 +17,11 @@ impl Instance {
         let inner = v1::Instance::decode(bytes)?;
         Ok(Parse::parse(inner, &())?)
     }
+
+    pub fn from_v2_bytes(bytes: &[u8]) -> Result<Self> {
+        let inner = v2::Instance::decode(bytes)?;
+        Ok(Parse::parse(inner, &())?)
+    }
 }
 
 impl ParametricInstance {
@@ -32,6 +37,11 @@ impl ParametricInstance {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let inner = v1::ParametricInstance::decode(bytes)?;
+        Ok(Parse::parse(inner, &())?)
+    }
+
+    pub fn from_v2_bytes(bytes: &[u8]) -> Result<Self> {
+        let inner = v2::ParametricInstance::decode(bytes)?;
         Ok(Parse::parse(inner, &())?)
     }
 }
@@ -231,6 +241,49 @@ mod tests {
     }
 
     #[test]
+    fn v2_instance_deserializes_special_constraint_collections() {
+        let instance = instance_with_special_constraints();
+        let restored = Instance::from_v2_bytes(&instance.to_v2_bytes()).unwrap();
+
+        assert_eq!(restored, instance);
+        assert_eq!(
+            restored
+                .indicator_constraint_context()
+                .name(IndicatorConstraintID::from(10)),
+            Some("indicator")
+        );
+        assert_eq!(
+            restored
+                .one_hot_constraint_context()
+                .name(OneHotConstraintID::from(20)),
+            Some("one_hot")
+        );
+        assert_eq!(
+            restored
+                .sos1_constraint_context()
+                .name(Sos1ConstraintID::from(30)),
+            Some("sos1")
+        );
+    }
+
+    #[test]
+    fn v2_instance_deserialization_rejects_missing_required_feature() {
+        let mut proto = v2::Instance::from(instance_with_special_constraints());
+        proto.required_features = vec![
+            v2::Feature::ConstraintOneHot as i32,
+            v2::Feature::ConstraintSos1 as i32,
+        ];
+
+        let err = Instance::try_from(proto).unwrap_err();
+
+        assert!(
+            err.to_string().contains("required_features")
+                && err.to_string().contains("ConstraintIndicator"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
     fn v2_solution_serializes_evaluated_special_constraint_collections() {
         let instance = instance_with_special_constraints();
         let solution = instance
@@ -263,6 +316,68 @@ mod tests {
     }
 
     #[test]
+    fn v2_solution_deserializes_evaluated_special_constraint_collections() {
+        let instance = instance_with_special_constraints();
+        let solution = instance
+            .evaluate(
+                &v1::State {
+                    entries: HashMap::from([(1, 1.0), (2, 0.0)]),
+                },
+                ATol::default(),
+            )
+            .unwrap();
+
+        let restored = crate::Solution::from_v2_bytes(&solution.to_v2_bytes()).unwrap();
+
+        assert_eq!(restored, solution);
+        assert_eq!(
+            restored
+                .evaluated_indicator_constraints()
+                .context()
+                .name(IndicatorConstraintID::from(10)),
+            Some("indicator")
+        );
+        assert!(restored
+            .evaluated_one_hot_constraints()
+            .contains_key(&OneHotConstraintID::from(20)));
+        assert!(restored
+            .evaluated_sos1_constraints()
+            .contains_key(&Sos1ConstraintID::from(30)));
+    }
+
+    #[test]
+    fn v2_solution_deserialization_rejects_unknown_structural_special_variable() {
+        let instance = instance_with_special_constraints();
+        let solution = instance
+            .evaluate(
+                &v1::State {
+                    entries: HashMap::from([(1, 1.0), (2, 0.0)]),
+                },
+                ATol::default(),
+            )
+            .unwrap();
+        let mut proto = v2::Solution::from(solution);
+        let one_hot = proto
+            .evaluated_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&20)
+            .unwrap();
+        one_hot.variables = vec![999];
+        one_hot.active_variable = None;
+        one_hot.used_decision_variable_ids.clear();
+
+        let err = crate::Solution::try_from(proto).unwrap_err();
+
+        assert!(
+            err.to_string().contains("One-hot variable")
+                && err.to_string().contains("decision_variables"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
     fn v2_sample_set_serializes_sampled_special_constraint_collections() {
         let instance = instance_with_special_constraints();
         let samples = Sampled::from(v1::State {
@@ -290,6 +405,54 @@ mod tests {
             .unwrap()
             .entries
             .contains_key(&30));
+    }
+
+    #[test]
+    fn v2_sample_set_deserializes_sampled_special_constraint_collections() {
+        let instance = instance_with_special_constraints();
+        let samples = Sampled::from(v1::State {
+            entries: HashMap::from([(1, 1.0), (2, 0.0)]),
+        });
+        let sample_set = instance
+            .evaluate_samples(&samples, ATol::default())
+            .unwrap();
+
+        let restored = crate::SampleSet::from_v2_bytes(&sample_set.to_v2_bytes()).unwrap();
+
+        assert_eq!(restored.feasible(), sample_set.feasible());
+        assert_eq!(restored.feasible_relaxed(), sample_set.feasible_relaxed());
+        assert_eq!(restored.indicator_constraints().len(), 1);
+        assert_eq!(restored.one_hot_constraints().len(), 1);
+        assert_eq!(restored.sos1_constraints().len(), 1);
+        assert_eq!(
+            restored
+                .indicator_constraints()
+                .context()
+                .name(IndicatorConstraintID::from(10)),
+            Some("indicator")
+        );
+    }
+
+    #[test]
+    fn v2_sample_set_deserialization_rejects_missing_feasible_sample_id() {
+        let instance = instance_with_special_constraints();
+        let samples = Sampled::from(v1::State {
+            entries: HashMap::from([(1, 1.0), (2, 0.0)]),
+        });
+        let sample_set = instance
+            .evaluate_samples(&samples, ATol::default())
+            .unwrap();
+        let mut proto = v2::SampleSet::from(sample_set);
+        let sample_id = *proto.feasible.keys().next().unwrap();
+        proto.feasible.remove(&sample_id);
+
+        let err = crate::SampleSet::try_from(proto).unwrap_err();
+
+        assert!(
+            err.to_string().contains("feasible")
+                && err.to_string().contains("Inconsistent sample IDs"),
+            "unexpected error: {err}",
+        );
     }
 
     #[test]
@@ -345,5 +508,32 @@ mod tests {
                 .and_then(|label| label.name.as_deref()),
             Some("p")
         );
+    }
+
+    #[test]
+    fn v2_parametric_instance_deserializes_parameter_table() {
+        let decision_variable_id = VariableID::from(1);
+        let parameter_id = VariableID::from(100);
+        let mut parameter_labels = ParameterLabelStore::default();
+        parameter_labels.set_name(parameter_id, "p");
+
+        let instance = ParametricInstance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::from([(
+                decision_variable_id,
+                DecisionVariable::binary(),
+            )]))
+            .parameters(
+                ParameterTable::new(BTreeSet::from([parameter_id]), parameter_labels).unwrap(),
+            )
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap();
+
+        let restored = ParametricInstance::from_v2_bytes(&instance.to_v2_bytes()).unwrap();
+
+        assert_eq!(restored, instance);
+        assert_eq!(restored.parameters().labels().name(parameter_id), Some("p"));
     }
 }

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -365,7 +365,7 @@ mod tests {
             .get_mut(&20)
             .unwrap();
         one_hot.variables = vec![999];
-        one_hot.active_variable = None;
+        one_hot.active_variable = Some(999);
         one_hot.used_decision_variable_ids.clear();
 
         let err = crate::Solution::try_from(proto).unwrap_err();

--- a/rust/ommx/src/modeling_label.rs
+++ b/rust/ommx/src/modeling_label.rs
@@ -1,7 +1,7 @@
 use crate::constraint_type::IDType;
 use crate::logical_memory::LogicalMemoryProfile;
 use fnv::FnvHashMap;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
 fn empty_parameters() -> &'static FnvHashMap<String, String> {
@@ -217,29 +217,6 @@ impl From<crate::v2::ModelingLabel> for ModelingLabel {
             description: label.description,
         }
     }
-}
-
-pub(crate) fn modeling_label_store_to_v2_map<ID: IDType>(
-    store: &ModelingLabelStore<ID>,
-) -> BTreeMap<u64, crate::v2::ModelingLabel> {
-    store
-        .ids()
-        .into_iter()
-        .map(|id| (id.into(), store.collect_for(id).into()))
-        .collect()
-}
-
-// Shared by decision-variable, parameter, and named-function table v2
-// converters. The table owner validates orphan IDs after reconstructing the
-// store from the protobuf map.
-pub(crate) fn modeling_label_store_from_v2_map<ID: IDType>(
-    labels: BTreeMap<u64, crate::v2::ModelingLabel>,
-) -> ModelingLabelStore<ID> {
-    let mut store = ModelingLabelStore::default();
-    for (id, label) in labels {
-        store.insert(ID::from(id), label.into());
-    }
-    store
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/modeling_label.rs
+++ b/rust/ommx/src/modeling_label.rs
@@ -229,6 +229,9 @@ pub(crate) fn modeling_label_store_to_v2_map<ID: IDType>(
         .collect()
 }
 
+// Shared by decision-variable, parameter, and named-function table v2
+// converters. The table owner validates orphan IDs after reconstructing the
+// store from the protobuf map.
 pub(crate) fn modeling_label_store_from_v2_map<ID: IDType>(
     labels: BTreeMap<u64, crate::v2::ModelingLabel>,
 ) -> ModelingLabelStore<ID> {

--- a/rust/ommx/src/modeling_label.rs
+++ b/rust/ommx/src/modeling_label.rs
@@ -208,6 +208,17 @@ impl From<ModelingLabel> for crate::v2::ModelingLabel {
     }
 }
 
+impl From<crate::v2::ModelingLabel> for ModelingLabel {
+    fn from(label: crate::v2::ModelingLabel) -> Self {
+        Self {
+            name: label.name,
+            subscripts: label.subscripts,
+            parameters: label.parameters.into_iter().collect(),
+            description: label.description,
+        }
+    }
+}
+
 pub(crate) fn modeling_label_store_to_v2_map<ID: IDType>(
     store: &ModelingLabelStore<ID>,
 ) -> BTreeMap<u64, crate::v2::ModelingLabel> {
@@ -216,6 +227,16 @@ pub(crate) fn modeling_label_store_to_v2_map<ID: IDType>(
         .into_iter()
         .map(|id| (id.into(), store.collect_for(id).into()))
         .collect()
+}
+
+pub(crate) fn modeling_label_store_from_v2_map<ID: IDType>(
+    labels: BTreeMap<u64, crate::v2::ModelingLabel>,
+) -> ModelingLabelStore<ID> {
+    let mut store = ModelingLabelStore::default();
+    for (id, label) in labels {
+        store.insert(ID::from(id), label.into());
+    }
+    store
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -9,7 +9,7 @@ use getset::*;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::logical_memory::LogicalMemoryProfile;
-use crate::{Function, SampleID, Sampled, VariableIDSet};
+use crate::{Function, Parse, ParseError, RawParseError, SampleID, Sampled, VariableIDSet};
 pub use arbitrary::*;
 pub use label_store::NamedFunctionLabelStore;
 
@@ -419,6 +419,24 @@ impl From<NamedFunction> for crate::v2::NamedFunction {
     }
 }
 
+impl Parse for crate::v2::NamedFunction {
+    type Output = NamedFunction;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.NamedFunction";
+        Ok(NamedFunction {
+            function: self
+                .function
+                .ok_or(RawParseError::MissingField {
+                    message,
+                    field: "function",
+                })?
+                .parse_as(&(), message, "function")?,
+        })
+    }
+}
+
 impl From<EvaluatedNamedFunction> for crate::v2::EvaluatedNamedFunction {
     fn from(value: EvaluatedNamedFunction) -> Self {
         Self {
@@ -429,6 +447,23 @@ impl From<EvaluatedNamedFunction> for crate::v2::EvaluatedNamedFunction {
                 .map(|id| id.into_inner())
                 .collect(),
         }
+    }
+}
+
+impl Parse for crate::v2::EvaluatedNamedFunction {
+    type Output = EvaluatedNamedFunction;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.EvaluatedNamedFunction";
+        Ok(EvaluatedNamedFunction {
+            evaluated_value: self.evaluated_value,
+            used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                self.used_decision_variable_ids,
+                message,
+                "used_decision_variable_ids",
+            )?,
+        })
     }
 }
 
@@ -445,12 +480,44 @@ impl From<SampledNamedFunction> for crate::v2::SampledNamedFunction {
     }
 }
 
+impl Parse for crate::v2::SampledNamedFunction {
+    type Output = SampledNamedFunction;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampledNamedFunction";
+        Ok(SampledNamedFunction {
+            evaluated_values: self
+                .evaluated_values
+                .ok_or(RawParseError::MissingField {
+                    message,
+                    field: "evaluated_values",
+                })?
+                .parse_as(&(), message, "evaluated_values")?,
+            used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                self.used_decision_variable_ids,
+                message,
+                "used_decision_variable_ids",
+            )?,
+        })
+    }
+}
+
 impl From<NamedFunctionTable<NamedFunction>> for crate::v2::NamedFunctionTable {
     fn from(table: NamedFunctionTable<NamedFunction>) -> Self {
         Self {
             entries: named_function_entries_to_v2_map(table.entries),
             labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
         }
+    }
+}
+
+impl Parse for crate::v2::NamedFunctionTable {
+    type Output = NamedFunctionTable<NamedFunction>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        parse_v2_named_function_table(self.entries, self.labels, "ommx.v2.NamedFunctionTable")
     }
 }
 
@@ -463,12 +530,38 @@ impl From<NamedFunctionTable<EvaluatedNamedFunction>> for crate::v2::EvaluatedNa
     }
 }
 
+impl Parse for crate::v2::EvaluatedNamedFunctionTable {
+    type Output = NamedFunctionTable<EvaluatedNamedFunction>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        parse_v2_named_function_table(
+            self.entries,
+            self.labels,
+            "ommx.v2.EvaluatedNamedFunctionTable",
+        )
+    }
+}
+
 impl From<NamedFunctionTable<SampledNamedFunction>> for crate::v2::SampledNamedFunctionTable {
     fn from(table: NamedFunctionTable<SampledNamedFunction>) -> Self {
         Self {
             entries: named_function_entries_to_v2_map(table.entries),
             labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
         }
+    }
+}
+
+impl Parse for crate::v2::SampledNamedFunctionTable {
+    type Output = NamedFunctionTable<SampledNamedFunction>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        parse_v2_named_function_table(
+            self.entries,
+            self.labels,
+            "ommx.v2.SampledNamedFunctionTable",
+        )
     }
 }
 
@@ -482,6 +575,28 @@ where
         .into_iter()
         .map(|(id, row)| (id.into_inner(), row.into()))
         .collect()
+}
+
+fn parse_v2_named_function_table<T, V2>(
+    entries: BTreeMap<u64, V2>,
+    labels: BTreeMap<u64, crate::v2::ModelingLabel>,
+    message: &'static str,
+) -> Result<NamedFunctionTable<T>, ParseError>
+where
+    V2: Parse<Output = T, Context = ()>,
+{
+    let entries = entries
+        .into_iter()
+        .map(|(id, row)| {
+            Ok((
+                NamedFunctionID::from(id),
+                row.parse_as(&(), message, "entries")?,
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, ParseError>>()?;
+    let labels = crate::modeling_label::modeling_label_store_from_v2_map(labels);
+    NamedFunctionTable::new(entries, labels)
+        .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
 }
 
 #[cfg(test)]

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -456,6 +456,7 @@ impl Parse for crate::v2::EvaluatedNamedFunction {
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.EvaluatedNamedFunction";
+        crate::v2_io::validate_finite_f64(self.evaluated_value, message, "evaluated_value")?;
         Ok(EvaluatedNamedFunction {
             evaluated_value: self.evaluated_value,
             used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
@@ -486,14 +487,16 @@ impl Parse for crate::v2::SampledNamedFunction {
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.SampledNamedFunction";
+        let evaluated_values = self
+            .evaluated_values
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "evaluated_values",
+            })?
+            .parse_as(&(), message, "evaluated_values")?;
+        crate::v2_io::validate_sampled_f64_values(&evaluated_values, message, "evaluated_values")?;
         Ok(SampledNamedFunction {
-            evaluated_values: self
-                .evaluated_values
-                .ok_or(RawParseError::MissingField {
-                    message,
-                    field: "evaluated_values",
-                })?
-                .parse_as(&(), message, "evaluated_values")?,
+            evaluated_values,
             used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
                 self.used_decision_variable_ids,
                 message,
@@ -659,5 +662,40 @@ mod table_tests {
         assert!(err.to_string().contains("Duplicate named function ID"));
         assert_eq!(table.get(&id), Some(&row));
         assert_eq!(table.labels().name(id), Some("cost"));
+    }
+
+    #[test]
+    fn parse_v2_evaluated_rejects_non_finite_value() {
+        let proto = crate::v2::EvaluatedNamedFunction {
+            evaluated_value: f64::INFINITY,
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("evaluated_value must be finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_sampled_rejects_non_finite_values() {
+        let proto = crate::v2::SampledNamedFunction {
+            evaluated_values: Some(crate::v1::SampledValues {
+                entries: vec![crate::v1::sampled_values::SampledValuesEntry {
+                    ids: vec![0],
+                    value: f64::INFINITY,
+                }],
+            }),
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&()).unwrap_err();
+
+        assert!(
+            err.to_string().contains("evaluated_values must be finite"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -507,7 +507,7 @@ impl From<NamedFunctionTable<NamedFunction>> for crate::v2::NamedFunctionTable {
     fn from(table: NamedFunctionTable<NamedFunction>) -> Self {
         Self {
             entries: named_function_entries_to_v2_map(table.entries),
-            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            labels: crate::v2_io::modeling_label_store_to_v2_map(&table.labels),
         }
     }
 }
@@ -525,7 +525,7 @@ impl From<NamedFunctionTable<EvaluatedNamedFunction>> for crate::v2::EvaluatedNa
     fn from(table: NamedFunctionTable<EvaluatedNamedFunction>) -> Self {
         Self {
             entries: named_function_entries_to_v2_map(table.entries),
-            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            labels: crate::v2_io::modeling_label_store_to_v2_map(&table.labels),
         }
     }
 }
@@ -547,7 +547,7 @@ impl From<NamedFunctionTable<SampledNamedFunction>> for crate::v2::SampledNamedF
     fn from(table: NamedFunctionTable<SampledNamedFunction>) -> Self {
         Self {
             entries: named_function_entries_to_v2_map(table.entries),
-            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            labels: crate::v2_io::modeling_label_store_to_v2_map(&table.labels),
         }
     }
 }
@@ -594,7 +594,7 @@ where
             ))
         })
         .collect::<Result<BTreeMap<_, _>, ParseError>>()?;
-    let labels = crate::modeling_label::modeling_label_store_from_v2_map(labels);
+    let labels = crate::v2_io::modeling_label_store_from_v2_map(labels);
     NamedFunctionTable::new(entries, labels)
         .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
 }

--- a/rust/ommx/src/ommx.v2.rs
+++ b/rust/ommx/src/ommx.v2.rs
@@ -700,6 +700,10 @@ pub struct SampleSet {
     pub sampled_one_hot_constraints: ::core::option::Option<SampledOneHotConstraintCollection>,
     #[prost(message, optional, tag = "13")]
     pub sampled_sos1_constraints: ::core::option::Option<SampledSos1ConstraintCollection>,
+    /// Absolute tolerance used to compute and validate `feasible`,
+    /// `feasible_relaxed`, and per-constraint feasibility columns.
+    #[prost(double, optional, tag = "14")]
+    pub feasibility_atol: ::core::option::Option<f64>,
 }
 /// Validated single-state solver output serialization root.
 #[non_exhaustive]
@@ -740,4 +744,8 @@ pub struct Solution {
     pub evaluated_one_hot_constraints: ::core::option::Option<EvaluatedOneHotConstraintCollection>,
     #[prost(message, optional, tag = "15")]
     pub evaluated_sos1_constraints: ::core::option::Option<EvaluatedSos1ConstraintCollection>,
+    /// Absolute tolerance used to compute and validate `feasible`,
+    /// `feasible_relaxed`, and per-constraint feasibility columns.
+    #[prost(double, optional, tag = "16")]
+    pub feasibility_atol: ::core::option::Option<f64>,
 }

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     constraint_type::{
         sample_ids_from_map, ConstraintType, EvaluatedConstraintBehavior, SampledConstraintBehavior,
     },
-    Parse, ParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
+    ATol, Parse, ParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
 };
 use derive_more::{Deref, From};
 use std::collections::{BTreeMap, BTreeSet};
@@ -245,7 +245,7 @@ impl From<EvaluatedOneHotConstraint> for crate::v2::EvaluatedOneHotConstraint {
 
 impl Parse for crate::v2::EvaluatedOneHotConstraint {
     type Output = EvaluatedOneHotConstraint;
-    type Context = ();
+    type Context = ATol;
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.EvaluatedOneHotConstraint";
@@ -261,6 +261,12 @@ impl Parse for crate::v2::EvaluatedOneHotConstraint {
         if active_variable.is_some_and(|id| !variables.contains(&id)) {
             return Err(crate::RawParseError::InvalidInstance(
                 "One-hot active_variable must be a member of variables".to_string(),
+            )
+            .context(message, "active_variable"));
+        }
+        if self.feasible != active_variable.is_some() {
+            return Err(crate::RawParseError::InvalidInstance(
+                "One-hot feasible must be true exactly when active_variable is set".to_string(),
             )
             .context(message, "active_variable"));
         }
@@ -318,7 +324,7 @@ impl From<SampledOneHotConstraint> for crate::v2::SampledOneHotConstraint {
 
 impl Parse for crate::v2::SampledOneHotConstraint {
     type Output = SampledOneHotConstraint;
-    type Context = ();
+    type Context = ATol;
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.SampledOneHotConstraint";
@@ -342,10 +348,22 @@ impl Parse for crate::v2::SampledOneHotConstraint {
             )
             .context(message, "active_variable"));
         }
+        let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
+        for (sample_id, feasible) in &feasible {
+            if let Some(active_variable) = active_variable.get(sample_id) {
+                if *feasible != active_variable.is_some() {
+                    return Err(crate::RawParseError::InvalidInstance(
+                        "One-hot feasible must be true exactly when active_variable is set"
+                            .to_string(),
+                    )
+                    .context(message, "active_variable"));
+                }
+            }
+        }
         Ok(OneHotConstraint {
             variables,
             stage: OneHotSampledData {
-                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
+                feasible,
                 active_variable,
                 used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
                     self.used_decision_variable_ids,

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     constraint_type::{
         sample_ids_from_map, ConstraintType, EvaluatedConstraintBehavior, SampledConstraintBehavior,
     },
-    SampleID, SampleIDSet, VariableID, VariableIDSet,
+    Parse, ParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
 };
 use derive_more::{Deref, From};
 use std::collections::{BTreeMap, BTreeSet};
@@ -121,6 +121,10 @@ impl EvaluatedConstraintBehavior for EvaluatedOneHotConstraint {
     fn is_feasible(&self) -> bool {
         self.stage.feasible
     }
+
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
+    }
 }
 
 impl SampledConstraintBehavior for SampledOneHotConstraint {
@@ -202,6 +206,23 @@ impl From<OneHotConstraint<Created>> for crate::v2::OneHotConstraint {
     }
 }
 
+impl Parse for crate::v2::OneHotConstraint {
+    type Output = OneHotConstraint<Created>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.OneHotConstraint";
+        OneHotConstraint::new(crate::v2_io::variable_id_set_from_v2(
+            self.variables,
+            message,
+            "variables",
+        )?)
+        .map_err(|e| {
+            crate::RawParseError::InvalidInstance(e.to_string()).context(message, "variables")
+        })
+    }
+}
+
 impl From<EvaluatedOneHotConstraint> for crate::v2::EvaluatedOneHotConstraint {
     fn from(constraint: EvaluatedOneHotConstraint) -> Self {
         Self {
@@ -219,6 +240,42 @@ impl From<EvaluatedOneHotConstraint> for crate::v2::EvaluatedOneHotConstraint {
                 .map(|id| id.into_inner())
                 .collect(),
         }
+    }
+}
+
+impl Parse for crate::v2::EvaluatedOneHotConstraint {
+    type Output = EvaluatedOneHotConstraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.EvaluatedOneHotConstraint";
+        let variables =
+            crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
+        if variables.is_empty() {
+            return Err(crate::RawParseError::InvalidInstance(
+                "One-hot constraints must contain at least one variable".to_string(),
+            )
+            .context(message, "variables"));
+        }
+        let active_variable = self.active_variable.map(VariableID::from);
+        if active_variable.is_some_and(|id| !variables.contains(&id)) {
+            return Err(crate::RawParseError::InvalidInstance(
+                "One-hot active_variable must be a member of variables".to_string(),
+            )
+            .context(message, "active_variable"));
+        }
+        Ok(OneHotConstraint {
+            variables,
+            stage: OneHotEvaluatedData {
+                feasible: self.feasible,
+                active_variable,
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+            },
+        })
     }
 }
 
@@ -256,6 +313,47 @@ impl From<SampledOneHotConstraint> for crate::v2::SampledOneHotConstraint {
                 .map(|id| id.into_inner())
                 .collect(),
         }
+    }
+}
+
+impl Parse for crate::v2::SampledOneHotConstraint {
+    type Output = SampledOneHotConstraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampledOneHotConstraint";
+        let variables =
+            crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
+        if variables.is_empty() {
+            return Err(crate::RawParseError::InvalidInstance(
+                "One-hot constraints must contain at least one variable".to_string(),
+            )
+            .context(message, "variables"));
+        }
+        let active_variable =
+            crate::v2_io::sampled_active_variable_map_from_v2(self.active_variable);
+        if active_variable
+            .values()
+            .flatten()
+            .any(|id| !variables.contains(id))
+        {
+            return Err(crate::RawParseError::InvalidInstance(
+                "One-hot active_variable values must be members of variables".to_string(),
+            )
+            .context(message, "active_variable"));
+        }
+        Ok(OneHotConstraint {
+            variables,
+            stage: OneHotSampledData {
+                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
+                active_variable,
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+            },
+        })
     }
 }
 

--- a/rust/ommx/src/parameter.rs
+++ b/rust/ommx/src/parameter.rs
@@ -197,7 +197,16 @@ impl Parse for crate::v2::ParameterTable {
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.ParameterTable";
-        let ids = self.ids.into_iter().map(VariableID::from).collect();
+        let mut ids = BTreeSet::new();
+        for id in self.ids {
+            let id = VariableID::from(id);
+            if !ids.insert(id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Duplicated parameter ID is found in ommx.v2.ParameterTable: {id:?}",
+                ))
+                .context(message, "ids"));
+            }
+        }
         let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         ParameterTable::new(ids, labels)
             .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "ids"))
@@ -297,6 +306,22 @@ mod tests {
                 ..Default::default()
             },
         ])
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Duplicated parameter ID")
+                && err.to_string().contains("VariableID(100)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_v2_parameter_ids() {
+        let err = crate::v2::ParameterTable {
+            ids: vec![100, 100],
+            labels: Default::default(),
+        }
+        .parse(&())
         .unwrap_err();
 
         assert!(

--- a/rust/ommx/src/parameter.rs
+++ b/rust/ommx/src/parameter.rs
@@ -209,7 +209,7 @@ impl Parse for crate::v2::ParameterTable {
         }
         let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         ParameterTable::new(ids, labels)
-            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "ids"))
+            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
     }
 }
 
@@ -327,6 +327,29 @@ mod tests {
         assert!(
             err.to_string().contains("Duplicated parameter ID")
                 && err.to_string().contains("VariableID(100)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_orphan_label_reports_labels_field() {
+        let err = crate::v2::ParameterTable {
+            ids: vec![],
+            labels: [(
+                100,
+                crate::v2::ModelingLabel {
+                    name: Some("orphan".to_string()),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("ommx.v2.ParameterTable[labels]"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/parameter.rs
+++ b/rust/ommx/src/parameter.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeSet, HashMap};
 
 use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
-use crate::{ModelingLabel, ModelingLabelStore, VariableID};
+use crate::{ModelingLabel, ModelingLabelStore, Parse, ParseError, RawParseError, VariableID};
 
 /// Modeling label for parametric-instance parameters.
 pub type ParameterLabel = ModelingLabel;
@@ -188,6 +188,19 @@ impl From<ParameterTable> for crate::v2::ParameterTable {
             ids: table.ids.into_iter().map(|id| id.into_inner()).collect(),
             labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
         }
+    }
+}
+
+impl Parse for crate::v2::ParameterTable {
+    type Output = ParameterTable;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.ParameterTable";
+        let ids = self.ids.into_iter().map(VariableID::from).collect();
+        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        ParameterTable::new(ids, labels)
+            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "ids"))
     }
 }
 

--- a/rust/ommx/src/parameter.rs
+++ b/rust/ommx/src/parameter.rs
@@ -186,7 +186,7 @@ impl From<ParameterTable> for crate::v2::ParameterTable {
     fn from(table: ParameterTable) -> Self {
         Self {
             ids: table.ids.into_iter().map(|id| id.into_inner()).collect(),
-            labels: crate::modeling_label::modeling_label_store_to_v2_map(&table.labels),
+            labels: crate::v2_io::modeling_label_store_to_v2_map(&table.labels),
         }
     }
 }
@@ -198,7 +198,7 @@ impl Parse for crate::v2::ParameterTable {
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.ParameterTable";
         let ids = self.ids.into_iter().map(VariableID::from).collect();
-        let labels = crate::modeling_label::modeling_label_store_from_v2_map(self.labels);
+        let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         ParameterTable::new(ids, labels)
             .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "ids"))
     }

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -7,7 +7,7 @@ use crate::{
         ConstraintType, EvaluatedCollection, SampledCollection, SampledConstraintBehavior,
     },
     indicator_constraint::IndicatorConstraint,
-    Constraint, ConstraintID, EvaluatedConstraint, EvaluatedDecisionVariable,
+    ATol, Constraint, ConstraintID, EvaluatedConstraint, EvaluatedDecisionVariable,
     EvaluatedNamedFunction, NamedFunctionID, NamedFunctionTable, SampleID, SampleIDSet, Sampled,
     SampledConstraint, SampledDecisionVariable, SampledNamedFunction, Sense, Solution, VariableID,
 };
@@ -125,6 +125,9 @@ pub enum SampleSetError {
 ///   sampled constraint collections:
 ///   - `feasible`: true if all constraints are satisfied for that sample.
 ///   - `feasible_relaxed`: true if all non-removed constraints are satisfied.
+/// - [`Self::feasibility_atol`] is the absolute tolerance used to validate
+///   serialized per-constraint feasibility columns and to interpret per-sample
+///   [`Solution`] values extracted from this sample set.
 #[derive(Debug, Clone, Getters)]
 pub struct SampleSet {
     /// Sampled decision-variable rows plus their modeling labels.
@@ -147,6 +150,9 @@ pub struct SampleSet {
     feasible: BTreeMap<SampleID, bool>,
     #[getset(get = "pub")]
     feasible_relaxed: BTreeMap<SampleID, bool>,
+    /// Absolute tolerance used to compute and validate feasibility fields.
+    #[getset(get_copy = "pub")]
+    feasibility_atol: ATol,
     /// OMMX-defined provenance metadata.
     pub metadata: Option<crate::v1::ProcessMetadata>,
     /// User-defined or third-party extension annotations.
@@ -361,6 +367,7 @@ impl SampleSet {
                 .variable_labels(self.variable_labels().clone())
                 .named_function_labels(self.named_functions.labels().clone())
                 .sense(sense)
+                .feasibility_atol(self.feasibility_atol)
                 .build_unchecked()
                 .expect("SampleSet invariants guarantee Solution invariants")
         })
@@ -447,6 +454,7 @@ pub struct SampleSetBuilder {
     named_functions: BTreeMap<NamedFunctionID, SampledNamedFunction>,
     named_function_labels: crate::named_function::NamedFunctionLabelStore,
     sense: Option<Sense>,
+    feasibility_atol: ATol,
 }
 
 impl SampleSetBuilder {
@@ -592,6 +600,12 @@ impl SampleSetBuilder {
     /// Sets the optimization sense.
     pub fn sense(mut self, sense: Sense) -> Self {
         self.sense = Some(sense);
+        self
+    }
+
+    /// Sets the absolute tolerance used to compute and validate feasibility fields.
+    pub fn feasibility_atol(mut self, feasibility_atol: ATol) -> Self {
+        self.feasibility_atol = feasibility_atol;
         self
     }
 
@@ -751,6 +765,7 @@ impl SampleSetBuilder {
             sense,
             feasible,
             feasible_relaxed,
+            feasibility_atol: self.feasibility_atol,
             metadata: Default::default(),
             annotations: Default::default(),
         })
@@ -828,6 +843,7 @@ impl SampleSetBuilder {
             sense,
             feasible,
             feasible_relaxed,
+            feasibility_atol: self.feasibility_atol,
             metadata: Default::default(),
             annotations: Default::default(),
         })

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -32,6 +32,15 @@ pub enum SampleSetError {
         computed_feasible_relaxed: bool,
     },
 
+    #[error("Inconsistent feasibility for {constraint_family} constraint {constraint_id} at sample {sample_id:?}: provided={provided_feasible}, computed={computed_feasible}")]
+    InconsistentConstraintFeasibility {
+        constraint_family: &'static str,
+        constraint_id: String,
+        sample_id: SampleID,
+        provided_feasible: bool,
+        computed_feasible: bool,
+    },
+
     #[error("Inconsistent sample IDs: expected {expected:?}, found {found:?}")]
     InconsistentSampleIDs {
         expected: SampleIDSet,
@@ -457,6 +466,126 @@ pub struct SampleSetBuilder {
     feasibility_atol: ATol,
 }
 
+fn expected_sampled_regular_constraint_feasible(
+    equality: crate::Equality,
+    evaluated_value: f64,
+    atol: ATol,
+) -> bool {
+    match equality {
+        crate::Equality::EqualToZero => evaluated_value.abs() < *atol,
+        crate::Equality::LessThanOrEqualToZero => evaluated_value < *atol,
+    }
+}
+
+fn expected_sampled_indicator_constraint_feasible(
+    equality: crate::Equality,
+    evaluated_value: f64,
+    indicator_active: bool,
+    atol: ATol,
+) -> bool {
+    if !indicator_active {
+        return true;
+    }
+    expected_sampled_regular_constraint_feasible(equality, evaluated_value, atol)
+}
+
+fn validate_sampled_constraint_feasibility(
+    regular_constraints: &SampledCollection<Constraint>,
+    indicator_constraints: &SampledCollection<IndicatorConstraint>,
+    one_hot_constraints: &SampledCollection<crate::OneHotConstraint>,
+    sos1_constraints: &SampledCollection<crate::Sos1Constraint>,
+    atol: ATol,
+) -> Result<(), SampleSetError> {
+    for (id, constraint) in regular_constraints.inner() {
+        for (sample_id, provided_feasible) in &constraint.stage.feasible {
+            let Some(evaluated_value) = constraint.stage.evaluated_values.get(*sample_id) else {
+                continue;
+            };
+            let computed_feasible = expected_sampled_regular_constraint_feasible(
+                constraint.equality,
+                *evaluated_value,
+                atol,
+            );
+            if *provided_feasible != computed_feasible {
+                return Err(SampleSetError::InconsistentConstraintFeasibility {
+                    constraint_family: "regular",
+                    constraint_id: format!("{id:?}"),
+                    sample_id: *sample_id,
+                    provided_feasible: *provided_feasible,
+                    computed_feasible,
+                });
+            }
+        }
+    }
+
+    for (id, constraint) in indicator_constraints.inner() {
+        for (sample_id, provided_feasible) in &constraint.stage.feasible {
+            let (Some(evaluated_value), Some(indicator_active)) = (
+                constraint.stage.evaluated_values.get(*sample_id),
+                constraint.stage.indicator_active.get(sample_id),
+            ) else {
+                continue;
+            };
+            let computed_feasible = expected_sampled_indicator_constraint_feasible(
+                constraint.equality,
+                *evaluated_value,
+                *indicator_active,
+                atol,
+            );
+            if *provided_feasible != computed_feasible {
+                return Err(SampleSetError::InconsistentConstraintFeasibility {
+                    constraint_family: "indicator",
+                    constraint_id: format!("{id:?}"),
+                    sample_id: *sample_id,
+                    provided_feasible: *provided_feasible,
+                    computed_feasible,
+                });
+            }
+        }
+    }
+
+    for (id, constraint) in one_hot_constraints.inner() {
+        for (sample_id, provided_feasible) in &constraint.stage.feasible {
+            let computed_feasible = constraint
+                .stage
+                .active_variable
+                .get(sample_id)
+                .is_some_and(Option::is_some);
+            if *provided_feasible != computed_feasible {
+                return Err(SampleSetError::InconsistentConstraintFeasibility {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    sample_id: *sample_id,
+                    provided_feasible: *provided_feasible,
+                    computed_feasible,
+                });
+            }
+        }
+    }
+
+    for (id, constraint) in sos1_constraints.inner() {
+        for (sample_id, active_variable) in &constraint.stage.active_variable {
+            if active_variable.is_some()
+                && constraint
+                    .stage
+                    .feasible
+                    .get(sample_id)
+                    .is_some_and(|feasible| !feasible)
+            {
+                return Err(SampleSetError::InconsistentConstraintFeasibility {
+                    constraint_family: "SOS1",
+                    constraint_id: format!("{id:?}"),
+                    sample_id: *sample_id,
+                    provided_feasible: false,
+                    computed_feasible: true,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 impl SampleSetBuilder {
     /// Creates a new `SampleSetBuilder` with all fields unset.
     pub fn new() -> Self {
@@ -707,6 +836,13 @@ impl SampleSetBuilder {
                 expected: objective_sample_ids.clone(),
                 found,
             })?;
+        validate_sampled_constraint_feasibility(
+            &constraints,
+            &self.indicator_constraints,
+            &self.one_hot_constraints,
+            &self.sos1_constraints,
+            self.feasibility_atol,
+        )?;
 
         validate_sampled_constraint_used_ids("regular", &constraints, &decision_variable_ids)?;
         validate_sampled_constraint_used_ids(
@@ -949,6 +1085,35 @@ mod tests {
         assert!(
             err.to_string().contains("unknown decision variable ID")
                 && err.to_string().contains("VariableID(99)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn builder_rejects_inconsistent_regular_constraint_feasibility() {
+        let sample_id = SampleID::from(0);
+        let constraint = SampledConstraint {
+            equality: crate::Equality::EqualToZero,
+            stage: crate::constraint::SampledData {
+                evaluated_values: crate::Sampled::from((sample_id, 1.0)),
+                feasible: BTreeMap::from([(sample_id, true)]),
+                used_decision_variable_ids: BTreeSet::new(),
+                dual_variables: None,
+            },
+        };
+
+        let err = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(crate::Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::from([(ConstraintID::from(1), constraint)]))
+            .sense(Sense::Minimize)
+            .feasibility_atol(ATol::new(0.1).unwrap())
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Inconsistent feasibility for regular constraint"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -41,6 +41,13 @@ pub enum SampleSetError {
         computed_feasible: bool,
     },
 
+    #[error("Invalid structure for {constraint_family} constraint {constraint_id}: {message}")]
+    InvalidConstraintStructure {
+        constraint_family: &'static str,
+        constraint_id: String,
+        message: String,
+    },
+
     #[error("Inconsistent sample IDs: expected {expected:?}, found {found:?}")]
     InconsistentSampleIDs {
         expected: SampleIDSet,
@@ -130,6 +137,10 @@ pub enum SampleSetError {
 /// - [`Self::decision_variables`] contains all variable IDs referenced in
 ///   `used_decision_variable_ids` of each sampled constraint and sampled named
 ///   function.
+/// - Sampled special-constraint structural variables are defined in
+///   [`Self::decision_variables`]. Indicator variables and one-hot variables
+///   must be binary; one-hot and SOS1 variable sets must be non-empty, and
+///   `active_variable` values must belong to their structural variable set.
 /// - [`Self::feasible`] and [`Self::feasible_relaxed`] are computed from all
 ///   sampled constraint collections:
 ///   - `feasible`: true if all constraints are satisfied for that sample.
@@ -586,6 +597,96 @@ fn validate_sampled_constraint_feasibility(
     Ok(())
 }
 
+fn validate_sampled_special_constraint_structure(
+    decision_variables: &crate::SampledDecisionVariableTable,
+    indicator_constraints: &SampledCollection<IndicatorConstraint>,
+    one_hot_constraints: &SampledCollection<crate::OneHotConstraint>,
+    sos1_constraints: &SampledCollection<crate::Sos1Constraint>,
+) -> Result<(), SampleSetError> {
+    for (id, constraint) in indicator_constraints.inner() {
+        let variable_id = constraint.indicator_variable;
+        let Some(variable) = decision_variables.get(&variable_id) else {
+            return Err(SampleSetError::InvalidConstraintStructure {
+                constraint_family: "indicator",
+                constraint_id: format!("{id:?}"),
+                message: format!("indicator variable {variable_id:?} is not in decision_variables"),
+            });
+        };
+        if *variable.kind() != crate::decision_variable::Kind::Binary {
+            return Err(SampleSetError::InvalidConstraintStructure {
+                constraint_family: "indicator",
+                constraint_id: format!("{id:?}"),
+                message: format!("indicator variable {variable_id:?} must be binary"),
+            });
+        }
+    }
+
+    for (id, constraint) in one_hot_constraints.inner() {
+        if constraint.variables.is_empty() {
+            return Err(SampleSetError::InvalidConstraintStructure {
+                constraint_family: "one-hot",
+                constraint_id: format!("{id:?}"),
+                message: "one-hot constraints must contain at least one variable".to_string(),
+            });
+        }
+        for variable_id in &constraint.variables {
+            let Some(variable) = decision_variables.get(variable_id) else {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    message: format!("variable {variable_id:?} is not in decision_variables"),
+                });
+            };
+            if *variable.kind() != crate::decision_variable::Kind::Binary {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    message: format!("variable {variable_id:?} must be binary"),
+                });
+            }
+        }
+        for active_variable in constraint.stage.active_variable.values().flatten() {
+            if !constraint.variables.contains(active_variable) {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    message: "active_variable must be a member of variables".to_string(),
+                });
+            }
+        }
+    }
+
+    for (id, constraint) in sos1_constraints.inner() {
+        if constraint.variables.is_empty() {
+            return Err(SampleSetError::InvalidConstraintStructure {
+                constraint_family: "SOS1",
+                constraint_id: format!("{id:?}"),
+                message: "SOS1 constraints must contain at least one variable".to_string(),
+            });
+        }
+        for variable_id in &constraint.variables {
+            if !decision_variables.contains_key(variable_id) {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "SOS1",
+                    constraint_id: format!("{id:?}"),
+                    message: format!("variable {variable_id:?} is not in decision_variables"),
+                });
+            }
+        }
+        for active_variable in constraint.stage.active_variable.values().flatten() {
+            if !constraint.variables.contains(active_variable) {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "SOS1",
+                    constraint_id: format!("{id:?}"),
+                    message: "active_variable must be a member of variables".to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 impl SampleSetBuilder {
     /// Creates a new `SampleSetBuilder` with all fields unset.
     pub fn new() -> Self {
@@ -842,6 +943,12 @@ impl SampleSetBuilder {
             &self.one_hot_constraints,
             &self.sos1_constraints,
             self.feasibility_atol,
+        )?;
+        validate_sampled_special_constraint_structure(
+            &decision_variables,
+            &self.indicator_constraints,
+            &self.one_hot_constraints,
+            &self.sos1_constraints,
         )?;
 
         validate_sampled_constraint_used_ids("regular", &constraints, &decision_variable_ids)?;
@@ -1114,6 +1221,41 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("Inconsistent feasibility for regular constraint"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn builder_rejects_unknown_one_hot_structural_variable() {
+        let sample_id = SampleID::from(0);
+        let variable_id = VariableID::from(1);
+        let one_hot = crate::one_hot_constraint::SampledOneHotConstraint {
+            variables: BTreeSet::from([variable_id]),
+            stage: crate::one_hot_constraint::OneHotSampledData {
+                feasible: BTreeMap::from([(sample_id, false)]),
+                active_variable: BTreeMap::from([(sample_id, None)]),
+                used_decision_variable_ids: BTreeSet::new(),
+            },
+        };
+
+        let err = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(crate::Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::new())
+            .one_hot_constraints_collection(
+                SampledCollection::new(
+                    BTreeMap::from([(crate::OneHotConstraintID::from(1), one_hot)]),
+                    BTreeMap::new(),
+                )
+                .unwrap(),
+            )
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Invalid structure for one-hot constraint"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -141,6 +141,10 @@ pub enum SampleSetError {
 ///   [`Self::decision_variables`]. Indicator variables and one-hot variables
 ///   must be binary; one-hot and SOS1 variable sets must be non-empty, and
 ///   `active_variable` values must belong to their structural variable set.
+/// - Sampled special-constraint stage fields are consistent with
+///   [`Self::decision_variables`]: `indicator_active` reflects the indicator
+///   variable values, and one-hot/SOS1 `active_variable` plus `feasible`
+///   reflect the structural variable values under `feasibility_atol`.
 /// - [`Self::feasible`] and [`Self::feasible_relaxed`] are computed from all
 ///   sampled constraint collections:
 ///   - `feasible`: true if all constraints are satisfied for that sample.
@@ -687,6 +691,236 @@ fn validate_sampled_special_constraint_structure(
     Ok(())
 }
 
+fn expected_binary_activity(
+    variable_id: VariableID,
+    value: f64,
+    atol: ATol,
+    role: &'static str,
+) -> Result<bool, String> {
+    if (value - 1.0).abs() < *atol {
+        Ok(true)
+    } else if value.abs() < *atol {
+        Ok(false)
+    } else {
+        Err(format!(
+            "{role} variable {variable_id:?} has value {value}, but must be 0 or 1",
+        ))
+    }
+}
+
+fn expected_sampled_one_hot_active_variable(
+    variables: &BTreeSet<VariableID>,
+    decision_variables: &crate::SampledDecisionVariableTable,
+    sample_id: SampleID,
+    atol: ATol,
+) -> (bool, Option<VariableID>) {
+    let mut active = None;
+    for variable_id in variables {
+        let value = *decision_variables
+            .get(variable_id)
+            .expect("one-hot structural variables must be validated first")
+            .samples()
+            .get(sample_id)
+            .expect("sample IDs must be validated first");
+        if (value - 1.0).abs() < *atol {
+            if active.is_some() {
+                return (false, None);
+            }
+            active = Some(*variable_id);
+        } else if value.abs() >= *atol {
+            return (false, None);
+        }
+    }
+    match active {
+        Some(variable_id) => (true, Some(variable_id)),
+        None => (false, None),
+    }
+}
+
+fn expected_sampled_sos1_active_variable(
+    variables: &BTreeSet<VariableID>,
+    decision_variables: &crate::SampledDecisionVariableTable,
+    sample_id: SampleID,
+    atol: ATol,
+) -> (bool, Option<VariableID>) {
+    let mut active = None;
+    for variable_id in variables {
+        let value = *decision_variables
+            .get(variable_id)
+            .expect("SOS1 structural variables must be validated first")
+            .samples()
+            .get(sample_id)
+            .expect("sample IDs must be validated first");
+        if value.abs() >= *atol {
+            if active.is_some() {
+                return (false, None);
+            }
+            active = Some(*variable_id);
+        }
+    }
+    (true, active)
+}
+
+fn validate_sampled_indicator_stage_values(
+    decision_variables: &crate::SampledDecisionVariableTable,
+    indicator_constraints: &SampledCollection<IndicatorConstraint>,
+    atol: ATol,
+) -> Result<(), SampleSetError> {
+    for (id, constraint) in indicator_constraints.inner() {
+        let variable = decision_variables
+            .get(&constraint.indicator_variable)
+            .expect("indicator structural variables must be validated first");
+        for (sample_id, provided_indicator_active) in &constraint.stage.indicator_active {
+            let value = *variable
+                .samples()
+                .get(*sample_id)
+                .expect("sample IDs must be validated first");
+            let computed_indicator_active =
+                expected_binary_activity(constraint.indicator_variable, value, atol, "indicator")
+                    .map_err(|message| SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "indicator",
+                    constraint_id: format!("{id:?}"),
+                    message: format!("{message} at sample {sample_id:?}"),
+                })?;
+            if *provided_indicator_active != computed_indicator_active {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "indicator",
+                    constraint_id: format!("{id:?}"),
+                    message: format!(
+                        "indicator_active={} at sample {sample_id:?} does not match indicator variable {:?} value {value}",
+                        provided_indicator_active,
+                        constraint.indicator_variable,
+                    ),
+                });
+            }
+            let evaluated_value = *constraint
+                .stage
+                .evaluated_values
+                .get(*sample_id)
+                .expect("sample IDs must be validated first");
+            let computed_feasible = expected_sampled_indicator_constraint_feasible(
+                constraint.equality,
+                evaluated_value,
+                computed_indicator_active,
+                atol,
+            );
+            let provided_feasible = *constraint
+                .stage
+                .feasible
+                .get(sample_id)
+                .expect("sample IDs must be validated first");
+            if provided_feasible != computed_feasible {
+                return Err(SampleSetError::InconsistentConstraintFeasibility {
+                    constraint_family: "indicator",
+                    constraint_id: format!("{id:?}"),
+                    sample_id: *sample_id,
+                    provided_feasible,
+                    computed_feasible,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_sampled_one_hot_stage_values(
+    decision_variables: &crate::SampledDecisionVariableTable,
+    one_hot_constraints: &SampledCollection<crate::OneHotConstraint>,
+    atol: ATol,
+) -> Result<(), SampleSetError> {
+    for (id, constraint) in one_hot_constraints.inner() {
+        for (sample_id, provided_feasible) in &constraint.stage.feasible {
+            let (computed_feasible, computed_active_variable) =
+                expected_sampled_one_hot_active_variable(
+                    &constraint.variables,
+                    decision_variables,
+                    *sample_id,
+                    atol,
+                );
+            let provided_active_variable = constraint
+                .stage
+                .active_variable
+                .get(sample_id)
+                .copied()
+                .flatten();
+            if provided_active_variable != computed_active_variable {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    message: format!(
+                        "active_variable={provided_active_variable:?} at sample {sample_id:?} does not match decision-variable values; computed={computed_active_variable:?}",
+                    ),
+                });
+            }
+            if *provided_feasible != computed_feasible {
+                return Err(SampleSetError::InconsistentConstraintFeasibility {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    sample_id: *sample_id,
+                    provided_feasible: *provided_feasible,
+                    computed_feasible,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_sampled_sos1_stage_values(
+    decision_variables: &crate::SampledDecisionVariableTable,
+    sos1_constraints: &SampledCollection<crate::Sos1Constraint>,
+    atol: ATol,
+) -> Result<(), SampleSetError> {
+    for (id, constraint) in sos1_constraints.inner() {
+        for (sample_id, provided_feasible) in &constraint.stage.feasible {
+            let (computed_feasible, computed_active_variable) =
+                expected_sampled_sos1_active_variable(
+                    &constraint.variables,
+                    decision_variables,
+                    *sample_id,
+                    atol,
+                );
+            let provided_active_variable = constraint
+                .stage
+                .active_variable
+                .get(sample_id)
+                .copied()
+                .flatten();
+            if provided_active_variable != computed_active_variable {
+                return Err(SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "SOS1",
+                    constraint_id: format!("{id:?}"),
+                    message: format!(
+                        "active_variable={provided_active_variable:?} at sample {sample_id:?} does not match decision-variable values; computed={computed_active_variable:?}",
+                    ),
+                });
+            }
+            if *provided_feasible != computed_feasible {
+                return Err(SampleSetError::InconsistentConstraintFeasibility {
+                    constraint_family: "SOS1",
+                    constraint_id: format!("{id:?}"),
+                    sample_id: *sample_id,
+                    provided_feasible: *provided_feasible,
+                    computed_feasible,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_sampled_special_constraint_stage_values(
+    decision_variables: &crate::SampledDecisionVariableTable,
+    indicator_constraints: &SampledCollection<IndicatorConstraint>,
+    one_hot_constraints: &SampledCollection<crate::OneHotConstraint>,
+    sos1_constraints: &SampledCollection<crate::Sos1Constraint>,
+    atol: ATol,
+) -> Result<(), SampleSetError> {
+    validate_sampled_indicator_stage_values(decision_variables, indicator_constraints, atol)?;
+    validate_sampled_one_hot_stage_values(decision_variables, one_hot_constraints, atol)?;
+    validate_sampled_sos1_stage_values(decision_variables, sos1_constraints, atol)
+}
+
 impl SampleSetBuilder {
     /// Creates a new `SampleSetBuilder` with all fields unset.
     pub fn new() -> Self {
@@ -950,6 +1184,13 @@ impl SampleSetBuilder {
             &self.one_hot_constraints,
             &self.sos1_constraints,
         )?;
+        validate_sampled_special_constraint_stage_values(
+            &decision_variables,
+            &self.indicator_constraints,
+            &self.one_hot_constraints,
+            &self.sos1_constraints,
+            self.feasibility_atol,
+        )?;
 
         validate_sampled_constraint_used_ids("regular", &constraints, &decision_variable_ids)?;
         validate_sampled_constraint_used_ids(
@@ -1025,6 +1266,9 @@ impl SampleSetBuilder {
     /// - All `used_decision_variable_ids` in sampled constraints and sampled
     ///   named functions exist in `decision_variables`
     /// - Sample IDs are consistent across all components
+    /// - Special-constraint `indicator_active`, `active_variable`, and
+    ///   per-constraint `feasible` fields are consistent with
+    ///   `decision_variables` under `feasibility_atol`
     ///
     /// Use [`Self::build`] for validated construction.
     /// This method is useful when invariants are guaranteed by construction,

--- a/rust/ommx/src/sample_set.rs
+++ b/rust/ommx/src/sample_set.rs
@@ -125,7 +125,7 @@ pub enum SampleSetError {
 ///   sampled constraint collections:
 ///   - `feasible`: true if all constraints are satisfied for that sample.
 ///   - `feasible_relaxed`: true if all non-removed constraints are satisfied.
-/// - [`Self::feasibility_atol`] is the absolute tolerance used to validate
+/// - `feasibility_atol` is the absolute tolerance used to validate
 ///   serialized per-constraint feasibility columns and to interpret per-sample
 ///   [`Solution`] values extracted from this sample set.
 #[derive(Debug, Clone, Getters)]

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -1,6 +1,110 @@
 use super::*;
-use crate::{Parse, ParseError};
-use std::collections::BTreeMap;
+use crate::{v2, Parse, ParseError, RawParseError};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn sampled_collection_has_payload<T: crate::ConstraintType>(
+    collection: &crate::constraint_type::SampledCollection<T>,
+) -> bool {
+    !collection.is_empty()
+}
+
+fn validate_sampled_indicator_structural_ids(
+    constraints: &crate::constraint_type::SampledCollection<crate::IndicatorConstraint>,
+    decision_variables: &crate::SampledDecisionVariableTable,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        let id = constraint.indicator_variable;
+        let Some(variable) = decision_variables.get(&id) else {
+            return Err(RawParseError::InvalidInstance(format!(
+                "Indicator variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
+            ))
+            .context(message, "sampled_indicator_constraints"));
+        };
+        if *variable.kind() != crate::decision_variable::Kind::Binary {
+            return Err(RawParseError::InvalidInstance(format!(
+                "Indicator variable {id:?} in constraint {constraint_id:?} must be binary",
+            ))
+            .context(message, "sampled_indicator_constraints"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_sampled_one_hot_structural_ids(
+    constraints: &crate::constraint_type::SampledCollection<crate::OneHotConstraint>,
+    decision_variables: &crate::SampledDecisionVariableTable,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        for id in &constraint.variables {
+            let Some(variable) = decision_variables.get(id) else {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "One-hot variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
+                ))
+                .context(message, "sampled_one_hot_constraints"));
+            };
+            if *variable.kind() != crate::decision_variable::Kind::Binary {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "One-hot variable {id:?} in constraint {constraint_id:?} must be binary",
+                ))
+                .context(message, "sampled_one_hot_constraints"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_sampled_sos1_structural_ids(
+    constraints: &crate::constraint_type::SampledCollection<crate::Sos1Constraint>,
+    decision_variables: &crate::SampledDecisionVariableTable,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        for id in &constraint.variables {
+            if !decision_variables.contains_key(id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "SOS1 variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
+                ))
+                .context(message, "sampled_sos1_constraints"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn first_feasibility_mismatch(
+    provided: &BTreeMap<SampleID, bool>,
+    computed: &BTreeMap<SampleID, bool>,
+) -> Option<(SampleID, bool, bool)> {
+    computed.iter().find_map(|(id, computed)| {
+        let provided = provided
+            .get(id)
+            .copied()
+            .expect("feasibility maps must be validated to have identical sample IDs");
+        let computed = *computed;
+        (provided != computed).then_some((*id, provided, computed))
+    })
+}
+
+fn validate_sample_bool_map_ids(
+    map: &BTreeMap<SampleID, bool>,
+    expected: &SampleIDSet,
+    message: &'static str,
+    field: &'static str,
+) -> Result<(), ParseError> {
+    let found = map.keys().copied().collect::<SampleIDSet>();
+    if &found != expected {
+        return Err(
+            RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                expected: expected.clone(),
+                found,
+            })
+            .context(message, field),
+        );
+    }
+    Ok(())
+}
 
 impl Parse for crate::v1::SampleSet {
     type Output = SampleSet;
@@ -147,6 +251,264 @@ impl Parse for crate::v1::SampleSet {
         }
 
         Ok(sample_set)
+    }
+}
+
+impl Parse for v2::SampleSet {
+    type Output = SampleSet;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampleSet";
+        let required_features =
+            crate::v2_io::parse_required_features(self.required_features, message)?;
+        let annotations =
+            crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
+        let decision_variables = self
+            .decision_variables
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "decision_variables",
+            })?
+            .parse_as(&(), message, "decision_variables")?;
+        let objectives = self
+            .objectives
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "objectives",
+            })?
+            .parse_as(&(), message, "objectives")?;
+        let constraints = self
+            .sampled_regular_constraints
+            .map(|value| value.parse_as(&(), message, "sampled_regular_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let indicator_constraints = self
+            .sampled_indicator_constraints
+            .map(|value| value.parse_as(&(), message, "sampled_indicator_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let one_hot_constraints = self
+            .sampled_one_hot_constraints
+            .map(|value| value.parse_as(&(), message, "sampled_one_hot_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let sos1_constraints = self
+            .sampled_sos1_constraints
+            .map(|value| value.parse_as(&(), message, "sampled_sos1_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+
+        crate::v2_io::validate_feature_payload(
+            &required_features,
+            v2::Feature::ConstraintIndicator,
+            sampled_collection_has_payload(&indicator_constraints),
+            message,
+            "sampled_indicator_constraints",
+        )?;
+        crate::v2_io::validate_feature_payload(
+            &required_features,
+            v2::Feature::ConstraintOneHot,
+            sampled_collection_has_payload(&one_hot_constraints),
+            message,
+            "sampled_one_hot_constraints",
+        )?;
+        crate::v2_io::validate_feature_payload(
+            &required_features,
+            v2::Feature::ConstraintSos1,
+            sampled_collection_has_payload(&sos1_constraints),
+            message,
+            "sampled_sos1_constraints",
+        )?;
+
+        let named_functions = self
+            .sampled_named_functions
+            .map(|value| value.parse_as(&(), message, "sampled_named_functions"))
+            .transpose()?
+            .unwrap_or_default();
+        let sense = self.sense.try_into().map_err(|_| {
+            RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Sense",
+                value: self.sense,
+            }
+            .context(message, "sense")
+        })?;
+
+        let objective_sample_ids = objectives.ids();
+        for sampled_dv in decision_variables.values() {
+            if !sampled_dv.samples().has_same_ids(&objective_sample_ids) {
+                return Err(RawParseError::SampleSetError(
+                    crate::SampleSetError::InconsistentSampleIDs {
+                        expected: objective_sample_ids.clone(),
+                        found: sampled_dv.samples().ids(),
+                    },
+                )
+                .context(message, "decision_variables"));
+            }
+        }
+        constraints
+            .validate_sample_ids(&objective_sample_ids)
+            .map_err(|found| {
+                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                    expected: objective_sample_ids.clone(),
+                    found,
+                })
+                .context(message, "sampled_regular_constraints")
+            })?;
+        indicator_constraints
+            .validate_sample_ids(&objective_sample_ids)
+            .map_err(|found| {
+                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                    expected: objective_sample_ids.clone(),
+                    found,
+                })
+                .context(message, "sampled_indicator_constraints")
+            })?;
+        one_hot_constraints
+            .validate_sample_ids(&objective_sample_ids)
+            .map_err(|found| {
+                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                    expected: objective_sample_ids.clone(),
+                    found,
+                })
+                .context(message, "sampled_one_hot_constraints")
+            })?;
+        sos1_constraints
+            .validate_sample_ids(&objective_sample_ids)
+            .map_err(|found| {
+                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                    expected: objective_sample_ids.clone(),
+                    found,
+                })
+                .context(message, "sampled_sos1_constraints")
+            })?;
+
+        let decision_variable_ids = decision_variables.keys().copied().collect::<BTreeSet<_>>();
+        validate_sampled_constraint_used_ids("regular", &constraints, &decision_variable_ids)
+            .map_err(|e| {
+                RawParseError::SampleSetError(e).context(message, "sampled_regular_constraints")
+            })?;
+        validate_sampled_constraint_used_ids(
+            "indicator",
+            &indicator_constraints,
+            &decision_variable_ids,
+        )
+        .map_err(|e| {
+            RawParseError::SampleSetError(e).context(message, "sampled_indicator_constraints")
+        })?;
+        validate_sampled_constraint_used_ids(
+            "one-hot",
+            &one_hot_constraints,
+            &decision_variable_ids,
+        )
+        .map_err(|e| {
+            RawParseError::SampleSetError(e).context(message, "sampled_one_hot_constraints")
+        })?;
+        validate_sampled_constraint_used_ids("SOS1", &sos1_constraints, &decision_variable_ids)
+            .map_err(|e| {
+                RawParseError::SampleSetError(e).context(message, "sampled_sos1_constraints")
+            })?;
+        validate_sampled_indicator_structural_ids(
+            &indicator_constraints,
+            &decision_variables,
+            message,
+        )?;
+        validate_sampled_one_hot_structural_ids(
+            &one_hot_constraints,
+            &decision_variables,
+            message,
+        )?;
+        validate_sampled_sos1_structural_ids(&sos1_constraints, &decision_variables, message)?;
+
+        for (named_function_id, sampled_named_function) in named_functions.iter() {
+            if !sampled_named_function
+                .evaluated_values()
+                .has_same_ids(&objective_sample_ids)
+            {
+                return Err(RawParseError::SampleSetError(
+                    crate::SampleSetError::InconsistentSampleIDs {
+                        expected: objective_sample_ids.clone(),
+                        found: sampled_named_function.evaluated_values().ids(),
+                    },
+                )
+                .context(message, "sampled_named_functions"));
+            }
+            for var_id in sampled_named_function.used_decision_variable_ids() {
+                if !decision_variables.contains_key(var_id) {
+                    return Err(RawParseError::SampleSetError(
+                        crate::SampleSetError::UndefinedVariableInNamedFunction {
+                            id: *var_id,
+                            named_function_id: *named_function_id,
+                        },
+                    )
+                    .context(message, "sampled_named_functions"));
+                }
+            }
+        }
+
+        let (computed_feasible, computed_feasible_relaxed) = SampleSetBuilder::compute_feasibility(
+            &constraints,
+            &indicator_constraints,
+            &one_hot_constraints,
+            &sos1_constraints,
+            &objective_sample_ids,
+        );
+        let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
+        validate_sample_bool_map_ids(&feasible, &objective_sample_ids, message, "feasible")?;
+        if let Some((sample_id, provided_feasible, computed_feasible)) =
+            first_feasibility_mismatch(&feasible, &computed_feasible)
+        {
+            return Err(RawParseError::SampleSetError(
+                crate::SampleSetError::InconsistentFeasibility {
+                    sample_id: sample_id.into_inner(),
+                    provided_feasible,
+                    computed_feasible,
+                },
+            )
+            .context(message, "feasible"));
+        }
+        let feasible_relaxed = crate::v2_io::sample_bool_map_from_v2(self.feasible_relaxed);
+        validate_sample_bool_map_ids(
+            &feasible_relaxed,
+            &objective_sample_ids,
+            message,
+            "feasible_relaxed",
+        )?;
+        if let Some((sample_id, provided_feasible_relaxed, computed_feasible_relaxed)) =
+            first_feasibility_mismatch(&feasible_relaxed, &computed_feasible_relaxed)
+        {
+            return Err(RawParseError::SampleSetError(
+                crate::SampleSetError::InconsistentFeasibilityRelaxed {
+                    sample_id: sample_id.into_inner(),
+                    provided_feasible_relaxed,
+                    computed_feasible_relaxed,
+                },
+            )
+            .context(message, "feasible_relaxed"));
+        }
+
+        Ok(SampleSet {
+            decision_variables,
+            objectives,
+            constraints,
+            indicator_constraints,
+            one_hot_constraints,
+            sos1_constraints,
+            named_functions,
+            sense,
+            feasible,
+            feasible_relaxed,
+            metadata: self.metadata,
+            annotations,
+        })
+    }
+}
+
+impl TryFrom<v2::SampleSet> for SampleSet {
+    type Error = ParseError;
+
+    fn try_from(value: v2::SampleSet) -> Result<Self, Self::Error> {
+        value.parse(&())
     }
 }
 

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -418,6 +418,30 @@ impl Parse for v2::SampleSet {
             message,
         )?;
         validate_sampled_sos1_structural_ids(&sos1_constraints, &decision_variables, message)?;
+        validate_sampled_indicator_stage_values(
+            &decision_variables,
+            &indicator_constraints,
+            feasibility_atol,
+        )
+        .map_err(|e| {
+            RawParseError::SampleSetError(e).context(message, "sampled_indicator_constraints")
+        })?;
+        validate_sampled_one_hot_stage_values(
+            &decision_variables,
+            &one_hot_constraints,
+            feasibility_atol,
+        )
+        .map_err(|e| {
+            RawParseError::SampleSetError(e).context(message, "sampled_one_hot_constraints")
+        })?;
+        validate_sampled_sos1_stage_values(
+            &decision_variables,
+            &sos1_constraints,
+            feasibility_atol,
+        )
+        .map_err(|e| {
+            RawParseError::SampleSetError(e).context(message, "sampled_sos1_constraints")
+        })?;
 
         for (named_function_id, sampled_named_function) in named_functions.iter() {
             if !sampled_named_function
@@ -1068,6 +1092,132 @@ mod tests {
         assert!(
             err.to_string().contains("objectives must be finite")
                 && err.to_string().contains("SampleID(0)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_rejects_indicator_active_mismatching_variable_value() {
+        use crate::{
+            indicator_constraint::{IndicatorSampledData, SampledIndicatorConstraint},
+            DecisionVariable, IndicatorConstraintID, SampleID, Sampled, SampledDecisionVariable,
+            Sense, VariableID,
+        };
+        use std::collections::BTreeMap;
+
+        let var_id = VariableID::from(1);
+        let sample_id = SampleID::from(0);
+        let decision_variable = DecisionVariable::binary();
+        let sampled_variable = SampledDecisionVariable::new(
+            var_id,
+            decision_variable,
+            Sampled::from((sample_id, 1.0)),
+        )
+        .unwrap();
+        let indicator = SampledIndicatorConstraint {
+            indicator_variable: var_id,
+            equality: crate::Equality::EqualToZero,
+            stage: IndicatorSampledData {
+                evaluated_values: Sampled::from((sample_id, 0.0)),
+                feasible: BTreeMap::from([(sample_id, true)]),
+                indicator_active: BTreeMap::from([(sample_id, true)]),
+                used_decision_variable_ids: [var_id].into_iter().collect(),
+            },
+        };
+        let sample_set = SampleSet::builder()
+            .decision_variables(BTreeMap::from([(var_id, sampled_variable)]))
+            .objectives(Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(1),
+                indicator,
+            )]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::SampleSet::from(sample_set);
+        let row = proto
+            .sampled_indicator_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.indicator_active.insert(sample_id.into_inner(), false);
+        row.feasible.insert(sample_id.into_inner(), true);
+
+        let err = SampleSet::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains("indicator_active=false")
+                && err
+                    .to_string()
+                    .contains("does not match indicator variable"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_rejects_one_hot_active_variable_mismatching_values() {
+        use crate::{
+            one_hot_constraint::{OneHotSampledData, SampledOneHotConstraint},
+            DecisionVariable, OneHotConstraintID, SampleID, Sampled, SampledDecisionVariable,
+            Sense, VariableID,
+        };
+        use std::collections::{BTreeMap, BTreeSet};
+
+        let var_id = VariableID::from(1);
+        let sample_id = SampleID::from(0);
+        let decision_variable = DecisionVariable::binary();
+        let sampled_variable = SampledDecisionVariable::new(
+            var_id,
+            decision_variable,
+            Sampled::from((sample_id, 1.0)),
+        )
+        .unwrap();
+        let one_hot = SampledOneHotConstraint {
+            variables: BTreeSet::from([var_id]),
+            stage: OneHotSampledData {
+                feasible: BTreeMap::from([(sample_id, true)]),
+                active_variable: BTreeMap::from([(sample_id, Some(var_id))]),
+                used_decision_variable_ids: [var_id].into_iter().collect(),
+            },
+        };
+        let sample_set = SampleSet::builder()
+            .decision_variables(BTreeMap::from([(var_id, sampled_variable)]))
+            .objectives(Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::new())
+            .one_hot_constraints_collection(
+                crate::SampledCollection::new(
+                    BTreeMap::from([(OneHotConstraintID::from(1), one_hot)]),
+                    BTreeMap::new(),
+                )
+                .unwrap(),
+            )
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::SampleSet::from(sample_set);
+        let row = proto
+            .sampled_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.feasible.insert(sample_id.into_inner(), false);
+        row.active_variable.insert(
+            sample_id.into_inner(),
+            crate::v2::SampledActiveVariable { variable_id: None },
+        );
+
+        let err = SampleSet::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains("active_variable=None")
+                && err
+                    .to_string()
+                    .contains("does not match decision-variable values"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -262,6 +262,8 @@ impl Parse for v2::SampleSet {
         let message = "ommx.v2.SampleSet";
         let required_features =
             crate::v2_io::parse_required_features(self.required_features, message)?;
+        let feasibility_atol =
+            crate::v2_io::parse_feasibility_atol(self.feasibility_atol, message)?;
         let annotations =
             crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
         let decision_variables = self
@@ -280,22 +282,24 @@ impl Parse for v2::SampleSet {
             .parse_as(&(), message, "objectives")?;
         let constraints = self
             .sampled_regular_constraints
-            .map(|value| value.parse_as(&(), message, "sampled_regular_constraints"))
+            .map(|value| value.parse_as(&feasibility_atol, message, "sampled_regular_constraints"))
             .transpose()?
             .unwrap_or_default();
         let indicator_constraints = self
             .sampled_indicator_constraints
-            .map(|value| value.parse_as(&(), message, "sampled_indicator_constraints"))
+            .map(|value| {
+                value.parse_as(&feasibility_atol, message, "sampled_indicator_constraints")
+            })
             .transpose()?
             .unwrap_or_default();
         let one_hot_constraints = self
             .sampled_one_hot_constraints
-            .map(|value| value.parse_as(&(), message, "sampled_one_hot_constraints"))
+            .map(|value| value.parse_as(&feasibility_atol, message, "sampled_one_hot_constraints"))
             .transpose()?
             .unwrap_or_default();
         let sos1_constraints = self
             .sampled_sos1_constraints
-            .map(|value| value.parse_as(&(), message, "sampled_sos1_constraints"))
+            .map(|value| value.parse_as(&feasibility_atol, message, "sampled_sos1_constraints"))
             .transpose()?
             .unwrap_or_default();
 
@@ -498,6 +502,7 @@ impl Parse for v2::SampleSet {
             sense,
             feasible,
             feasible_relaxed,
+            feasibility_atol,
             metadata: self.metadata,
             annotations,
         })
@@ -533,6 +538,7 @@ impl From<SampleSet> for crate::v1::SampleSet {
             sense,
             feasible,
             feasible_relaxed,
+            feasibility_atol: _,
             metadata,
             annotations,
         } = sample_set;
@@ -980,5 +986,60 @@ mod tests {
         assert_eq!(nf_meta.name(nf_id), Some("offset_x"));
         assert_eq!(nf_meta.subscripts(nf_id), &[0]);
         assert_eq!(nf_meta.description(nf_id), Some("x plus a constant"));
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_rejects_inconsistent_regular_feasibility() {
+        use crate::{
+            constraint::SampledData, Constraint, ConstraintID, Equality, SampleID, Sampled, Sense,
+        };
+        use std::collections::BTreeMap;
+
+        let sample_id = SampleID::from(0);
+        let mut objectives = Sampled::default();
+        objectives.append([sample_id], 0.0).unwrap();
+
+        let mut evaluated_values = Sampled::default();
+        evaluated_values.append([sample_id], 0.0).unwrap();
+        let constraint = Constraint {
+            equality: Equality::EqualToZero,
+            stage: SampledData {
+                evaluated_values,
+                feasible: BTreeMap::from([(sample_id, true)]),
+                used_decision_variable_ids: Default::default(),
+                dual_variables: None,
+            },
+        };
+        let sample_set = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(objectives)
+            .constraints(BTreeMap::from([(ConstraintID::from(1), constraint)]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::SampleSet::from(sample_set);
+        let row = proto
+            .sampled_regular_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.evaluated_values
+            .as_mut()
+            .unwrap()
+            .entries
+            .first_mut()
+            .unwrap()
+            .value = 1.0;
+        row.feasible.insert(sample_id.into_inner(), true);
+
+        let err = SampleSet::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Inconsistent constraint feasibility"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -331,13 +331,7 @@ impl Parse for v2::SampleSet {
             .map(|value| value.parse_as(&(), message, "sampled_named_functions"))
             .transpose()?
             .unwrap_or_default();
-        let sense = self.sense.try_into().map_err(|_| {
-            RawParseError::UnknownEnumValue {
-                enum_name: "ommx.v1.Sense",
-                value: self.sense,
-            }
-            .context(message, "sense")
-        })?;
+        let sense = crate::v2_io::parse_v2_required_sense(self.sense, message)?;
 
         let objective_sample_ids = objectives.ids();
         for sampled_dv in decision_variables.values() {
@@ -1072,7 +1066,37 @@ mod tests {
 
         let err = SampleSet::try_from(proto).unwrap_err();
         assert!(
-            err.to_string().contains("objectives must be finite"),
+            err.to_string().contains("objectives must be finite")
+                && err.to_string().contains("SampleID(0)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_rejects_unspecified_sense() {
+        use crate::{SampleID, Sampled, Sense};
+        use std::collections::BTreeMap;
+
+        let sample_id = SampleID::from(0);
+        let mut objectives = Sampled::default();
+        objectives.append([sample_id], 0.0).unwrap();
+        let sample_set = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(objectives)
+            .constraints(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::SampleSet::from(sample_set);
+        proto.sense = crate::v1::instance::Sense::Unspecified as i32;
+
+        let err = SampleSet::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unknown or unsupported enum value")
+                && err.to_string().contains("ommx.v2.SampleSet")
+                && err.to_string().contains("sense"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -280,6 +280,7 @@ impl Parse for v2::SampleSet {
                 field: "objectives",
             })?
             .parse_as(&(), message, "objectives")?;
+        crate::v2_io::validate_sampled_f64_values(&objectives, message, "objectives")?;
         let constraints = self
             .sampled_regular_constraints
             .map(|value| value.parse_as(&feasibility_atol, message, "sampled_regular_constraints"))
@@ -1039,6 +1040,39 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("Inconsistent constraint feasibility"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_rejects_non_finite_objective() {
+        use crate::{SampleID, Sampled, Sense};
+        use std::collections::BTreeMap;
+
+        let sample_id = SampleID::from(0);
+        let mut objectives = Sampled::default();
+        objectives.append([sample_id], 0.0).unwrap();
+        let sample_set = SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(objectives)
+            .constraints(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::SampleSet::from(sample_set);
+        proto
+            .objectives
+            .as_mut()
+            .unwrap()
+            .entries
+            .first_mut()
+            .unwrap()
+            .value = f64::INFINITY;
+
+        let err = SampleSet::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains("objectives must be finite"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/sample_set/serialize.rs
+++ b/rust/ommx/src/sample_set/serialize.rs
@@ -17,6 +17,11 @@ impl SampleSet {
         let inner = v1::SampleSet::decode(bytes)?;
         Ok(Parse::parse(inner, &())?)
     }
+
+    pub fn from_v2_bytes(bytes: &[u8]) -> Result<Self> {
+        let inner = v2::SampleSet::decode(bytes)?;
+        Ok(Parse::parse(inner, &())?)
+    }
 }
 
 impl From<SampleSet> for v2::SampleSet {

--- a/rust/ommx/src/sample_set/serialize.rs
+++ b/rust/ommx/src/sample_set/serialize.rs
@@ -43,6 +43,7 @@ impl From<SampleSet> for v2::SampleSet {
             sense,
             feasible,
             feasible_relaxed,
+            feasibility_atol,
             metadata,
             annotations,
         } = value;
@@ -61,6 +62,7 @@ impl From<SampleSet> for v2::SampleSet {
             sampled_indicator_constraints: Some(indicator_constraints.into()),
             sampled_one_hot_constraints: Some(one_hot_constraints.into()),
             sampled_sos1_constraints: Some(sos1_constraints.into()),
+            feasibility_atol: Some(feasibility_atol.into_inner()),
         }
     }
 }

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -35,6 +35,13 @@ pub enum SolutionError {
         computed_feasible: bool,
     },
 
+    #[error("Invalid structure for {constraint_family} constraint {constraint_id}: {message}")]
+    InvalidConstraintStructure {
+        constraint_family: &'static str,
+        constraint_id: String,
+        message: String,
+    },
+
     #[error("Inconsistent value for variable {id}: state={state_value}, substituted_value={substituted_value}")]
     InconsistentVariableValue {
         id: u64,
@@ -123,6 +130,10 @@ pub enum SolutionError {
 /// - [`Self::decision_variables`] contains all variable IDs referenced in
 ///   `used_decision_variable_ids` of each evaluated constraint and evaluated
 ///   named function.
+/// - Evaluated special-constraint structural variables are defined in
+///   [`Self::decision_variables`]. Indicator variables and one-hot variables
+///   must be binary; one-hot and SOS1 variable sets must be non-empty, and
+///   `active_variable` values must belong to their structural variable set.
 /// - `feasibility_atol` is the absolute tolerance used to interpret
 ///   decision-variable feasibility and to validate serialized per-constraint
 ///   feasibility columns.
@@ -707,6 +718,100 @@ fn validate_solution_constraint_feasibility(
     Ok(())
 }
 
+fn validate_solution_special_constraint_structure(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    indicator_constraints: &EvaluatedCollection<IndicatorConstraint>,
+    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+) -> Result<(), SolutionError> {
+    for (id, constraint) in indicator_constraints.inner() {
+        let variable_id = constraint.indicator_variable;
+        let Some(variable) = decision_variables.get(&variable_id) else {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "indicator",
+                constraint_id: format!("{id:?}"),
+                message: format!("indicator variable {variable_id:?} is not in decision_variables"),
+            });
+        };
+        if *variable.kind() != crate::decision_variable::Kind::Binary {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "indicator",
+                constraint_id: format!("{id:?}"),
+                message: format!("indicator variable {variable_id:?} must be binary"),
+            });
+        }
+    }
+
+    for (id, constraint) in one_hot_constraints.inner() {
+        if constraint.variables.is_empty() {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "one-hot",
+                constraint_id: format!("{id:?}"),
+                message: "one-hot constraints must contain at least one variable".to_string(),
+            });
+        }
+        for variable_id in &constraint.variables {
+            let Some(variable) = decision_variables.get(variable_id) else {
+                return Err(SolutionError::InvalidConstraintStructure {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    message: format!("variable {variable_id:?} is not in decision_variables"),
+                });
+            };
+            if *variable.kind() != crate::decision_variable::Kind::Binary {
+                return Err(SolutionError::InvalidConstraintStructure {
+                    constraint_family: "one-hot",
+                    constraint_id: format!("{id:?}"),
+                    message: format!("variable {variable_id:?} must be binary"),
+                });
+            }
+        }
+        if constraint
+            .stage
+            .active_variable
+            .is_some_and(|variable_id| !constraint.variables.contains(&variable_id))
+        {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "one-hot",
+                constraint_id: format!("{id:?}"),
+                message: "active_variable must be a member of variables".to_string(),
+            });
+        }
+    }
+
+    for (id, constraint) in sos1_constraints.inner() {
+        if constraint.variables.is_empty() {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "SOS1",
+                constraint_id: format!("{id:?}"),
+                message: "SOS1 constraints must contain at least one variable".to_string(),
+            });
+        }
+        for variable_id in &constraint.variables {
+            if !decision_variables.contains_key(variable_id) {
+                return Err(SolutionError::InvalidConstraintStructure {
+                    constraint_family: "SOS1",
+                    constraint_id: format!("{id:?}"),
+                    message: format!("variable {variable_id:?} is not in decision_variables"),
+                });
+            }
+        }
+        if constraint
+            .stage
+            .active_variable
+            .is_some_and(|variable_id| !constraint.variables.contains(&variable_id))
+        {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "SOS1",
+                constraint_id: format!("{id:?}"),
+                message: "active_variable must be a member of variables".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 impl SolutionBuilder {
     /// Creates a new `SolutionBuilder` with all fields unset.
     pub fn new() -> Self {
@@ -899,6 +1004,12 @@ impl SolutionBuilder {
             &self.evaluated_one_hot_constraints,
             &self.evaluated_sos1_constraints,
             self.feasibility_atol,
+        )?;
+        validate_solution_special_constraint_structure(
+            &decision_variables,
+            &self.evaluated_indicator_constraints,
+            &self.evaluated_one_hot_constraints,
+            &self.evaluated_sos1_constraints,
         )?;
 
         // Validate all used_decision_variable_ids in indicator constraints
@@ -1430,6 +1541,40 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("Inconsistent feasibility for regular constraint"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn builder_rejects_unknown_one_hot_structural_variable() {
+        let variable_id = VariableID::from(1);
+        let one_hot = crate::one_hot_constraint::EvaluatedOneHotConstraint {
+            variables: BTreeSet::from([variable_id]),
+            stage: crate::one_hot_constraint::OneHotEvaluatedData {
+                feasible: false,
+                active_variable: None,
+                used_decision_variable_ids: BTreeSet::new(),
+            },
+        };
+
+        let err = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_one_hot_constraints_collection(
+                EvaluatedCollection::new(
+                    BTreeMap::from([(crate::OneHotConstraintID::from(1), one_hot)]),
+                    BTreeMap::new(),
+                )
+                .unwrap(),
+            )
+            .decision_variables(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Invalid structure for one-hot constraint"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -5,7 +5,7 @@ use crate::{
     constraint_type::EvaluatedCollection,
     decision_variable::{EvaluatedDecisionVariableTable, VariableLabelStore},
     indicator_constraint::IndicatorConstraint,
-    Constraint, ConstraintID, EvaluatedConstraint, EvaluatedDecisionVariable,
+    ATol, Constraint, ConstraintID, EvaluatedConstraint, EvaluatedDecisionVariable,
     EvaluatedNamedFunction, NamedFunctionID, NamedFunctionTable, Sense, VariableID,
 };
 use getset::Getters;
@@ -115,6 +115,9 @@ pub enum SolutionError {
 /// - [`Self::decision_variables`] contains all variable IDs referenced in
 ///   `used_decision_variable_ids` of each evaluated constraint and evaluated
 ///   named function.
+/// - [`Self::feasibility_atol`] is the absolute tolerance used to interpret
+///   decision-variable feasibility and to validate serialized per-constraint
+///   feasibility columns.
 ///
 /// Note
 /// -----
@@ -142,6 +145,9 @@ pub struct Solution {
     pub relaxation: crate::v1::Relaxation,
     #[getset(get = "pub")]
     sense: Option<Sense>,
+    /// Absolute tolerance used to compute and validate feasibility fields.
+    #[getset(get_copy = "pub")]
+    feasibility_atol: ATol,
     /// OMMX-defined provenance metadata.
     pub metadata: Option<crate::v1::ProcessMetadata>,
     /// User-defined or third-party extension annotations.
@@ -215,7 +221,7 @@ impl Solution {
     pub fn feasible_decision_variables(&self) -> bool {
         self.decision_variables
             .values()
-            .all(|dv| dv.is_valid(crate::ATol::default()))
+            .all(|dv| dv.is_valid(self.feasibility_atol))
     }
 
     /// Check if all constraints are feasible
@@ -599,6 +605,7 @@ pub struct SolutionBuilder {
     variable_labels: VariableLabelStore,
     named_function_labels: crate::named_function::NamedFunctionLabelStore,
     sense: Option<Sense>,
+    feasibility_atol: ATol,
     optimality: crate::v1::Optimality,
     relaxation: crate::v1::Relaxation,
 }
@@ -731,6 +738,12 @@ impl SolutionBuilder {
         self
     }
 
+    /// Sets the absolute tolerance used to compute and validate feasibility fields.
+    pub fn feasibility_atol(mut self, feasibility_atol: ATol) -> Self {
+        self.feasibility_atol = feasibility_atol;
+        self
+    }
+
     /// Sets the optimality status.
     pub fn optimality(mut self, optimality: crate::v1::Optimality) -> Self {
         self.optimality = optimality;
@@ -848,6 +861,7 @@ impl SolutionBuilder {
             optimality: self.optimality,
             relaxation: self.relaxation,
             sense: Some(sense),
+            feasibility_atol: self.feasibility_atol,
             metadata: Default::default(),
             annotations: Default::default(),
         })
@@ -908,6 +922,7 @@ impl SolutionBuilder {
             optimality: self.optimality,
             relaxation: self.relaxation,
             sense: Some(sense),
+            feasibility_atol: self.feasibility_atol,
             metadata: Default::default(),
             annotations: Default::default(),
         })

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -134,6 +134,10 @@ pub enum SolutionError {
 ///   [`Self::decision_variables`]. Indicator variables and one-hot variables
 ///   must be binary; one-hot and SOS1 variable sets must be non-empty, and
 ///   `active_variable` values must belong to their structural variable set.
+/// - Evaluated special-constraint stage fields are consistent with
+///   [`Self::decision_variables`]: `indicator_active` reflects the indicator
+///   variable value, and one-hot/SOS1 `active_variable` plus `feasible` reflect
+///   the structural variable values under `feasibility_atol`.
 /// - `feasibility_atol` is the absolute tolerance used to interpret
 ///   decision-variable feasibility and to validate serialized per-constraint
 ///   feasibility columns.
@@ -812,6 +816,192 @@ fn validate_solution_special_constraint_structure(
     Ok(())
 }
 
+fn expected_binary_activity(
+    variable_id: VariableID,
+    value: f64,
+    atol: ATol,
+    role: &'static str,
+) -> Result<bool, String> {
+    if (value - 1.0).abs() < *atol {
+        Ok(true)
+    } else if value.abs() < *atol {
+        Ok(false)
+    } else {
+        Err(format!(
+            "{role} variable {variable_id:?} has value {value}, but must be 0 or 1",
+        ))
+    }
+}
+
+fn expected_one_hot_active_variable(
+    variables: &BTreeSet<VariableID>,
+    decision_variables: &EvaluatedDecisionVariableTable,
+    atol: ATol,
+) -> (bool, Option<VariableID>) {
+    let mut active = None;
+    for variable_id in variables {
+        let value = *decision_variables
+            .get(variable_id)
+            .expect("one-hot structural variables must be validated first")
+            .value();
+        if (value - 1.0).abs() < *atol {
+            if active.is_some() {
+                return (false, None);
+            }
+            active = Some(*variable_id);
+        } else if value.abs() >= *atol {
+            return (false, None);
+        }
+    }
+    match active {
+        Some(variable_id) => (true, Some(variable_id)),
+        None => (false, None),
+    }
+}
+
+fn expected_sos1_active_variable(
+    variables: &BTreeSet<VariableID>,
+    decision_variables: &EvaluatedDecisionVariableTable,
+    atol: ATol,
+) -> (bool, Option<VariableID>) {
+    let mut active = None;
+    for variable_id in variables {
+        let value = *decision_variables
+            .get(variable_id)
+            .expect("SOS1 structural variables must be validated first")
+            .value();
+        if value.abs() >= *atol {
+            if active.is_some() {
+                return (false, None);
+            }
+            active = Some(*variable_id);
+        }
+    }
+    (true, active)
+}
+
+fn validate_solution_indicator_stage_values(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    indicator_constraints: &EvaluatedCollection<IndicatorConstraint>,
+    atol: ATol,
+) -> Result<(), SolutionError> {
+    for (id, constraint) in indicator_constraints.inner() {
+        let variable = decision_variables
+            .get(&constraint.indicator_variable)
+            .expect("indicator structural variables must be validated first");
+        let computed_indicator_active = expected_binary_activity(
+            constraint.indicator_variable,
+            *variable.value(),
+            atol,
+            "indicator",
+        )
+        .map_err(|message| SolutionError::InvalidConstraintStructure {
+            constraint_family: "indicator",
+            constraint_id: format!("{id:?}"),
+            message,
+        })?;
+        if constraint.stage.indicator_active != computed_indicator_active {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "indicator",
+                constraint_id: format!("{id:?}"),
+                message: format!(
+                    "indicator_active={} does not match indicator variable {:?} value {}",
+                    constraint.stage.indicator_active,
+                    constraint.indicator_variable,
+                    variable.value(),
+                ),
+            });
+        }
+        let computed_feasible = expected_indicator_constraint_feasible(
+            constraint.equality,
+            constraint.stage.evaluated_value,
+            computed_indicator_active,
+            atol,
+        );
+        if constraint.stage.feasible != computed_feasible {
+            return Err(SolutionError::InconsistentConstraintFeasibility {
+                constraint_family: "indicator",
+                constraint_id: format!("{id:?}"),
+                provided_feasible: constraint.stage.feasible,
+                computed_feasible,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_solution_one_hot_stage_values(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+    atol: ATol,
+) -> Result<(), SolutionError> {
+    for (id, constraint) in one_hot_constraints.inner() {
+        let (computed_feasible, computed_active_variable) =
+            expected_one_hot_active_variable(&constraint.variables, decision_variables, atol);
+        if constraint.stage.active_variable != computed_active_variable {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "one-hot",
+                constraint_id: format!("{id:?}"),
+                message: format!(
+                    "active_variable={:?} does not match decision-variable values; computed={computed_active_variable:?}",
+                    constraint.stage.active_variable,
+                ),
+            });
+        }
+        if constraint.stage.feasible != computed_feasible {
+            return Err(SolutionError::InconsistentConstraintFeasibility {
+                constraint_family: "one-hot",
+                constraint_id: format!("{id:?}"),
+                provided_feasible: constraint.stage.feasible,
+                computed_feasible,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_solution_sos1_stage_values(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+    atol: ATol,
+) -> Result<(), SolutionError> {
+    for (id, constraint) in sos1_constraints.inner() {
+        let (computed_feasible, computed_active_variable) =
+            expected_sos1_active_variable(&constraint.variables, decision_variables, atol);
+        if constraint.stage.active_variable != computed_active_variable {
+            return Err(SolutionError::InvalidConstraintStructure {
+                constraint_family: "SOS1",
+                constraint_id: format!("{id:?}"),
+                message: format!(
+                    "active_variable={:?} does not match decision-variable values; computed={computed_active_variable:?}",
+                    constraint.stage.active_variable,
+                ),
+            });
+        }
+        if constraint.stage.feasible != computed_feasible {
+            return Err(SolutionError::InconsistentConstraintFeasibility {
+                constraint_family: "SOS1",
+                constraint_id: format!("{id:?}"),
+                provided_feasible: constraint.stage.feasible,
+                computed_feasible,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_solution_special_constraint_stage_values(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    indicator_constraints: &EvaluatedCollection<IndicatorConstraint>,
+    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+    atol: ATol,
+) -> Result<(), SolutionError> {
+    validate_solution_indicator_stage_values(decision_variables, indicator_constraints, atol)?;
+    validate_solution_one_hot_stage_values(decision_variables, one_hot_constraints, atol)?;
+    validate_solution_sos1_stage_values(decision_variables, sos1_constraints, atol)
+}
+
 impl SolutionBuilder {
     /// Creates a new `SolutionBuilder` with all fields unset.
     pub fn new() -> Self {
@@ -1011,6 +1201,13 @@ impl SolutionBuilder {
             &self.evaluated_one_hot_constraints,
             &self.evaluated_sos1_constraints,
         )?;
+        validate_solution_special_constraint_stage_values(
+            &decision_variables,
+            &self.evaluated_indicator_constraints,
+            &self.evaluated_one_hot_constraints,
+            &self.evaluated_sos1_constraints,
+            self.feasibility_atol,
+        )?;
 
         // Validate all used_decision_variable_ids in indicator constraints
         for (ic_id, ic) in self.evaluated_indicator_constraints.iter() {
@@ -1092,6 +1289,9 @@ impl SolutionBuilder {
     /// - `decision_variables` is keyed by the intended [`VariableID`] for each row
     /// - All `used_decision_variable_ids` in constraints and evaluated named
     ///   functions exist in `decision_variables`
+    /// - Special-constraint `indicator_active`, `active_variable`, and
+    ///   per-constraint `feasible` fields are consistent with
+    ///   `decision_variables` under `feasibility_atol`
     ///
     /// Use [`Self::build`] for validated construction.
     /// This method is useful when invariants are guaranteed by construction,

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -115,7 +115,7 @@ pub enum SolutionError {
 /// - [`Self::decision_variables`] contains all variable IDs referenced in
 ///   `used_decision_variable_ids` of each evaluated constraint and evaluated
 ///   named function.
-/// - [`Self::feasibility_atol`] is the absolute tolerance used to interpret
+/// - `feasibility_atol` is the absolute tolerance used to interpret
 ///   decision-variable feasibility and to validate serialized per-constraint
 ///   feasibility columns.
 ///

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -27,6 +27,14 @@ pub enum SolutionError {
         computed_feasible_relaxed: bool,
     },
 
+    #[error("Inconsistent feasibility for {constraint_family} constraint {constraint_id}: provided={provided_feasible}, computed={computed_feasible}")]
+    InconsistentConstraintFeasibility {
+        constraint_family: &'static str,
+        constraint_id: String,
+        provided_feasible: bool,
+        computed_feasible: bool,
+    },
+
     #[error("Inconsistent value for variable {id}: state={state_value}, substituted_value={substituted_value}")]
     InconsistentVariableValue {
         id: u64,
@@ -610,6 +618,95 @@ pub struct SolutionBuilder {
     relaxation: crate::v1::Relaxation,
 }
 
+fn expected_regular_constraint_feasible(
+    equality: crate::Equality,
+    evaluated_value: f64,
+    atol: ATol,
+) -> bool {
+    match equality {
+        crate::Equality::EqualToZero => evaluated_value.abs() < *atol,
+        crate::Equality::LessThanOrEqualToZero => evaluated_value < *atol,
+    }
+}
+
+fn expected_indicator_constraint_feasible(
+    equality: crate::Equality,
+    evaluated_value: f64,
+    indicator_active: bool,
+    atol: ATol,
+) -> bool {
+    if !indicator_active {
+        return true;
+    }
+    expected_regular_constraint_feasible(equality, evaluated_value, atol)
+}
+
+fn validate_solution_constraint_feasibility(
+    regular_constraints: &EvaluatedCollection<Constraint>,
+    indicator_constraints: &EvaluatedCollection<IndicatorConstraint>,
+    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+    atol: ATol,
+) -> Result<(), SolutionError> {
+    for (id, constraint) in regular_constraints.inner() {
+        let computed_feasible = expected_regular_constraint_feasible(
+            constraint.equality,
+            constraint.stage.evaluated_value,
+            atol,
+        );
+        if constraint.stage.feasible != computed_feasible {
+            return Err(SolutionError::InconsistentConstraintFeasibility {
+                constraint_family: "regular",
+                constraint_id: format!("{id:?}"),
+                provided_feasible: constraint.stage.feasible,
+                computed_feasible,
+            });
+        }
+    }
+
+    for (id, constraint) in indicator_constraints.inner() {
+        let computed_feasible = expected_indicator_constraint_feasible(
+            constraint.equality,
+            constraint.stage.evaluated_value,
+            constraint.stage.indicator_active,
+            atol,
+        );
+        if constraint.stage.feasible != computed_feasible {
+            return Err(SolutionError::InconsistentConstraintFeasibility {
+                constraint_family: "indicator",
+                constraint_id: format!("{id:?}"),
+                provided_feasible: constraint.stage.feasible,
+                computed_feasible,
+            });
+        }
+    }
+
+    for (id, constraint) in one_hot_constraints.inner() {
+        let computed_feasible = constraint.stage.active_variable.is_some();
+        if constraint.stage.feasible != computed_feasible {
+            return Err(SolutionError::InconsistentConstraintFeasibility {
+                constraint_family: "one-hot",
+                constraint_id: format!("{id:?}"),
+                provided_feasible: constraint.stage.feasible,
+                computed_feasible,
+            });
+        }
+    }
+
+    for (id, constraint) in sos1_constraints.inner() {
+        if constraint.stage.active_variable.is_some() && !constraint.stage.feasible {
+            return Err(SolutionError::InconsistentConstraintFeasibility {
+                constraint_family: "SOS1",
+                constraint_id: format!("{id:?}"),
+                provided_feasible: constraint.stage.feasible,
+                computed_feasible: true,
+            });
+        }
+    }
+
+    Ok(())
+}
+
 impl SolutionBuilder {
     /// Creates a new `SolutionBuilder` with all fields unset.
     pub fn new() -> Self {
@@ -796,6 +893,13 @@ impl SolutionBuilder {
             .validate_context_ids()?;
         self.evaluated_one_hot_constraints.validate_context_ids()?;
         self.evaluated_sos1_constraints.validate_context_ids()?;
+        validate_solution_constraint_feasibility(
+            &evaluated_constraints,
+            &self.evaluated_indicator_constraints,
+            &self.evaluated_one_hot_constraints,
+            &self.evaluated_sos1_constraints,
+            self.feasibility_atol,
+        )?;
 
         // Validate all used_decision_variable_ids in indicator constraints
         for (ic_id, ic) in self.evaluated_indicator_constraints.iter() {
@@ -1298,6 +1402,34 @@ mod tests {
         assert!(
             err.to_string().contains("unknown decision variable ID")
                 && err.to_string().contains("VariableID(99)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn builder_rejects_inconsistent_regular_constraint_feasibility() {
+        let constraint = EvaluatedConstraint {
+            equality: crate::Equality::EqualToZero,
+            stage: crate::constraint::EvaluatedData {
+                evaluated_value: 1.0,
+                feasible: true,
+                used_decision_variable_ids: BTreeSet::new(),
+                dual_variable: None,
+            },
+        };
+
+        let err = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::from([(ConstraintID::from(1), constraint)]))
+            .decision_variables(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .feasibility_atol(ATol::new(0.1).unwrap())
+            .build()
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Inconsistent feasibility for regular constraint"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -328,6 +328,7 @@ impl Parse for v2::Solution {
             crate::v2_io::parse_feasibility_atol(self.feasibility_atol, message)?;
         let annotations =
             crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
+        crate::v2_io::validate_finite_f64(self.objective, message, "objective")?;
         let decision_variables = self
             .decision_variables
             .ok_or(RawParseError::MissingField {
@@ -1150,6 +1151,29 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("Inconsistent constraint feasibility"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_rejects_non_finite_objective() {
+        use crate::Sense;
+        use std::collections::BTreeMap;
+
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .decision_variables(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::Solution::from(solution);
+        proto.objective = f64::INFINITY;
+
+        let err = Solution::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains("objective must be finite"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -433,6 +433,30 @@ impl Parse for v2::Solution {
             &decision_variables,
             message,
         )?;
+        validate_solution_indicator_stage_values(
+            &decision_variables,
+            &evaluated_indicator_constraints,
+            feasibility_atol,
+        )
+        .map_err(|e| {
+            RawParseError::SolutionError(e).context(message, "evaluated_indicator_constraints")
+        })?;
+        validate_solution_one_hot_stage_values(
+            &decision_variables,
+            &evaluated_one_hot_constraints,
+            feasibility_atol,
+        )
+        .map_err(|e| {
+            RawParseError::SolutionError(e).context(message, "evaluated_one_hot_constraints")
+        })?;
+        validate_solution_sos1_stage_values(
+            &decision_variables,
+            &evaluated_sos1_constraints,
+            feasibility_atol,
+        )
+        .map_err(|e| {
+            RawParseError::SolutionError(e).context(message, "evaluated_sos1_constraints")
+        })?;
         validate_evaluated_named_function_used_ids(&decision_variables, &evaluated_named_functions)
             .map_err(|e| {
                 RawParseError::SolutionError(e).context(message, "evaluated_named_functions")
@@ -1179,6 +1203,83 @@ mod tests {
     }
 
     #[test]
+    fn test_v2_solution_parse_rejects_non_finite_feasibility_atol() {
+        use crate::Sense;
+        use std::collections::BTreeMap;
+
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .decision_variables(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::Solution::from(solution);
+        proto.feasibility_atol = Some(f64::INFINITY);
+
+        let err = Solution::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains("feasibility_atol must be finite"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_rejects_indicator_active_mismatching_variable_value() {
+        use crate::{
+            indicator_constraint::{EvaluatedIndicatorConstraint, IndicatorEvaluatedData},
+            DecisionVariable, EvaluatedDecisionVariable, IndicatorConstraintID, Sense, VariableID,
+        };
+        use std::collections::BTreeMap;
+
+        let var_id = VariableID::from(1);
+        let decision_variable =
+            EvaluatedDecisionVariable::new(var_id, DecisionVariable::binary(), 1.0).unwrap();
+        let indicator = EvaluatedIndicatorConstraint {
+            indicator_variable: var_id,
+            equality: crate::Equality::EqualToZero,
+            stage: IndicatorEvaluatedData {
+                evaluated_value: 0.0,
+                feasible: true,
+                indicator_active: true,
+                used_decision_variable_ids: [var_id].into_iter().collect(),
+            },
+        };
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(1),
+                indicator,
+            )]))
+            .decision_variables(BTreeMap::from([(var_id, decision_variable)]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::Solution::from(solution);
+        let row = proto
+            .evaluated_indicator_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.indicator_active = false;
+        row.feasible = true;
+
+        let err = Solution::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains("indicator_active=false")
+                && err
+                    .to_string()
+                    .contains("does not match indicator variable"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn test_v2_solution_parse_rejects_inactive_infeasible_indicator() {
         use crate::{
             indicator_constraint::{EvaluatedIndicatorConstraint, IndicatorEvaluatedData},
@@ -1226,6 +1327,61 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("Inconsistent indicator constraint feasibility"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_rejects_one_hot_active_variable_mismatching_values() {
+        use crate::{
+            one_hot_constraint::{EvaluatedOneHotConstraint, OneHotEvaluatedData},
+            DecisionVariable, EvaluatedDecisionVariable, OneHotConstraintID, Sense, VariableID,
+        };
+        use std::collections::{BTreeMap, BTreeSet};
+
+        let var_id = VariableID::from(1);
+        let decision_variable =
+            EvaluatedDecisionVariable::new(var_id, DecisionVariable::binary(), 1.0).unwrap();
+        let one_hot = EvaluatedOneHotConstraint {
+            variables: BTreeSet::from([var_id]),
+            stage: OneHotEvaluatedData {
+                feasible: true,
+                active_variable: Some(var_id),
+                used_decision_variable_ids: [var_id].into_iter().collect(),
+            },
+        };
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_one_hot_constraints_collection(
+                crate::constraint_type::EvaluatedCollection::new(
+                    BTreeMap::from([(OneHotConstraintID::from(1), one_hot)]),
+                    BTreeMap::new(),
+                )
+                .unwrap(),
+            )
+            .decision_variables(BTreeMap::from([(var_id, decision_variable)]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::Solution::from(solution);
+        let row = proto
+            .evaluated_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.feasible = false;
+        row.active_variable = None;
+
+        let err = Solution::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string().contains("active_variable=None")
+                && err
+                    .to_string()
+                    .contains("does not match decision-variable values"),
             "unexpected error: {err}"
         );
     }

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -283,6 +283,7 @@ impl Parse for crate::v1::Solution {
             optimality,
             relaxation,
             sense,
+            feasibility_atol: ATol::default(),
             metadata: self.metadata,
             annotations: self.annotations,
         };
@@ -323,6 +324,8 @@ impl Parse for v2::Solution {
         let message = "ommx.v2.Solution";
         let required_features =
             crate::v2_io::parse_required_features(self.required_features, message)?;
+        let feasibility_atol =
+            crate::v2_io::parse_feasibility_atol(self.feasibility_atol, message)?;
         let annotations =
             crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
         let decision_variables = self
@@ -334,22 +337,32 @@ impl Parse for v2::Solution {
             .parse_as(&(), message, "decision_variables")?;
         let evaluated_constraints = self
             .evaluated_regular_constraints
-            .map(|value| value.parse_as(&(), message, "evaluated_regular_constraints"))
+            .map(|value| {
+                value.parse_as(&feasibility_atol, message, "evaluated_regular_constraints")
+            })
             .transpose()?
             .unwrap_or_default();
         let evaluated_indicator_constraints = self
             .evaluated_indicator_constraints
-            .map(|value| value.parse_as(&(), message, "evaluated_indicator_constraints"))
+            .map(|value| {
+                value.parse_as(
+                    &feasibility_atol,
+                    message,
+                    "evaluated_indicator_constraints",
+                )
+            })
             .transpose()?
             .unwrap_or_default();
         let evaluated_one_hot_constraints = self
             .evaluated_one_hot_constraints
-            .map(|value| value.parse_as(&(), message, "evaluated_one_hot_constraints"))
+            .map(|value| {
+                value.parse_as(&feasibility_atol, message, "evaluated_one_hot_constraints")
+            })
             .transpose()?
             .unwrap_or_default();
         let evaluated_sos1_constraints = self
             .evaluated_sos1_constraints
-            .map(|value| value.parse_as(&(), message, "evaluated_sos1_constraints"))
+            .map(|value| value.parse_as(&feasibility_atol, message, "evaluated_sos1_constraints"))
             .transpose()?
             .unwrap_or_default();
 
@@ -449,6 +462,7 @@ impl Parse for v2::Solution {
             optimality,
             relaxation,
             sense,
+            feasibility_atol,
             metadata: self.metadata,
             annotations,
         };
@@ -510,6 +524,7 @@ impl From<Solution> for crate::v1::Solution {
             optimality,
             relaxation,
             sense,
+            feasibility_atol: _,
             metadata,
             annotations,
         } = solution;
@@ -1094,5 +1109,153 @@ mod tests {
         assert_eq!(nf_meta.name(nf_id), Some("offset_x"));
         assert_eq!(nf_meta.subscripts(nf_id), &[0]);
         assert_eq!(nf_meta.description(nf_id), Some("x plus a constant"));
+    }
+
+    #[test]
+    fn test_v2_solution_parse_rejects_inconsistent_regular_feasibility() {
+        use crate::{
+            constraint::EvaluatedData, ConstraintID, Equality, EvaluatedConstraint, Sense,
+        };
+        use std::collections::BTreeMap;
+
+        let constraint = EvaluatedConstraint {
+            equality: Equality::EqualToZero,
+            stage: EvaluatedData {
+                evaluated_value: 0.0,
+                feasible: true,
+                used_decision_variable_ids: Default::default(),
+                dual_variable: None,
+            },
+        };
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::from([(ConstraintID::from(1), constraint)]))
+            .decision_variables(BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::Solution::from(solution);
+        let row = proto
+            .evaluated_regular_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.evaluated_value = 1.0;
+        row.feasible = true;
+
+        let err = Solution::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Inconsistent constraint feasibility"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_rejects_inactive_infeasible_indicator() {
+        use crate::{
+            indicator_constraint::{EvaluatedIndicatorConstraint, IndicatorEvaluatedData},
+            DecisionVariable, EvaluatedDecisionVariable, IndicatorConstraintID, Sense, VariableID,
+        };
+        use std::collections::BTreeMap;
+
+        let var_id = VariableID::from(1);
+        let decision_variable =
+            EvaluatedDecisionVariable::new(var_id, DecisionVariable::binary(), 0.0).unwrap();
+        let indicator = EvaluatedIndicatorConstraint {
+            indicator_variable: var_id,
+            equality: crate::Equality::EqualToZero,
+            stage: IndicatorEvaluatedData {
+                evaluated_value: 1.0,
+                feasible: true,
+                indicator_active: false,
+                used_decision_variable_ids: [var_id].into_iter().collect(),
+            },
+        };
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(1),
+                indicator,
+            )]))
+            .decision_variables(BTreeMap::from([(var_id, decision_variable)]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::Solution::from(solution);
+        let row = proto
+            .evaluated_indicator_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.indicator_active = false;
+        row.feasible = false;
+
+        let err = Solution::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Inconsistent indicator constraint feasibility"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_rejects_feasible_one_hot_without_active_variable() {
+        use crate::{
+            one_hot_constraint::{EvaluatedOneHotConstraint, OneHotEvaluatedData},
+            DecisionVariable, EvaluatedDecisionVariable, OneHotConstraintID, Sense, VariableID,
+        };
+        use std::collections::{BTreeMap, BTreeSet};
+
+        let var_id = VariableID::from(1);
+        let decision_variable =
+            EvaluatedDecisionVariable::new(var_id, DecisionVariable::binary(), 1.0).unwrap();
+        let one_hot = EvaluatedOneHotConstraint {
+            variables: BTreeSet::from([var_id]),
+            stage: OneHotEvaluatedData {
+                feasible: true,
+                active_variable: Some(var_id),
+                used_decision_variable_ids: [var_id].into_iter().collect(),
+            },
+        };
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_one_hot_constraints_collection(
+                crate::constraint_type::EvaluatedCollection::new(
+                    BTreeMap::from([(OneHotConstraintID::from(1), one_hot)]),
+                    BTreeMap::new(),
+                )
+                .unwrap(),
+            )
+            .decision_variables(BTreeMap::from([(var_id, decision_variable)]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+
+        let mut proto = crate::v2::Solution::from(solution);
+        let row = proto
+            .evaluated_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.feasible = true;
+        row.active_variable = None;
+
+        let err = Solution::try_from(proto).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("feasible must be true exactly when active_variable is set"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -1,5 +1,110 @@
 use super::*;
-use crate::{ATol, Parse, ParseError, SolutionError};
+use crate::constraint_type::EvaluatedConstraintBehavior;
+use crate::{v2, ATol, Parse, ParseError, RawParseError, SolutionError};
+
+fn parse_v2_solution_sense(value: i32, message: &'static str) -> Result<Option<Sense>, ParseError> {
+    let sense = crate::v1::instance::Sense::try_from(value)
+        .map_err(|_| RawParseError::UnknownEnumValue {
+            enum_name: "ommx.v1.Sense",
+            value,
+        })
+        .map_err(|e| ParseError::from(e).context(message, "sense"))?;
+    Ok(match sense {
+        crate::v1::instance::Sense::Unspecified => None,
+        crate::v1::instance::Sense::Minimize => Some(crate::Sense::Minimize),
+        crate::v1::instance::Sense::Maximize => Some(crate::Sense::Maximize),
+    })
+}
+
+fn validate_evaluated_constraint_used_ids<T: crate::ConstraintType>(
+    constraints: &crate::constraint_type::EvaluatedCollection<T>,
+    decision_variables: &crate::EvaluatedDecisionVariableTable,
+    message: &'static str,
+    field: &'static str,
+) -> Result<(), ParseError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        for var_id in constraint.used_decision_variable_ids() {
+            if !decision_variables.contains_key(var_id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "Variable {var_id:?} used in constraint {constraint_id:?} is not defined in decision_variables",
+                ))
+                .context(message, field));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn evaluated_collection_has_payload<T: crate::ConstraintType>(
+    collection: &crate::constraint_type::EvaluatedCollection<T>,
+) -> bool {
+    !collection.is_empty()
+}
+
+fn validate_solution_indicator_structural_ids(
+    constraints: &crate::constraint_type::EvaluatedCollection<crate::IndicatorConstraint>,
+    decision_variables: &crate::EvaluatedDecisionVariableTable,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        let id = constraint.indicator_variable;
+        let Some(variable) = decision_variables.get(&id) else {
+            return Err(RawParseError::InvalidInstance(format!(
+                "Indicator variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
+            ))
+            .context(message, "evaluated_indicator_constraints"));
+        };
+        if *variable.kind() != crate::decision_variable::Kind::Binary {
+            return Err(RawParseError::InvalidInstance(format!(
+                "Indicator variable {id:?} in constraint {constraint_id:?} must be binary",
+            ))
+            .context(message, "evaluated_indicator_constraints"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_solution_one_hot_structural_ids(
+    constraints: &crate::constraint_type::EvaluatedCollection<crate::OneHotConstraint>,
+    decision_variables: &crate::EvaluatedDecisionVariableTable,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        for id in &constraint.variables {
+            let Some(variable) = decision_variables.get(id) else {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "One-hot variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
+                ))
+                .context(message, "evaluated_one_hot_constraints"));
+            };
+            if *variable.kind() != crate::decision_variable::Kind::Binary {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "One-hot variable {id:?} in constraint {constraint_id:?} must be binary",
+                ))
+                .context(message, "evaluated_one_hot_constraints"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_solution_sos1_structural_ids(
+    constraints: &crate::constraint_type::EvaluatedCollection<crate::Sos1Constraint>,
+    decision_variables: &crate::EvaluatedDecisionVariableTable,
+    message: &'static str,
+) -> Result<(), ParseError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        for id in &constraint.variables {
+            if !decision_variables.contains_key(id) {
+                return Err(RawParseError::InvalidInstance(format!(
+                    "SOS1 variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
+                ))
+                .context(message, "evaluated_sos1_constraints"));
+            }
+        }
+    }
+    Ok(())
+}
 
 impl Parse for crate::v1::Solution {
     type Output = Solution;
@@ -207,6 +312,178 @@ impl Parse for crate::v1::Solution {
         }
 
         Ok(solution)
+    }
+}
+
+impl Parse for v2::Solution {
+    type Output = Solution;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.Solution";
+        let required_features =
+            crate::v2_io::parse_required_features(self.required_features, message)?;
+        let annotations =
+            crate::v2_io::extension_annotations_from_v2_map(self.annotations, message)?;
+        let decision_variables = self
+            .decision_variables
+            .ok_or(RawParseError::MissingField {
+                message,
+                field: "decision_variables",
+            })?
+            .parse_as(&(), message, "decision_variables")?;
+        let evaluated_constraints = self
+            .evaluated_regular_constraints
+            .map(|value| value.parse_as(&(), message, "evaluated_regular_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let evaluated_indicator_constraints = self
+            .evaluated_indicator_constraints
+            .map(|value| value.parse_as(&(), message, "evaluated_indicator_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let evaluated_one_hot_constraints = self
+            .evaluated_one_hot_constraints
+            .map(|value| value.parse_as(&(), message, "evaluated_one_hot_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+        let evaluated_sos1_constraints = self
+            .evaluated_sos1_constraints
+            .map(|value| value.parse_as(&(), message, "evaluated_sos1_constraints"))
+            .transpose()?
+            .unwrap_or_default();
+
+        crate::v2_io::validate_feature_payload(
+            &required_features,
+            v2::Feature::ConstraintIndicator,
+            evaluated_collection_has_payload(&evaluated_indicator_constraints),
+            message,
+            "evaluated_indicator_constraints",
+        )?;
+        crate::v2_io::validate_feature_payload(
+            &required_features,
+            v2::Feature::ConstraintOneHot,
+            evaluated_collection_has_payload(&evaluated_one_hot_constraints),
+            message,
+            "evaluated_one_hot_constraints",
+        )?;
+        crate::v2_io::validate_feature_payload(
+            &required_features,
+            v2::Feature::ConstraintSos1,
+            evaluated_collection_has_payload(&evaluated_sos1_constraints),
+            message,
+            "evaluated_sos1_constraints",
+        )?;
+
+        let evaluated_named_functions = self
+            .evaluated_named_functions
+            .map(|value| value.parse_as(&(), message, "evaluated_named_functions"))
+            .transpose()?
+            .unwrap_or_default();
+        validate_evaluated_constraint_used_ids(
+            &evaluated_constraints,
+            &decision_variables,
+            message,
+            "evaluated_regular_constraints",
+        )?;
+        validate_evaluated_constraint_used_ids(
+            &evaluated_indicator_constraints,
+            &decision_variables,
+            message,
+            "evaluated_indicator_constraints",
+        )?;
+        validate_evaluated_constraint_used_ids(
+            &evaluated_one_hot_constraints,
+            &decision_variables,
+            message,
+            "evaluated_one_hot_constraints",
+        )?;
+        validate_evaluated_constraint_used_ids(
+            &evaluated_sos1_constraints,
+            &decision_variables,
+            message,
+            "evaluated_sos1_constraints",
+        )?;
+        validate_solution_indicator_structural_ids(
+            &evaluated_indicator_constraints,
+            &decision_variables,
+            message,
+        )?;
+        validate_solution_one_hot_structural_ids(
+            &evaluated_one_hot_constraints,
+            &decision_variables,
+            message,
+        )?;
+        validate_solution_sos1_structural_ids(
+            &evaluated_sos1_constraints,
+            &decision_variables,
+            message,
+        )?;
+        validate_evaluated_named_function_used_ids(&decision_variables, &evaluated_named_functions)
+            .map_err(|e| {
+                RawParseError::SolutionError(e).context(message, "evaluated_named_functions")
+            })?;
+
+        let optimality = crate::v1::Optimality::try_from(self.optimality)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Optimality",
+                value: self.optimality,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "optimality"))?;
+        let relaxation = crate::v1::Relaxation::try_from(self.relaxation)
+            .map_err(|_| RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v1.Relaxation",
+                value: self.relaxation,
+            })
+            .map_err(|e| ParseError::from(e).context(message, "relaxation"))?;
+        let sense = parse_v2_solution_sense(self.sense, message)?;
+
+        let solution = Solution {
+            objective: self.objective,
+            evaluated_constraints,
+            evaluated_indicator_constraints,
+            evaluated_one_hot_constraints,
+            evaluated_sos1_constraints,
+            evaluated_named_functions,
+            decision_variables,
+            optimality,
+            relaxation,
+            sense,
+            metadata: self.metadata,
+            annotations,
+        };
+
+        let computed_feasible = solution.feasible();
+        if computed_feasible != self.feasible {
+            return Err(
+                RawParseError::SolutionError(SolutionError::InconsistentFeasibility {
+                    provided_feasible: self.feasible,
+                    computed_feasible,
+                })
+                .context(message, "feasible"),
+            );
+        }
+        let provided_feasible_relaxed = self.feasible_relaxed.unwrap_or(self.feasible);
+        let computed_feasible_relaxed = solution.feasible_relaxed();
+        if computed_feasible_relaxed != provided_feasible_relaxed {
+            return Err(RawParseError::SolutionError(
+                SolutionError::InconsistentFeasibilityRelaxed {
+                    provided_feasible_relaxed,
+                    computed_feasible_relaxed,
+                },
+            )
+            .context(message, "feasible_relaxed"));
+        }
+
+        Ok(solution)
+    }
+}
+
+impl TryFrom<v2::Solution> for Solution {
+    type Error = ParseError;
+
+    fn try_from(value: v2::Solution) -> Result<Self, Self::Error> {
+        value.parse(&())
     }
 }
 

--- a/rust/ommx/src/solution/serialize.rs
+++ b/rust/ommx/src/solution/serialize.rs
@@ -45,6 +45,7 @@ impl From<Solution> for v2::Solution {
             optimality,
             relaxation,
             sense,
+            feasibility_atol,
             metadata,
             annotations,
         } = value;
@@ -65,6 +66,7 @@ impl From<Solution> for v2::Solution {
             evaluated_indicator_constraints: Some(evaluated_indicator_constraints.into()),
             evaluated_one_hot_constraints: Some(evaluated_one_hot_constraints.into()),
             evaluated_sos1_constraints: Some(evaluated_sos1_constraints.into()),
+            feasibility_atol: Some(feasibility_atol.into_inner()),
         }
     }
 }

--- a/rust/ommx/src/solution/serialize.rs
+++ b/rust/ommx/src/solution/serialize.rs
@@ -17,6 +17,11 @@ impl Solution {
         let inner = v1::Solution::decode(bytes)?;
         Ok(Parse::parse(inner, &())?)
     }
+
+    pub fn from_v2_bytes(bytes: &[u8]) -> Result<Self> {
+        let inner = v2::Solution::decode(bytes)?;
+        Ok(Parse::parse(inner, &())?)
+    }
 }
 
 impl From<Solution> for v2::Solution {

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -264,6 +264,12 @@ impl Parse for crate::v2::EvaluatedSos1Constraint {
             )
             .context(message, "active_variable"));
         }
+        if active_variable.is_some() && !self.feasible {
+            return Err(crate::RawParseError::InvalidInstance(
+                "SOS1 active_variable must be unset when feasible is false".to_string(),
+            )
+            .context(message, "active_variable"));
+        }
         Ok(Sos1Constraint {
             variables,
             stage: Sos1EvaluatedData {
@@ -342,10 +348,21 @@ impl Parse for crate::v2::SampledSos1Constraint {
             )
             .context(message, "active_variable"));
         }
+        let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
+        for (sample_id, active_variable) in &active_variable {
+            if active_variable.is_some()
+                && feasible.get(sample_id).is_some_and(|feasible| !feasible)
+            {
+                return Err(crate::RawParseError::InvalidInstance(
+                    "SOS1 active_variable must be unset when feasible is false".to_string(),
+                )
+                .context(message, "active_variable"));
+            }
+        }
         Ok(Sos1Constraint {
             variables,
             stage: Sos1SampledData {
-                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
+                feasible,
                 active_variable,
                 used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
                     self.used_decision_variable_ids,
@@ -387,6 +404,47 @@ mod tests {
     fn sos1_constraint_rejects_empty_variable_set() {
         let err = Sos1Constraint::new(BTreeSet::new()).unwrap_err();
         assert!(err.to_string().contains("at least one variable"));
+    }
+
+    #[test]
+    fn parse_v2_evaluated_rejects_infeasible_active_variable() {
+        let proto = crate::v2::EvaluatedSos1Constraint {
+            variables: vec![1],
+            feasible: false,
+            active_variable: Some(1),
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("active_variable must be unset when feasible is false"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_v2_sampled_rejects_infeasible_active_variable() {
+        let proto = crate::v2::SampledSos1Constraint {
+            variables: vec![1],
+            feasible: BTreeMap::from([(0, false)]),
+            active_variable: BTreeMap::from([(
+                0,
+                crate::v2::SampledActiveVariable {
+                    variable_id: Some(1),
+                },
+            )]),
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("active_variable must be unset when feasible is false"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     constraint_type::{
         sample_ids_from_map, ConstraintType, EvaluatedConstraintBehavior, SampledConstraintBehavior,
     },
-    Parse, ParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
+    ATol, Parse, ParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
 };
 use derive_more::{Deref, From};
 use std::collections::{BTreeMap, BTreeSet};
@@ -245,7 +245,7 @@ impl From<EvaluatedSos1Constraint> for crate::v2::EvaluatedSos1Constraint {
 
 impl Parse for crate::v2::EvaluatedSos1Constraint {
     type Output = EvaluatedSos1Constraint;
-    type Context = ();
+    type Context = ATol;
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.EvaluatedSos1Constraint";
@@ -318,7 +318,7 @@ impl From<SampledSos1Constraint> for crate::v2::SampledSos1Constraint {
 
 impl Parse for crate::v2::SampledSos1Constraint {
     type Output = SampledSos1Constraint;
-    type Context = ();
+    type Context = ATol;
 
     fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
         let message = "ommx.v2.SampledSos1Constraint";

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     constraint_type::{
         sample_ids_from_map, ConstraintType, EvaluatedConstraintBehavior, SampledConstraintBehavior,
     },
-    SampleID, SampleIDSet, VariableID, VariableIDSet,
+    Parse, ParseError, SampleID, SampleIDSet, VariableID, VariableIDSet,
 };
 use derive_more::{Deref, From};
 use std::collections::{BTreeMap, BTreeSet};
@@ -121,6 +121,10 @@ impl EvaluatedConstraintBehavior for EvaluatedSos1Constraint {
     fn is_feasible(&self) -> bool {
         self.stage.feasible
     }
+
+    fn used_decision_variable_ids(&self) -> &VariableIDSet {
+        &self.stage.used_decision_variable_ids
+    }
 }
 
 impl SampledConstraintBehavior for SampledSos1Constraint {
@@ -202,6 +206,23 @@ impl From<Sos1Constraint<Created>> for crate::v2::Sos1Constraint {
     }
 }
 
+impl Parse for crate::v2::Sos1Constraint {
+    type Output = Sos1Constraint<Created>;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.Sos1Constraint";
+        Sos1Constraint::new(crate::v2_io::variable_id_set_from_v2(
+            self.variables,
+            message,
+            "variables",
+        )?)
+        .map_err(|e| {
+            crate::RawParseError::InvalidInstance(e.to_string()).context(message, "variables")
+        })
+    }
+}
+
 impl From<EvaluatedSos1Constraint> for crate::v2::EvaluatedSos1Constraint {
     fn from(constraint: EvaluatedSos1Constraint) -> Self {
         Self {
@@ -219,6 +240,42 @@ impl From<EvaluatedSos1Constraint> for crate::v2::EvaluatedSos1Constraint {
                 .map(|id| id.into_inner())
                 .collect(),
         }
+    }
+}
+
+impl Parse for crate::v2::EvaluatedSos1Constraint {
+    type Output = EvaluatedSos1Constraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.EvaluatedSos1Constraint";
+        let variables =
+            crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
+        if variables.is_empty() {
+            return Err(crate::RawParseError::InvalidInstance(
+                "SOS1 constraints must contain at least one variable".to_string(),
+            )
+            .context(message, "variables"));
+        }
+        let active_variable = self.active_variable.map(VariableID::from);
+        if active_variable.is_some_and(|id| !variables.contains(&id)) {
+            return Err(crate::RawParseError::InvalidInstance(
+                "SOS1 active_variable must be a member of variables".to_string(),
+            )
+            .context(message, "active_variable"));
+        }
+        Ok(Sos1Constraint {
+            variables,
+            stage: Sos1EvaluatedData {
+                feasible: self.feasible,
+                active_variable,
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+            },
+        })
     }
 }
 
@@ -256,6 +313,47 @@ impl From<SampledSos1Constraint> for crate::v2::SampledSos1Constraint {
                 .map(|id| id.into_inner())
                 .collect(),
         }
+    }
+}
+
+impl Parse for crate::v2::SampledSos1Constraint {
+    type Output = SampledSos1Constraint;
+    type Context = ();
+
+    fn parse(self, _: &Self::Context) -> Result<Self::Output, ParseError> {
+        let message = "ommx.v2.SampledSos1Constraint";
+        let variables =
+            crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
+        if variables.is_empty() {
+            return Err(crate::RawParseError::InvalidInstance(
+                "SOS1 constraints must contain at least one variable".to_string(),
+            )
+            .context(message, "variables"));
+        }
+        let active_variable =
+            crate::v2_io::sampled_active_variable_map_from_v2(self.active_variable);
+        if active_variable
+            .values()
+            .flatten()
+            .any(|id| !variables.contains(id))
+        {
+            return Err(crate::RawParseError::InvalidInstance(
+                "SOS1 active_variable values must be members of variables".to_string(),
+            )
+            .context(message, "active_variable"));
+        }
+        Ok(Sos1Constraint {
+            variables,
+            stage: Sos1SampledData {
+                feasible: crate::v2_io::sample_bool_map_from_v2(self.feasible),
+                active_variable,
+                used_decision_variable_ids: crate::v2_io::variable_id_set_from_v2(
+                    self.used_decision_variable_ids,
+                    message,
+                    "used_decision_variable_ids",
+                )?,
+            },
+        })
     }
 }
 

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -1,8 +1,9 @@
 //! IO-adjacent helpers for protobuf-generated `v2::*` roots.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::v2::Feature;
+use crate::{ParseError, RawParseError, SampleID, VariableID, VariableIDSet};
 
 pub(crate) fn required_features(
     has_indicator_constraints: bool,
@@ -27,5 +28,101 @@ pub(crate) fn extension_annotations_to_v2_map(
 ) -> BTreeMap<String, String> {
     crate::protobuf_extension_annotations(annotations)
         .into_iter()
+        .collect()
+}
+
+pub(crate) fn extension_annotations_from_v2_map(
+    annotations: BTreeMap<String, String>,
+    message: &'static str,
+) -> Result<HashMap<String, String>, ParseError> {
+    for key in annotations.keys() {
+        if crate::is_reserved_annotation_key(key) {
+            return Err(RawParseError::ReservedAnnotationKey { key: key.clone() }
+                .context(message, "annotations"));
+        }
+    }
+    Ok(annotations.into_iter().collect())
+}
+
+pub(crate) fn parse_required_features(
+    features: Vec<i32>,
+    message: &'static str,
+) -> Result<BTreeSet<Feature>, ParseError> {
+    let mut parsed = BTreeSet::new();
+    for value in features {
+        let feature = Feature::try_from(value).map_err(|_| {
+            RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v2.Feature",
+                value,
+            }
+            .context(message, "required_features")
+        })?;
+        if feature == Feature::Unspecified {
+            return Err(RawParseError::UnknownEnumValue {
+                enum_name: "ommx.v2.Feature",
+                value,
+            }
+            .context(message, "required_features"));
+        }
+        parsed.insert(feature);
+    }
+    Ok(parsed)
+}
+
+pub(crate) fn validate_feature_payload(
+    required_features: &BTreeSet<Feature>,
+    feature: Feature,
+    has_payload: bool,
+    message: &'static str,
+    field: &'static str,
+) -> Result<(), ParseError> {
+    let feature_required = required_features.contains(&feature);
+    match (feature_required, has_payload) {
+        (true, true) | (false, false) => Ok(()),
+        (true, false) => Err(RawParseError::InvalidInstance(format!(
+            "{feature:?} is listed in required_features, but {field} is empty",
+        ))
+        .context(message, field)),
+        (false, true) => Err(RawParseError::InvalidInstance(format!(
+            "{field} is non-empty, but required_features does not include {feature:?}",
+        ))
+        .context(message, "required_features")),
+    }
+}
+
+pub(crate) fn variable_id_set_from_v2(
+    ids: Vec<u64>,
+    message: &'static str,
+    field: &'static str,
+) -> Result<VariableIDSet, ParseError> {
+    let mut out = VariableIDSet::default();
+    for id in ids {
+        let id = VariableID::from(id);
+        if !out.insert(id) {
+            return Err(RawParseError::InvalidInstance(format!(
+                "Duplicated variable ID is found in {field}: {id:?}",
+            ))
+            .context(message, field));
+        }
+    }
+    Ok(out)
+}
+
+pub(crate) fn sample_bool_map_from_v2(map: BTreeMap<u64, bool>) -> BTreeMap<SampleID, bool> {
+    map.into_iter()
+        .map(|(id, value)| (SampleID::from(id), value))
+        .collect()
+}
+
+pub(crate) fn sampled_active_variable_map_from_v2(
+    map: BTreeMap<u64, crate::v2::SampledActiveVariable>,
+) -> BTreeMap<SampleID, Option<VariableID>> {
+    map.into_iter()
+        .map(|(sample_id, value)| {
+            (
+                SampleID::from(sample_id),
+                value.variable_id.map(VariableID::from),
+            )
+        })
         .collect()
 }

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -102,13 +102,18 @@ pub fn parse_feasibility_atol(
     value: Option<f64>,
     message: &'static str,
 ) -> Result<ATol, ParseError> {
-    value
-        .map(ATol::new)
-        .transpose()
-        .map_err(|e| {
-            RawParseError::InvalidInstance(e.to_string()).context(message, "feasibility_atol")
-        })?
-        .map_or_else(|| Ok(ATol::default()), Ok)
+    let Some(value) = value else {
+        return Ok(ATol::default());
+    };
+    if !value.is_finite() {
+        return Err(RawParseError::InvalidInstance(format!(
+            "feasibility_atol must be finite: value={value}",
+        ))
+        .context(message, "feasibility_atol"));
+    }
+    ATol::new(value).map_err(|e| {
+        RawParseError::InvalidInstance(e.to_string()).context(message, "feasibility_atol")
+    })
 }
 
 pub fn validate_finite_f64(

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use crate::constraint_type::IDType;
 use crate::v2::Feature;
 use crate::{
-    ATol, ModelingLabelStore, ParseError, RawParseError, SampleID, Sampled, VariableID,
+    ATol, ModelingLabelStore, ParseError, RawParseError, SampleID, Sampled, Sense, VariableID,
     VariableIDSet,
 };
 
@@ -126,20 +126,33 @@ pub fn validate_finite_f64(
     }
 }
 
+pub fn parse_v2_required_sense(value: i32, message: &'static str) -> Result<Sense, ParseError> {
+    let sense = crate::v1::instance::Sense::try_from(value)
+        .map_err(|_| RawParseError::UnknownEnumValue {
+            enum_name: "ommx.v1.Sense",
+            value,
+        })
+        .map_err(|e| ParseError::from(e).context(message, "sense"))?;
+    match sense {
+        crate::v1::instance::Sense::Minimize => Ok(Sense::Minimize),
+        crate::v1::instance::Sense::Maximize => Ok(Sense::Maximize),
+        crate::v1::instance::Sense::Unspecified => Err(RawParseError::UnknownEnumValue {
+            enum_name: "ommx.v1.Sense",
+            value,
+        }
+        .context(message, "sense")),
+    }
+}
+
 pub fn validate_sampled_f64_values(
     values: &Sampled<f64>,
     message: &'static str,
     field: &'static str,
 ) -> Result<(), ParseError> {
-    for (value, sample_ids) in values.clone().chunk() {
+    for (sample_id, value) in values.iter() {
         if !value.is_finite() {
-            let sample_context = sample_ids
-                .iter()
-                .next()
-                .map(|sample_id| format!(" for sample {sample_id:?}"))
-                .unwrap_or_else(|| " for an empty sample group".to_string());
             return Err(RawParseError::InvalidInstance(format!(
-                "{field} must be finite{sample_context}: value={value}",
+                "{field} must be finite for sample {sample_id:?}: value={value}",
             ))
             .context(message, field));
         }

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -8,7 +8,9 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::constraint_type::IDType;
 use crate::v2::Feature;
-use crate::{ModelingLabelStore, ParseError, RawParseError, SampleID, VariableID, VariableIDSet};
+use crate::{
+    ATol, ModelingLabelStore, ParseError, RawParseError, SampleID, VariableID, VariableIDSet,
+};
 
 pub fn required_features(
     has_indicator_constraints: bool,
@@ -93,6 +95,19 @@ pub fn validate_feature_payload(
         ))
         .context(message, "required_features")),
     }
+}
+
+pub fn parse_feasibility_atol(
+    value: Option<f64>,
+    message: &'static str,
+) -> Result<ATol, ParseError> {
+    value
+        .map(ATol::new)
+        .transpose()
+        .map_err(|e| {
+            RawParseError::InvalidInstance(e.to_string()).context(message, "feasibility_atol")
+        })?
+        .map_or_else(|| Ok(ATol::default()), Ok)
 }
 
 pub fn variable_id_set_from_v2(

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -1,4 +1,9 @@
 //! IO-adjacent helpers for protobuf-generated `v2::*` roots.
+//!
+//! These are crate-internal because v2 protobuf conversion is implemented at
+//! the domain owner that has complete information for each table or collection,
+//! while feature-gate, annotation, ID-list, and sample-axis policies must be
+//! identical across `Instance`, `Solution`, `SampleSet`, and row-family modules.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -1,16 +1,16 @@
 //! IO-adjacent helpers for protobuf-generated `v2::*` roots.
 //!
-//! These are crate-internal because v2 protobuf conversion is implemented at
-//! the domain owner that has complete information for each table or collection,
-//! while feature-gate, annotation, ID-list, and sample-axis policies must be
-//! identical across `Instance`, `Solution`, `SampleSet`, and row-family modules.
+//! `v2_io` itself is a private crate-root module. Its items are `pub` only so
+//! sibling domain owner modules can share the same protobuf-boundary policies
+//! without exporting those helpers as Rust SDK API.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use crate::constraint_type::IDType;
 use crate::v2::Feature;
-use crate::{ParseError, RawParseError, SampleID, VariableID, VariableIDSet};
+use crate::{ModelingLabelStore, ParseError, RawParseError, SampleID, VariableID, VariableIDSet};
 
-pub(crate) fn required_features(
+pub fn required_features(
     has_indicator_constraints: bool,
     has_one_hot_constraints: bool,
     has_sos1_constraints: bool,
@@ -28,7 +28,7 @@ pub(crate) fn required_features(
     features
 }
 
-pub(crate) fn extension_annotations_to_v2_map(
+pub fn extension_annotations_to_v2_map(
     annotations: HashMap<String, String>,
 ) -> BTreeMap<String, String> {
     crate::protobuf_extension_annotations(annotations)
@@ -36,7 +36,7 @@ pub(crate) fn extension_annotations_to_v2_map(
         .collect()
 }
 
-pub(crate) fn extension_annotations_from_v2_map(
+pub fn extension_annotations_from_v2_map(
     annotations: BTreeMap<String, String>,
     message: &'static str,
 ) -> Result<HashMap<String, String>, ParseError> {
@@ -49,7 +49,7 @@ pub(crate) fn extension_annotations_from_v2_map(
     Ok(annotations.into_iter().collect())
 }
 
-pub(crate) fn parse_required_features(
+pub fn parse_required_features(
     features: Vec<i32>,
     message: &'static str,
 ) -> Result<BTreeSet<Feature>, ParseError> {
@@ -74,7 +74,7 @@ pub(crate) fn parse_required_features(
     Ok(parsed)
 }
 
-pub(crate) fn validate_feature_payload(
+pub fn validate_feature_payload(
     required_features: &BTreeSet<Feature>,
     feature: Feature,
     has_payload: bool,
@@ -95,7 +95,7 @@ pub(crate) fn validate_feature_payload(
     }
 }
 
-pub(crate) fn variable_id_set_from_v2(
+pub fn variable_id_set_from_v2(
     ids: Vec<u64>,
     message: &'static str,
     field: &'static str,
@@ -113,13 +113,13 @@ pub(crate) fn variable_id_set_from_v2(
     Ok(out)
 }
 
-pub(crate) fn sample_bool_map_from_v2(map: BTreeMap<u64, bool>) -> BTreeMap<SampleID, bool> {
+pub fn sample_bool_map_from_v2(map: BTreeMap<u64, bool>) -> BTreeMap<SampleID, bool> {
     map.into_iter()
         .map(|(id, value)| (SampleID::from(id), value))
         .collect()
 }
 
-pub(crate) fn sampled_active_variable_map_from_v2(
+pub fn sampled_active_variable_map_from_v2(
     map: BTreeMap<u64, crate::v2::SampledActiveVariable>,
 ) -> BTreeMap<SampleID, Option<VariableID>> {
     map.into_iter()
@@ -130,4 +130,24 @@ pub(crate) fn sampled_active_variable_map_from_v2(
             )
         })
         .collect()
+}
+
+pub fn modeling_label_store_to_v2_map<ID: IDType>(
+    store: &ModelingLabelStore<ID>,
+) -> BTreeMap<u64, crate::v2::ModelingLabel> {
+    store
+        .ids()
+        .into_iter()
+        .map(|id| (id.into(), store.collect_for(id).into()))
+        .collect()
+}
+
+pub fn modeling_label_store_from_v2_map<ID: IDType>(
+    labels: BTreeMap<u64, crate::v2::ModelingLabel>,
+) -> ModelingLabelStore<ID> {
+    let mut store = ModelingLabelStore::default();
+    for (id, label) in labels {
+        store.insert(ID::from(id), label.into());
+    }
+    store
 }

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -9,7 +9,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use crate::constraint_type::IDType;
 use crate::v2::Feature;
 use crate::{
-    ATol, ModelingLabelStore, ParseError, RawParseError, SampleID, VariableID, VariableIDSet,
+    ATol, ModelingLabelStore, ParseError, RawParseError, SampleID, Sampled, VariableID,
+    VariableIDSet,
 };
 
 pub fn required_features(
@@ -108,6 +109,42 @@ pub fn parse_feasibility_atol(
             RawParseError::InvalidInstance(e.to_string()).context(message, "feasibility_atol")
         })?
         .map_or_else(|| Ok(ATol::default()), Ok)
+}
+
+pub fn validate_finite_f64(
+    value: f64,
+    message: &'static str,
+    field: &'static str,
+) -> Result<(), ParseError> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(
+            RawParseError::InvalidInstance(format!("{field} must be finite: value={value}",))
+                .context(message, field),
+        )
+    }
+}
+
+pub fn validate_sampled_f64_values(
+    values: &Sampled<f64>,
+    message: &'static str,
+    field: &'static str,
+) -> Result<(), ParseError> {
+    for (value, sample_ids) in values.clone().chunk() {
+        if !value.is_finite() {
+            let sample_context = sample_ids
+                .iter()
+                .next()
+                .map(|sample_id| format!(" for sample {sample_id:?}"))
+                .unwrap_or_else(|| " for an empty sample group".to_string());
+            return Err(RawParseError::InvalidInstance(format!(
+                "{field} must be finite{sample_context}: value={value}",
+            ))
+            .context(message, field));
+        }
+    }
+    Ok(())
 }
 
 pub fn variable_id_set_from_v2(


### PR DESCRIPTION
## Summary

Part of #958.

This PR completes Rust-side OMMX v2 protobuf round-trip support for the normalized SDK roots.

It adds:

- v2 byte encoders and decoders for `Instance`, `ParametricInstance`, `Solution`, and `SampleSet`
- v2 parse paths that rebuild normalized decision-variable, parameter, named-function, and constraint collection owners
- feature-based forward-compatibility checks through `required_features`
- root-boundary validation for sidecar ownership, removed-reason ownership, structural special-constraint IDs, fixed/dependent partitions, sample-ID axes, and stored feasibility fields
- `feasibility_atol` on v2 `Solution` and `SampleSet` so stored feasibility columns can be checked without re-evaluating the model
- round-trip and malformed-payload coverage for special constraints, named functions, parameters, labels/context, required features, and v2 root decoding

The v2 serializer remains infallible from normalized Rust SDK data. The decoder is fallible because protobuf payloads are an external boundary and can violate table, collection, or root invariants.
