### PR TITLE
Fix pull_artifact example API usage

### DIFF
--- a/rust/ommx/examples/pull_artifact.rs
+++ b/rust/ommx/examples/pull_artifact.rs
@@ -1,8 +1,5 @@
 use anyhow::Result;
-use ommx::artifact::{
-    local_registry::{pull_image, LocalRegistry},
-    media_types, ImageRef, LocalArtifact,
-};
+use ommx::artifact::{local_registry::LocalRegistry, media_types, ImageRef, LocalArtifact};
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -18,7 +15,7 @@ fn main() -> Result<()> {
     // Pull the artifact from the remote registry into the v3 SQLite
     // Local Registry, then open it for read by ref.
     let registry = LocalRegistry::shared_default()?;
-    pull_image(registry, &image_name)?;
+    registry.pull_image(&image_name)?;
     let local = LocalArtifact::open_in_registry(registry, image_name)?;
 
     // Print the digest of each instance layer.


### PR DESCRIPTION
## Summary

Updates the Rust `pull_artifact` example to use the current `LocalRegistry::pull_image` method API.

## Details

The example still imported a removed `local_registry::pull_image` free function. Remote artifact pulls now live on `LocalRegistry`, so the example failed to compile when checked directly. The import is simplified and the pull call now uses `registry.pull_image(&image_name)?`.

Fixes #1006.