### PR TITLE
Add checked SOS1 inverse lowering

### DIFF
--- a/rust/ommx/src/instance/reduction.rs
+++ b/rust/ommx/src/instance/reduction.rs
@@ -16,7 +16,9 @@ use std::collections::{BTreeMap, BTreeSet};
 /// Projection steps run in reduction order. Lifting runs the same steps in
 /// reverse so eliminated private coordinates are reconstructed before an
 /// earlier step depends on them. This transforms raw, unevaluated states;
-/// callers must evaluate the result against the corresponding Instance.
+/// callers must evaluate the result against the corresponding Instance. SOS1
+/// lifting uses mathematical exact zero and does not claim equivalence between
+/// tolerance-based feasibility classifications for arbitrary `ATol` values.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct AssignmentMap {
     source_ids: VariableIDSet,

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -1,4 +1,8 @@
-use super::{Instance, GENERATED_CONSTRAINT_IDS_PARAMETER, SOS1_LOWERING_REASON};
+use super::{
+    reduction::{AssignmentMap, SelectorRole},
+    AdditionalCapability, Capabilities, Instance, GENERATED_CONSTRAINT_IDS_PARAMETER,
+    SOS1_LOWERING_REASON,
+};
 use crate::{
     coeff,
     constraint::{ConstraintContext, ConstraintID, Provenance, RemovedReason},
@@ -7,7 +11,7 @@ use crate::{
     Bound, Coefficient, Constraint, Function, Kind, Linear, LinearMonomial, VariableID,
 };
 use anyhow::{bail, Context, Result};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Plan for each SOS1 variable: reuse it as its own indicator, or allocate a fresh one.
 #[derive(Debug)]
@@ -18,7 +22,133 @@ enum IndicatorPlan {
     Fresh { bound: Bound },
 }
 
+/// Private one-shot plan for an exact checked inverse lowering.
+///
+/// All fallible proof, isolation, assignment-map, and storage work is applied
+/// to `staged`. Committing the plan is one infallible replacement of the root
+/// Instance.
+#[allow(dead_code)] // Used by the stacked public inverse-lowering facade.
+struct Sos1InversePlan {
+    staged: Instance,
+    assignment_map: AssignmentMap,
+}
+
+#[allow(dead_code)] // Used by the stacked public inverse-lowering facade.
+impl Sos1InversePlan {
+    fn commit(self, target: &mut Instance) -> AssignmentMap {
+        *target = self.staged;
+        self.assignment_map
+    }
+}
+
 impl Instance {
+    /// Restore one SOS1 that this Instance previously lowered, after exact V1
+    /// content verification and complete isolation of fresh selectors.
+    ///
+    /// Private while the common reduction result and public capability request
+    /// API are still being exercised by the first family consumers.
+    /// `permitted_additions` is an explicit permission for the semantic
+    /// capability introduced by this operation; it is not a declaration of
+    /// every capability already present in the Instance.
+    #[allow(dead_code)] // Used by the stacked public inverse-lowering facade.
+    pub(super) fn restore_sos1_from_lowering_checked(
+        &mut self,
+        id: Sos1ConstraintID,
+        permitted_additions: &Capabilities,
+    ) -> Result<AssignmentMap> {
+        let plan = self.plan_sos1_inverse(id, permitted_additions)?;
+        Ok(plan.commit(self))
+    }
+
+    #[allow(dead_code)] // Used by the checked inverse entry point above.
+    fn plan_sos1_inverse(
+        &self,
+        id: Sos1ConstraintID,
+        permitted_additions: &Capabilities,
+    ) -> Result<Sos1InversePlan> {
+        if !permitted_additions.contains(&AdditionalCapability::Sos1) {
+            bail!("Restoring SOS1 constraint {id:?} requires explicit SOS1 capability permission");
+        }
+
+        let verified = crate::proof::verify_sos1_big_m_v1(self, id)?;
+        debug_assert_eq!(verified.source_id(), id);
+        for &member in &verified.source().variables {
+            if !self.decision_variables.contains_key(&member) {
+                bail!("Cannot restore SOS1 constraint {id:?}: member {member:?} is not registered");
+            }
+            if self.decision_variable_dependency.get(&member).is_some() {
+                bail!(
+                    "Cannot restore SOS1 constraint {id:?}: member {member:?} is a dependency target"
+                );
+            }
+            if self.fixed_decision_variable_values().contains_key(&member) {
+                bail!("Cannot restore SOS1 constraint {id:?}: member {member:?} is fixed");
+            }
+        }
+
+        let selector_roles = verified
+            .selectors()
+            .iter()
+            .map(|(&member, &selector)| {
+                let role = if member == selector {
+                    SelectorRole::Reused
+                } else {
+                    SelectorRole::Fresh(selector)
+                };
+                (member, role)
+            })
+            .collect::<BTreeMap<_, _>>();
+        let fresh_selectors = selector_roles
+            .values()
+            .filter_map(|role| match role {
+                SelectorRole::Reused => None,
+                SelectorRole::Fresh(selector) => Some(*selector),
+            })
+            .collect::<BTreeSet<_>>();
+        let generated_rows = verified
+            .generated_rows()
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+
+        self.ensure_variables_isolated_for_removal(&fresh_selectors, &generated_rows)?;
+        let assignment_map = AssignmentMap::sos1_selectors(
+            self.decision_variables.keys().copied().collect(),
+            id,
+            selector_roles,
+        )?;
+
+        let mut staged = self.clone();
+        staged
+            .constraint_collection
+            .consume_active_rows(&generated_rows)?;
+        staged
+            .decision_variables
+            .remove_unfixed_rows(&fresh_selectors)?;
+        staged
+            .sos1_constraint_collection
+            .restore_removed_row(id, verified.source().clone())?;
+        let staged_variable_ids = staged
+            .decision_variables
+            .keys()
+            .copied()
+            .collect::<crate::VariableIDSet>();
+        debug_assert_eq!(&staged_variable_ids, assignment_map.target_ids());
+        debug_assert!(staged.constraint_collection.validate_context_ids().is_ok());
+        debug_assert!(staged
+            .sos1_constraint_collection
+            .validate_context_ids()
+            .is_ok());
+        debug_assert!(staged
+            .required_capabilities()
+            .contains(&AdditionalCapability::Sos1));
+
+        Ok(Sos1InversePlan {
+            staged,
+            assignment_map,
+        })
+    }
+
     #[cfg_attr(doc, katexit::katexit)]
     /// Convert a SOS1 constraint to regular constraints using the Big-M method.
     ///
@@ -277,7 +407,10 @@ impl Instance {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{constraint::Equality, sos1_constraint::Sos1Constraint, DecisionVariable, Sense};
+    use crate::{
+        constraint::Equality, sos1_constraint::Sos1Constraint, DecisionVariable, Evaluate,
+        IndicatorConstraint, ModelingLabel, Sense, Substitute,
+    };
     use ::approx::assert_abs_diff_eq;
     use maplit::btreemap;
     use std::collections::{BTreeMap, BTreeSet};
@@ -319,6 +452,72 @@ mod tests {
             .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(9), sos1)]))
             .build()
             .unwrap()
+    }
+
+    fn sos1_capability() -> Capabilities {
+        [AdditionalCapability::Sos1].into_iter().collect()
+    }
+
+    fn mixed_sos1_instance() -> Instance {
+        let integer = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-2.0, 3.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from((linear!(0) + linear!(1)).unwrap()))
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::binary(),
+                VariableID::from(1) => integer,
+            })
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(
+                Sos1ConstraintID::from(9),
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(0), VariableID::from(1)]))
+                    .unwrap(),
+            )]))
+            .build()
+            .unwrap()
+    }
+
+    fn generated_selector(
+        instance: &Instance,
+        sos1_id: Sos1ConstraintID,
+        member: VariableID,
+    ) -> VariableID {
+        instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .find(|id| {
+                instance.variable_labels().collect_for(*id)
+                    == ModelingLabel {
+                        name: Some("ommx.sos1_indicator".to_string()),
+                        subscripts: vec![sos1_id.into_inner() as i64, member.into_inner() as i64],
+                        ..Default::default()
+                    }
+            })
+            .expect("current SOS1 lowerer generated the selector")
+    }
+
+    fn assert_checked_inverse_failure_unchanged(
+        instance: &mut Instance,
+        id: Sos1ConstraintID,
+        expected_message: &str,
+    ) {
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+        let error = instance
+            .restore_sos1_from_lowering_checked(id, &sos1_capability())
+            .unwrap_err();
+        assert!(
+            error.to_string().contains(expected_message),
+            "expected {expected_message:?}, got {error:#}"
+        );
+        assert_eq!(instance, &before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
     }
 
     #[test]
@@ -439,6 +638,318 @@ mod tests {
             new_ids.len(),
             2,
             "l=0 should skip lower Big-M and emit only upper + cardinality"
+        );
+    }
+
+    #[test]
+    fn checked_inverse_restores_mixed_sos1_and_removes_only_fresh_selectors() {
+        let mut instance = mixed_sos1_instance();
+        instance
+            .set_sos1_constraint_context(
+                Sos1ConstraintID::from(9),
+                ConstraintContext {
+                    label: ModelingLabel {
+                        name: Some("source-sos1".to_string()),
+                        ..Default::default()
+                    },
+                    provenance: Vec::new(),
+                },
+            )
+            .unwrap();
+        let original = instance.clone();
+        let original_bytes = instance.to_v2_bytes();
+        let generated = instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        let selector =
+            generated_selector(&instance, Sos1ConstraintID::from(9), VariableID::from(1));
+        let lowered = instance.clone();
+
+        let map = instance
+            .restore_sos1_from_lowering_checked(Sos1ConstraintID::from(9), &sos1_capability())
+            .unwrap();
+
+        assert_eq!(instance, original);
+        assert_eq!(instance.to_v2_bytes(), original_bytes);
+        assert!(!instance.decision_variables().contains_key(&selector));
+        assert_eq!(
+            instance.variable_labels().collect_for(selector),
+            Default::default()
+        );
+        for id in generated {
+            assert!(!instance.constraints().contains_key(&id));
+            assert!(!instance.removed_constraints().contains_key(&id));
+            assert!(!instance.constraint_context().contains(id));
+        }
+        assert_eq!(
+            instance
+                .sos1_constraint_context()
+                .name(Sos1ConstraintID::from(9)),
+            Some("source-sos1")
+        );
+        assert_eq!(
+            instance.required_capabilities(),
+            [AdditionalCapability::Sos1].into_iter().collect()
+        );
+
+        let full = crate::v1::State::from_iter([(0, 0.0), (1, 2.0), (selector.into_inner(), 1.0)]);
+        let projected = map.project_state(&full).unwrap();
+        assert_eq!(projected, crate::v1::State::from_iter([(0, 0.0), (1, 2.0)]));
+        assert_eq!(map.lift_state(&projected).unwrap(), full);
+        assert!(lowered
+            .evaluate(&full, crate::ATol::default())
+            .unwrap()
+            .feasible());
+        assert!(instance
+            .evaluate(&projected, crate::ATol::default())
+            .unwrap()
+            .feasible());
+
+        // On values separated from every tolerance boundary, the checked
+        // exact correspondence also agrees with the runtime classifier and
+        // preserves the objective for both feasible and infeasible states.
+        for binary in [0.0, 1.0] {
+            for integer in -2..=3 {
+                let target = crate::v1::State::from_iter([(0, binary), (1, integer as f64)]);
+                let source = map.lift_state(&target).unwrap();
+                assert_eq!(map.project_state(&source).unwrap(), target);
+                let restored_solution = instance.evaluate(&target, crate::ATol::default()).unwrap();
+                let lowered_solution = lowered.evaluate(&source, crate::ATol::default()).unwrap();
+                assert_eq!(lowered_solution.feasible(), restored_solution.feasible());
+                assert_eq!(lowered_solution.objective(), restored_solution.objective());
+            }
+        }
+
+        // Lift uses mathematical exact zero, independently of evaluation
+        // tolerance: both signed zeros map to selector 0 and any finite
+        // nonzero value, including a subnormal, maps to 1.
+        for (member, expected_selector) in [
+            (0.0, 0.0),
+            (-0.0, 0.0),
+            (f64::from_bits(1), 1.0),
+            (-f64::from_bits(1), 1.0),
+        ] {
+            let target = crate::v1::State::from_iter([(0, 0.0), (1, member)]);
+            let lifted = map.lift_state(&target).unwrap();
+            assert_eq!(lifted.entries[&selector.into_inner()], expected_selector);
+            assert_eq!(map.project_state(&lifted).unwrap(), target);
+        }
+    }
+
+    #[test]
+    fn checked_inverse_all_reused_sos1_has_identity_map() {
+        let mut instance = binary_sos1_instance();
+        let original = instance.clone();
+        instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(5))
+            .unwrap();
+
+        let map = instance
+            .restore_sos1_from_lowering_checked(Sos1ConstraintID::from(5), &sos1_capability())
+            .unwrap();
+
+        assert_eq!(instance, original);
+        let state = crate::v1::State::from_iter([(0, 1.0), (1, 0.0)]);
+        assert_eq!(map.project_state(&state).unwrap(), state);
+        assert_eq!(map.lift_state(&state).unwrap(), state);
+    }
+
+    #[test]
+    fn checked_inverse_requires_explicit_sos1_permission_only() {
+        let mut denied = mixed_sos1_instance();
+        denied
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        let before = denied.clone();
+        let before_bytes = denied.to_v2_bytes();
+        let error = denied
+            .restore_sos1_from_lowering_checked(Sos1ConstraintID::from(9), &Capabilities::new())
+            .unwrap_err();
+        assert!(error.to_string().contains("explicit SOS1 capability"));
+        assert_eq!(denied, before);
+        assert_eq!(denied.to_v2_bytes(), before_bytes);
+
+        let mut allowed = before;
+        allowed
+            .add_indicator_constraint(
+                IndicatorConstraint::new(
+                    VariableID::from(0),
+                    Equality::LessThanOrEqualToZero,
+                    Function::zero(),
+                ),
+                Default::default(),
+            )
+            .unwrap();
+        allowed
+            .restore_sos1_from_lowering_checked(Sos1ConstraintID::from(9), &sos1_capability())
+            .unwrap();
+        assert_eq!(
+            allowed.required_capabilities(),
+            [AdditionalCapability::Indicator, AdditionalCapability::Sos1]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn checked_inverse_rejects_partial_evaluated_and_substituted_histories() {
+        let mut partial = mixed_sos1_instance();
+        partial
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        partial
+            .partial_evaluate(
+                &crate::v1::State::from_iter([(1, 1.0)]),
+                crate::ATol::default(),
+            )
+            .unwrap();
+        assert_checked_inverse_failure_unchanged(
+            &mut partial,
+            Sos1ConstraintID::from(9),
+            "canonical V1 content exactly",
+        );
+
+        let mut substituted = mixed_sos1_instance();
+        substituted
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        substituted = substituted
+            .substitute_one(VariableID::from(1), &Function::zero())
+            .unwrap();
+        assert_checked_inverse_failure_unchanged(
+            &mut substituted,
+            Sos1ConstraintID::from(9),
+            "canonical V1 content exactly",
+        );
+    }
+
+    #[test]
+    fn checked_inverse_rejects_ulp_modified_link_row_without_mutation() {
+        let mut instance = mixed_sos1_instance();
+        let generated = instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        let selector =
+            generated_selector(&instance, Sos1ConstraintID::from(9), VariableID::from(1));
+        let altered_m = f64::from_bits((-3.0f64).to_bits() + 1);
+        let altered = Constraint::less_than_or_equal_to_zero(Function::from(
+            (Linear::single_term(LinearMonomial::Variable(VariableID::from(1)), coeff!(1.0))
+                + Linear::single_term(LinearMonomial::Variable(selector), coeff!(altered_m)))
+            .unwrap(),
+        ));
+        instance
+            .constraint_collection
+            .replace_active_rows(BTreeMap::from([(generated[0], altered)]))
+            .unwrap();
+
+        assert_checked_inverse_failure_unchanged(
+            &mut instance,
+            Sos1ConstraintID::from(9),
+            "canonical V1 content exactly",
+        );
+    }
+
+    #[test]
+    fn checked_inverse_rejects_modified_selector_domain_without_mutation() {
+        let mut instance = mixed_sos1_instance();
+        instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        let selector =
+            generated_selector(&instance, Sos1ConstraintID::from(9), VariableID::from(1));
+        instance
+            .clip_bounds(
+                &crate::Bounds::from_iter([(selector, Bound::new(0.0, 0.0).unwrap())]),
+                crate::ATol::default(),
+            )
+            .unwrap();
+
+        assert_checked_inverse_failure_unchanged(
+            &mut instance,
+            Sos1ConstraintID::from(9),
+            "canonical binary domain",
+        );
+    }
+
+    #[test]
+    fn checked_inverse_rejects_fixed_or_dependent_members_without_mutation() {
+        let zero_bound_lowering = || {
+            let mut instance = integer_sos1_instance(0.0, 0.0);
+            assert_eq!(
+                instance
+                    .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+                    .unwrap()
+                    .len(),
+                1
+            );
+            instance
+        };
+
+        let mut fixed = zero_bound_lowering();
+        fixed
+            .partial_evaluate(
+                &crate::v1::State::from_iter([(0, 0.0)]),
+                crate::ATol::default(),
+            )
+            .unwrap();
+        assert_checked_inverse_failure_unchanged(&mut fixed, Sos1ConstraintID::from(9), "is fixed");
+
+        let mut dependent = zero_bound_lowering()
+            .substitute_one(VariableID::from(0), &Function::zero())
+            .unwrap();
+        assert_checked_inverse_failure_unchanged(
+            &mut dependent,
+            Sos1ConstraintID::from(9),
+            "dependency target",
+        );
+    }
+
+    #[test]
+    fn checked_inverse_rejects_nonisolated_or_relabelled_selector_without_mutation() {
+        let mut used = mixed_sos1_instance();
+        used.convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        let selector = generated_selector(&used, Sos1ConstraintID::from(9), VariableID::from(1));
+        used.add_constraint(
+            Constraint::less_than_or_equal_to_zero(Function::from(linear!(selector.into_inner()))),
+            Default::default(),
+        )
+        .unwrap();
+        assert_checked_inverse_failure_unchanged(
+            &mut used,
+            Sos1ConstraintID::from(9),
+            "active regular constraint",
+        );
+
+        let mut relabelled = mixed_sos1_instance();
+        relabelled
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        let selector =
+            generated_selector(&relabelled, Sos1ConstraintID::from(9), VariableID::from(1));
+        relabelled
+            .set_variable_label(selector, ModelingLabel::default())
+            .unwrap();
+        assert_checked_inverse_failure_unchanged(
+            &mut relabelled,
+            Sos1ConstraintID::from(9),
+            "exactly one canonical V1 selector",
+        );
+    }
+
+    #[test]
+    fn checked_inverse_rejects_removed_generated_row_without_mutation() {
+        let mut instance = mixed_sos1_instance();
+        let generated = instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        instance
+            .relax_constraint(generated[0], "test preprocessing".to_string(), [])
+            .unwrap();
+        assert_checked_inverse_failure_unchanged(
+            &mut instance,
+            Sos1ConstraintID::from(9),
+            "is not active",
         );
     }
 

--- a/rust/ommx/src/proof/linear.rs
+++ b/rust/ommx/src/proof/linear.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 mod activity;
 mod candidate;
 
-pub(crate) use candidate::verify_indicator_big_m_v1;
+pub(crate) use candidate::{verify_indicator_big_m_v1, verify_sos1_big_m_v1};
 
 const FINGERPRINT_DOMAIN: &[u8] = b"org.ommx.proof.linear-relaxation\0";
 const FINGERPRINT_VERSION: u32 = 1;

--- a/rust/ommx/src/proof/linear/candidate.rs
+++ b/rust/ommx/src/proof/linear/candidate.rs
@@ -6,10 +6,11 @@ use crate::{
     instance::{
         GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON, SOS1_LOWERING_REASON,
     },
-    ConstraintID, Equality, IndicatorConstraint, IndicatorConstraintID, Instance, Kind,
-    Sos1ConstraintID,
+    proof::exact::from_f64,
+    Bound, ConstraintID, Equality, IndicatorConstraint, IndicatorConstraintID, Instance, Kind,
+    ModelingLabel, Sos1Constraint, Sos1ConstraintID, VariableID,
 };
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Untrusted, versioned lookup result for one historical Indicator Big-M
 /// lowering. The generated rows have not yet been proven equivalent to the
@@ -55,6 +56,39 @@ impl VerifiedIndicatorBigMV1 {
 
     pub(crate) fn generated_rows(&self) -> &[ConstraintID] {
         &self.generated_rows
+    }
+}
+
+/// Exact, representation-bound fact that the recorded regular rows are the
+/// complete current V1 lowering of one retained removed SOS1 constraint.
+///
+/// `selectors` maps every source member to either itself (the binary-reuse
+/// case) or to one verified fresh binary selector. The root `Instance` still
+/// has to prove that every fresh selector is isolated before removing it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct VerifiedSos1BigMV1 {
+    source_id: Sos1ConstraintID,
+    source: Sos1Constraint,
+    generated_rows: Vec<ConstraintID>,
+    selectors: BTreeMap<VariableID, VariableID>,
+    representation: LinearRelaxationFingerprint,
+}
+
+impl VerifiedSos1BigMV1 {
+    pub(crate) fn source_id(&self) -> Sos1ConstraintID {
+        self.source_id
+    }
+
+    pub(crate) fn source(&self) -> &Sos1Constraint {
+        &self.source
+    }
+
+    pub(crate) fn generated_rows(&self) -> &[ConstraintID] {
+        &self.generated_rows
+    }
+
+    pub(crate) fn selectors(&self) -> &BTreeMap<VariableID, VariableID> {
+        &self.selectors
     }
 }
 
@@ -257,6 +291,233 @@ pub(crate) fn verify_indicator_big_m_v1(
     })
 }
 
+/// Verify the complete current V1 SOS1 Big-M lowering exactly.
+///
+/// The V1 contract is intentionally strict: selector roles are reconstructed
+/// from the exact generated-variable label, every selector has the original
+/// binary domain, and generated rows must appear in the lowerer's canonical
+/// order with exact dyadic content. For fresh selectors this checks every
+/// nontrivial bound link and the final cardinality row; reused binary members
+/// contribute only to cardinality.
+///
+/// Together with the current member bounds, these rows prove both directions:
+/// projection of a feasible gadget satisfies SOS1, and the canonical lift
+/// `selector = 1 iff member != 0` satisfies the gadget for every feasible SOS1
+/// assignment. These are exact mathematical statements: tolerance-based
+/// classification of a tiny nonzero value by `Sos1Constraint::evaluate` is not
+/// an alternate zero test for the lift. Fresh-selector isolation is a separate
+/// root-owned obligation.
+pub(crate) fn verify_sos1_big_m_v1(
+    instance: &Instance,
+    id: Sos1ConstraintID,
+) -> crate::Result<VerifiedSos1BigMV1> {
+    let candidate = instance.sos1_big_m_candidate_v1(id)?;
+    let snapshot = instance.certified_linear_relaxation()?;
+    if candidate.representation != snapshot.fingerprint() {
+        crate::bail!(
+            { ?id },
+            "SOS1 inverse-lowering candidate {id:?} is bound to a stale representation"
+        );
+    }
+
+    let (source, _) = instance
+        .removed_sos1_constraints()
+        .get(&id)
+        .expect("candidate lookup proved that the removed source exists");
+    let mut selectors = BTreeMap::new();
+    let mut fresh_member_bounds = BTreeMap::new();
+    let mut expected_row_count = 1usize; // The final cardinality row.
+
+    for &member in &source.variables {
+        let variable = instance.decision_variables().get(&member).ok_or_else(|| {
+            crate::error!(
+                { ?id, ?member },
+                "SOS1 member {member:?} is not registered"
+            )
+        })?;
+        let bound = variable.bound();
+        if variable.kind() == Kind::Binary && bound == Bound::of_binary() {
+            selectors.insert(member, member);
+            continue;
+        }
+        if matches!(variable.kind(), Kind::SemiContinuous | Kind::SemiInteger) {
+            crate::bail!(
+                { ?id, ?member, kind = ?variable.kind() },
+                "SOS1 member {member:?} has a semi-variable kind unsupported by V1 lowering"
+            );
+        }
+        if !bound.is_finite() || bound.lower() > 0.0 || bound.upper() < 0.0 {
+            crate::bail!(
+                { ?id, ?member, ?bound },
+                "SOS1 member {member:?} does not have a finite V1 Big-M domain containing zero"
+            );
+        }
+        expected_row_count += usize::from(bound.upper() > 0.0);
+        expected_row_count += usize::from(bound.lower() < 0.0);
+        fresh_member_bounds.insert(member, bound);
+    }
+
+    if candidate.generated_rows.len() != expected_row_count {
+        crate::bail!(
+            {
+                ?id,
+                actual = candidate.generated_rows.len(),
+                expected = expected_row_count
+            },
+            "SOS1 lowering has an unexpected number of generated rows"
+        );
+    }
+
+    // The V1 lowerer emits cardinality last. Read selector candidates only
+    // from that exact row so an unrelated variable with the same generated
+    // label cannot make an otherwise valid lowering ambiguous.
+    let cardinality_id = *candidate
+        .generated_rows
+        .last()
+        .expect("a non-empty SOS1 V1 lowering always has a cardinality row");
+    let cardinality = snapshot.inequality(InequalityRef::RegularConstraint(cardinality_id))?;
+    let one = ExactRational::from_integer(1.into());
+    let minus_one = ExactRational::from_integer((-1).into());
+    if cardinality.constant() != &minus_one
+        || cardinality.coefficients().len() != source.variables.len()
+        || cardinality
+            .coefficients()
+            .values()
+            .any(|coefficient| coefficient != &one)
+    {
+        crate::bail!(
+            { ?id, ?cardinality_id },
+            "Generated SOS1 cardinality row does not have canonical V1 shape"
+        );
+    }
+    for (&member, &selector) in &selectors {
+        debug_assert_eq!(member, selector);
+        if !cardinality.coefficients().contains_key(&selector) {
+            crate::bail!(
+                { ?id, ?member, ?cardinality_id },
+                "Generated SOS1 cardinality row is missing reused member {member:?}"
+            );
+        }
+    }
+
+    let fresh_selector_candidates = cardinality
+        .coefficients()
+        .keys()
+        .copied()
+        .filter(|selector| !selectors.values().any(|reused| reused == selector))
+        .collect::<BTreeSet<_>>();
+    if fresh_selector_candidates.len() != fresh_member_bounds.len()
+        || fresh_selector_candidates
+            .iter()
+            .any(|selector| source.variables.contains(selector))
+    {
+        crate::bail!(
+            { ?id, ?cardinality_id },
+            "Generated SOS1 cardinality row has an invalid fresh-selector set"
+        );
+    }
+
+    for &member in fresh_member_bounds.keys() {
+        let expected_label = sos1_selector_label_v1(id, member);
+        let matching_selectors = fresh_selector_candidates
+            .iter()
+            .copied()
+            .filter(|selector| instance.variable_labels().collect_for(*selector) == expected_label)
+            .collect::<Vec<_>>();
+        let [selector] = matching_selectors.as_slice() else {
+            crate::bail!(
+                { ?id, ?member, matches = matching_selectors.len() },
+                "SOS1 member {member:?} does not have exactly one canonical V1 selector"
+            );
+        };
+        let selector = *selector;
+        let selector_variable = instance
+            .decision_variables()
+            .get(&selector)
+            .expect("selector ID was read from the decision-variable table");
+        if selector_variable.kind() != Kind::Binary
+            || selector_variable.bound() != Bound::of_binary()
+        {
+            crate::bail!(
+                { ?id, ?member, ?selector },
+                "SOS1 selector {selector:?} does not have the canonical binary domain"
+            );
+        }
+        if selectors.values().any(|existing| *existing == selector) {
+            crate::bail!(
+                { ?id, ?member, ?selector },
+                "SOS1 selector {selector:?} is assigned to more than one member"
+            );
+        }
+        selectors.insert(member, selector);
+    }
+
+    let mut expected_rows = Vec::with_capacity(expected_row_count);
+    for (&member, &bound) in &fresh_member_bounds {
+        let selector = selectors[&member];
+        if bound.upper() > 0.0 {
+            expected_rows.push(ExactAffine {
+                coefficients: BTreeMap::from([
+                    (member, ExactRational::from_integer(1.into())),
+                    (selector, -from_f64(bound.upper())?),
+                ]),
+                constant: ExactRational::from_integer(0.into()),
+            });
+        }
+        if bound.lower() < 0.0 {
+            expected_rows.push(ExactAffine {
+                coefficients: BTreeMap::from([
+                    (member, ExactRational::from_integer((-1).into())),
+                    (selector, from_f64(bound.lower())?),
+                ]),
+                constant: ExactRational::from_integer(0.into()),
+            });
+        }
+    }
+
+    let cardinality_coefficients = selectors
+        .values()
+        .copied()
+        .map(|selector| (selector, ExactRational::from_integer(1.into())))
+        .collect();
+    expected_rows.push(ExactAffine {
+        coefficients: cardinality_coefficients,
+        constant: ExactRational::from_integer((-1).into()),
+    });
+
+    debug_assert_eq!(expected_rows.len(), expected_row_count);
+    for (index, (&row_id, expected)) in candidate
+        .generated_rows
+        .iter()
+        .zip(&expected_rows)
+        .enumerate()
+    {
+        let actual = snapshot.inequality(InequalityRef::RegularConstraint(row_id))?;
+        if actual != *expected {
+            crate::bail!(
+                { ?id, ?row_id, index },
+                "Generated SOS1 row {row_id:?} does not match the canonical V1 content exactly"
+            );
+        }
+    }
+
+    Ok(VerifiedSos1BigMV1 {
+        source_id: candidate.source,
+        source: source.clone(),
+        generated_rows: candidate.generated_rows,
+        selectors,
+        representation: candidate.representation,
+    })
+}
+
+fn sos1_selector_label_v1(id: Sos1ConstraintID, member: VariableID) -> ModelingLabel {
+    ModelingLabel {
+        name: Some("ommx.sos1_indicator".to_string()),
+        subscripts: vec![id.into_inner() as i64, member.into_inner() as i64],
+        ..Default::default()
+    }
+}
+
 fn equality_roles_cover(roles: &[(bool, bool)], upper_implied: bool, lower_implied: bool) -> bool {
     for assignment in 0..(1usize << roles.len()) {
         let mut upper_used = false;
@@ -340,6 +601,7 @@ mod tests {
     use crate::{
         coeff, linear, Bound, Constraint, ConstraintContextStore, DecisionVariable, Equality,
         Function, IndicatorConstraint, Kind, ModelingLabel, Sense, Sos1Constraint, VariableID,
+        VariableLabelStore,
     };
     use fnv::FnvHashMap;
     use std::collections::{BTreeMap, BTreeSet};
@@ -718,20 +980,28 @@ mod tests {
     }
 
     #[test]
-    fn reads_current_sos1_lowering_without_inferring_selector_roles() {
+    fn reads_and_verifies_current_sos1_lowering() {
         let x = DecisionVariable::new(
             Kind::Continuous,
             Bound::new(-1.0, 2.0).unwrap(),
             crate::ATol::default(),
         )
         .unwrap();
+        let mut labels = VariableLabelStore::default();
+        labels.set_name(VariableID::from(50), "ommx.sos1_indicator");
+        labels.set_subscripts(VariableID::from(50), vec![9, 1]);
         let mut instance = Instance::builder()
             .sense(Sense::Minimize)
             .objective(Function::zero())
             .decision_variables(BTreeMap::from([
                 (VariableID::from(1), x),
                 (VariableID::from(2), DecisionVariable::binary()),
+                // A pre-existing exact label collision is legal. Selector
+                // reconstruction is scoped to the cardinality row, so this
+                // unrelated variable must not make the history ambiguous.
+                (VariableID::from(50), DecisionVariable::binary()),
             ]))
+            .variable_labels(labels)
             .constraints(BTreeMap::new())
             .sos1_constraints(BTreeMap::from([(
                 Sos1ConstraintID::from(9),
@@ -756,6 +1026,93 @@ mod tests {
                 .unwrap()
                 .fingerprint()
         );
+
+        let verified = verify_sos1_big_m_v1(&instance, Sos1ConstraintID::from(9)).unwrap();
+        assert_eq!(verified.source_id(), Sos1ConstraintID::from(9));
+        assert_eq!(verified.generated_rows(), generated);
+        assert_eq!(
+            verified.selectors(),
+            &BTreeMap::from([
+                (VariableID::from(1), VariableID::from(51)),
+                (VariableID::from(2), VariableID::from(2)),
+            ])
+        );
+    }
+
+    #[test]
+    fn verifies_all_current_sos1_omitted_side_shapes() {
+        let tiny = f64::from_bits(1);
+        for (kind, lower, upper, expected_rows) in [
+            (Kind::Integer, -2.0, 3.0, 3),
+            (Kind::Integer, 0.0, 3.0, 2),
+            (Kind::Integer, -2.0, 0.0, 2),
+            (Kind::Integer, 0.0, 0.0, 1),
+            // A restricted Binary is not the canonical [0, 1] reuse case.
+            (Kind::Binary, 0.0, 0.0, 1),
+            (Kind::Continuous, -f64::MAX, f64::MAX, 3),
+            (Kind::Continuous, -tiny, tiny, 3),
+        ] {
+            let variable = DecisionVariable::new(
+                kind,
+                Bound::new(lower, upper).unwrap(),
+                crate::ATol::default(),
+            )
+            .unwrap();
+            let mut instance = Instance::builder()
+                .sense(Sense::Minimize)
+                .objective(Function::zero())
+                .decision_variables(BTreeMap::from([(VariableID::from(0), variable)]))
+                .constraints(BTreeMap::new())
+                .sos1_constraints(BTreeMap::from([(
+                    Sos1ConstraintID::from(9),
+                    Sos1Constraint::new(BTreeSet::from([VariableID::from(0)])).unwrap(),
+                )]))
+                .build()
+                .unwrap();
+            let generated = instance
+                .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+                .unwrap();
+            assert_eq!(generated.len(), expected_rows);
+
+            let verified = verify_sos1_big_m_v1(&instance, Sos1ConstraintID::from(9)).unwrap();
+            assert_eq!(
+                verified.selectors()[&VariableID::from(0)],
+                VariableID::from(1)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_sos1_history_after_member_bound_change() {
+        let variable = DecisionVariable::new(
+            Kind::Continuous,
+            Bound::new(-2.0, 3.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([(VariableID::from(0), variable)]))
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(
+                Sos1ConstraintID::from(9),
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(0)])).unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+        instance
+            .clip_bounds(
+                &crate::Bounds::from_iter([(VariableID::from(0), Bound::new(-2.0, 2.0).unwrap())]),
+                crate::ATol::default(),
+            )
+            .unwrap();
+
+        let error = verify_sos1_big_m_v1(&instance, Sos1ConstraintID::from(9)).unwrap_err();
+        assert!(error.to_string().contains("canonical V1 content exactly"));
     }
 
     #[test]

--- a/rust/ommx/src/proof/mod.rs
+++ b/rust/ommx/src/proof/mod.rs
@@ -13,4 +13,4 @@
 mod exact;
 mod linear;
 
-pub(crate) use linear::verify_indicator_big_m_v1;
+pub(crate) use linear::{verify_indicator_big_m_v1, verify_sos1_big_m_v1};


### PR DESCRIPTION
Stacked on #1064.

## Summary

- reconstruct current OMMX SOS1 Big-M lowering history from the retained source, canonical generated-row IDs, the exact cardinality row, generated selector labels, and current variable domains
- verify every nontrivial upper/lower link and the final cardinality row with exact IEEE-754 dyadic content, including reused binary members and omitted zero-bound sides
- prove fresh selectors are isolated from the objective, unrelated active and removed constraints, every special-constraint family, named functions, dependencies, and fixed state before removing them
- derive a private root-owned plan that consumes verified generated rows, removes only verified fresh selectors and their labels, restores the original SOS1 with its context, and returns a composable projection/lift map in one atomic commit
- reconstruct fresh selectors with the exact mathematical rule `selector = 1 iff member != 0`; this raw-state map does not claim preservation of tolerance-based `Evaluate(ATol)` classifications

This slice remains crate-private and implements only strict history-guided inversion of the current V1 lowering contract. It does not add a durable receipt format, flat-model SOS1 recognition, or a public recovery API.
