### PR TITLE
Reconstruct exact inverse-lowering candidates

### DIFF
--- a/rust/ommx/src/proof/linear.rs
+++ b/rust/ommx/src/proof/linear.rs
@@ -4,6 +4,9 @@ use num::{BigInt, Signed};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
+mod activity;
+mod candidate;
+
 const FINGERPRINT_DOMAIN: &[u8] = b"org.ommx.proof.linear-relaxation\0";
 const FINGERPRINT_VERSION: u32 = 1;
 

--- a/rust/ommx/src/proof/linear/activity.rs
+++ b/rust/ommx/src/proof/linear/activity.rs
@@ -1,0 +1,284 @@
+use super::{CertifiedLinearRelaxation, ExactAffine, ExactRational, LinearProofError};
+use num::{Signed, Zero};
+
+/// Exact interval activity of one affine expression over the proof-domain
+/// facts in a [`CertifiedLinearRelaxation`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityBounds {
+    lower: Option<ExactRational>,
+    upper: Option<ExactRational>,
+}
+
+impl ActivityBounds {
+    pub fn lower(&self) -> Option<&ExactRational> {
+        self.lower.as_ref()
+    }
+
+    pub fn upper(&self) -> Option<&ExactRational> {
+        self.upper.as_ref()
+    }
+}
+
+impl CertifiedLinearRelaxation {
+    /// Evaluate exact lower and upper activity using only stored finite bound
+    /// sides and fixed-value equations.
+    ///
+    /// A missing required side makes only that result side unbounded. No
+    /// round-to-nearest `f64` operation or tolerance is used.
+    pub fn activity_bounds(
+        &self,
+        affine: &ExactAffine,
+    ) -> Result<ActivityBounds, LinearProofError> {
+        let mut lower = Some(affine.constant().clone());
+        let mut upper = Some(affine.constant().clone());
+
+        for (id, coefficient) in affine.coefficients() {
+            if coefficient.is_zero() {
+                continue;
+            }
+            let domain = self
+                .domains()
+                .get(id)
+                .ok_or(LinearProofError::UnknownDomain { id: *id })?;
+            let (lower_value, upper_value) = if let Some(fixed) = domain.fixed() {
+                (Some(fixed), Some(fixed))
+            } else if coefficient.is_positive() {
+                (domain.lower(), domain.upper())
+            } else {
+                debug_assert!(coefficient.is_negative());
+                (domain.upper(), domain.lower())
+            };
+
+            lower = add_term(lower, coefficient, lower_value);
+            upper = add_term(upper, coefficient, upper_value);
+        }
+
+        Ok(ActivityBounds { lower, upper })
+    }
+
+    /// Check whether variable-domain proof atoms imply `affine <= 0`.
+    pub fn variable_facts_imply_nonpositive(
+        &self,
+        affine: &ExactAffine,
+    ) -> Result<bool, LinearProofError> {
+        Ok(self
+            .activity_bounds(affine)?
+            .upper()
+            .is_some_and(|upper| upper <= &ExactRational::zero()))
+    }
+}
+
+fn add_term(
+    total: Option<ExactRational>,
+    coefficient: &ExactRational,
+    value: Option<&ExactRational>,
+) -> Option<ExactRational> {
+    Some(total? + coefficient * value?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        coeff, linear, Bound, Constraint, DecisionVariable, Function, Instance, Kind, Sense,
+        VariableID,
+    };
+    use num::BigRational;
+    use std::collections::BTreeMap;
+
+    fn exact(value: i64) -> ExactRational {
+        BigRational::from_integer(value.into())
+    }
+
+    fn bounded_instance(fixed: Option<f64>) -> Instance {
+        let mut builder = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (
+                    VariableID::from(1),
+                    DecisionVariable::new(
+                        Kind::Continuous,
+                        Bound::new(-2.0, 3.0).unwrap(),
+                        crate::ATol::default(),
+                    )
+                    .unwrap(),
+                ),
+                (VariableID::from(2), DecisionVariable::continuous()),
+            ]))
+            .constraints(BTreeMap::from([(
+                crate::ConstraintID::from(1),
+                Constraint::less_than_or_equal_to_zero(Function::from(linear!(1))),
+            )]));
+        if let Some(value) = fixed {
+            builder = builder
+                .objective(Function::zero())
+                .fixed_decision_variable_values(BTreeMap::from([(VariableID::from(2), value)]));
+        }
+        builder.build().unwrap()
+    }
+
+    #[test]
+    fn activity_uses_coefficient_signs_exactly() {
+        let snapshot = bounded_instance(None)
+            .certified_linear_relaxation()
+            .unwrap();
+        let affine = ExactAffine::from_function(&Function::from(
+            ((coeff!(2.0) * linear!(1)).unwrap() + coeff!(-1.0)).unwrap(),
+        ))
+        .unwrap()
+        .unwrap();
+        let activity = snapshot.activity_bounds(&affine).unwrap();
+        assert_eq!(activity.lower(), Some(&exact(-5)));
+        assert_eq!(activity.upper(), Some(&exact(5)));
+
+        let negated = snapshot.activity_bounds(&affine.negated()).unwrap();
+        assert_eq!(negated.lower(), Some(&exact(-5)));
+        assert_eq!(negated.upper(), Some(&exact(5)));
+    }
+
+    #[test]
+    fn unbounded_coordinate_only_removes_the_required_side() {
+        let snapshot = bounded_instance(None)
+            .certified_linear_relaxation()
+            .unwrap();
+        let affine = ExactAffine::from_function(&Function::from(linear!(2)))
+            .unwrap()
+            .unwrap();
+        let activity = snapshot.activity_bounds(&affine).unwrap();
+        assert_eq!(activity.lower(), None);
+        assert_eq!(activity.upper(), None);
+        assert!(!snapshot.variable_facts_imply_nonpositive(&affine).unwrap());
+    }
+
+    #[test]
+    fn fixed_equation_supplies_both_activity_sides() {
+        let snapshot = bounded_instance(Some(0.25))
+            .certified_linear_relaxation()
+            .unwrap();
+        let affine = ExactAffine::from_function(&Function::from(linear!(2)))
+            .unwrap()
+            .unwrap();
+        let activity = snapshot.activity_bounds(&affine).unwrap();
+        let expected = crate::proof::exact::from_f64(0.25).unwrap();
+        assert_eq!(activity.lower(), Some(&expected));
+        assert_eq!(activity.upper(), Some(&expected));
+    }
+
+    #[test]
+    fn fixed_equation_takes_precedence_over_finite_bounds() {
+        let instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([(
+                VariableID::from(1),
+                DecisionVariable::new(
+                    Kind::Continuous,
+                    Bound::new(-4.0, 6.0).unwrap(),
+                    crate::ATol::default(),
+                )
+                .unwrap(),
+            )]))
+            .fixed_decision_variable_values(BTreeMap::from([(VariableID::from(1), 0.25)]))
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap();
+        let snapshot = instance.certified_linear_relaxation().unwrap();
+        let affine = ExactAffine::coordinate(VariableID::from(1), 1, ExactRational::zero());
+        let activity = snapshot.activity_bounds(&affine).unwrap();
+        let expected = crate::proof::exact::from_f64(0.25).unwrap();
+        assert_eq!(activity.lower(), Some(&expected));
+        assert_eq!(activity.upper(), Some(&expected));
+    }
+
+    #[test]
+    fn one_sided_domains_propagate_by_coefficient_sign() {
+        let instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (
+                    VariableID::from(1),
+                    DecisionVariable::new(
+                        Kind::Continuous,
+                        Bound::new(2.0, f64::INFINITY).unwrap(),
+                        crate::ATol::default(),
+                    )
+                    .unwrap(),
+                ),
+                (
+                    VariableID::from(2),
+                    DecisionVariable::new(
+                        Kind::Continuous,
+                        Bound::new(f64::NEG_INFINITY, 5.0).unwrap(),
+                        crate::ATol::default(),
+                    )
+                    .unwrap(),
+                ),
+            ]))
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap();
+        let snapshot = instance.certified_linear_relaxation().unwrap();
+
+        let cases = [
+            (VariableID::from(1), 3, Some(exact(6)), None),
+            (VariableID::from(1), -3, None, Some(exact(-6))),
+            (VariableID::from(2), 4, None, Some(exact(20))),
+            (VariableID::from(2), -4, Some(exact(-20)), None),
+        ];
+        for (id, coefficient, expected_lower, expected_upper) in cases {
+            let affine = ExactAffine::coordinate(id, coefficient, ExactRational::zero());
+            let activity = snapshot.activity_bounds(&affine).unwrap();
+            assert_eq!(activity.lower(), expected_lower.as_ref());
+            assert_eq!(activity.upper(), expected_upper.as_ref());
+        }
+    }
+
+    #[test]
+    fn implication_has_no_tolerance() {
+        let snapshot = bounded_instance(None)
+            .certified_linear_relaxation()
+            .unwrap();
+        let implied =
+            ExactAffine::from_function(&Function::from((linear!(1) + coeff!(-3.0)).unwrap()))
+                .unwrap()
+                .unwrap();
+        assert!(snapshot.variable_facts_imply_nonpositive(&implied).unwrap());
+
+        let not_implied = ExactAffine::from_function(&Function::from(
+            (linear!(1) + coeff!(-2.9999999999999996)).unwrap(),
+        ))
+        .unwrap()
+        .unwrap();
+        assert!(!snapshot
+            .variable_facts_imply_nonpositive(&not_implied)
+            .unwrap());
+    }
+
+    #[test]
+    fn zero_coefficient_does_not_require_a_domain_or_bound() {
+        let snapshot = bounded_instance(None)
+            .certified_linear_relaxation()
+            .unwrap();
+        let affine = ExactAffine {
+            coefficients: BTreeMap::from([(VariableID::from(999), ExactRational::zero())]),
+            constant: exact(4),
+        };
+        let activity = snapshot.activity_bounds(&affine).unwrap();
+        assert_eq!(activity.lower(), Some(&exact(4)));
+        assert_eq!(activity.upper(), Some(&exact(4)));
+    }
+
+    #[test]
+    fn nonzero_unknown_coordinate_fails_closed() {
+        let snapshot = bounded_instance(None)
+            .certified_linear_relaxation()
+            .unwrap();
+        let affine = ExactAffine::coordinate(VariableID::from(999), 1, ExactRational::zero());
+        assert!(matches!(
+            snapshot.activity_bounds(&affine),
+            Err(LinearProofError::UnknownDomain { id }) if id == VariableID::from(999)
+        ));
+    }
+}

--- a/rust/ommx/src/proof/linear/candidate.rs
+++ b/rust/ommx/src/proof/linear/candidate.rs
@@ -1,0 +1,420 @@
+use super::{LinearProofError, LinearRelaxationFingerprint};
+use crate::{
+    constraint::{Provenance, RemovedReason},
+    ConstraintID, IndicatorConstraintID, Instance, Sos1ConstraintID,
+};
+use std::collections::BTreeSet;
+
+const GENERATED_CONSTRAINT_IDS: &str = "constraint_ids";
+const INDICATOR_LOWERING_REASON: &str = "ommx.Instance.convert_indicator_to_constraint";
+const SOS1_LOWERING_REASON: &str = "ommx.Instance.convert_sos1_to_constraints";
+
+/// Untrusted, versioned lookup result for one historical Indicator Big-M
+/// lowering. The generated rows have not yet been proven equivalent to the
+/// removed source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IndicatorBigMV1 {
+    source: IndicatorConstraintID,
+    generated_rows: Vec<ConstraintID>,
+    representation: LinearRelaxationFingerprint,
+}
+
+/// Untrusted, versioned lookup result for one historical SOS1 Big-M lowering.
+/// Selector roles and generated-row semantics remain to be verified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Sos1BigMV1 {
+    source: Sos1ConstraintID,
+    generated_rows: Vec<ConstraintID>,
+    representation: LinearRelaxationFingerprint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+enum InverseLoweringCandidateError {
+    #[error("removed Indicator constraint {id:?} was not found")]
+    MissingRemovedIndicator { id: IndicatorConstraintID },
+    #[error("removed SOS1 constraint {id:?} was not found")]
+    MissingRemovedSos1 { id: Sos1ConstraintID },
+    #[error("expected lowering reason {expected}, found {actual}")]
+    UnexpectedRemovalReason {
+        expected: &'static str,
+        actual: String,
+    },
+    #[error("lowering reason is missing the {GENERATED_CONSTRAINT_IDS} parameter")]
+    MissingGeneratedConstraintIds,
+    #[error("generated constraint ID token {token:?} is not canonical u64 text")]
+    InvalidGeneratedConstraintId { token: String },
+    #[error("generated constraint ID {id:?} is listed more than once")]
+    DuplicateGeneratedConstraintId { id: ConstraintID },
+    #[error("generated regular constraint {id:?} is not active")]
+    MissingGeneratedConstraint { id: ConstraintID },
+    #[error("generated regular constraint {id:?} has unexpected provenance")]
+    ProvenanceMismatch { id: ConstraintID },
+    #[error(transparent)]
+    LinearProof(#[from] LinearProofError),
+}
+
+impl Instance {
+    fn indicator_big_m_candidate_v1(
+        &self,
+        id: IndicatorConstraintID,
+    ) -> Result<IndicatorBigMV1, InverseLoweringCandidateError> {
+        let (_, reason) = self
+            .removed_indicator_constraints()
+            .get(&id)
+            .ok_or(InverseLoweringCandidateError::MissingRemovedIndicator { id })?;
+        let generated_rows = parse_generated_constraint_ids(reason, INDICATOR_LOWERING_REASON)?;
+        self.validate_candidate_rows(&generated_rows, Provenance::IndicatorConstraint(id))?;
+        let representation = self.certified_linear_relaxation()?.fingerprint();
+        Ok(IndicatorBigMV1 {
+            source: id,
+            generated_rows,
+            representation,
+        })
+    }
+
+    fn sos1_big_m_candidate_v1(
+        &self,
+        id: Sos1ConstraintID,
+    ) -> Result<Sos1BigMV1, InverseLoweringCandidateError> {
+        let (_, reason) = self
+            .removed_sos1_constraints()
+            .get(&id)
+            .ok_or(InverseLoweringCandidateError::MissingRemovedSos1 { id })?;
+        let generated_rows = parse_generated_constraint_ids(reason, SOS1_LOWERING_REASON)?;
+        self.validate_candidate_rows(&generated_rows, Provenance::Sos1Constraint(id))?;
+        let representation = self.certified_linear_relaxation()?.fingerprint();
+        Ok(Sos1BigMV1 {
+            source: id,
+            generated_rows,
+            representation,
+        })
+    }
+
+    fn validate_candidate_rows(
+        &self,
+        generated_rows: &[ConstraintID],
+        expected_provenance: Provenance,
+    ) -> Result<(), InverseLoweringCandidateError> {
+        for id in generated_rows {
+            if !self.constraints().contains_key(id) {
+                return Err(InverseLoweringCandidateError::MissingGeneratedConstraint { id: *id });
+            }
+            if self.constraint_context().provenance(*id) != [expected_provenance.clone()] {
+                return Err(InverseLoweringCandidateError::ProvenanceMismatch { id: *id });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn parse_generated_constraint_ids(
+    reason: &RemovedReason,
+    expected_reason: &'static str,
+) -> Result<Vec<ConstraintID>, InverseLoweringCandidateError> {
+    if reason.reason != expected_reason {
+        return Err(InverseLoweringCandidateError::UnexpectedRemovalReason {
+            expected: expected_reason,
+            actual: reason.reason.clone(),
+        });
+    }
+    let raw = reason
+        .parameters
+        .get(GENERATED_CONSTRAINT_IDS)
+        .ok_or(InverseLoweringCandidateError::MissingGeneratedConstraintIds)?;
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut ids = Vec::new();
+    for token in raw.split(',') {
+        let value = token.parse::<u64>().map_err(|_| {
+            InverseLoweringCandidateError::InvalidGeneratedConstraintId {
+                token: token.to_string(),
+            }
+        })?;
+        if token != value.to_string() {
+            return Err(
+                InverseLoweringCandidateError::InvalidGeneratedConstraintId {
+                    token: token.to_string(),
+                },
+            );
+        }
+        let id = ConstraintID::from(value);
+        if !seen.insert(id) {
+            return Err(InverseLoweringCandidateError::DuplicateGeneratedConstraintId { id });
+        }
+        ids.push(id);
+    }
+    Ok(ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        coeff, linear, Bound, Constraint, ConstraintContextStore, DecisionVariable, Equality,
+        Function, IndicatorConstraint, Kind, Sense, Sos1Constraint, VariableID,
+    };
+    use fnv::FnvHashMap;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn removed_reason(reason: &str, ids: &str) -> RemovedReason {
+        RemovedReason {
+            reason: reason.to_string(),
+            parameters: FnvHashMap::from_iter([(
+                GENERATED_CONSTRAINT_IDS.to_string(),
+                ids.to_string(),
+            )]),
+        }
+    }
+
+    #[test]
+    fn reads_current_indicator_lowering_as_untrusted_candidate() {
+        let x = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), x),
+                (VariableID::from(10), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                IndicatorConstraint::new(
+                    VariableID::from(10),
+                    Equality::LessThanOrEqualToZero,
+                    Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+                ),
+            )]))
+            .build()
+            .unwrap();
+        let generated = instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+
+        let candidate = instance
+            .indicator_big_m_candidate_v1(IndicatorConstraintID::from(7))
+            .unwrap();
+        assert_eq!(candidate.source, IndicatorConstraintID::from(7));
+        assert_eq!(candidate.generated_rows, generated);
+        assert_eq!(
+            candidate.representation,
+            instance
+                .certified_linear_relaxation()
+                .unwrap()
+                .fingerprint()
+        );
+    }
+
+    #[test]
+    fn reads_current_sos1_lowering_without_inferring_selector_roles() {
+        let x = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(-1.0, 2.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), x),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(
+                Sos1ConstraintID::from(9),
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(1), VariableID::from(2)]))
+                    .unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        let generated = instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+
+        let candidate = instance
+            .sos1_big_m_candidate_v1(Sos1ConstraintID::from(9))
+            .unwrap();
+        assert_eq!(candidate.source, Sos1ConstraintID::from(9));
+        assert_eq!(candidate.generated_rows, generated);
+        assert_eq!(
+            candidate.representation,
+            instance
+                .certified_linear_relaxation()
+                .unwrap()
+                .fingerprint()
+        );
+    }
+
+    #[test]
+    fn generated_id_text_is_strict_and_unique() {
+        assert_eq!(
+            parse_generated_constraint_ids(
+                &removed_reason(INDICATOR_LOWERING_REASON, ""),
+                INDICATOR_LOWERING_REASON,
+            )
+            .unwrap(),
+            Vec::<ConstraintID>::new()
+        );
+        assert!(matches!(
+            parse_generated_constraint_ids(
+                &removed_reason(INDICATOR_LOWERING_REASON, "01"),
+                INDICATOR_LOWERING_REASON,
+            ),
+            Err(InverseLoweringCandidateError::InvalidGeneratedConstraintId { .. })
+        ));
+        assert!(matches!(
+            parse_generated_constraint_ids(
+                &removed_reason(INDICATOR_LOWERING_REASON, "1,1"),
+                INDICATOR_LOWERING_REASON,
+            ),
+            Err(InverseLoweringCandidateError::DuplicateGeneratedConstraintId { .. })
+        ));
+        assert!(matches!(
+            parse_generated_constraint_ids(
+                &removed_reason("other", "1"),
+                INDICATOR_LOWERING_REASON,
+            ),
+            Err(InverseLoweringCandidateError::UnexpectedRemovalReason { .. })
+        ));
+    }
+
+    fn forged_indicator_history(
+        generated_ids: &str,
+        provenance: Vec<Provenance>,
+        include_row: bool,
+    ) -> Instance {
+        let row_id = ConstraintID::from(10);
+        let constraints = include_row
+            .then(|| {
+                BTreeMap::from([(
+                    row_id,
+                    Constraint::less_than_or_equal_to_zero(Function::from(linear!(1))),
+                )])
+            })
+            .unwrap_or_default();
+        let mut context = ConstraintContextStore::default();
+        if include_row {
+            context.set_provenance(row_id, provenance);
+        }
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), DecisionVariable::continuous()),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(constraints)
+            .constraint_context(context)
+            .removed_indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                (
+                    IndicatorConstraint::new(
+                        VariableID::from(2),
+                        Equality::LessThanOrEqualToZero,
+                        Function::from(linear!(1)),
+                    ),
+                    removed_reason(INDICATOR_LOWERING_REASON, generated_ids),
+                ),
+            )]))
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn candidate_lookup_requires_active_rows_and_exact_lineage_hint() {
+        let missing = forged_indicator_history(
+            "10",
+            vec![Provenance::IndicatorConstraint(
+                IndicatorConstraintID::from(7),
+            )],
+            false,
+        );
+        assert!(matches!(
+            missing.indicator_big_m_candidate_v1(IndicatorConstraintID::from(7)),
+            Err(InverseLoweringCandidateError::MissingGeneratedConstraint { .. })
+        ));
+
+        let wrong_provenance = forged_indicator_history(
+            "10",
+            vec![Provenance::IndicatorConstraint(
+                IndicatorConstraintID::from(8),
+            )],
+            true,
+        );
+        assert!(matches!(
+            wrong_provenance.indicator_big_m_candidate_v1(IndicatorConstraintID::from(7)),
+            Err(InverseLoweringCandidateError::ProvenanceMismatch { .. })
+        ));
+
+        let extra_provenance = forged_indicator_history(
+            "10",
+            vec![
+                Provenance::IndicatorConstraint(IndicatorConstraintID::from(7)),
+                Provenance::Sos1Constraint(Sos1ConstraintID::from(99)),
+            ],
+            true,
+        );
+        assert!(matches!(
+            extra_provenance.indicator_big_m_candidate_v1(IndicatorConstraintID::from(7)),
+            Err(InverseLoweringCandidateError::ProvenanceMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn candidate_lookup_rejects_a_generated_row_that_is_only_removed() {
+        let row_id = ConstraintID::from(10);
+        let mut context = ConstraintContextStore::default();
+        context.set_provenance(
+            row_id,
+            vec![Provenance::IndicatorConstraint(
+                IndicatorConstraintID::from(7),
+            )],
+        );
+        let instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), DecisionVariable::continuous()),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .removed_constraints(BTreeMap::from([(
+                row_id,
+                (
+                    Constraint::less_than_or_equal_to_zero(Function::from(linear!(1))),
+                    RemovedReason {
+                        reason: "already removed".to_string(),
+                        parameters: FnvHashMap::default(),
+                    },
+                ),
+            )]))
+            .constraint_context(context)
+            .removed_indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                (
+                    IndicatorConstraint::new(
+                        VariableID::from(2),
+                        Equality::LessThanOrEqualToZero,
+                        Function::from(linear!(1)),
+                    ),
+                    removed_reason(INDICATOR_LOWERING_REASON, "10"),
+                ),
+            )]))
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            instance.indicator_big_m_candidate_v1(IndicatorConstraintID::from(7)),
+            Err(InverseLoweringCandidateError::MissingGeneratedConstraint { id }) if id == row_id
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- compute exact affine activity bounds from the canonical proof snapshot, using finite bound sides and fixed-value equations without ordinary `f64` arithmetic or verifier tolerances
- reconstruct current Indicator and SOS1 lowering history as private, explicitly untrusted V1 candidates
- parse generated regular-row IDs canonically, preserve their recorded order, and reject duplicate IDs, missing active rows, and any provenance other than the exact one-step source lineage
- bind each reconstructed candidate to the fingerprint of the complete current active linear representation

## Design boundaries

- current string-valued `RemovedReason.parameters` and `Provenance` are lookup hints, not a certificate or reusable transformation receipt
- this slice does not infer Big-M row roles, selector mappings, semantic equivalence, omitted sides, or selector isolation
- this slice performs no mutation and exposes no Rust, Python, protobuf, certificate, receipt, or reduction-plan API
- ordinary-`f64` output from the existing lowerers is not trusted merely because OMMX produced it; follow-up verifiers must re-derive the exact active and inactive branch obligations and reject histories that do not satisfy them

This is the second stacked implementation slice of #1057's checked history-guided inverse-lowering path, based on #1061. Follow-up drafts add private verify-plan-commit storage machinery, checked Indicator inversion, and checked SOS1 inversion with a constructive selector lift.