### PR TITLE
Split Instance arbitrary spaces

### DIFF
--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -601,9 +601,12 @@ modeling labels.
 [`InstanceParameters`](crate::InstanceParameters) now distinguishes between
 the full V3 [`Instance`](crate::Instance) domain and narrower constructive
 subspaces for property tests. `InstanceParameters::default()` and
-`InstanceParameters::full_v3()` generate instances with special constraint
-families, active and removed lifecycle states, fixed variables, dependent
-variables, sidecars, and annotations. Tests whose property assumes a narrower
+`InstanceParameters::full_v3()` generate instances that exercise the V3
+features: special constraint families, active and removed lifecycle states,
+fixed variables, dependent variables, sidecars, and annotations. The regular
+parts are sampled from strategies, while the V3-specific structure is injected
+deterministically, so each V3 dimension is covered at one representative point
+(smoke coverage) rather than sampled. Tests whose property assumes a narrower
 domain should opt in explicitly with `InstanceParameters::regular_only()`,
 `InstanceParameters::v1_compatible()`, or
 `InstanceParameters::mps_compatible_qcqp()`.

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -595,3 +595,19 @@ compact whole-instance view. The summary resolves labels for objectives,
 regular and special constraints, and named functions, so printing an instance is
 useful for checking the correspondence between encoded IDs and upstream
 modeling labels.
+
+### Explicit `Instance` arbitrary spaces ([#1014](https://github.com/Jij-Inc/ommx/pull/1014))
+
+[`InstanceParameters`](crate::InstanceParameters) now distinguishes between
+the full V3 [`Instance`](crate::Instance) domain and narrower constructive
+subspaces for property tests. `InstanceParameters::default()` and
+`InstanceParameters::full_v3()` generate instances with special constraint
+families, active and removed lifecycle states, fixed variables, dependent
+variables, sidecars, and annotations. Tests whose property assumes a narrower
+domain should opt in explicitly with `InstanceParameters::regular_only()`,
+`InstanceParameters::v1_compatible()`, or
+`InstanceParameters::mps_compatible_qcqp()`.
+
+The new [`InstanceSpace`](crate::InstanceSpace) field records the selected
+space. This makes rejected-case-heavy `prop_filter` usage unnecessary for
+common preconditions such as v1 or MPS compatibility.

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -27,7 +27,7 @@ mod stats;
 mod substitute;
 
 pub use analysis::*;
-pub use arbitrary::InstanceParameters;
+pub use arbitrary::{InstanceParameters, InstanceSpace};
 pub use builder::*;
 pub use parametric_builder::*;
 pub use stats::*;

--- a/rust/ommx/src/instance/arbitrary.rs
+++ b/rust/ommx/src/instance/arbitrary.rs
@@ -1,15 +1,15 @@
 use super::*;
 use crate::{
     arbitrary_constraints, arbitrary_decision_variables, arbitrary_named_functions,
-    constraint_type::ConstraintCollection,
     random::{arbitrary_samples, SamplesParameters},
     v1::State,
-    ATol, Bounds, ConstraintIDParameters, Evaluate, KindParameters, NamedFunctionIDParameters,
-    PolynomialParameters, Sampled,
+    Bounds, ConstraintIDParameters, Equality, Evaluate, IndicatorConstraintID, Kind,
+    KindParameters, NamedFunctionIDParameters, OneHotConstraintID, PolynomialParameters, Sampled,
+    Sos1ConstraintID,
 };
 use fnv::FnvHashSet;
 use proptest::prelude::*;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 fn arbitrary_integer_state(bounds: &Bounds, max_abs: u64) -> BoxedStrategy<State> {
     let mut strategy = Just(HashMap::new()).boxed();
@@ -111,8 +111,18 @@ impl Arbitrary for Sense {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstanceSpace {
+    /// Generate the V3 `Instance` domain, including feature families and roles.
+    FullV3,
+    /// Generate only regular constraints with no fixed/dependent variables or
+    /// non-standard constraint families.
+    RegularOnly,
+}
+
 #[derive(Debug, Clone)]
 pub struct InstanceParameters {
+    pub space: InstanceSpace,
     pub constraint_ids: ConstraintIDParameters,
     pub objective: PolynomialParameters,
     pub constraint: PolynomialParameters,
@@ -123,9 +133,54 @@ pub struct InstanceParameters {
 }
 
 impl InstanceParameters {
+    pub fn full_v3() -> Self {
+        Self {
+            space: InstanceSpace::FullV3,
+            constraint_ids: ConstraintIDParameters::default(),
+            named_function_ids: NamedFunctionIDParameters::default(),
+            objective: PolynomialParameters::default(),
+            constraint: PolynomialParameters::default(),
+            named_function: PolynomialParameters::default(),
+            kinds: KindParameters::new(&[
+                Kind::Binary,
+                Kind::Integer,
+                Kind::Continuous,
+                Kind::SemiInteger,
+                Kind::SemiContinuous,
+            ])
+            .unwrap(),
+            max_irrelevant_ids: 5,
+        }
+    }
+
+    pub fn regular_only() -> Self {
+        Self {
+            space: InstanceSpace::RegularOnly,
+            constraint_ids: ConstraintIDParameters::default(),
+            named_function_ids: NamedFunctionIDParameters::default(),
+            objective: PolynomialParameters::default(),
+            constraint: PolynomialParameters::default(),
+            named_function: PolynomialParameters::default(),
+            kinds: KindParameters::default(),
+            max_irrelevant_ids: 5,
+        }
+    }
+
+    pub fn v1_compatible() -> Self {
+        Self::regular_only()
+    }
+
+    pub fn mps_compatible_qcqp() -> Self {
+        Self {
+            named_function_ids: NamedFunctionIDParameters::new(0, 0.into()).unwrap(),
+            ..Self::default_qcqp()
+        }
+    }
+
     /// Default parameter for Linear Programming (LP), i.e. linear objective and linear constraints.
     pub fn default_lp() -> Self {
         Self {
+            space: InstanceSpace::RegularOnly,
             constraint_ids: ConstraintIDParameters::default(),
             named_function_ids: NamedFunctionIDParameters::default(),
             named_function: PolynomialParameters::default_linear(),
@@ -139,6 +194,7 @@ impl InstanceParameters {
     /// Default parameter for Quadratic Programming (QP), i.e. quadratic objective and linear constraints.
     pub fn default_qp() -> Self {
         Self {
+            space: InstanceSpace::RegularOnly,
             constraint_ids: ConstraintIDParameters::default(),
             named_function_ids: NamedFunctionIDParameters::default(),
             objective: PolynomialParameters::default_quadratic(),
@@ -152,6 +208,7 @@ impl InstanceParameters {
     /// Default parameter for Quadratically Constrained Quadratic Programming (QCQP), i.e. quadratic objective and quadratic constraints.
     pub fn default_qcqp() -> Self {
         Self {
+            space: InstanceSpace::RegularOnly,
             constraint_ids: ConstraintIDParameters::default(),
             named_function_ids: NamedFunctionIDParameters::default(),
             objective: PolynomialParameters::default_quadratic(),
@@ -165,15 +222,37 @@ impl InstanceParameters {
 
 impl Default for InstanceParameters {
     fn default() -> Self {
-        Self {
-            constraint_ids: ConstraintIDParameters::default(),
-            named_function_ids: NamedFunctionIDParameters::default(),
-            objective: PolynomialParameters::default(),
-            constraint: PolynomialParameters::default(),
-            named_function: PolynomialParameters::default(),
-            kinds: KindParameters::default(),
-            max_irrelevant_ids: 5,
+        Self::full_v3()
+    }
+}
+
+fn fresh_variable_ids(existing: &mut FnvHashSet<VariableID>, size: usize) -> Vec<VariableID> {
+    let mut ids = Vec::with_capacity(size);
+    let mut raw_id = 0_u64;
+    while ids.len() < size {
+        let id = VariableID::from(raw_id);
+        if existing.insert(id) {
+            ids.push(id);
         }
+        raw_id = raw_id
+            .checked_add(1)
+            .expect("exhausted variable ID space while generating fresh IDs");
+    }
+    ids
+}
+
+fn next_constraint_id(constraints: &BTreeMap<ConstraintID, Constraint>) -> ConstraintID {
+    constraints
+        .keys()
+        .next_back()
+        .map(|id| ConstraintID::from(id.into_inner() + 1))
+        .unwrap_or_else(|| ConstraintID::from(0))
+}
+
+fn arbitrary_removed_reason() -> crate::constraint::RemovedReason {
+    crate::constraint::RemovedReason {
+        reason: "arbitrary".to_string(),
+        parameters: Default::default(),
     }
 }
 
@@ -185,6 +264,8 @@ impl Arbitrary for Instance {
         let objective = Function::arbitrary_with(p.objective);
         let constraints = arbitrary_constraints(p.constraint_ids, p.constraint);
         let named_functions = arbitrary_named_functions(p.named_function_ids, p.named_function);
+        let space = p.space;
+        let kinds = p.kinds.clone();
         // Generate candidates for irrelevant IDs.
         // Since these IDs are generated without checking against the objective or constraints, some of these may be relevant.
         let max_id = p
@@ -212,47 +293,176 @@ impl Arbitrary for Instance {
                         unique_ids.extend(nf.function.required_ids());
                     }
                     unique_ids.extend(irrelevant_candidates.into_iter().map(VariableID::from));
+                    let full_v3_ids = (space == InstanceSpace::FullV3)
+                        .then(|| fresh_variable_ids(&mut unique_ids, 7));
                     (
                         Just(objective),
                         Just(constraints),
                         Just(named_functions),
-                        arbitrary_decision_variables(unique_ids, p.kinds.clone()),
+                        Just(full_v3_ids),
+                        arbitrary_decision_variables(unique_ids, kinds.clone()),
                         Sense::arbitrary(),
                     )
                         .prop_map(
-                            |(
+                            move |(
                                 objective,
                                 constraints,
                                 named_functions,
+                                full_v3_ids,
                                 decision_variables,
                                 sense,
                             )| {
-                                Instance {
-                                    objective,
-                                    constraint_collection: ConstraintCollection::new(
-                                        constraints,
-                                        Default::default(),
-                                    )
-                                    .expect("empty removed constraints cannot overlap active constraints"),
-                                    named_functions: crate::NamedFunctionTable::from_entries(
-                                        named_functions,
-                                    ),
-                                    sense,
-                                    decision_variables: crate::DecisionVariableTable::with_fixed_values(
-                                        decision_variables,
-                                        Default::default(),
-                                        Default::default(),
-                                        ATol::default(),
-                                    )
-                                    .expect("empty fixed-value column is valid"),
-                                    parameters: Default::default(),
-                                    indicator_constraint_collection: Default::default(),
-                                    one_hot_constraint_collection: Default::default(),
-                                    sos1_constraint_collection: Default::default(),
-                                    decision_variable_dependency: Default::default(),
-                                    description: None,
-                                    annotations: Default::default(),
+                                let mut decision_variables = decision_variables;
+                                let mut variable_labels = VariableLabelStore::default();
+                                let mut named_function_labels =
+                                    crate::named_function::NamedFunctionLabelStore::default();
+                                let mut constraint_context =
+                                    ConstraintContextStore::<ConstraintID>::default();
+                                let mut removed_constraints = BTreeMap::new();
+                                let mut fixed_decision_variable_values = BTreeMap::new();
+                                let mut decision_variable_dependency =
+                                    AcyclicAssignments::default();
+                                let mut indicator_constraints = BTreeMap::new();
+                                let mut removed_indicator_constraints = BTreeMap::new();
+                                let mut indicator_constraint_context =
+                                    ConstraintContextStore::<IndicatorConstraintID>::default();
+                                let mut one_hot_constraints = BTreeMap::new();
+                                let mut one_hot_constraint_context =
+                                    ConstraintContextStore::<OneHotConstraintID>::default();
+                                let mut sos1_constraints = BTreeMap::new();
+                                let mut sos1_constraint_context =
+                                    ConstraintContextStore::<Sos1ConstraintID>::default();
+
+                                if let Some((id, _)) = decision_variables.iter().next() {
+                                    variable_labels.set_name(*id, "arbitrary_variable");
                                 }
+                                if let Some(id) = named_functions.keys().next().copied() {
+                                    named_function_labels.set_name(id, "arbitrary_named_function");
+                                }
+                                if let Some(id) = constraints.keys().next().copied() {
+                                    constraint_context.set_name(id, "arbitrary_constraint");
+                                }
+
+                                if let Some(ids) = full_v3_ids {
+                                    let fixed_id = ids[0];
+                                    let dependent_id = ids[1];
+                                    let indicator_var = ids[2];
+                                    let indicator_removed_var = ids[3];
+                                    let one_hot_a = ids[4];
+                                    let one_hot_b = ids[5];
+                                    let sos1_var = ids[6];
+
+                                    decision_variables.insert(fixed_id, DecisionVariable::binary());
+                                    fixed_decision_variable_values.insert(fixed_id, 0.0);
+                                    variable_labels.set_name(fixed_id, "arbitrary_fixed");
+
+                                    decision_variables
+                                        .insert(dependent_id, DecisionVariable::continuous());
+                                    decision_variable_dependency =
+                                        AcyclicAssignments::new([(dependent_id, Function::Zero)])
+                                            .expect("constant assignment is acyclic");
+                                    variable_labels.set_name(dependent_id, "arbitrary_dependent");
+
+                                    for id in [
+                                        indicator_var,
+                                        indicator_removed_var,
+                                        one_hot_a,
+                                        one_hot_b,
+                                        sos1_var,
+                                    ] {
+                                        decision_variables.insert(id, DecisionVariable::binary());
+                                    }
+
+                                    let removed_id = next_constraint_id(&constraints);
+                                    removed_constraints.insert(
+                                        removed_id,
+                                        (
+                                            Constraint::equal_to_zero(Function::Zero),
+                                            arbitrary_removed_reason(),
+                                        ),
+                                    );
+                                    constraint_context
+                                        .set_name(removed_id, "arbitrary_removed_constraint");
+
+                                    let indicator_id = IndicatorConstraintID::from(0);
+                                    indicator_constraints.insert(
+                                        indicator_id,
+                                        IndicatorConstraint::new(
+                                            indicator_var,
+                                            Equality::LessThanOrEqualToZero,
+                                            Function::Zero,
+                                        ),
+                                    );
+                                    indicator_constraint_context
+                                        .set_name(indicator_id, "arbitrary_indicator");
+
+                                    let removed_indicator_id = IndicatorConstraintID::from(1);
+                                    removed_indicator_constraints.insert(
+                                        removed_indicator_id,
+                                        (
+                                            IndicatorConstraint::new(
+                                                indicator_removed_var,
+                                                Equality::EqualToZero,
+                                                Function::Zero,
+                                            ),
+                                            arbitrary_removed_reason(),
+                                        ),
+                                    );
+                                    indicator_constraint_context.set_name(
+                                        removed_indicator_id,
+                                        "arbitrary_removed_indicator",
+                                    );
+
+                                    let one_hot_id = OneHotConstraintID::from(0);
+                                    one_hot_constraints.insert(
+                                        one_hot_id,
+                                        OneHotConstraint::new(BTreeSet::from([
+                                            one_hot_a, one_hot_b,
+                                        ]))
+                                        .expect("one-hot set is non-empty"),
+                                    );
+                                    one_hot_constraint_context
+                                        .set_name(one_hot_id, "arbitrary_one_hot");
+
+                                    let sos1_id = Sos1ConstraintID::from(0);
+                                    sos1_constraints.insert(
+                                        sos1_id,
+                                        Sos1Constraint::new(BTreeSet::from([sos1_var, one_hot_b]))
+                                            .expect("SOS1 set is non-empty"),
+                                    );
+                                    sos1_constraint_context.set_name(sos1_id, "arbitrary_sos1");
+                                }
+
+                                let mut instance = Instance::builder()
+                                    .sense(sense)
+                                    .objective(objective)
+                                    .decision_variables(decision_variables)
+                                    .variable_labels(variable_labels)
+                                    .fixed_decision_variable_values(fixed_decision_variable_values)
+                                    .constraints(constraints)
+                                    .constraint_context(constraint_context)
+                                    .removed_constraints(removed_constraints)
+                                    .indicator_constraints(indicator_constraints)
+                                    .indicator_constraint_context(indicator_constraint_context)
+                                    .removed_indicator_constraints(removed_indicator_constraints)
+                                    .one_hot_constraints(one_hot_constraints)
+                                    .one_hot_constraint_context(one_hot_constraint_context)
+                                    .sos1_constraints(sos1_constraints)
+                                    .sos1_constraint_context(sos1_constraint_context)
+                                    .named_functions(named_functions)
+                                    .named_function_labels(named_function_labels)
+                                    .decision_variable_dependency(decision_variable_dependency)
+                                    .build()
+                                    .expect("arbitrary Instance must satisfy builder invariants");
+
+                                if space == InstanceSpace::FullV3 {
+                                    instance.annotations.insert(
+                                        "org.ommx.user.arbitrary".to_string(),
+                                        "true".to_string(),
+                                    );
+                                }
+
+                                instance
                             },
                         )
                 },
@@ -279,6 +489,42 @@ mod tests {
                         prop_assert!(instance.decision_variables.contains_key(&id));
                     }
                 }
+            }
+            for (c, _) in instance.removed_constraints().values() {
+                for id in c.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
+            for c in instance.indicator_constraints().values() {
+                for id in c.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
+            for (c, _) in instance.removed_indicator_constraints().values() {
+                for id in c.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
+            for c in instance.one_hot_constraints().values() {
+                for id in c.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
+            for c in instance.sos1_constraints().values() {
+                for id in c.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
+            for nf in instance.named_functions().values() {
+                for id in nf.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
+            for id in instance.decision_variable_dependency().keys() {
+                prop_assert!(instance.decision_variables.contains_key(&id));
+            }
+            for id in instance.decision_variable_dependency().required_ids() {
+                prop_assert!(instance.decision_variables.contains_key(&id));
             }
         }
     }

--- a/rust/ommx/src/instance/arbitrary.rs
+++ b/rust/ommx/src/instance/arbitrary.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    arbitrary_constraints, arbitrary_decision_variables, arbitrary_named_functions,
+    arbitrary_constraints, arbitrary_decision_variables, arbitrary_named_functions, linear,
     random::{arbitrary_samples, SamplesParameters},
     v1::State,
     Bounds, ConstraintIDParameters, Equality, Evaluate, IndicatorConstraintID, Kind,
@@ -113,13 +113,20 @@ impl Arbitrary for Sense {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstanceSpace {
-    /// Generate the V3 `Instance` domain, including feature families and roles.
+    /// Generate the V3 [`Instance`] domain, including special constraint
+    /// families, lifecycle states, and decision-variable roles.
     FullV3,
-    /// Generate only regular constraints with no fixed/dependent variables or
-    /// non-standard constraint families.
+    /// Generate only the regular-constraint subspace with no fixed/dependent
+    /// variables or non-standard constraint families.
     RegularOnly,
 }
 
+/// Parameters for [`Instance`] generation.
+///
+/// `space` selects the domain being sampled. Use [`InstanceSpace::FullV3`]
+/// when the property under test should hold for arbitrary V3 instances. Use
+/// [`InstanceSpace::RegularOnly`] or one of the compatibility constructors
+/// when the property has a stricter precondition such as v1 or MPS support.
 #[derive(Debug, Clone)]
 pub struct InstanceParameters {
     pub space: InstanceSpace,
@@ -294,7 +301,7 @@ impl Arbitrary for Instance {
                     }
                     unique_ids.extend(irrelevant_candidates.into_iter().map(VariableID::from));
                     let full_v3_ids = (space == InstanceSpace::FullV3)
-                        .then(|| fresh_variable_ids(&mut unique_ids, 7));
+                        .then(|| fresh_variable_ids(&mut unique_ids, 12));
                     (
                         Just(objective),
                         Just(constraints),
@@ -348,9 +355,14 @@ impl Arbitrary for Instance {
                                     let dependent_id = ids[1];
                                     let indicator_var = ids[2];
                                     let indicator_removed_var = ids[3];
-                                    let one_hot_a = ids[4];
-                                    let one_hot_b = ids[5];
-                                    let sos1_var = ids[6];
+                                    let indicator_body_var = ids[4];
+                                    let removed_indicator_body_var = ids[5];
+                                    let one_hot_active_a = ids[6];
+                                    let one_hot_active_b = ids[7];
+                                    let one_hot_removed_a = ids[8];
+                                    let one_hot_removed_b = ids[9];
+                                    let sos1_active_var = ids[10];
+                                    let sos1_removed_var = ids[11];
 
                                     decision_variables.insert(fixed_id, DecisionVariable::binary());
                                     fixed_decision_variable_values.insert(fixed_id, 0.0);
@@ -366,9 +378,14 @@ impl Arbitrary for Instance {
                                     for id in [
                                         indicator_var,
                                         indicator_removed_var,
-                                        one_hot_a,
-                                        one_hot_b,
-                                        sos1_var,
+                                        indicator_body_var,
+                                        removed_indicator_body_var,
+                                        one_hot_active_a,
+                                        one_hot_active_b,
+                                        one_hot_removed_a,
+                                        one_hot_removed_b,
+                                        sos1_active_var,
+                                        sos1_removed_var,
                                     ] {
                                         decision_variables.insert(id, DecisionVariable::binary());
                                     }
@@ -390,7 +407,9 @@ impl Arbitrary for Instance {
                                         IndicatorConstraint::new(
                                             indicator_var,
                                             Equality::LessThanOrEqualToZero,
-                                            Function::Zero,
+                                            Function::from(
+                                                linear!(indicator_body_var.into_inner()),
+                                            ),
                                         ),
                                     );
                                     indicator_constraint_context
@@ -403,7 +422,9 @@ impl Arbitrary for Instance {
                                             IndicatorConstraint::new(
                                                 indicator_removed_var,
                                                 Equality::EqualToZero,
-                                                Function::Zero,
+                                                Function::from(linear!(
+                                                    removed_indicator_body_var.into_inner()
+                                                )),
                                             ),
                                             arbitrary_removed_reason(),
                                         ),
@@ -417,20 +438,48 @@ impl Arbitrary for Instance {
                                     one_hot_constraints.insert(
                                         one_hot_id,
                                         OneHotConstraint::new(BTreeSet::from([
-                                            one_hot_a, one_hot_b,
+                                            one_hot_active_a,
+                                            one_hot_active_b,
                                         ]))
                                         .expect("one-hot set is non-empty"),
                                     );
                                     one_hot_constraint_context
                                         .set_name(one_hot_id, "arbitrary_one_hot");
 
+                                    let removed_one_hot_id = OneHotConstraintID::from(1);
+                                    one_hot_constraints.insert(
+                                        removed_one_hot_id,
+                                        OneHotConstraint::new(BTreeSet::from([
+                                            one_hot_removed_a,
+                                            one_hot_removed_b,
+                                        ]))
+                                        .expect("one-hot set is non-empty"),
+                                    );
+                                    one_hot_constraint_context
+                                        .set_name(removed_one_hot_id, "arbitrary_removed_one_hot");
+
                                     let sos1_id = Sos1ConstraintID::from(0);
                                     sos1_constraints.insert(
                                         sos1_id,
-                                        Sos1Constraint::new(BTreeSet::from([sos1_var, one_hot_b]))
-                                            .expect("SOS1 set is non-empty"),
+                                        Sos1Constraint::new(BTreeSet::from([
+                                            sos1_active_var,
+                                            one_hot_active_b,
+                                        ]))
+                                        .expect("SOS1 set is non-empty"),
                                     );
                                     sos1_constraint_context.set_name(sos1_id, "arbitrary_sos1");
+
+                                    let removed_sos1_id = Sos1ConstraintID::from(1);
+                                    sos1_constraints.insert(
+                                        removed_sos1_id,
+                                        Sos1Constraint::new(BTreeSet::from([
+                                            sos1_removed_var,
+                                            one_hot_removed_b,
+                                        ]))
+                                        .expect("SOS1 set is non-empty"),
+                                    );
+                                    sos1_constraint_context
+                                        .set_name(removed_sos1_id, "arbitrary_removed_sos1");
                                 }
 
                                 let mut instance = Instance::builder()
@@ -456,6 +505,26 @@ impl Arbitrary for Instance {
                                     .expect("arbitrary Instance must satisfy builder invariants");
 
                                 if space == InstanceSpace::FullV3 {
+                                    instance
+                                        .convert_one_hot_to_constraint(OneHotConstraintID::from(1))
+                                        .expect("arbitrary removed one-hot conversion must work");
+                                    instance
+                                        .convert_sos1_to_constraints(Sos1ConstraintID::from(1))
+                                        .expect("arbitrary removed SOS1 conversion must work");
+                                    let mut parameters = v1::Parameters {
+                                        entries: HashMap::new(),
+                                    };
+                                    parameters.entries.insert(0, 1.0);
+                                    instance.parameters = Some(parameters);
+                                    instance.description = Some(v1::instance::Description {
+                                        name: Some("arbitrary instance".to_string()),
+                                        description: Some(
+                                            "generated by Instance::arbitrary".to_string(),
+                                        ),
+                                        authors: vec!["ommx".to_string()],
+                                        created_by: Some("ommx".to_string()),
+                                        ..Default::default()
+                                    });
                                     instance.annotations.insert(
                                         "org.ommx.user.arbitrary".to_string(),
                                         "true".to_string(),
@@ -510,7 +579,17 @@ mod tests {
                     prop_assert!(instance.decision_variables.contains_key(&id));
                 }
             }
+            for (c, _) in instance.removed_one_hot_constraints().values() {
+                for id in c.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
             for c in instance.sos1_constraints().values() {
+                for id in c.required_ids() {
+                    prop_assert!(instance.decision_variables.contains_key(&id));
+                }
+            }
+            for (c, _) in instance.removed_sos1_constraints().values() {
                 for id in c.required_ids() {
                     prop_assert!(instance.decision_variables.contains_key(&id));
                 }
@@ -526,6 +605,34 @@ mod tests {
             for id in instance.decision_variable_dependency().required_ids() {
                 prop_assert!(instance.decision_variables.contains_key(&id));
             }
+        }
+
+        #[test]
+        fn full_v3_space_exercises_v3_instance_state(instance in Instance::arbitrary()) {
+            prop_assert!(!instance.fixed_decision_variable_values().is_empty());
+            prop_assert!(!instance.decision_variable_dependency().is_empty());
+            prop_assert!(!instance.removed_constraints().is_empty());
+            prop_assert!(!instance.indicator_constraints().is_empty());
+            prop_assert!(!instance.removed_indicator_constraints().is_empty());
+            prop_assert!(!instance.one_hot_constraints().is_empty());
+            prop_assert!(!instance.removed_one_hot_constraints().is_empty());
+            prop_assert!(!instance.sos1_constraints().is_empty());
+            prop_assert!(!instance.removed_sos1_constraints().is_empty());
+            prop_assert!(instance.parameters.is_some());
+            prop_assert!(instance.description.is_some());
+            prop_assert!(!instance.annotations.is_empty());
+            prop_assert!(
+                instance
+                    .indicator_constraints()
+                    .values()
+                    .any(|constraint| !constraint.function().required_ids().is_empty())
+            );
+            prop_assert!(
+                instance
+                    .removed_indicator_constraints()
+                    .values()
+                    .any(|(constraint, _)| !constraint.function().required_ids().is_empty())
+            );
         }
     }
 }

--- a/rust/ommx/src/instance/arbitrary.rs
+++ b/rust/ommx/src/instance/arbitrary.rs
@@ -112,6 +112,7 @@ impl Arbitrary for Sense {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum InstanceSpace {
     /// Generate the V3 [`Instance`] domain, including special constraint
     /// families, lifecycle states, and decision-variable roles.
@@ -140,6 +141,17 @@ pub struct InstanceParameters {
 }
 
 impl InstanceParameters {
+    /// Parameters for the full V3 [`Instance`] space. This is the default.
+    ///
+    /// The objective, regular constraints, named functions, and decision
+    /// variables are sampled from strategies. The V3-specific structure —
+    /// fixed and dependent variables, removed constraints, indicator,
+    /// one-hot, and SOS1 families, parameters, description, and annotations
+    /// — is injected deterministically, so each of those dimensions is
+    /// exercised at a single representative point (smoke coverage) rather
+    /// than sampled. Every generated instance contains all V3 features;
+    /// feature-absent combinations are covered by the narrower spaces such
+    /// as [`Self::regular_only`].
     pub fn full_v3() -> Self {
         Self {
             space: InstanceSpace::FullV3,
@@ -160,6 +172,8 @@ impl InstanceParameters {
         }
     }
 
+    /// Parameters for the regular-constraint subspace: no special constraint
+    /// families, no removed constraints, and no fixed or dependent variables.
     pub fn regular_only() -> Self {
         Self {
             space: InstanceSpace::RegularOnly,
@@ -173,10 +187,18 @@ impl InstanceParameters {
         }
     }
 
+    /// Parameters for instances that round-trip through the v1 protobuf
+    /// format losslessly.
+    ///
+    /// Currently identical to [`Self::regular_only`]; the claim is pinned by
+    /// the `instance_roundtrip` property test, which fails if the two spaces
+    /// drift apart.
     pub fn v1_compatible() -> Self {
         Self::regular_only()
     }
 
+    /// Parameters for QCQP instances that the MPS writer supports: regular
+    /// constraints only and no named functions.
     pub fn mps_compatible_qcqp() -> Self {
         Self {
             named_function_ids: NamedFunctionIDParameters::new(0, 0.into()).unwrap(),
@@ -300,6 +322,10 @@ impl Arbitrary for Instance {
                         unique_ids.extend(nf.function.required_ids());
                     }
                     unique_ids.extend(irrelevant_candidates.into_iter().map(VariableID::from));
+                    // Reserving the fresh IDs in `unique_ids` means
+                    // `arbitrary_decision_variables` also generates variables
+                    // for them; those are overwritten below with the kinds the
+                    // V3 structure requires (binary/continuous).
                     let full_v3_ids = (space == InstanceSpace::FullV3)
                         .then(|| fresh_variable_ids(&mut unique_ids, 12));
                     (
@@ -458,6 +484,11 @@ impl Arbitrary for Instance {
                                     one_hot_constraint_context
                                         .set_name(removed_one_hot_id, "arbitrary_removed_one_hot");
 
+                                    // The SOS1 sets deliberately share one
+                                    // variable with the one-hot sets so the
+                                    // generated instances cover variables that
+                                    // belong to more than one special
+                                    // constraint family.
                                     let sos1_id = Sos1ConstraintID::from(0);
                                     sos1_constraints.insert(
                                         sos1_id,
@@ -607,6 +638,9 @@ mod tests {
             }
         }
 
+        // Generator-regression test: the asserted structure is injected
+        // deterministically by the FullV3 space, so this pins the generator's
+        // coverage of V3 features rather than a domain property.
         #[test]
         fn full_v3_space_exercises_v3_instance_state(instance in Instance::arbitrary()) {
             prop_assert!(!instance.fixed_decision_variable_values().is_empty());

--- a/rust/ommx/src/instance/evaluate.rs
+++ b/rust/ommx/src/instance/evaluate.rs
@@ -609,7 +609,7 @@ mod tests {
 
         #[test]
         fn partial_evaluate(
-            (mut instance, state, (u, v)) in Instance::arbitrary()
+            (mut instance, state, (u, v)) in Instance::arbitrary_with(crate::InstanceParameters::regular_only())
                 .prop_flat_map(|instance| {
                     let state = instance.arbitrary_state();
                     (Just(instance), state).prop_flat_map(|(instance, state)| {

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -1324,7 +1324,9 @@ mod tests {
 
     proptest! {
         #[test]
-        fn instance_roundtrip(original_instance in Instance::arbitrary()) {
+        fn instance_roundtrip(
+            original_instance in Instance::arbitrary_with(crate::InstanceParameters::v1_compatible())
+        ) {
             let v1_instance = v1::Instance::try_from(original_instance.clone()).unwrap();
             let roundtripped_instance = Instance::try_from(v1_instance).unwrap();
             assert_eq!(original_instance, roundtripped_instance);

--- a/rust/ommx/src/mps/tests/write_arbitrary.rs
+++ b/rust/ommx/src/mps/tests/write_arbitrary.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use crate::{arbitrary::InstanceParameters, Instance, NamedFunctionIDParameters};
+use crate::{arbitrary::InstanceParameters, Instance};
 use approx::AbsDiffEq;
 use proptest::prelude::*;
 use similar::{ChangeTag, TextDiff};
@@ -22,20 +22,13 @@ fn take_diff(expected: &Instance, actual: &Instance) -> String {
 
 proptest! {
     #[test]
-    fn test_write_mps(instance in Instance::arbitrary_with(<Instance as Arbitrary>::Parameters::default_qcqp())) {
+    fn test_write_mps(instance in Instance::arbitrary_with(InstanceParameters::mps_compatible_qcqp())) {
         let mut buffer = Vec::new();
         prop_assert!(format::format(&instance, &mut buffer).is_ok())
     }
 
-    // NOTE: MPS doesn't support named functions, so we limit the test
-    // just to test against instances without named functions.
     #[test]
-    fn test_roundtrip(instance in Instance::arbitrary_with(
-        InstanceParameters {
-            named_function_ids: NamedFunctionIDParameters::new(0, 0.into()).unwrap(),
-            .. <Instance as Arbitrary>::Parameters::default_qcqp()
-        })
-    ) {
+    fn test_roundtrip(instance in Instance::arbitrary_with(InstanceParameters::mps_compatible_qcqp())) {
         let mut buffer = Vec::new();
         prop_assert!(format::format(&instance, &mut buffer).is_ok());
         let loaded = parse(&buffer[..]).unwrap();


### PR DESCRIPTION
## Summary

- Split `Instance` arbitrary generation into explicit `FullV3` and `RegularOnly` spaces.
- Make default `InstanceParameters` exercise the broader V3 structure, including active and removed regular, indicator, one-hot, and SOS1 constraints; fixed and dependent variables; sidecars; metadata; and annotations.
- Give generated indicator constraints non-empty function bodies so properties cover body variable references.
- Move v1, MPS, and regular-only partial-evaluation properties onto named compatible spaces.
- Document the Rust SDK API change in the 3.0 release notes.

## Rationale

`Instance` property tests need two different concepts: broad valid-domain generation and efficient generation of preconditioned subspaces. This change makes `any::<Instance>()` represent the current V3 domain more directly, while format-specific or algebraically narrower properties request the subspace they actually require.
