### PR TITLE
Reorganize benchmark guardrails and diagnostics

### DIFF
--- a/.agents/skills/benchmark-review/SKILL.md
+++ b/.agents/skills/benchmark-review/SKILL.md
@@ -1,84 +1,201 @@
 ---
 name: benchmark-review
-description: Use when reviewing, designing, or triaging OMMX benchmarks, CodSpeed results, flamegraphs, performance PRs/issues, or benchmark workload changes to verify that each benchmark has a clear measurement intent, cost model, expected scaling/flamegraph, and actionable regression signal.
+description: Use when reviewing, designing, triaging, or managing OMMX benchmarks, CodSpeed runs or flamegraphs, performance PRs or issues, benchmark workload changes, or benchmark CI policy. Classify the measurement purpose, define the benchmark contract and cost model, validate the required scaling or profile evidence, assign a lifecycle and run policy, and keep CI cost proportional to the regression signal.
 ---
 
 # Benchmark Review
 
-Use this skill to review benchmarks as measurement instruments, not as
-standalone slow workloads. A good benchmark should connect a specific
-regression risk to an explicit cost model and produce evidence that confirms
-or falsifies that model.
+Treat each benchmark family as a hypothesis-driven measurement instrument.
+Connect a concrete regression risk to a cost model, the evidence needed to
+confirm or falsify it, and an explicit lifecycle. Do not retain a workload only
+because it is slow or because a profiler can produce a flame graph for it.
 
 ## Review Flow
 
-1. Name the measured operation and boundary.
-   - State the public or internal entrypoint being measured.
-   - Identify whether the benchmark targets Rust SDK internals, Python API
-     boundary behavior, PyO3 dispatch, solver adapter behavior, artifact I/O,
-     or CI/workflow overhead.
-   - For Python benchmarks, justify why the cost must be measured through the
-     Python API. If almost all expected work is Rust-internal algorithmic
-     scaling, prefer a Rust benchmark plus a smaller Python smoke benchmark.
+### 1. Classify the primary question
 
-2. State the cost model before judging the numbers.
-   - Write the expected decomposition, for example:
-     `T ~= fixed_overhead + N * per_row_work + clone_cost + drop_cost`.
-   - Name the independent variables: variables, constraints, terms, samples,
-     special-constraint families, active vs removed rows, dense vs sparse
-     structure, or Python operation count.
-   - Separate semantic work from incidental overhead: validation, atomic
-     staging, clone, allocation, hashing, drop, tracing, PyO3 dispatch, and
-     data conversion.
-   - State the expected scaling and which term should dominate at the chosen
-     input sizes.
+Choose one primary purpose before judging the implementation or numbers:
 
-3. Check whether the input shape isolates the intended term.
-   - Prefer input shapes that make one suspected cost visible without mixing
-     unrelated costs.
-   - Include enough sizes to distinguish fixed overhead from scaling behavior.
-   - Use no-op, removed-only, or degenerate shapes when the goal is to detect
-     overhead that should not scale with semantic work.
-   - Avoid retaining very large CI benchmarks whose only signal is that a
-     Rust-internal operation is expensive; move that signal to the narrower
-     benchmark layer.
+- **Scaling guardrail**: determine how cost changes as an independent variable
+  grows and detect a complexity regression such as `O(N)` to `O(N^2)`.
+- **Fixed-input regression**: compare the same deterministic workload across
+  commits to detect a constant-factor regression.
+- **Profiling diagnostic**: attribute a fixed input's cost to functions or
+  subsystems while investigating an optimization.
+- **Workflow cost**: determine whether setup, build, instrumentation, and
+  benchmark execution are affordable under the CI run policy.
 
-4. Predict the flamegraph.
-   - List the functions or subsystems that should dominate if the benchmark is
-     measuring the intended quantity.
-   - Treat unexpected dominance as evidence that the benchmark measures a
-     different thing. Common red flags are whole-object clone/drop, memcpy,
-     allocator churn, tracing/OpenTelemetry setup, Python import/setup, or
-     serialization when those are not the stated target.
-   - If the expected root function or call path is absent, do not accept the
-     benchmark label at face value.
+Keep the measurement layer as a separate axis. Name whether the boundary is a
+Rust SDK operation, Python API and PyO3 boundary, adapter, end-to-end user flow,
+artifact I/O, or CI workflow. Do not use `end-to-end` as a substitute for an
+explicit primary purpose.
 
-5. Validate performance claims with measurements.
-   - Never claim a performance improvement or regression without benchmark
-     data and methodology.
-   - Use CodSpeed results and flamegraphs when available. If the relevant run
-     or flamegraph is unavailable, state the evidence gap instead of inferring
-     from code shape alone.
-   - Compare like with like: same benchmark, same input shape, same branch/run
-     relationship, and enough context to avoid confusing new benchmarks with
-     changed results.
+### 2. Write the benchmark contract
 
-6. Write findings as benchmark-design issues.
-   - Lead with the measurement failure: missing hypothesis, mixed cost model,
-     wrong layer, fixed-overhead domination, absent flamegraph evidence, or CI
-     cost disproportionate to the regression signal.
-   - Propose the narrower benchmark or workload split that would detect the
-     intended regression.
-   - Do not require every benchmark to prove an optimization. A benchmark can
-     be valuable as a canary if its cost model and expected failure mode are
-     explicit.
+Write one contract for each benchmark family, not one for every parameter:
+
+```text
+Purpose:
+Regression:
+Origin:
+Measured boundary:
+Independent variables:
+Cost model:
+Expected evidence:
+Input rationale:
+Lifecycle:
+Run policy:
+Runtime budget:
+```
+
+Link `Origin` to the issue, PR, incident, or optimization that established the
+regression risk when one exists. State a concrete failure mode rather than a
+generic goal such as "measure addition performance."
+
+### 3. Match the evidence to the purpose
+
+#### Scaling guardrail
+
+- Use at least three geometrically spaced input sizes, such as `N`, `2N`,
+  `4N` or `N`, `10N`, `100N`.
+- Keep other shape dimensions fixed unless they are independent variables in
+  the stated cost model.
+- Estimate the observed exponent between adjacent points:
+
+  ```text
+  p = log(T2 / T1) / log(N2 / N1)
+  ```
+
+  Expect `p ~= 1` for linear scaling and `p ~= 2` for quadratic scaling.
+- Prefer the larger points when fixed overhead distorts small inputs. Use
+  same-run ratios where possible so hardware differences cancel.
+- Inspect or generate a cross-size table or graph. CodSpeed tracks each
+  parameter as a separate result and does not replace explicit cross-size
+  scaling analysis.
+- Do not require a flame graph unless the task is also diagnosing why the
+  observed scaling is wrong.
+
+#### Fixed-input regression
+
+- Keep the input deterministic and representative of the regression risk.
+- Compare the same benchmark URI, input shape, runner mode, and environment.
+- Use commit-to-commit timing as the primary evidence. Use a profile only when
+  explaining a detected change.
+
+#### Profiling diagnostic
+
+- Fix an input large enough for the suspected term to be visible without
+  mixing unrelated work.
+- Predict the expected root path and dominant subsystems. Treat unexpected
+  clone/drop, allocator churn, tracing, serialization, import/setup, or data
+  conversion as evidence that the benchmark measures a different cost.
+- Inspect absolute self and total time when available. Use percentages to
+  prioritize work, not as a permanent threshold: optimizing one function
+  necessarily raises other functions' percentages.
+- Keep a diagnostic workload only when it also provides an actionable
+  regression signal. Otherwise remove it after the investigation or keep it
+  manual.
+
+#### Workflow cost
+
+- Report setup, dependency installation, build, benchmark execution, job wall
+  time, and total runner time separately.
+- Treat build and cache behavior as CI cost, not measured SDK performance.
+- Ensure the measured artifact uses the intended optimized profile. Do not
+  interpret an unoptimized development build as a product runtime benchmark.
+- Evaluate the build-included job time against the run policy; reducing only
+  benchmark duration is insufficient when build time already exceeds budget.
+
+### 4. Choose the narrowest valid layer
+
+- Prefer Rust benchmarks for Rust-internal algorithmic scaling such as large
+  `to_qubo`, substitution, encoding, sampling evaluation, or expression
+  rewriting.
+- Keep Python benchmarks when the regression includes Python-visible behavior:
+  overloaded operators, PyO3 dispatch, Python-driven expression construction,
+  container conversion, or a public Python end-to-end path.
+- Pair a narrow Rust benchmark with a small Python smoke benchmark when Python
+  only dispatches a heavy Rust-internal operation.
+- Review workflow overhead independently from benchmark runtime.
+
+### 5. Assign lifecycle and run policy
+
+- **Persistent guardrail**: retain on `main` when it detects a concrete
+  complexity or fixed-input regression.
+- **Diagnostic benchmark**: run manually during performance work; remove it or
+  convert it to a persistent guardrail once the hypothesis is resolved.
+- Allow CodSpeed to produce profiles on `main` without treating every profile
+  as a review artifact. Keep inputs that exist only for profile detail out of
+  the persistent suite.
+- For OMMX, treat a build-included wall time of roughly 2-3 minutes as the
+  target at which a lightweight guardrail suite is cheap enough to run
+  automatically on PRs. Until then, keep full PR runs manual and use automatic
+  `main` runs as catch-all coverage.
+- State both the regression signal and CI cost before retaining a large input.
+
+### 6. Validate claims with CodSpeed evidence
+
+- Use CodSpeed run results to discover benchmark URIs and values.
+- Use run comparisons for fixed-input regressions and verify environment
+  differences before attributing a change to code.
+- Compute cross-size ratios or exponents explicitly for scaling guardrails.
+- Query flame graphs for profiling diagnostics or to explain a scaling failure;
+  do not query every flame graph merely because it is available.
+- Never claim a performance improvement or regression without comparable
+  benchmark data and methodology. State the evidence gap when the relevant run
+  or profile is unavailable.
+
+### 7. Produce an actionable review
+
+Review benchmark families rather than listing every parameter separately. For
+each family, state the purpose, boundary, cost model, evidence, lifecycle, and
+recommended action: retain on `main`, move to manual diagnostics, narrow or
+relocate the benchmark, or remove it. Lead findings with missing hypotheses,
+mixed cost models, wrong layers, insufficient scaling points, profile-only
+workloads in CI, or cost disproportionate to the signal.
+
+Do not require every benchmark to prove an optimization. A benchmark can be a
+valuable canary when its expected failure mode and response are explicit.
 
 ## OMMX Patterns
 
+### Python `small_many` accumulation
+
+Treat the Python `small_many` addition benchmarks as persistent scaling
+guardrails originating from PR #498:
+
+```text
+Purpose: Scaling guardrail
+Regression: Repeated += clones the growing accumulator and changes O(N) to O(N^2)
+Origin: PR #498
+Measured boundary: Python += -> PyO3 __iadd__ -> Rust in-place merge
+Independent variable: Number N of fixed-size operands
+Expected evidence: Geometric input sizes and an observed exponent near 1
+Lifecycle: Persistent on main
+```
+
+For operand size `m`, the intended cost is approximately:
+
+```text
+T(N, m) ~= N * Python_and_PyO3_dispatch
+          + N * merge(m)
+          + amortized_hash_table_growth(N * m)
+          = O(N * m)
+```
+
+Cloning the accumulator on iteration `k` adds
+`sum(k * m) = O(N^2 * m)`. During an optimization, expect the profile to enter
+`__iadd__`, `try_add_assign_in_place`, and `add_term`. Hash-table rehash copies
+may be legitimate; distinguish them from a whole-accumulator clone on every
+addition. Keep `large_little` under a separate contract because a fixed number
+of large merges tests per-term merge and rehash cost, not the `small_many`
+quadratic regression.
+
 ### Instance partial evaluation
 
-For `Instance::partial_evaluate`, distinguish semantic partial evaluation
-from transaction overhead:
+Treat the removed-constraint `Instance::partial_evaluate` benchmark from issue
+#1027 and PR #1028 as a regression-shaped guardrail. Its cost model separates
+semantic evaluation from transaction overhead:
 
 ```text
 T ~= fixed_value_state
@@ -89,50 +206,30 @@ T ~= fixed_value_state
    + commit_swap_and_drop
 ```
 
-A removed-regular-constraints-only shape is valuable because semantic active
-constraint work should be small. If the flamegraph is dominated by
-`Instance::clone`, fixed-value registration, or dropping the old instance, the
-benchmark detects transaction overhead rather than constraint rewriting.
+Use a removed-regular-constraints-only shape to keep active semantic work small.
+When diagnosing it, dominance by `Instance::clone`, fixed-value registration,
+or old-instance drop identifies transaction overhead rather than constraint
+rewriting.
 
-### Python API benchmarks
+### Python API boundary
 
-For Python benchmarks, separate API-boundary regressions from Rust algorithm
-scaling:
-
-- Keep Python benchmarks when the risk is Python-visible behavior: PyO3 method
-  dispatch, overloaded arithmetic, Python-driven expression construction,
-  conversion between Python containers and Rust types, or the public API
-  end-to-end path.
-- Prefer Rust benchmarks for heavy internal algorithms such as large
-  `to_qubo`, substitution, encoding, sampling evaluation, or expression
-  rewriting unless the Python boundary is part of the suspected regression.
-- If a tiny benchmark is dominated by tracing or setup, describe it as an API
-  smoke/overhead benchmark rather than a scaling benchmark.
-
-### Expression construction
-
-For Python-driven expression construction, the useful cost model often is:
-
-```text
-T ~= Python operation count * PyO3 dispatch
-   + number_of_additions * Rust add_or_merge
-   + number_of_clones * expression_size
-```
-
-Expected flamegraph entries include `_ommx_rust` PyO3 methods,
-`polynomial_base::add`, hash-map merge/clone work, and memcpy when clone cost
-is dominant. This benchmark is useful if the suspected regression is caused by
-Python operators triggering expensive Rust-side expression cloning.
+Keep a heavy Python benchmark only when the Python boundary is part of the
+regression hypothesis. If nearly all expected work is Rust-internal, move the
+scaling guardrail to Rust and retain only a small Python boundary smoke test.
+Describe a tiny benchmark dominated by tracing or setup as an overhead smoke
+test, not as an algorithmic scaling benchmark.
 
 ## Review Checklist
 
-- What regression should this benchmark detect?
-- What operation and API/language boundary does it measure?
-- What is the explicit cost model, and which input dimension exercises each
-  term?
-- Which term should dominate at each benchmark size?
-- Does the chosen input shape isolate the intended cost?
-- What flamegraph path is expected, and was it observed?
-- Is the benchmark in the right layer: Rust, Python, adapter, or workflow?
-- Is any retained CI workload proportionate to the signal it provides?
-- Are performance claims backed by comparable benchmark data?
+- What is the primary purpose: scaling, fixed-input regression, profiling, or
+  workflow cost?
+- What concrete regression and origin does the contract record?
+- What operation and language or system boundary does it measure?
+- What is the cost model, and which dimensions are independent variables?
+- Does the evidence match the purpose?
+- For scaling, are there enough geometric points and was the exponent examined?
+- For profiling, are percentages used diagnostically rather than as thresholds?
+- Is the benchmark in the narrowest valid layer?
+- Is it a persistent guardrail or a temporary/manual diagnostic?
+- Are build-included wall time and runner cost proportionate to the signal?
+- Are performance claims backed by comparable measurements?

--- a/.agents/skills/benchmark-review/SKILL.md
+++ b/.agents/skills/benchmark-review/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: benchmark-review
+description: Use when reviewing, designing, or triaging OMMX benchmarks, CodSpeed results, flamegraphs, performance PRs/issues, or benchmark workload changes to verify that each benchmark has a clear measurement intent, cost model, expected scaling/flamegraph, and actionable regression signal.
+---
+
+# Benchmark Review
+
+Use this skill to review benchmarks as measurement instruments, not as
+standalone slow workloads. A good benchmark should connect a specific
+regression risk to an explicit cost model and produce evidence that confirms
+or falsifies that model.
+
+## Review Flow
+
+1. Name the measured operation and boundary.
+   - State the public or internal entrypoint being measured.
+   - Identify whether the benchmark targets Rust SDK internals, Python API
+     boundary behavior, PyO3 dispatch, solver adapter behavior, artifact I/O,
+     or CI/workflow overhead.
+   - For Python benchmarks, justify why the cost must be measured through the
+     Python API. If almost all expected work is Rust-internal algorithmic
+     scaling, prefer a Rust benchmark plus a smaller Python smoke benchmark.
+
+2. State the cost model before judging the numbers.
+   - Write the expected decomposition, for example:
+     `T ~= fixed_overhead + N * per_row_work + clone_cost + drop_cost`.
+   - Name the independent variables: variables, constraints, terms, samples,
+     special-constraint families, active vs removed rows, dense vs sparse
+     structure, or Python operation count.
+   - Separate semantic work from incidental overhead: validation, atomic
+     staging, clone, allocation, hashing, drop, tracing, PyO3 dispatch, and
+     data conversion.
+   - State the expected scaling and which term should dominate at the chosen
+     input sizes.
+
+3. Check whether the input shape isolates the intended term.
+   - Prefer input shapes that make one suspected cost visible without mixing
+     unrelated costs.
+   - Include enough sizes to distinguish fixed overhead from scaling behavior.
+   - Use no-op, removed-only, or degenerate shapes when the goal is to detect
+     overhead that should not scale with semantic work.
+   - Avoid retaining very large CI benchmarks whose only signal is that a
+     Rust-internal operation is expensive; move that signal to the narrower
+     benchmark layer.
+
+4. Predict the flamegraph.
+   - List the functions or subsystems that should dominate if the benchmark is
+     measuring the intended quantity.
+   - Treat unexpected dominance as evidence that the benchmark measures a
+     different thing. Common red flags are whole-object clone/drop, memcpy,
+     allocator churn, tracing/OpenTelemetry setup, Python import/setup, or
+     serialization when those are not the stated target.
+   - If the expected root function or call path is absent, do not accept the
+     benchmark label at face value.
+
+5. Validate performance claims with measurements.
+   - Never claim a performance improvement or regression without benchmark
+     data and methodology.
+   - Use CodSpeed results and flamegraphs when available. If the relevant run
+     or flamegraph is unavailable, state the evidence gap instead of inferring
+     from code shape alone.
+   - Compare like with like: same benchmark, same input shape, same branch/run
+     relationship, and enough context to avoid confusing new benchmarks with
+     changed results.
+
+6. Write findings as benchmark-design issues.
+   - Lead with the measurement failure: missing hypothesis, mixed cost model,
+     wrong layer, fixed-overhead domination, absent flamegraph evidence, or CI
+     cost disproportionate to the regression signal.
+   - Propose the narrower benchmark or workload split that would detect the
+     intended regression.
+   - Do not require every benchmark to prove an optimization. A benchmark can
+     be valuable as a canary if its cost model and expected failure mode are
+     explicit.
+
+## OMMX Patterns
+
+### Instance partial evaluation
+
+For `Instance::partial_evaluate`, distinguish semantic partial evaluation
+from transaction overhead:
+
+```text
+T ~= fixed_value_state
+   + atomic_staging_or_clone
+   + fixed_value_registration
+   + active_constraint_partial_evaluation
+   + special_constraint_delta_preparation
+   + commit_swap_and_drop
+```
+
+A removed-regular-constraints-only shape is valuable because semantic active
+constraint work should be small. If the flamegraph is dominated by
+`Instance::clone`, fixed-value registration, or dropping the old instance, the
+benchmark detects transaction overhead rather than constraint rewriting.
+
+### Python API benchmarks
+
+For Python benchmarks, separate API-boundary regressions from Rust algorithm
+scaling:
+
+- Keep Python benchmarks when the risk is Python-visible behavior: PyO3 method
+  dispatch, overloaded arithmetic, Python-driven expression construction,
+  conversion between Python containers and Rust types, or the public API
+  end-to-end path.
+- Prefer Rust benchmarks for heavy internal algorithms such as large
+  `to_qubo`, substitution, encoding, sampling evaluation, or expression
+  rewriting unless the Python boundary is part of the suspected regression.
+- If a tiny benchmark is dominated by tracing or setup, describe it as an API
+  smoke/overhead benchmark rather than a scaling benchmark.
+
+### Expression construction
+
+For Python-driven expression construction, the useful cost model often is:
+
+```text
+T ~= Python operation count * PyO3 dispatch
+   + number_of_additions * Rust add_or_merge
+   + number_of_clones * expression_size
+```
+
+Expected flamegraph entries include `_ommx_rust` PyO3 methods,
+`polynomial_base::add`, hash-map merge/clone work, and memcpy when clone cost
+is dominant. This benchmark is useful if the suspected regression is caused by
+Python operators triggering expensive Rust-side expression cloning.
+
+## Review Checklist
+
+- What regression should this benchmark detect?
+- What operation and API/language boundary does it measure?
+- What is the explicit cost model, and which input dimension exercises each
+  term?
+- Which term should dominate at each benchmark size?
+- Does the chosen input shape isolate the intended cost?
+- What flamegraph path is expected, and was it observed?
+- Is the benchmark in the right layer: Rust, Python, adapter, or workflow?
+- Is any retained CI workload proportionate to the signal it provides?
+- Are performance claims backed by comparable benchmark data?

--- a/.agents/skills/benchmark-review/agents/openai.yaml
+++ b/.agents/skills/benchmark-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Benchmark Review"
-  short_description: "Review benchmark intent and cost models"
-  default_prompt: "Review this benchmark by stating the intended measurement, cost model, expected flamegraph, and regression it should detect."
+  short_description: "Review benchmark intent, evidence, and lifecycle"
+  default_prompt: "Use $benchmark-review to classify this benchmark's purpose, define its cost model and required evidence, and recommend its lifecycle and CI run policy."

--- a/.agents/skills/benchmark-review/agents/openai.yaml
+++ b/.agents/skills/benchmark-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Benchmark Review"
+  short_description: "Review benchmark intent and cost models"
+  default_prompt: "Review this benchmark by stating the intended measurement, cost model, expected flamegraph, and regression it should detect."

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed --locked
       - name: Build CodSpeed Benchmark Target(s)
-        run: cargo codspeed build -p ommx
+        run: cargo codspeed build -p ommx --no-default-features
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          run: cargo codspeed run -p ommx
+          run: cargo codspeed run -p ommx --no-default-features
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation
 
@@ -47,20 +47,24 @@ jobs:
           # but updates in 3.13 seems to be required for generating trace information.
           # https://docs.python.org/3/library/sys.monitoring.html
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            python/ommx/pyproject.toml
+            python/ommx-tests/pyproject.toml
 
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
 
-      # FIXME: `codspeed` command used in `CodSpeedHQ/action` cannot work with `uv run`
       - name: Build wheel
         env:
           # Keep Rust/PyO3 frames useful in CodSpeed's Python FFI flame graphs
           # without forcing debuginfo into every release build.
           CARGO_PROFILE_RELEASE_DEBUG: "true"
         run: |
-          pip install python/ommx
-          pip install pytest-codspeed
+          pip install "maturin>=1.12.2" pytest-codspeed
+          maturin build --out wheels -m python/ommx/Cargo.toml
+          pip install wheels/*.whl
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed --locked
       - name: Build CodSpeed Benchmark Target(s)
-        run: cargo codspeed build
+        run: cargo codspeed build -p ommx
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          run: cargo codspeed run
+          run: cargo codspeed run -p ommx
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation
 
@@ -48,6 +48,10 @@ jobs:
           # https://docs.python.org/3/library/sys.monitoring.html
           python-version: "3.13"
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
       # FIXME: `codspeed` command used in `CodSpeedHQ/action` cannot work with `uv run`
       - name: Build wheel
         env:
@@ -61,6 +65,6 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          run: pytest python/ommx-tests/ --codspeed
+          run: pytest python/ommx-tests/tests/test_bench_*.py --codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,6 @@
-# Since most of PR does not affect benchmark, we do not run benchmarks on PR by default.
-# Run manually if needed via `task codspeed:trigger`.
+# Since most PRs do not affect performance, benchmarks do not run on PRs by default.
+# `main` and release tags run persistent guardrails. Performance PRs can run the
+# full suite, including diagnostic profiles, via `task codspeed:trigger`.
 # Release tags (rust-*, python-*) also trigger benchmarks so each release has a
 # comparison baseline against the previous release.
 
@@ -12,6 +13,15 @@ on:
       - rust-*
       - python-*
   workflow_dispatch:
+    inputs:
+      suite:
+        description: Benchmark suite to run
+        required: true
+        default: full
+        type: choice
+        options:
+          - guardrail
+          - full
 
 permissions:
   contents: read
@@ -69,6 +79,11 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          run: pytest python/ommx-tests/tests/test_bench_*.py --codspeed
+          run: |
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.suite }}" = "full" ]; then
+              pytest python/ommx-tests/tests/test_bench_*.py --codspeed
+            else
+              pytest python/ommx-tests/tests/test_bench_*.py --codspeed -m benchmark_guardrail
+            fi
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          run: cargo codspeed run -p ommx --no-default-features
+          run: cargo codspeed run -p ommx
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation
 
@@ -63,7 +63,7 @@ jobs:
           CARGO_PROFILE_RELEASE_DEBUG: "true"
         run: |
           pip install "maturin>=1.12.2" pytest-codspeed
-          maturin build --out wheels -m python/ommx/Cargo.toml
+          maturin build --release --out wheels -m python/ommx/Cargo.toml
           pip install wheels/*.whl
 
       - name: Run benchmarks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,10 @@ Run `task -l` to see all available commands.
 - When a diff touches an `Arbitrary` implementation, a `*Parameters` strategy type, or what a default strategy generates, use `.agents/skills/proptest-arbitrary-review/SKILL.md`.
 - Enumerate every call site whose quantification domain changes, distinguish sampled dimensions from constant injected structure, and verify by running the affected proptest suites.
 
+### Benchmark Review
+- When reviewing, designing, or triaging benchmarks, CodSpeed results, flamegraphs, performance PRs/issues, or benchmark workload changes, use `.agents/skills/benchmark-review/SKILL.md`.
+- Treat each benchmark as a hypothesis-driven measurement: state the intended regression signal, cost model, expected scaling/flamegraph, and the layer where the benchmark belongs.
+
 ### Rust SDK Artifact API Boundaries
 - Treat new public Rust artifact APIs as SDK commitments, not just convenient access to registry or manifest internals.
 - Keep raw OCI `Descriptor` exposure limited to low-level manifest or registry escape hatches that genuinely need OCI identity.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,9 +21,9 @@ includes:
 
 tasks:
   codspeed:trigger:
-    desc: Trigger GitHub Actions workflow for Codspeed on current branch
+    desc: Trigger the full CodSpeed suite on the current branch
     cmds:
-      - gh workflow run bench.yml --ref $(git branch --show-current)
+      - gh workflow run bench.yml --ref $(git branch --show-current) --field suite=full
 
   codspeed:list:
     desc: List all Codspeed workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,10 @@ dev = [
   "ruff>=0.9.6",
   "syrupy>=4.7.2",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+  "benchmark: performance benchmark collected by pytest-codspeed",
+  "benchmark_guardrail: persistent regression guardrail run on main and release tags",
+  "benchmark_diagnostic: profiling workload run only by the full manual benchmark suite",
+]

--- a/python/ommx-pyscipopt-adapter/tests/test_bench_placement.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_bench_placement.py
@@ -1,4 +1,4 @@
-"""Benchmark eight Plant Placement Problem formulations through SCIP only.
+"""Manual diagnostic comparing eight Plant Placement formulations in SCIP.
 
 Each ``placement_inputs`` parameterisation is converted to ``ommx.Instance``,
 then to ``pyscipopt.Model``, in session-scoped fixtures — the OMMX construction
@@ -6,7 +6,9 @@ and the OMMX → SCIP translation are *not* in the measurement. Each benchmark
 calls ``model.freeTransform()`` to discard SCIP's transformed problem from any
 previous run, then ``model.optimize()`` to re-run presolve and
 branch-and-bound. The reported time is therefore SCIP's own processing time,
-isolated from adapter overhead.
+isolated from adapter overhead. Originating from PR #809, this is a local
+formulation experiment rather than an OMMX regression guardrail; it remains
+outside the CodSpeed workflow and should be run only when revisiting the model.
 """
 
 from __future__ import annotations
@@ -30,6 +32,9 @@ from ommx.testing.placement import (
 )
 from ommx import Instance
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
+
+
+pytestmark = pytest.mark.benchmark_diagnostic
 
 _SIZES = [(6, 10), (12, 20), (24, 40), (48, 80)]
 _INSTANCES_PER_SIZE = 3

--- a/python/ommx-tests/tests/test_bench_evaluate.py
+++ b/python/ommx-tests/tests/test_bench_evaluate.py
@@ -1,3 +1,10 @@
+"""Python API benchmarks for Instance evaluation.
+
+These benchmarks measure end-to-end evaluation through the public Python
+bindings on a real MIPLIB instance. Large-scale evaluation throughput belongs
+in Rust SDK benchmarks; this file keeps representative Python-call coverage.
+"""
+
 import pytest
 from ommx import Rng
 from ommx.dataset import miplib2017
@@ -38,11 +45,11 @@ def evaluate_samples_batch(instance, samples):
 
 @pytest.mark.benchmark
 def test_evaluate(benchmark, miplib_supportcase10, random_state):
-    """Benchmark individual evaluate call"""
+    """Measure one public `Instance.evaluate` call on a real instance."""
     benchmark(evaluate_state, miplib_supportcase10, random_state)
 
 
 @pytest.mark.benchmark
 def test_evaluate_samples(benchmark, miplib_supportcase10, samples):
-    """Benchmark evaluate_samples with different configurations"""
+    """Measure one representative public `Instance.evaluate_samples` call."""
     benchmark(evaluate_samples_batch, miplib_supportcase10, samples)

--- a/python/ommx-tests/tests/test_bench_evaluate.py
+++ b/python/ommx-tests/tests/test_bench_evaluate.py
@@ -1,55 +1,95 @@
-"""Python API benchmarks for Instance evaluation.
+"""Python API benchmarks for ``Instance`` evaluation.
 
-These benchmarks measure end-to-end evaluation through the public Python
-bindings on a real MIPLIB instance. Large-scale evaluation throughput belongs
-in Rust SDK benchmarks; this file keeps representative Python-call coverage.
+The persistent fixed-input guardrails use a small synthetic instance to detect
+Python/PyO3 boundary regressions without repeatedly profiling heavy Rust
+evaluation work. The ``supportcase10`` workloads reproduce issue #336 and stay
+in the manual diagnostic suite for end-to-end profiling. Instance-level
+algorithmic scaling is measured in ``rust/ommx/benches/evaluate.rs``.
 """
 
 import pytest
-from ommx import Rng
+from ommx import DecisionVariable, Instance, Rng
 from ommx.dataset import miplib2017
 
 
 @pytest.fixture
+def boundary_instance():
+    """Create a deterministic, small instance for Python boundary guardrails."""
+    size = 32
+    x = [DecisionVariable.binary(i) for i in range(size)]
+    return Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={i: x[i] <= 1 for i in range(size)},
+        sense=Instance.MINIMIZE,
+    )
+
+
+@pytest.fixture
+def boundary_state(boundary_instance):
+    rng = Rng()
+    return boundary_instance.random_state(rng)
+
+
+@pytest.fixture
+def boundary_samples(boundary_instance):
+    rng = Rng()
+    return boundary_instance.random_samples(rng, num_different_samples=1, num_samples=1)
+
+
+@pytest.fixture
 def miplib_supportcase10():
-    """Load MIPLIB supportcase10 instance for benchmarking"""
+    """Load the issue #336 reproduction instance for manual profiling."""
     return miplib2017("supportcase10")
 
 
 @pytest.fixture
-def random_state(miplib_supportcase10):
-    """Generate a random state for evaluation"""
+def miplib_state(miplib_supportcase10):
     rng = Rng()
     return miplib_supportcase10.random_state(rng)
 
 
-@pytest.fixture(params=[(1, 1)], ids=["single-sample"])
-def samples(request, miplib_supportcase10):
-    """Generate a representative sample set for Python E2E benchmarking."""
-    num_different_samples, num_samples = request.param
+@pytest.fixture
+def miplib_samples(miplib_supportcase10):
     rng = Rng()
     return miplib_supportcase10.random_samples(
-        rng, num_different_samples=num_different_samples, num_samples=num_samples
+        rng, num_different_samples=1, num_samples=1
     )
 
 
 def evaluate_state(instance, state):
-    """Evaluate a single state"""
     return instance.evaluate(state)
 
 
 def evaluate_samples_batch(instance, samples):
-    """Evaluate samples using evaluate_samples method"""
     return instance.evaluate_samples(samples)
 
 
+@pytest.mark.benchmark_guardrail
 @pytest.mark.benchmark
-def test_evaluate(benchmark, miplib_supportcase10, random_state):
-    """Measure one public `Instance.evaluate` call on a real instance."""
-    benchmark(evaluate_state, miplib_supportcase10, random_state)
+def test_evaluate_python_boundary(benchmark, boundary_instance, boundary_state):
+    """Detect fixed-cost regressions in one public ``Instance.evaluate`` call."""
+    benchmark(evaluate_state, boundary_instance, boundary_state)
 
 
+@pytest.mark.benchmark_guardrail
 @pytest.mark.benchmark
-def test_evaluate_samples(benchmark, miplib_supportcase10, samples):
-    """Measure one representative public `Instance.evaluate_samples` call."""
-    benchmark(evaluate_samples_batch, miplib_supportcase10, samples)
+def test_evaluate_samples_python_boundary(
+    benchmark, boundary_instance, boundary_samples
+):
+    """Detect fixed-cost regressions in the public single-sample boundary."""
+    benchmark(evaluate_samples_batch, boundary_instance, boundary_samples)
+
+
+@pytest.mark.benchmark_diagnostic
+@pytest.mark.benchmark
+def test_evaluate_miplib(benchmark, miplib_supportcase10, miplib_state):
+    """Profile end-to-end evaluation on the issue #336 MIPLIB input."""
+    benchmark(evaluate_state, miplib_supportcase10, miplib_state)
+
+
+@pytest.mark.benchmark_diagnostic
+@pytest.mark.benchmark
+def test_evaluate_samples_miplib(benchmark, miplib_supportcase10, miplib_samples):
+    """Profile single-sample evaluation on the issue #336 MIPLIB input."""
+    benchmark(evaluate_samples_batch, miplib_supportcase10, miplib_samples)

--- a/python/ommx-tests/tests/test_bench_evaluate.py
+++ b/python/ommx-tests/tests/test_bench_evaluate.py
@@ -16,9 +16,9 @@ def random_state(miplib_supportcase10):
     return miplib_supportcase10.random_state(rng)
 
 
-@pytest.fixture(params=[(1, 1), (10, 10), (10, 100)])
+@pytest.fixture(params=[(1, 1)], ids=["single-sample"])
 def samples(request, miplib_supportcase10):
-    """Generate samples with different configurations"""
+    """Generate a representative sample set for Python E2E benchmarking."""
     num_different_samples, num_samples = request.param
     rng = Rng()
     return miplib_supportcase10.random_samples(

--- a/python/ommx-tests/tests/test_bench_function_add.py
+++ b/python/ommx-tests/tests/test_bench_function_add.py
@@ -1,8 +1,11 @@
-"""Python API benchmarks for generic Function addition.
+"""Persistent Python scaling guardrails for ``Function.__iadd__``.
 
-These benchmarks measure the public Python operator path after degree-specific
-expressions have been wrapped as Function values. They cover many small
-objects and a few large objects to make wrapper dispatch costs visible.
+PR #498 introduced the Python in-place path and PR #990 removed per-operation
+Function normalization round-trips. ``small_many`` detects a return to
+quadratic accumulator rebuilding; ``large_little`` holds the operation count
+fixed and varies operand size to expose merge and wrapper-normalization cost.
+The latter is Rust-internal characterization and remains in the manual Python
+diagnostic suite; the Python ``small_many`` operator path is the guardrail.
 """
 
 import pytest
@@ -45,12 +48,14 @@ def sum_function_functions(functions: list[Function]):
     return result
 
 
+@pytest.mark.benchmark_guardrail
 @pytest.mark.benchmark
 def test_sum_function_small_many(benchmark, function_small_many):
     """Measure repeated accumulation of many small Function wrappers."""
     benchmark(sum_function_functions, function_small_many)
 
 
+@pytest.mark.benchmark_diagnostic
 @pytest.mark.benchmark
 def test_sum_function_large_little(benchmark, function_large_little):
     """Measure accumulation of a few high-term-count Function wrappers."""

--- a/python/ommx-tests/tests/test_bench_function_add.py
+++ b/python/ommx-tests/tests/test_bench_function_add.py
@@ -1,3 +1,10 @@
+"""Python API benchmarks for generic Function addition.
+
+These benchmarks measure the public Python operator path after degree-specific
+expressions have been wrapped as Function values. They cover many small
+objects and a few large objects to make wrapper dispatch costs visible.
+"""
+
 import pytest
 from ommx import Function, Rng
 
@@ -40,11 +47,11 @@ def sum_function_functions(functions: list[Function]):
 
 @pytest.mark.benchmark
 def test_sum_function_small_many(benchmark, function_small_many):
-    """Benchmark summing many small functions"""
+    """Measure repeated accumulation of many small Function wrappers."""
     benchmark(sum_function_functions, function_small_many)
 
 
 @pytest.mark.benchmark
 def test_sum_function_large_little(benchmark, function_large_little):
-    """Benchmark summing few large functions"""
+    """Measure accumulation of a few high-term-count Function wrappers."""
     benchmark(sum_function_functions, function_large_little)

--- a/python/ommx-tests/tests/test_bench_linear_add.py
+++ b/python/ommx-tests/tests/test_bench_linear_add.py
@@ -1,8 +1,11 @@
-"""Python API benchmarks for linear-function addition.
+"""Persistent Python scaling guardrails for ``Linear.__iadd__``.
 
-These benchmarks measure the public Python operator path for two shapes:
-many small objects, and a few large objects. They intentionally include
-Python object dispatch plus the Rust-backed addition work reached through it.
+Originating from PR #498, ``small_many`` detects a fallback that clones the
+growing accumulator and changes fixed-size accumulation from O(N) to O(N^2).
+``large_little`` holds the addition count at three and detects superlinear
+merge or rehash cost as operand term count grows. Because that work is
+Rust-internal and covered by the Rust ``sum`` suite, ``large_little`` is kept
+as a manual Python diagnostic rather than a persistent boundary guardrail.
 """
 
 import pytest
@@ -43,12 +46,14 @@ def sum_linear_functions(functions: list[Linear]):
     return result
 
 
+@pytest.mark.benchmark_guardrail
 @pytest.mark.benchmark
 def test_sum_linear_small_many(benchmark, linear_small_many):
     """Measure repeated accumulation of many small Linear objects."""
     benchmark(sum_linear_functions, linear_small_many)
 
 
+@pytest.mark.benchmark_diagnostic
 @pytest.mark.benchmark
 def test_sum_linear_large_little(benchmark, linear_large_little):
     """Measure accumulation of a few high-term-count Linear objects."""

--- a/python/ommx-tests/tests/test_bench_linear_add.py
+++ b/python/ommx-tests/tests/test_bench_linear_add.py
@@ -1,3 +1,10 @@
+"""Python API benchmarks for linear-function addition.
+
+These benchmarks measure the public Python operator path for two shapes:
+many small objects, and a few large objects. They intentionally include
+Python object dispatch plus the Rust-backed addition work reached through it.
+"""
+
 import pytest
 from ommx import Linear, Rng
 
@@ -38,11 +45,11 @@ def sum_linear_functions(functions: list[Linear]):
 
 @pytest.mark.benchmark
 def test_sum_linear_small_many(benchmark, linear_small_many):
-    """Benchmark summing many small linear functions"""
+    """Measure repeated accumulation of many small Linear objects."""
     benchmark(sum_linear_functions, linear_small_many)
 
 
 @pytest.mark.benchmark
 def test_sum_linear_large_little(benchmark, linear_large_little):
-    """Benchmark summing few large linear functions"""
+    """Measure accumulation of a few high-term-count Linear objects."""
     benchmark(sum_linear_functions, linear_large_little)

--- a/python/ommx-tests/tests/test_bench_polynomial_add.py
+++ b/python/ommx-tests/tests/test_bench_polynomial_add.py
@@ -1,3 +1,10 @@
+"""Python API benchmarks for polynomial-function addition.
+
+These benchmarks measure the public Python operator path for two shapes:
+many small objects, and a few large objects. They intentionally include
+Python object dispatch plus the Rust-backed addition work reached through it.
+"""
+
 import pytest
 from ommx import Polynomial, Rng
 
@@ -40,11 +47,11 @@ def sum_polynomial_functions(functions: list[Polynomial]):
 
 @pytest.mark.benchmark
 def test_sum_polynomial_small_many(benchmark, polynomial_small_many):
-    """Benchmark summing many small polynomial functions"""
+    """Measure repeated accumulation of many small Polynomial objects."""
     benchmark(sum_polynomial_functions, polynomial_small_many)
 
 
 @pytest.mark.benchmark
 def test_sum_polynomial_large_little(benchmark, polynomial_large_little):
-    """Benchmark summing few large polynomial functions"""
+    """Measure accumulation of a few high-term-count Polynomial objects."""
     benchmark(sum_polynomial_functions, polynomial_large_little)

--- a/python/ommx-tests/tests/test_bench_polynomial_add.py
+++ b/python/ommx-tests/tests/test_bench_polynomial_add.py
@@ -1,8 +1,11 @@
-"""Python API benchmarks for polynomial-function addition.
+"""Persistent Python scaling guardrails for ``Polynomial.__iadd__``.
 
-These benchmarks measure the public Python operator path for two shapes:
-many small objects, and a few large objects. They intentionally include
-Python object dispatch plus the Rust-backed addition work reached through it.
+Originating from PR #498, ``small_many`` detects a fallback that clones the
+growing accumulator and changes fixed-size accumulation from O(N) to O(N^2).
+``large_little`` holds the addition count at three and detects superlinear
+merge or rehash cost as operand term count grows. Because that work is
+Rust-internal and covered by the Rust ``sum`` suite, ``large_little`` is kept
+as a manual Python diagnostic rather than a persistent boundary guardrail.
 """
 
 import pytest
@@ -45,12 +48,14 @@ def sum_polynomial_functions(functions: list[Polynomial]):
     return result
 
 
+@pytest.mark.benchmark_guardrail
 @pytest.mark.benchmark
 def test_sum_polynomial_small_many(benchmark, polynomial_small_many):
     """Measure repeated accumulation of many small Polynomial objects."""
     benchmark(sum_polynomial_functions, polynomial_small_many)
 
 
+@pytest.mark.benchmark_diagnostic
 @pytest.mark.benchmark
 def test_sum_polynomial_large_little(benchmark, polynomial_large_little):
     """Measure accumulation of a few high-term-count Polynomial objects."""

--- a/python/ommx-tests/tests/test_bench_quadratic_add.py
+++ b/python/ommx-tests/tests/test_bench_quadratic_add.py
@@ -1,3 +1,10 @@
+"""Python API benchmarks for quadratic-function addition.
+
+These benchmarks measure the public Python operator path for two shapes:
+many small objects, and a few large objects. They intentionally include
+Python object dispatch plus the Rust-backed addition work reached through it.
+"""
+
 import pytest
 from ommx import Quadratic, Rng
 
@@ -38,11 +45,11 @@ def sum_quadratic_functions(functions: list[Quadratic]):
 
 @pytest.mark.benchmark
 def test_sum_quadratic_small_many(benchmark, quadratic_small_many):
-    """Benchmark summing many small quadratic functions"""
+    """Measure repeated accumulation of many small Quadratic objects."""
     benchmark(sum_quadratic_functions, quadratic_small_many)
 
 
 @pytest.mark.benchmark
 def test_sum_quadratic_large_little(benchmark, quadratic_large_little):
-    """Benchmark summing few large quadratic functions"""
+    """Measure accumulation of a few high-term-count Quadratic objects."""
     benchmark(sum_quadratic_functions, quadratic_large_little)

--- a/python/ommx-tests/tests/test_bench_quadratic_add.py
+++ b/python/ommx-tests/tests/test_bench_quadratic_add.py
@@ -1,8 +1,11 @@
-"""Python API benchmarks for quadratic-function addition.
+"""Persistent Python scaling guardrails for ``Quadratic.__iadd__``.
 
-These benchmarks measure the public Python operator path for two shapes:
-many small objects, and a few large objects. They intentionally include
-Python object dispatch plus the Rust-backed addition work reached through it.
+Originating from PR #498, ``small_many`` detects a fallback that clones the
+growing accumulator and changes fixed-size accumulation from O(N) to O(N^2).
+``large_little`` holds the addition count at three and detects superlinear
+merge or rehash cost as operand term count grows. Because that work is
+Rust-internal and covered by the Rust ``sum`` suite, ``large_little`` is kept
+as a manual Python diagnostic rather than a persistent boundary guardrail.
 """
 
 import pytest
@@ -43,12 +46,14 @@ def sum_quadratic_functions(functions: list[Quadratic]):
     return result
 
 
+@pytest.mark.benchmark_guardrail
 @pytest.mark.benchmark
 def test_sum_quadratic_small_many(benchmark, quadratic_small_many):
     """Measure repeated accumulation of many small Quadratic objects."""
     benchmark(sum_quadratic_functions, quadratic_small_many)
 
 
+@pytest.mark.benchmark_diagnostic
 @pytest.mark.benchmark
 def test_sum_quadratic_large_little(benchmark, quadratic_large_little):
     """Measure accumulation of a few high-term-count Quadratic objects."""

--- a/python/ommx-tests/tests/test_bench_to_qubo.py
+++ b/python/ommx-tests/tests/test_bench_to_qubo.py
@@ -1,14 +1,19 @@
-"""Python API benchmarks for `Instance.to_qubo`.
+"""Persistent Python scaling guardrails for ``Instance.to_qubo``.
 
-These benchmarks measure end-to-end conversion through the public Python API,
-including the defensive copy needed because `to_qubo` consumes mutable instance
-state. Large pseudo-Boolean scaling should be covered by Rust SDK benchmarks.
+``to_qubo`` is a Python driver API that sequences several Rust transformations,
+so the public boundary is part of the measured operation. The pseudo-Boolean
+family originates from issue #404 and PR #495 and varies the number of terms to
+detect renewed superlinear conversion. The defensive copy is included because
+the driver consumes mutable instance state.
 """
 
 import pytest
 import random
 from copy import deepcopy
 from ommx import DecisionVariable, Instance
+
+
+pytestmark = pytest.mark.benchmark_guardrail
 
 
 @pytest.fixture
@@ -26,7 +31,7 @@ def small():
     return instance
 
 
-@pytest.fixture(params=[10, 100])
+@pytest.fixture(params=[10, 32, 100])
 def pseudo_boolean_inequality(request):
     num_terms: int = request.param
     x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(num_terms)]
@@ -61,11 +66,11 @@ def to_qubo(instance: Instance):
 
 @pytest.mark.benchmark
 def test_to_qubo_small(small: Instance):
-    """Measure a tiny integer-constrained model through Python `to_qubo`."""
+    """Track fixed boundary cost for a tiny integer-constrained model."""
     to_qubo(small)
 
 
 @pytest.mark.benchmark
 def test_to_qubo_pbi(pseudo_boolean_inequality: Instance):
-    """Measure moderate pseudo-Boolean inequality conversion via Python."""
+    """Track scaling with the pseudo-Boolean inequality term count."""
     to_qubo(pseudo_boolean_inequality)

--- a/python/ommx-tests/tests/test_bench_to_qubo.py
+++ b/python/ommx-tests/tests/test_bench_to_qubo.py
@@ -19,7 +19,7 @@ def small():
     return instance
 
 
-@pytest.fixture(params=[10, 100, 1000])
+@pytest.fixture(params=[10, 100])
 def pseudo_boolean_inequality(request):
     num_terms: int = request.param
     x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(num_terms)]

--- a/python/ommx-tests/tests/test_bench_to_qubo.py
+++ b/python/ommx-tests/tests/test_bench_to_qubo.py
@@ -3,8 +3,11 @@
 ``to_qubo`` is a Python driver API that sequences several Rust transformations,
 so the public boundary is part of the measured operation. The pseudo-Boolean
 family originates from issue #404 and PR #495 and varies the number of terms to
-detect renewed superlinear conversion. The defensive copy is included because
-the driver consumes mutable instance state.
+guard the expected output-sensitive cost: penalizing an N-term equality creates
+Theta(N^2) QUBO coefficients, so conversion should not grow beyond quadratic.
+The bounded 10/32/100 inputs retain that trend without restoring the 1,000-term
+profile that dominated the CodSpeed workflow. The defensive copy is included
+because the driver consumes mutable instance state.
 """
 
 import pytest

--- a/python/ommx-tests/tests/test_bench_to_qubo.py
+++ b/python/ommx-tests/tests/test_bench_to_qubo.py
@@ -1,3 +1,10 @@
+"""Python API benchmarks for `Instance.to_qubo`.
+
+These benchmarks measure end-to-end conversion through the public Python API,
+including the defensive copy needed because `to_qubo` consumes mutable instance
+state. Large pseudo-Boolean scaling should be covered by Rust SDK benchmarks.
+"""
+
 import pytest
 import random
 from copy import deepcopy
@@ -54,9 +61,11 @@ def to_qubo(instance: Instance):
 
 @pytest.mark.benchmark
 def test_to_qubo_small(small: Instance):
+    """Measure a tiny integer-constrained model through Python `to_qubo`."""
     to_qubo(small)
 
 
 @pytest.mark.benchmark
 def test_to_qubo_pbi(pseudo_boolean_inequality: Instance):
+    """Measure moderate pseudo-Boolean inequality conversion via Python."""
     to_qubo(pseudo_boolean_inequality)

--- a/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
+++ b/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
@@ -1,8 +1,9 @@
 """Python expression-construction benchmarks for direct TSP QUBO generation.
 
-This benchmark measures the cost of constructing an OMMX expression through
-Python loops and overloaded arithmetic. It does not measure solver runtime or
-`Instance.to_qubo`; larger algorithmic scaling should live in Rust benchmarks.
+This benchmark measures Python-driven OMMX expression construction, including
+PyO3 overloaded arithmetic and the Rust-backed expression clone/add work it
+triggers. It does not measure solver runtime or `Instance.to_qubo`; larger
+algorithmic scaling should live in Rust benchmarks.
 """
 
 import pytest
@@ -84,6 +85,6 @@ def make_tsp_qubo_by_ommx(
 
 @pytest.mark.benchmark
 def test_tsp_qubo_direct_generation(tsp_distance_matrix: np.ndarray):
-    """Measure direct Python construction of a TSP QUBO expression."""
+    """Measure Python-driven construction of a TSP QUBO expression."""
     # Generate QUBO with custom penalty weights
     make_tsp_qubo_by_ommx(tsp_distance_matrix, lambda1=10.0, lambda2=10.0)

--- a/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
+++ b/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
@@ -1,3 +1,10 @@
+"""Python expression-construction benchmarks for direct TSP QUBO generation.
+
+This benchmark measures the cost of constructing an OMMX expression through
+Python loops and overloaded arithmetic. It does not measure solver runtime or
+`Instance.to_qubo`; larger algorithmic scaling should live in Rust benchmarks.
+"""
+
 import pytest
 import numpy as np
 import ommx
@@ -77,6 +84,6 @@ def make_tsp_qubo_by_ommx(
 
 @pytest.mark.benchmark
 def test_tsp_qubo_direct_generation(tsp_distance_matrix: np.ndarray):
-    """Benchmark the direct TSP QUBO generation using OMMX."""
+    """Measure direct Python construction of a TSP QUBO expression."""
     # Generate QUBO with custom penalty weights
     make_tsp_qubo_by_ommx(tsp_distance_matrix, lambda1=10.0, lambda2=10.0)

--- a/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
+++ b/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
@@ -1,14 +1,18 @@
-"""Python expression-construction benchmarks for direct TSP QUBO generation.
+"""Manual profiling diagnostic for direct TSP QUBO generation.
 
-This benchmark measures Python-driven OMMX expression construction, including
-PyO3 overloaded arithmetic and the Rust-backed expression clone/add work it
-triggers. It does not measure solver runtime or `Instance.to_qubo`; larger
-algorithmic scaling should live in Rust benchmarks.
+This end-to-end workload profiles Python-driven expression construction,
+including PyO3 overloaded arithmetic and Rust-backed clone/add work. It is
+useful for locating expression-construction hotspots, but its city count mixes
+the number of generated terms with accumulator growth and therefore is not a
+persistent complexity guardrail. Run it through the full manual suite.
 """
 
 import pytest
 import numpy as np
 import ommx
+
+
+pytestmark = pytest.mark.benchmark_diagnostic
 
 
 def generate_distance_matrix(num_city: int) -> np.ndarray:
@@ -85,6 +89,6 @@ def make_tsp_qubo_by_ommx(
 
 @pytest.mark.benchmark
 def test_tsp_qubo_direct_generation(tsp_distance_matrix: np.ndarray):
-    """Measure Python-driven construction of a TSP QUBO expression."""
+    """Profile Python-driven construction of a TSP QUBO expression."""
     # Generate QUBO with custom penalty weights
     make_tsp_qubo_by_ommx(tsp_distance_matrix, lambda1=10.0, lambda2=10.0)

--- a/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
+++ b/python/ommx-tests/tests/test_bench_tsp_qubo_direct.py
@@ -14,7 +14,7 @@ def generate_distance_matrix(num_city: int) -> np.ndarray:
     return distance
 
 
-@pytest.fixture(params=[2, 4, 8, 16, 32])
+@pytest.fixture(params=[2, 4, 8, 16])
 def tsp_distance_matrix(request):
     """Fixture to generate TSP distance matrices of different sizes."""
     num_city = request.param

--- a/python/ommx/Taskfile.yml
+++ b/python/ommx/Taskfile.yml
@@ -57,9 +57,15 @@ tasks:
     dir: ../..
 
   bench:
-    desc: Run benchmarks for OMMX Python SDK
+    desc: Run the full benchmark suite for OMMX Python SDK
     cmds:
-      - uv run pytest python/ommx-tests --codspeed
+      - uv run pytest python/ommx-tests/tests/test_bench_*.py --codspeed
+    dir: ../..
+
+  bench-guardrail:
+    desc: Run persistent benchmark guardrails for OMMX Python SDK
+    cmds:
+      - uv run pytest python/ommx-tests/tests/test_bench_*.py --codspeed -m benchmark_guardrail
     dir: ../..
 
   build:pyodide:

--- a/rust/ommx/benches/evaluate.rs
+++ b/rust/ommx/benches/evaluate.rs
@@ -3,7 +3,8 @@
 //! The expression families vary term count and should remain O(N). The
 //! Instance families reproduce the evaluate/evaluate_samples boundary from
 //! issue #336, using synthetic one-variable constraints so Rust-internal
-//! scaling is measured without the heavy MIPLIB profiling fixture.
+//! scaling is measured without the heavy MIPLIB profiling fixture. Both
+//! Instance paths should remain O(C) in the constraint count C.
 
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,

--- a/rust/ommx/benches/evaluate.rs
+++ b/rust/ommx/benches/evaluate.rs
@@ -1,10 +1,19 @@
+//! Persistent scaling guardrails for expression and Instance evaluation.
+//!
+//! The expression families vary term count and should remain O(N). The
+//! Instance families reproduce the evaluate/evaluate_samples boundary from
+//! issue #336, using synthetic one-variable constraints so Rust-internal
+//! scaling is measured without the heavy MIPLIB profiling fixture.
+
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
 };
 use ommx::{
+    linear,
     random::{arbitrary_state, random_deterministic, sample_deterministic},
-    Evaluate, Linear, LinearParameters, Polynomial, PolynomialParameters, Quadratic,
-    QuadraticParameters, VariableID,
+    Constraint, ConstraintID, DecisionVariable, Evaluate, Function, Instance, Linear,
+    LinearParameters, Polynomial, PolynomialParameters, Quadratic, QuadraticParameters, Sampled,
+    Sense, VariableID,
 };
 use proptest::prelude::Arbitrary;
 
@@ -50,10 +59,85 @@ fn evaluate_polynomial(c: &mut Criterion) {
     });
 }
 
+fn instance_evaluation_fixture(
+    num_constraints: usize,
+) -> (Instance, ommx::v1::State, Sampled<ommx::v1::State>) {
+    let decision_variables = (0..num_constraints as u64)
+        .map(|id| (VariableID::from(id), DecisionVariable::continuous()))
+        .collect();
+    let constraints = (0..num_constraints as u64)
+        .map(|id| {
+            (
+                ConstraintID::from(id),
+                Constraint::equal_to_zero(Function::from(linear!(id))),
+            )
+        })
+        .collect();
+    let state: ommx::v1::State = (0..num_constraints as u64).map(|id| (id, 0.0)).collect();
+    let samples = Sampled::from(state.clone());
+    let instance = Instance::builder()
+        .sense(Sense::Minimize)
+        .objective(Function::Zero)
+        .decision_variables(decision_variables)
+        .constraints(constraints)
+        .build()
+        .unwrap();
+
+    (instance, state, samples)
+}
+
+/// Scale one-state Instance evaluation with decision variables and constraints.
+fn evaluate_instance_single_state(c: &mut Criterion) {
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    let mut group = c.benchmark_group("evaluate-instance-single-state");
+    group.plot_config(plot_config);
+    for num_constraints in [100, 1_000, 10_000] {
+        let (instance, state, _) = instance_evaluation_fixture(num_constraints);
+        group.bench_with_input(
+            BenchmarkId::new(
+                "evaluate-instance-single-state",
+                num_constraints.to_string(),
+            ),
+            &(instance, state),
+            |b, (instance, state)| {
+                b.iter(|| instance.evaluate(state, ommx::ATol::default()).unwrap())
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Scale single-sample Instance evaluation against the one-state baseline.
+fn evaluate_instance_single_sample(c: &mut Criterion) {
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    let mut group = c.benchmark_group("evaluate-instance-single-sample");
+    group.plot_config(plot_config);
+    for num_constraints in [100, 1_000, 10_000] {
+        let (instance, _, samples) = instance_evaluation_fixture(num_constraints);
+        group.bench_with_input(
+            BenchmarkId::new(
+                "evaluate-instance-single-sample",
+                num_constraints.to_string(),
+            ),
+            &(instance, samples),
+            |b, (instance, samples)| {
+                b.iter(|| {
+                    instance
+                        .evaluate_samples(samples, ommx::ATol::default())
+                        .unwrap()
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     evaluate_linear,
     evaluate_quadratic,
-    evaluate_polynomial
+    evaluate_polynomial,
+    evaluate_instance_single_state,
+    evaluate_instance_single_sample,
 );
 criterion_main!(benches);

--- a/rust/ommx/benches/evaluate.rs
+++ b/rust/ommx/benches/evaluate.rs
@@ -17,6 +17,10 @@ use ommx::{
 };
 use proptest::prelude::Arbitrary;
 
+// A 10x span separates linear from quadratic growth without making every
+// instrumented expression benchmark pay for a 10,000-term profile.
+const EXPRESSION_SCALE: [usize; 3] = [100, 320, 1_000];
+
 fn evaluate<T, Params>(
     c: &mut Criterion,
     title: &str,
@@ -27,7 +31,7 @@ fn evaluate<T, Params>(
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group(title);
     group.plot_config(plot_config.clone());
-    for num_terms in [100, 1000, 10_000] {
+    for num_terms in EXPRESSION_SCALE {
         let params = parameter_generator(num_terms);
         let f: T = random_deterministic(params);
         let state = sample_deterministic(arbitrary_state(f.required_ids()));

--- a/rust/ommx/benches/mul.rs
+++ b/rust/ommx/benches/mul.rs
@@ -1,3 +1,10 @@
+//! Persistent quadratic-scaling guardrails for expression multiplication.
+//!
+//! Squaring an N-term expression generates up to N^2 term products. These
+//! families distinguish that expected quadratic work from additional
+//! superlinear allocation, hashing, or Function normalization overhead. The
+//! Function and PolynomialBase paths retain the regression signal from PR #990.
+
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
 };
@@ -13,7 +20,7 @@ fn square_linear(c: &mut Criterion) {
     let mut group = c.benchmark_group("square-linear");
     group.plot_config(plot_config.clone());
 
-    for &num_terms in &[10, 100] {
+    for &num_terms in &[10, 32, 100] {
         let f: Linear = random_deterministic(
             LinearParameters::new(num_terms, (3 * num_terms as u64).into()).unwrap(),
         );
@@ -37,7 +44,7 @@ fn square_quadratic(c: &mut Criterion) {
     let mut group = c.benchmark_group("square-quadratic");
     group.plot_config(plot_config.clone());
 
-    for &num_terms in &[10, 100] {
+    for &num_terms in &[10, 32, 100] {
         let f: Quadratic = random_deterministic(
             QuadraticParameters::new(num_terms, (3 * num_terms as u64).into()).unwrap(),
         );
@@ -61,7 +68,7 @@ fn square_polynomial(c: &mut Criterion) {
     let mut group = c.benchmark_group("square-polynomial");
     group.plot_config(plot_config.clone());
 
-    for &num_terms in &[10, 100] {
+    for &num_terms in &[10, 32, 100] {
         let f: Polynomial = random_deterministic(
             PolynomialParameters::new(num_terms, 3.into(), (3 * num_terms as u64).into()).unwrap(),
         );
@@ -89,7 +96,7 @@ fn square_function_linear(c: &mut Criterion) {
     let mut group = c.benchmark_group("square-function-linear");
     group.plot_config(plot_config.clone());
 
-    for &num_terms in &[10, 100] {
+    for &num_terms in &[10, 32, 100] {
         let f: Function = random_deterministic::<Linear>(
             LinearParameters::new(num_terms, (3 * num_terms as u64).into()).unwrap(),
         )

--- a/rust/ommx/benches/partial_evaluate.rs
+++ b/rust/ommx/benches/partial_evaluate.rs
@@ -3,7 +3,9 @@
 //! Expression families vary total term count while assignment density is one,
 //! half, or all required IDs; each should traverse terms linearly. Instance
 //! families originate from issue #1027 and compare removed-only transaction
-//! overhead with active-constraint atomic and consuming paths.
+//! overhead with active-constraint atomic and consuming paths. Each Instance
+//! family should remain O(C) in the constraint count C; the consuming path is
+//! expected to avoid the atomic path's whole-Instance clone constant.
 
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,

--- a/rust/ommx/benches/partial_evaluate.rs
+++ b/rust/ommx/benches/partial_evaluate.rs
@@ -1,4 +1,10 @@
-// Create partial evaluation benchmarks for Linear
+//! Persistent scaling guardrails for partial evaluation.
+//!
+//! Expression families vary total term count while assignment density is one,
+//! half, or all required IDs; each should traverse terms linearly. Instance
+//! families originate from issue #1027 and compare removed-only transaction
+//! overhead with active-constraint atomic and consuming paths.
+
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
 };

--- a/rust/ommx/benches/partial_evaluate.rs
+++ b/rust/ommx/benches/partial_evaluate.rs
@@ -18,6 +18,10 @@ use ommx::{
 use proptest::prelude::Arbitrary;
 use std::collections::BTreeMap;
 
+// A 10x span separates linear from quadratic growth without making every
+// instrumented expression benchmark pay for a 10,000-term profile.
+const EXPRESSION_SCALE: [usize; 3] = [100, 320, 1_000];
+
 fn removed_constraint_instance(num_constraints: usize) -> (Instance, ommx::v1::State) {
     let decision_variables = (0..num_constraints as u64)
         .map(|id| (VariableID::from(id), DecisionVariable::continuous()))
@@ -169,7 +173,7 @@ fn bench_partial_evaluate<T, Parameters>(
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group(group_name);
     group.plot_config(plot_config.clone());
-    for num_terms in [100, 1_000, 10_000] {
+    for num_terms in EXPRESSION_SCALE {
         let lin: T = random_deterministic(parameter_generator(num_terms));
         let ids = id_selector(lin.required_ids());
         let state = sample_deterministic(arbitrary_state(ids));

--- a/rust/ommx/benches/sum.rs
+++ b/rust/ommx/benches/sum.rs
@@ -1,3 +1,11 @@
+//! Persistent scaling guardrails for Rust expression accumulation.
+//!
+//! `small-many` varies the number of fixed-size operands and detects rebuilding
+//! a growing accumulator. `large-little` fixes the operation count and varies
+//! operand size, including the harmful over-reservation explored in PR #990.
+//! Cross-degree additions guard promotion paths, while Function-level families
+//! guard against the per-operation normalization round-trip fixed by PR #990.
+
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
 };

--- a/rust/ommx/benches/sum.rs
+++ b/rust/ommx/benches/sum.rs
@@ -5,6 +5,8 @@
 //! operand size, including the harmful over-reservation explored in PR #990.
 //! Cross-degree additions guard promotion paths, while Function-level families
 //! guard against the per-operation normalization round-trip fixed by PR #990.
+//! Every family should remain linear in its varied operand-count or term-count
+//! axis.
 
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,

--- a/rust/ommx/benches/sum.rs
+++ b/rust/ommx/benches/sum.rs
@@ -16,18 +16,22 @@ use ommx::{
     QuadraticParameters,
 };
 
+// A 10x span separates linear from quadratic growth without making every
+// instrumented expression benchmark pay for a 10,000-term profile.
+const EXPRESSION_SCALE: [usize; 3] = [100, 320, 1_000];
+
 /// Benchmark for summation of many linear functions with three terms
 fn sum_linear_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-linear-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Linear {
                 random(
                     &mut rng,
-                    LinearParameters::new(3, num_functions.into()).unwrap(),
+                    LinearParameters::new(3, (num_functions as u64).into()).unwrap(),
                 )
             })
             .collect::<Vec<_>>();
@@ -51,7 +55,7 @@ fn sum_linear_large_little(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-linear-large-little");
     group.plot_config(plot_config.clone());
-    for num_terms in [100, 1000, 10_000] {
+    for num_terms in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..3)
             .map(|_| -> Linear {
@@ -82,7 +86,7 @@ fn sum_quadratic_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-quadratic-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Quadratic {
@@ -113,7 +117,7 @@ fn sum_quadratic_large_little(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-quadratic-large-little");
     group.plot_config(plot_config.clone());
-    for num_terms in [100, 1000, 10_000] {
+    for num_terms in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..3)
             .map(|_| -> Quadratic {
@@ -144,7 +148,7 @@ fn sum_polynomial_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-polynomial-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Polynomial {
@@ -175,7 +179,7 @@ fn sum_polynomial_large_little(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-polynomial-large-little");
     group.plot_config(plot_config.clone());
-    for num_terms in [100, 1000, 10_000] {
+    for num_terms in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..3)
             .map(|_| -> Polynomial {
@@ -206,7 +210,7 @@ fn add_small_many_linear_to_quadratic(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("add-small-many-linear-to-quadratic");
     group.plot_config(plot_config.clone());
-    for num_lin in [100, 1000, 10_000] {
+    for num_lin in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let lins = (0..num_lin)
             .map(|_| -> Linear {
@@ -238,7 +242,7 @@ fn add_small_many_linear_to_polynomial(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("add-small-many-linear-to-polynomial");
     group.plot_config(plot_config.clone());
-    for num_lin in [100, 1000, 10_000] {
+    for num_lin in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let lins = (0..num_lin)
             .map(|_| -> Linear {
@@ -275,13 +279,13 @@ fn sum_function_linear_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-function-linear-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Function {
                 random::<Linear>(
                     &mut rng,
-                    LinearParameters::new(3, num_functions.into()).unwrap(),
+                    LinearParameters::new(3, (num_functions as u64).into()).unwrap(),
                 )
                 .into()
             })
@@ -308,7 +312,7 @@ fn sum_function_quadratic_small_many(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("sum-function-quadratic-small-many");
     group.plot_config(plot_config.clone());
-    for num_functions in [100, 1000, 10_000] {
+    for num_functions in EXPRESSION_SCALE {
         let mut rng = Rng::deterministic();
         let functions = (0..num_functions)
             .map(|_| -> Function {


### PR DESCRIPTION
## Summary

- Limit Rust CodSpeed builds to the `ommx` package without default features, and build the Python extension as an optimized release wheel with reusable Cargo and pip caches.
- Classify benchmark families as persistent regression guardrails or manual profiling diagnostics, with source-level contracts describing their regression risk, measured boundary, independent variables, and expected scaling.
- Run persistent Python guardrails on `main` and release tags while allowing manually dispatched workflows to select the full suite, including diagnostic flame graphs.
- Keep Python `small_many` operator benchmarks as O(N) guardrails for the in-place accumulation regressions fixed in PRs #498 and #990; move Python `large_little` merge characterization to the manual suite because equivalent Rust merge scaling is already covered by the Rust `sum` benchmarks.
- Replace the heavy MIPLIB evaluation workload on the persistent path with small Python boundary guardrails, retain the issue #336 MIPLIB case for manual profiling, and add synthetic Rust Instance state/single-sample scaling benchmarks for the underlying evaluation work.
- Keep `Instance.to_qubo` in Python because it is a Python driver API, use bounded geometric inputs to guard its expected Theta(N^2) output-sensitive cost without restoring the dominant 1,000-term profile, and move direct TSP expression construction to the diagnostic suite because its city count mixes term generation with accumulator growth.
- Add a third scale point to Rust multiplication families so expected quadratic growth can be distinguished from additional superlinear overhead.
- Bound Rust expression-level scaling guardrails to 100/320/1,000 terms, retaining a 10x range for exponent checks while preserving the larger issue #1027 Instance inputs under their separate transaction-cost contract.
- Mark the PySCIPOpt Plant Placement comparison from PR #809 as a local formulation diagnostic that measures SCIP rather than an OMMX regression, and keep it outside the CodSpeed workflow.
- Expand the repository-local `benchmark-review` skill to classify scaling, fixed-input, profiling, and workflow measurements; require benchmark contracts and lifecycle decisions; and account for build-included CI cost.

## Rationale

The workflow previously treated every benchmark as the same kind of permanent workload. That made heavy end-to-end profiling cases run on every `main` update, duplicated Rust-internal scaling through Python, and left the reason for retaining many benchmark shapes implicit.

The revised policy keeps continuous measurements focused on actionable regressions. Scaling guardrails use geometric inputs and an explicit expected complexity, fixed-input guardrails compare stable public boundaries, and workloads whose primary value is flame-graph attribution remain available through the full manual suite. This preserves profiling capability for performance work without making every diagnostic input part of the permanent `main` budget.

Workflow setup and build time are managed separately from measured SDK runtime. Rust benchmarks avoid unused remote-artifact dependencies, while the Python job uses an optimized PyO3 wheel and language-level caches so benchmark results come from release-equivalent artifacts.
