### PR TITLE
Add checked Indicator inverse lowering

### DIFF
--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -50,6 +50,10 @@ use crate::{
 };
 use std::collections::{BTreeMap, HashMap};
 
+pub(crate) const GENERATED_CONSTRAINT_IDS_PARAMETER: &str = "constraint_ids";
+pub(crate) const INDICATOR_LOWERING_REASON: &str = "ommx.Instance.convert_indicator_to_constraint";
+pub(crate) const SOS1_LOWERING_REASON: &str = "ommx.Instance.convert_sos1_to_constraints";
+
 /// A constraint type capability flag for non-standard constraint types.
 ///
 /// Standard constraints (`f(x) = 0` or `f(x) <= 0`) are always supported by all adapters

--- a/rust/ommx/src/instance/indicator.rs
+++ b/rust/ommx/src/instance/indicator.rs
@@ -1,4 +1,7 @@
-use super::Instance;
+use super::{
+    reduction::AssignmentMap, AdditionalCapability, Capabilities, Instance,
+    GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON,
+};
 use crate::{
     constraint::{ConstraintContext, ConstraintID, Equality, Provenance, RemovedReason},
     indicator_constraint::IndicatorConstraintID,
@@ -13,7 +16,107 @@ struct IndicatorPlan {
     generated_constraints: Vec<Constraint>,
 }
 
+/// Private one-shot plan for an exact checked inverse lowering.
+///
+/// All fallible proof and storage work is applied to `staged`. Committing the
+/// plan is one infallible replacement of the root Instance.
+#[allow(dead_code)] // Used by the stacked public inverse-lowering facade.
+struct IndicatorInversePlan {
+    staged: Instance,
+    assignment_map: AssignmentMap,
+}
+
+#[allow(dead_code)] // Used by the stacked public inverse-lowering facade.
+impl IndicatorInversePlan {
+    fn commit(self, target: &mut Instance) -> AssignmentMap {
+        *target = self.staged;
+        self.assignment_map
+    }
+}
+
 impl Instance {
+    /// Restore one Indicator that this Instance previously lowered, after
+    /// exact branch verification of the complete current representation.
+    ///
+    /// Private while the common reduction result and public capability request
+    /// API are still being exercised by the first family consumers.
+    /// `permitted_additions` is an explicit permission for the semantic
+    /// capability introduced by this operation; it is not a declaration of
+    /// every capability already present in the Instance.
+    #[allow(dead_code)] // Used by the stacked public inverse-lowering facade.
+    pub(super) fn restore_indicator_from_lowering_checked(
+        &mut self,
+        id: IndicatorConstraintID,
+        permitted_additions: &Capabilities,
+    ) -> Result<AssignmentMap> {
+        let plan = self.plan_indicator_inverse(id, permitted_additions)?;
+        Ok(plan.commit(self))
+    }
+
+    #[allow(dead_code)] // Used by the checked inverse entry point above.
+    fn plan_indicator_inverse(
+        &self,
+        id: IndicatorConstraintID,
+        permitted_additions: &Capabilities,
+    ) -> Result<IndicatorInversePlan> {
+        if !permitted_additions.contains(&AdditionalCapability::Indicator) {
+            bail!(
+                "Restoring Indicator constraint {id:?} requires explicit Indicator capability permission"
+            );
+        }
+
+        let verified = crate::proof::verify_indicator_big_m_v1(self, id)?;
+        debug_assert_eq!(verified.source_id(), id);
+        for variable_id in verified.source().required_ids() {
+            if !self.decision_variables.contains_key(&variable_id) {
+                bail!(
+                    "Cannot restore Indicator constraint {id:?}: variable {variable_id:?} is not registered"
+                );
+            }
+            if self
+                .decision_variable_dependency
+                .get(&variable_id)
+                .is_some()
+            {
+                bail!(
+                    "Cannot restore Indicator constraint {id:?}: variable {variable_id:?} is a dependency target"
+                );
+            }
+            if self
+                .fixed_decision_variable_values()
+                .contains_key(&variable_id)
+            {
+                bail!(
+                    "Cannot restore Indicator constraint {id:?}: variable {variable_id:?} is fixed"
+                );
+            }
+        }
+
+        let generated_rows = verified.generated_rows().iter().copied().collect();
+        let assignment_map =
+            AssignmentMap::identity(self.decision_variables.keys().copied().collect());
+        let mut staged = self.clone();
+        staged
+            .constraint_collection
+            .consume_active_rows(&generated_rows)?;
+        staged
+            .indicator_constraint_collection
+            .restore_removed_row(id, verified.source().clone())?;
+        debug_assert!(staged.constraint_collection.validate_context_ids().is_ok());
+        debug_assert!(staged
+            .indicator_constraint_collection
+            .validate_context_ids()
+            .is_ok());
+        debug_assert!(staged
+            .required_capabilities()
+            .contains(&AdditionalCapability::Indicator));
+
+        Ok(IndicatorInversePlan {
+            staged,
+            assignment_map,
+        })
+    }
+
     #[cfg_attr(doc, katexit::katexit)]
     /// Convert an indicator constraint to regular constraints using the Big-M method.
     ///
@@ -227,12 +330,15 @@ impl Instance {
             .map(|id| id.into_inner().to_string())
             .collect::<Vec<_>>()
             .join(",");
-        parameters.insert("constraint_ids".to_string(), constraint_ids_str);
+        parameters.insert(
+            GENERATED_CONSTRAINT_IDS_PARAMETER.to_string(),
+            constraint_ids_str,
+        );
         self.indicator_constraint_collection
             .relax(
                 id,
                 RemovedReason {
-                    reason: "ommx.Instance.convert_indicator_to_constraint".to_string(),
+                    reason: INDICATOR_LOWERING_REASON.to_string(),
                     parameters,
                 },
             )
@@ -265,11 +371,15 @@ mod tests {
     use super::*;
     use crate::{
         coeff, indicator_constraint::IndicatorConstraint, linear, Bound, DecisionVariable,
-        Function, Kind, Sense, VariableID,
+        Function, Kind, ModelingLabel, Sense, Sos1Constraint, Substitute, VariableID,
     };
     use ::approx::assert_abs_diff_eq;
     use maplit::btreemap;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn indicator_capability() -> Capabilities {
+        [AdditionalCapability::Indicator].into_iter().collect()
+    }
 
     /// Build an instance with one binary indicator `y` (id=10) and a continuous
     /// `x` (id=1) with the given bound, plus a single indicator constraint
@@ -560,6 +670,246 @@ mod tests {
 
         assert_eq!(instance.indicator_constraints(), &before_indicators);
         assert_eq!(instance.constraints(), &before_constraints);
+    }
+
+    #[test]
+    fn checked_inverse_restores_indicator_and_consumes_generated_rows_atomically() {
+        let mut instance = single_indicator_instance(
+            Bound::new(0.0, 5.0).unwrap(),
+            Equality::EqualToZero,
+            Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+        );
+        instance
+            .set_indicator_constraint_context(
+                IndicatorConstraintID::from(7),
+                ConstraintContext {
+                    label: ModelingLabel {
+                        name: Some("source-indicator".to_string()),
+                        ..Default::default()
+                    },
+                    provenance: Vec::new(),
+                },
+            )
+            .unwrap();
+        let generated = instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+        assert_eq!(generated.len(), 2);
+
+        let map = instance
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &indicator_capability(),
+            )
+            .unwrap();
+
+        assert!(instance
+            .indicator_constraints()
+            .contains_key(&IndicatorConstraintID::from(7)));
+        assert!(!instance
+            .removed_indicator_constraints()
+            .contains_key(&IndicatorConstraintID::from(7)));
+        for id in generated {
+            assert!(!instance.constraints().contains_key(&id));
+            assert!(!instance.removed_constraints().contains_key(&id));
+            assert!(!instance.constraint_context().contains(id));
+        }
+        assert_eq!(
+            instance
+                .indicator_constraint_context()
+                .name(IndicatorConstraintID::from(7)),
+            Some("source-indicator")
+        );
+        assert!(instance
+            .required_capabilities()
+            .contains(&AdditionalCapability::Indicator));
+
+        let state = crate::v1::State::from(std::collections::HashMap::from([(1, 2.0), (10, 1.0)]));
+        assert_eq!(map.project_state(&state).unwrap(), state);
+        assert_eq!(map.lift_state(&state).unwrap(), state);
+
+        let round_trip = Instance::from_v2_bytes(&instance.to_v2_bytes()).unwrap();
+        assert_eq!(round_trip, instance);
+    }
+
+    #[test]
+    fn checked_inverse_requires_explicit_family_capability_without_requiring_others() {
+        let mut denied = single_indicator_instance(
+            Bound::new(0.0, 5.0).unwrap(),
+            Equality::LessThanOrEqualToZero,
+            Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+        );
+        denied
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+        let before = denied.clone();
+        let before_bytes = denied.to_v2_bytes();
+        let error = denied
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &Capabilities::new(),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("explicit Indicator capability"));
+        assert_eq!(denied, before);
+        assert_eq!(denied.to_v2_bytes(), before_bytes);
+
+        let mut allowed = before;
+        allowed
+            .add_sos1_constraint(
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(1)])).unwrap(),
+                Default::default(),
+            )
+            .unwrap();
+        allowed
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &indicator_capability(),
+            )
+            .unwrap();
+        assert_eq!(
+            allowed.required_capabilities(),
+            [AdditionalCapability::Indicator, AdditionalCapability::Sos1]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn checked_inverse_rejects_rounding_damaged_history_without_mutation() {
+        let mut instance = single_indicator_instance(
+            Bound::new(0.0, 1.0e20).unwrap(),
+            Equality::LessThanOrEqualToZero,
+            Function::from((linear!(1) + coeff!(1.0)).unwrap()),
+        );
+        instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let error = instance
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &indicator_capability(),
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("active upper side exactly"));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+    }
+
+    #[test]
+    fn checked_inverse_rejects_partial_evaluated_history_without_mutation() {
+        let mut instance = single_indicator_instance(
+            Bound::new(0.0, 5.0).unwrap(),
+            Equality::LessThanOrEqualToZero,
+            Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+        );
+        instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+        instance
+            .partial_evaluate(
+                &crate::v1::State::from_iter([(1, 1.0)]),
+                crate::ATol::default(),
+            )
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let error = instance
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &indicator_capability(),
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("active upper side exactly"));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+    }
+
+    #[test]
+    fn checked_inverse_rejects_substituted_history_without_mutation() {
+        let mut instance = single_indicator_instance(
+            Bound::new(0.0, 5.0).unwrap(),
+            Equality::LessThanOrEqualToZero,
+            Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+        );
+        instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+        instance = instance
+            .substitute_one(VariableID::from(1), &Function::zero())
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let error = instance
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &indicator_capability(),
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("active upper side exactly"));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+    }
+
+    #[test]
+    fn checked_inverse_rejects_fixed_or_dependent_source_coordinates_without_mutation() {
+        // The source is already implied by x's bounds, so the lowerer emits no
+        // rows. This lets the proof succeed after owner-level transformations
+        // and exercises the explicit coordinate guards themselves.
+        let zero_row_instance = || {
+            let mut instance = single_indicator_instance(
+                Bound::new(0.0, 5.0).unwrap(),
+                Equality::LessThanOrEqualToZero,
+                Function::from((linear!(1) + coeff!(-10.0)).unwrap()),
+            );
+            assert!(instance
+                .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+                .unwrap()
+                .is_empty());
+            instance
+        };
+
+        let mut fixed = zero_row_instance();
+        fixed
+            .partial_evaluate(
+                &crate::v1::State::from_iter([(1, 1.0)]),
+                crate::ATol::default(),
+            )
+            .unwrap();
+        let before = fixed.clone();
+        let before_bytes = fixed.to_v2_bytes();
+        let error = fixed
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &indicator_capability(),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("is fixed"));
+        assert_eq!(fixed, before);
+        assert_eq!(fixed.to_v2_bytes(), before_bytes);
+
+        let mut dependency = zero_row_instance()
+            .substitute_one(VariableID::from(1), &Function::zero())
+            .unwrap();
+        let before = dependency.clone();
+        let before_bytes = dependency.to_v2_bytes();
+        let error = dependency
+            .restore_indicator_from_lowering_checked(
+                IndicatorConstraintID::from(7),
+                &indicator_capability(),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("dependency target"));
+        assert_eq!(dependency, before);
+        assert_eq!(dependency.to_v2_bytes(), before_bytes);
     }
 
     #[test]

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -1,4 +1,4 @@
-use super::Instance;
+use super::{Instance, GENERATED_CONSTRAINT_IDS_PARAMETER, SOS1_LOWERING_REASON};
 use crate::{
     coeff,
     constraint::{ConstraintContext, ConstraintID, Provenance, RemovedReason},
@@ -240,12 +240,15 @@ impl Instance {
             .map(|id| id.into_inner().to_string())
             .collect::<Vec<_>>()
             .join(",");
-        parameters.insert("constraint_ids".to_string(), constraint_ids_str);
+        parameters.insert(
+            GENERATED_CONSTRAINT_IDS_PARAMETER.to_string(),
+            constraint_ids_str,
+        );
         self.sos1_constraint_collection
             .relax(
                 id,
                 RemovedReason {
-                    reason: "ommx.Instance.convert_sos1_to_constraints".to_string(),
+                    reason: SOS1_LOWERING_REASON.to_string(),
                     parameters,
                 },
             )

--- a/rust/ommx/src/proof/linear.rs
+++ b/rust/ommx/src/proof/linear.rs
@@ -7,6 +7,8 @@ use std::collections::BTreeMap;
 mod activity;
 mod candidate;
 
+pub(crate) use candidate::verify_indicator_big_m_v1;
+
 const FINGERPRINT_DOMAIN: &[u8] = b"org.ommx.proof.linear-relaxation\0";
 const FINGERPRINT_VERSION: u32 = 1;
 

--- a/rust/ommx/src/proof/linear/candidate.rs
+++ b/rust/ommx/src/proof/linear/candidate.rs
@@ -1,13 +1,15 @@
-use super::{LinearProofError, LinearRelaxationFingerprint};
+use super::{
+    ExactAffine, ExactRational, InequalityRef, LinearProofError, LinearRelaxationFingerprint,
+};
 use crate::{
     constraint::{Provenance, RemovedReason},
-    ConstraintID, IndicatorConstraintID, Instance, Sos1ConstraintID,
+    instance::{
+        GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON, SOS1_LOWERING_REASON,
+    },
+    ConstraintID, Equality, IndicatorConstraint, IndicatorConstraintID, Instance, Kind,
+    Sos1ConstraintID,
 };
 use std::collections::BTreeSet;
-
-const GENERATED_CONSTRAINT_IDS: &str = "constraint_ids";
-const INDICATOR_LOWERING_REASON: &str = "ommx.Instance.convert_indicator_to_constraint";
-const SOS1_LOWERING_REASON: &str = "ommx.Instance.convert_sos1_to_constraints";
 
 /// Untrusted, versioned lookup result for one historical Indicator Big-M
 /// lowering. The generated rows have not yet been proven equivalent to the
@@ -28,6 +30,34 @@ struct Sos1BigMV1 {
     representation: LinearRelaxationFingerprint,
 }
 
+/// Exact, representation-bound fact that the recorded regular rows are
+/// semantically equivalent to one retained removed Indicator constraint over
+/// the current binary branches.
+///
+/// This remains crate-private proof output. It is not a reusable mutation plan:
+/// `Instance` immediately derives a one-shot storage plan from it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct VerifiedIndicatorBigMV1 {
+    source_id: IndicatorConstraintID,
+    source: IndicatorConstraint,
+    generated_rows: Vec<ConstraintID>,
+    representation: LinearRelaxationFingerprint,
+}
+
+impl VerifiedIndicatorBigMV1 {
+    pub(crate) fn source_id(&self) -> IndicatorConstraintID {
+        self.source_id
+    }
+
+    pub(crate) fn source(&self) -> &IndicatorConstraint {
+        &self.source
+    }
+
+    pub(crate) fn generated_rows(&self) -> &[ConstraintID] {
+        &self.generated_rows
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 enum InverseLoweringCandidateError {
     #[error("removed Indicator constraint {id:?} was not found")]
@@ -39,8 +69,10 @@ enum InverseLoweringCandidateError {
         expected: &'static str,
         actual: String,
     },
-    #[error("lowering reason is missing the {GENERATED_CONSTRAINT_IDS} parameter")]
+    #[error("lowering reason is missing the {GENERATED_CONSTRAINT_IDS_PARAMETER} parameter")]
     MissingGeneratedConstraintIds,
+    #[error("lowering reason contains unsupported V1 parameter {key:?}")]
+    UnexpectedRemovalParameter { key: String },
     #[error("generated constraint ID token {token:?} is not canonical u64 text")]
     InvalidGeneratedConstraintId { token: String },
     #[error("generated constraint ID {id:?} is listed more than once")]
@@ -49,6 +81,8 @@ enum InverseLoweringCandidateError {
     MissingGeneratedConstraint { id: ConstraintID },
     #[error("generated regular constraint {id:?} has unexpected provenance")]
     ProvenanceMismatch { id: ConstraintID },
+    #[error("generated regular constraint {id:?} has a modeling label that would be discarded")]
+    GeneratedConstraintHasModelingLabel { id: ConstraintID },
     #[error(transparent)]
     LinearProof(#[from] LinearProofError),
 }
@@ -102,9 +136,152 @@ impl Instance {
             if self.constraint_context().provenance(*id) != [expected_provenance.clone()] {
                 return Err(InverseLoweringCandidateError::ProvenanceMismatch { id: *id });
             }
+            if self.constraint_context().collect_for(*id).label != Default::default() {
+                return Err(
+                    InverseLoweringCandidateError::GeneratedConstraintHasModelingLabel { id: *id },
+                );
+            }
         }
         Ok(())
     }
+}
+
+/// Verify the current V1 Indicator Big-M history exactly.
+///
+/// For each generated row, substitution of the active branch must equal the
+/// corresponding Indicator side exactly, while substitution of the inactive
+/// branch must be implied by exact variable-domain facts. A missing side is
+/// accepted only when the Indicator side itself is implied by those facts.
+/// Generated rows are never used to prove their own redundancy.
+pub(crate) fn verify_indicator_big_m_v1(
+    instance: &Instance,
+    id: IndicatorConstraintID,
+) -> crate::Result<VerifiedIndicatorBigMV1> {
+    let candidate = instance.indicator_big_m_candidate_v1(id)?;
+    let snapshot = instance.certified_linear_relaxation()?;
+    if candidate.representation != snapshot.fingerprint() {
+        crate::bail!(
+            { ?id },
+            "Indicator inverse-lowering candidate {id:?} is bound to a stale representation"
+        );
+    }
+
+    let (source, _) = instance
+        .removed_indicator_constraints()
+        .get(&id)
+        .expect("candidate lookup proved that the removed source exists");
+    let indicator_variable = source.indicator_variable;
+    let Some(indicator) = instance.decision_variables().get(&indicator_variable) else {
+        crate::bail!(
+            { ?id, ?indicator_variable },
+            "Indicator variable {indicator_variable:?} is not registered"
+        );
+    };
+    if indicator.kind() != Kind::Binary {
+        crate::bail!(
+            { ?id, ?indicator_variable },
+            "Indicator variable {indicator_variable:?} is not binary"
+        );
+    }
+
+    let body = ExactAffine::from_function(source.function())?.ok_or_else(|| {
+        crate::error!(
+            { ?id },
+            "Removed Indicator constraint {id:?} has a nonlinear body"
+        )
+    })?;
+    let zero = ExactRational::from_integer(0.into());
+    let one = ExactRational::from_integer(1.into());
+    let active_upper = body.substitute(indicator_variable, &one);
+    let active_lower = active_upper.negated();
+
+    let mut roles = Vec::with_capacity(candidate.generated_rows.len());
+    for row_id in &candidate.generated_rows {
+        let row = snapshot.inequality(InequalityRef::RegularConstraint(*row_id))?;
+        let inactive = row.substitute(indicator_variable, &zero);
+        if !snapshot.variable_facts_imply_nonpositive(&inactive)? {
+            crate::bail!(
+                { ?id, ?row_id },
+                "Generated Indicator row {row_id:?} is not redundant on the inactive branch"
+            );
+        }
+        let active = row.substitute(indicator_variable, &one);
+        roles.push((active == active_upper, active == active_lower));
+    }
+
+    let upper_implied = snapshot.variable_facts_imply_nonpositive(&active_upper)?;
+    match source.equality {
+        Equality::LessThanOrEqualToZero => {
+            if roles.len() > 1 {
+                crate::bail!(
+                    { ?id, generated_rows = roles.len() },
+                    "Inequality Indicator {id:?} has more than one generated row"
+                );
+            }
+            if let Some((matches_upper, _)) = roles.first() {
+                if !matches_upper {
+                    crate::bail!(
+                        { ?id, row_id = ?candidate.generated_rows[0] },
+                        "Generated Indicator row does not equal the active upper side exactly"
+                    );
+                }
+            } else if !upper_implied {
+                crate::bail!(
+                    { ?id },
+                    "Missing Indicator upper side is not implied by exact variable facts"
+                );
+            }
+        }
+        Equality::EqualToZero => {
+            if roles.len() > 2 {
+                crate::bail!(
+                    { ?id, generated_rows = roles.len() },
+                    "Equality Indicator {id:?} has more than two generated rows"
+                );
+            }
+            let lower_implied = snapshot.variable_facts_imply_nonpositive(&active_lower)?;
+            if !equality_roles_cover(&roles, upper_implied, lower_implied) {
+                crate::bail!(
+                    { ?id },
+                    "Generated Indicator rows do not provide independent exact upper and lower active sides"
+                );
+            }
+        }
+    }
+
+    Ok(VerifiedIndicatorBigMV1 {
+        source_id: candidate.source,
+        source: source.clone(),
+        generated_rows: candidate.generated_rows,
+        representation: candidate.representation,
+    })
+}
+
+fn equality_roles_cover(roles: &[(bool, bool)], upper_implied: bool, lower_implied: bool) -> bool {
+    for assignment in 0..(1usize << roles.len()) {
+        let mut upper_used = false;
+        let mut lower_used = false;
+        let mut valid = true;
+        for (index, &(matches_upper, matches_lower)) in roles.iter().enumerate() {
+            if assignment & (1 << index) == 0 {
+                if !matches_upper || upper_used {
+                    valid = false;
+                    break;
+                }
+                upper_used = true;
+            } else {
+                if !matches_lower || lower_used {
+                    valid = false;
+                    break;
+                }
+                lower_used = true;
+            }
+        }
+        if valid && (upper_used || upper_implied) && (lower_used || lower_implied) {
+            return true;
+        }
+    }
+    false
 }
 
 fn parse_generated_constraint_ids(
@@ -117,9 +294,17 @@ fn parse_generated_constraint_ids(
             actual: reason.reason.clone(),
         });
     }
+    if let Some(key) = reason
+        .parameters
+        .keys()
+        .filter(|key| key.as_str() != GENERATED_CONSTRAINT_IDS_PARAMETER)
+        .min()
+    {
+        return Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { key: key.clone() });
+    }
     let raw = reason
         .parameters
-        .get(GENERATED_CONSTRAINT_IDS)
+        .get(GENERATED_CONSTRAINT_IDS_PARAMETER)
         .ok_or(InverseLoweringCandidateError::MissingGeneratedConstraintIds)?;
     if raw.is_empty() {
         return Ok(Vec::new());
@@ -154,7 +339,7 @@ mod tests {
     use super::*;
     use crate::{
         coeff, linear, Bound, Constraint, ConstraintContextStore, DecisionVariable, Equality,
-        Function, IndicatorConstraint, Kind, Sense, Sos1Constraint, VariableID,
+        Function, IndicatorConstraint, Kind, ModelingLabel, Sense, Sos1Constraint, VariableID,
     };
     use fnv::FnvHashMap;
     use std::collections::{BTreeMap, BTreeSet};
@@ -163,10 +348,64 @@ mod tests {
         RemovedReason {
             reason: reason.to_string(),
             parameters: FnvHashMap::from_iter([(
-                GENERATED_CONSTRAINT_IDS.to_string(),
+                GENERATED_CONSTRAINT_IDS_PARAMETER.to_string(),
                 ids.to_string(),
             )]),
         }
+    }
+
+    fn forged_indicator_semantics(
+        x_bound: Bound,
+        source_equality: Equality,
+        source_function: Function,
+        generated: Vec<Constraint>,
+    ) -> Instance {
+        let generated_ids = generated
+            .iter()
+            .enumerate()
+            .map(|(offset, _)| ConstraintID::from(10 + offset as u64))
+            .collect::<Vec<_>>();
+        let constraints = generated_ids
+            .iter()
+            .copied()
+            .zip(generated)
+            .collect::<BTreeMap<_, _>>();
+        let mut context = ConstraintContextStore::default();
+        for id in &generated_ids {
+            context.set_provenance(
+                *id,
+                vec![Provenance::IndicatorConstraint(
+                    IndicatorConstraintID::from(7),
+                )],
+            );
+        }
+        let generated_text = generated_ids
+            .iter()
+            .map(|id| id.into_inner().to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (
+                    VariableID::from(1),
+                    DecisionVariable::new(Kind::Continuous, x_bound, crate::ATol::default())
+                        .unwrap(),
+                ),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(constraints)
+            .constraint_context(context)
+            .removed_indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                (
+                    IndicatorConstraint::new(VariableID::from(2), source_equality, source_function),
+                    removed_reason(INDICATOR_LOWERING_REASON, &generated_text),
+                ),
+            )]))
+            .build()
+            .unwrap()
     }
 
     #[test]
@@ -211,6 +450,271 @@ mod tests {
                 .unwrap()
                 .fingerprint()
         );
+    }
+
+    #[test]
+    fn verifies_current_indicator_lowering_exactly() {
+        for equality in [Equality::LessThanOrEqualToZero, Equality::EqualToZero] {
+            let x = DecisionVariable::new(
+                Kind::Continuous,
+                Bound::new(0.0, 5.0).unwrap(),
+                crate::ATol::default(),
+            )
+            .unwrap();
+            let mut instance = Instance::builder()
+                .sense(Sense::Minimize)
+                .objective(Function::zero())
+                .decision_variables(BTreeMap::from([
+                    (VariableID::from(1), x),
+                    (VariableID::from(2), DecisionVariable::binary()),
+                ]))
+                .constraints(BTreeMap::new())
+                .indicator_constraints(BTreeMap::from([(
+                    IndicatorConstraintID::from(7),
+                    IndicatorConstraint::new(
+                        VariableID::from(2),
+                        equality,
+                        Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+                    ),
+                )]))
+                .build()
+                .unwrap();
+            let generated = instance
+                .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+                .unwrap();
+
+            let verified =
+                verify_indicator_big_m_v1(&instance, IndicatorConstraintID::from(7)).unwrap();
+            assert_eq!(verified.source_id(), IndicatorConstraintID::from(7));
+            assert_eq!(verified.generated_rows(), generated);
+        }
+    }
+
+    #[test]
+    fn verifies_indicator_body_that_references_its_indicator_variable() {
+        let x = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 5.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), x),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                IndicatorConstraint::new(
+                    VariableID::from(2),
+                    Equality::LessThanOrEqualToZero,
+                    Function::from(((linear!(1) + linear!(2)).unwrap() + coeff!(-3.0)).unwrap()),
+                ),
+            )]))
+            .build()
+            .unwrap();
+        instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+
+        verify_indicator_big_m_v1(&instance, IndicatorConstraintID::from(7)).unwrap();
+    }
+
+    #[test]
+    fn verifies_exactly_implied_omitted_indicator_sides() {
+        let mut inequality = forged_indicator_semantics(
+            Bound::new(0.0, 5.0).unwrap(),
+            Equality::LessThanOrEqualToZero,
+            Function::from((linear!(1) + coeff!(-10.0)).unwrap()),
+            Vec::new(),
+        );
+        // Rebuild this fixture through the current lowerer so the empty history
+        // contract itself is also exercised.
+        inequality = {
+            let source = inequality.removed_indicator_constraints()
+                [&IndicatorConstraintID::from(7)]
+                .0
+                .clone();
+            let mut current = Instance::builder()
+                .sense(Sense::Minimize)
+                .objective(Function::zero())
+                .decision_variables(inequality.decision_variables().clone())
+                .constraints(BTreeMap::new())
+                .indicator_constraints(BTreeMap::from([(IndicatorConstraintID::from(7), source)]))
+                .build()
+                .unwrap();
+            assert!(current
+                .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+                .unwrap()
+                .is_empty());
+            current
+        };
+        verify_indicator_big_m_v1(&inequality, IndicatorConstraintID::from(7)).unwrap();
+
+        // y=1 -> x=0 with x in [0,5]: upper is encoded, while -x<=0 is
+        // supplied exactly by the lower bound.
+        let equality = forged_indicator_semantics(
+            Bound::new(0.0, 5.0).unwrap(),
+            Equality::EqualToZero,
+            Function::from(linear!(1)),
+            vec![Constraint::less_than_or_equal_to_zero(Function::from(
+                ((linear!(1) + coeff!(5.0) * linear!(2)).unwrap() + coeff!(-5.0)).unwrap(),
+            ))],
+        );
+        verify_indicator_big_m_v1(&equality, IndicatorConstraintID::from(7)).unwrap();
+    }
+
+    #[test]
+    fn rejects_inactive_indicator_row_that_is_not_redundant() {
+        // Active y=1 substitution is x-2 exactly, but inactive y=0 leaves
+        // x-3<=0, which is not implied by x<=5.
+        let row = Constraint::less_than_or_equal_to_zero(Function::from(
+            ((linear!(1) + linear!(2)).unwrap() + coeff!(-3.0)).unwrap(),
+        ));
+        let instance = forged_indicator_semantics(
+            Bound::new(0.0, 5.0).unwrap(),
+            Equality::LessThanOrEqualToZero,
+            Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+            vec![row],
+        );
+        let error =
+            verify_indicator_big_m_v1(&instance, IndicatorConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains("inactive branch"));
+    }
+
+    #[test]
+    fn rejects_equality_with_an_unproved_missing_side() {
+        // The one row supplies x<=0 on the active branch and is redundant at
+        // y=0, but x>=0 is not implied by x in [-1,1].
+        let row = Constraint::less_than_or_equal_to_zero(Function::from(
+            ((linear!(1) + linear!(2)).unwrap() + coeff!(-1.0)).unwrap(),
+        ));
+        let instance = forged_indicator_semantics(
+            Bound::new(-1.0, 1.0).unwrap(),
+            Equality::EqualToZero,
+            Function::from(linear!(1)),
+            vec![row],
+        );
+        let error =
+            verify_indicator_big_m_v1(&instance, IndicatorConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains("upper and lower"));
+    }
+
+    #[test]
+    fn rejects_round_to_nearest_cancellation_from_the_current_lowerer() {
+        let x = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(0.0, 1.0e20).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), x),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                IndicatorConstraint::new(
+                    VariableID::from(2),
+                    Equality::LessThanOrEqualToZero,
+                    Function::from((linear!(1) + coeff!(1.0)).unwrap()),
+                ),
+            )]))
+            .build()
+            .unwrap();
+        let generated = instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+        assert_eq!(generated.len(), 1);
+
+        let error =
+            verify_indicator_big_m_v1(&instance, IndicatorConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains("active upper side exactly"));
+    }
+
+    #[test]
+    fn rejects_inward_rounded_inactive_bound_from_the_current_lowerer() {
+        let a = f64::from_bits(1.0f64.to_bits() + 1);
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (
+                    VariableID::from(1),
+                    DecisionVariable::new(
+                        Kind::Continuous,
+                        Bound::new(0.0, a).unwrap(),
+                        crate::ATol::default(),
+                    )
+                    .unwrap(),
+                ),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                IndicatorConstraint::new(
+                    VariableID::from(2),
+                    Equality::LessThanOrEqualToZero,
+                    Function::from((coeff!(a) * linear!(1)).unwrap()),
+                ),
+            )]))
+            .build()
+            .unwrap();
+        let generated = instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap();
+        assert_eq!(generated.len(), 1);
+
+        let error =
+            verify_indicator_big_m_v1(&instance, IndicatorConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains("inactive branch"));
+    }
+
+    #[test]
+    fn rejects_underflowed_skipped_side_from_the_current_lowerer() {
+        let tiny = f64::from_bits(1);
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (
+                    VariableID::from(1),
+                    DecisionVariable::new(
+                        Kind::Continuous,
+                        Bound::new(0.0, 0.5).unwrap(),
+                        crate::ATol::default(),
+                    )
+                    .unwrap(),
+                ),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                IndicatorConstraintID::from(7),
+                IndicatorConstraint::new(
+                    VariableID::from(2),
+                    Equality::LessThanOrEqualToZero,
+                    Function::from((coeff!(tiny) * linear!(1)).unwrap()),
+                ),
+            )]))
+            .build()
+            .unwrap();
+        assert!(instance
+            .convert_indicator_to_constraint(IndicatorConstraintID::from(7))
+            .unwrap()
+            .is_empty());
+
+        let error =
+            verify_indicator_big_m_v1(&instance, IndicatorConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains("Missing Indicator upper side"));
     }
 
     #[test]
@@ -284,6 +788,15 @@ mod tests {
                 INDICATOR_LOWERING_REASON,
             ),
             Err(InverseLoweringCandidateError::UnexpectedRemovalReason { .. })
+        ));
+
+        let mut extra_parameter = removed_reason(INDICATOR_LOWERING_REASON, "1");
+        extra_parameter
+            .parameters
+            .insert("future".to_string(), "value".to_string());
+        assert!(matches!(
+            parse_generated_constraint_ids(&extra_parameter, INDICATOR_LOWERING_REASON),
+            Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { .. })
         ));
     }
 
@@ -366,6 +879,32 @@ mod tests {
         assert!(matches!(
             extra_provenance.indicator_big_m_candidate_v1(IndicatorConstraintID::from(7)),
             Err(InverseLoweringCandidateError::ProvenanceMismatch { .. })
+        ));
+
+        let mut labeled = forged_indicator_history(
+            "10",
+            vec![Provenance::IndicatorConstraint(
+                IndicatorConstraintID::from(7),
+            )],
+            true,
+        );
+        labeled
+            .set_constraint_context(
+                ConstraintID::from(10),
+                crate::ConstraintContext {
+                    label: ModelingLabel {
+                        name: Some("edited-generated-row".to_string()),
+                        ..Default::default()
+                    },
+                    provenance: vec![Provenance::IndicatorConstraint(
+                        IndicatorConstraintID::from(7),
+                    )],
+                },
+            )
+            .unwrap();
+        assert!(matches!(
+            labeled.indicator_big_m_candidate_v1(IndicatorConstraintID::from(7)),
+            Err(InverseLoweringCandidateError::GeneratedConstraintHasModelingLabel { .. })
         ));
     }
 

--- a/rust/ommx/src/proof/mod.rs
+++ b/rust/ommx/src/proof/mod.rs
@@ -12,3 +12,5 @@
 
 mod exact;
 mod linear;
+
+pub(crate) use linear::verify_indicator_big_m_v1;


### PR DESCRIPTION
Stacked on #1063.

## Summary

- reconstruct current OMMX Indicator Big-M lowering history as an untrusted, strict V1 candidate from the retained source, canonical generated-row IDs, active rows, and exact provenance
- verify the current representation with exact IEEE-754 dyadic arithmetic: generated rows must equal the active Indicator sides and be independently redundant on the inactive branch using only variable-domain facts
- reject ambiguous, numerically damaged, partially evaluated, substituted, fixed-coordinate, and dependency-coordinate histories without mutating the Instance
- derive a private root-owned plan that consumes only verified generated rows, restores the original Indicator with its context, and returns an identity assignment map in one atomic commit

This slice keeps the verifier, proof output, mutation plan, and checked entry point crate-private. It adds no durable receipt format, protobuf contract, flat-model recognition, or public generic recovery API.
