### PR TITLE
Add checked OneHot inverse lowering

### DIFF
--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -53,6 +53,8 @@ use std::collections::{BTreeMap, HashMap};
 
 pub(crate) const GENERATED_CONSTRAINT_IDS_PARAMETER: &str = "constraint_ids";
 pub(crate) const INDICATOR_LOWERING_REASON: &str = "ommx.Instance.convert_indicator_to_constraint";
+pub(crate) const ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER: &str = "constraint_id";
+pub(crate) const ONE_HOT_LOWERING_REASON: &str = "ommx.Instance.convert_one_hot_to_constraint";
 pub(crate) const SOS1_LOWERING_REASON: &str = "ommx.Instance.convert_sos1_to_constraints";
 
 /// A constraint type capability flag for non-standard constraint types.

--- a/rust/ommx/src/instance/inverse_lowering.rs
+++ b/rust/ommx/src/instance/inverse_lowering.rs
@@ -1,7 +1,7 @@
 //! Crate-private end-to-end coordination for checked inverse lowering.
 //!
 //! The generic SDK surface remains deliberately unfrozen. This module proves
-//! that the family-specific Indicator and SOS1 consumers compose at the root
+//! that the family-specific Indicator, OneHot, and SOS1 consumers compose at the root
 //! `Instance` boundary without making the result/map vocabulary public.
 //! General lifecycle reactivation such as `restore_indicator_constraint`
 //! remains a distinct, potentially semantics-changing operation and is not an
@@ -11,7 +11,7 @@
 
 use super::{
     reduction::AssignmentMap, AdditionalCapability, Capabilities, Instance,
-    INDICATOR_LOWERING_REASON, SOS1_LOWERING_REASON,
+    INDICATOR_LOWERING_REASON, ONE_HOT_LOWERING_REASON, SOS1_LOWERING_REASON,
 };
 use crate::{v1, VariableIDSet};
 
@@ -57,7 +57,7 @@ impl InverseLoweringResult {
 }
 
 impl Instance {
-    /// Restore every current OMMX V1 Indicator/SOS1 lowering history in the
+    /// Restore every current OMMX V1 Indicator/OneHot/SOS1 lowering history in the
     /// requested families, or leave the Instance entirely unchanged.
     ///
     /// `requested` is both a family filter and explicit permission to add that
@@ -66,22 +66,27 @@ impl Instance {
     /// malformed parameter, row, provenance, selector, or use is a hard error
     /// for the complete batch rather than a skipped candidate.
     ///
-    /// OneHot is intentionally unsupported by this private V1 integration and
-    /// is rejected before any work. Public generic naming, serialized receipts,
-    /// and Python bindings remain deferred.
+    /// Public generic naming, serialized receipts, and Python bindings remain
+    /// deferred.
     pub(super) fn restore_lowered_capabilities_checked(
         &mut self,
         requested: &Capabilities,
     ) -> crate::Result<InverseLoweringResult> {
-        if requested.contains(&AdditionalCapability::OneHot) {
-            crate::bail!("Checked inverse lowering does not yet support the OneHot capability");
-        }
-
         let mut indicator_ids = if requested.contains(&AdditionalCapability::Indicator) {
             self.removed_indicator_constraints()
                 .iter()
                 .filter_map(|(&id, (_, reason))| {
                     (reason.reason == INDICATOR_LOWERING_REASON).then_some(id)
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let mut one_hot_ids = if requested.contains(&AdditionalCapability::OneHot) {
+            self.removed_one_hot_constraints()
+                .iter()
+                .filter_map(|(&id, (_, reason))| {
+                    (reason.reason == ONE_HOT_LOWERING_REASON).then_some(id)
                 })
                 .collect::<Vec<_>>()
         } else {
@@ -100,18 +105,19 @@ impl Instance {
 
         let mut assignment_map =
             AssignmentMap::identity(self.decision_variables.keys().copied().collect());
-        if indicator_ids.is_empty() && sos1_ids.is_empty() {
+        if indicator_ids.is_empty() && one_hot_ids.is_empty() && sos1_ids.is_empty() {
             return Ok(InverseLoweringResult {
                 restored_capabilities: Capabilities::new(),
                 assignment_map,
             });
         }
 
-        // `reduce_capabilities` lowers Indicator before SOS1, and each family
-        // lowers IDs in ascending order. Undo that deterministic stack in
-        // reverse. Every family operation commits only to this staged clone;
-        // the caller-visible root is replaced once after the whole batch.
+        // `reduce_capabilities` lowers Indicator, then OneHot, then SOS1, and
+        // each family lowers IDs in ascending order. Undo that deterministic
+        // stack in reverse. Every family operation commits only to this staged
+        // clone; the caller-visible root is replaced once after the whole batch.
         indicator_ids.reverse();
+        one_hot_ids.reverse();
         sos1_ids.reverse();
         let mut staged = self.clone();
         let mut restored_capabilities = Capabilities::new();
@@ -120,6 +126,11 @@ impl Instance {
             let step = staged.restore_sos1_from_lowering_checked(id, requested)?;
             assignment_map = assignment_map.then(step)?;
             restored_capabilities.insert(AdditionalCapability::Sos1);
+        }
+        for id in one_hot_ids {
+            let step = staged.restore_one_hot_from_lowering_checked(id, requested)?;
+            assignment_map = assignment_map.then(step)?;
+            restored_capabilities.insert(AdditionalCapability::OneHot);
         }
         for id in indicator_ids {
             let step = staged.restore_indicator_from_lowering_checked(id, requested)?;
@@ -376,7 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_unmatched_and_unsupported_requests_are_atomic() {
+    fn empty_and_unmatched_requests_are_atomic() {
         let mut instance = combined_instance();
         let before = instance.clone();
         let before_bytes = instance.to_v2_bytes();
@@ -390,10 +401,140 @@ mod tests {
         assert_eq!(instance, before);
         assert_eq!(instance.to_v2_bytes(), before_bytes);
 
-        let error = instance
+        let unmatched = instance
             .restore_lowered_capabilities_checked(&requested([AdditionalCapability::OneHot]))
+            .unwrap();
+        assert!(unmatched.restored_capabilities().is_empty());
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+    }
+
+    #[test]
+    fn restores_reduce_capabilities_one_hot_end_to_end() {
+        let id = crate::OneHotConstraintID::from(4);
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from((linear!(0) + linear!(1)).unwrap()))
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::binary(),
+                VariableID::from(1) => DecisionVariable::binary(),
+            })
+            .constraints(BTreeMap::new())
+            .one_hot_constraints(BTreeMap::from([(
+                id,
+                OneHotConstraint::new(BTreeSet::from([VariableID::from(0), VariableID::from(1)]))
+                    .unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        instance
+            .set_one_hot_constraint_context(
+                id,
+                crate::ConstraintContext {
+                    label: crate::ModelingLabel {
+                        name: Some("choose".to_string()),
+                        ..Default::default()
+                    },
+                    provenance: vec![crate::Provenance::IndicatorConstraint(
+                        crate::IndicatorConstraintID::from(12),
+                    )],
+                },
+            )
+            .unwrap();
+        let original = instance.clone();
+        let original_bytes = instance.to_v2_bytes();
+        assert_eq!(
+            instance.reduce_capabilities(&Capabilities::new()).unwrap(),
+            requested([AdditionalCapability::OneHot])
+        );
+        let lowered = instance.clone();
+
+        let result = instance
+            .restore_lowered_capabilities_checked(&requested([AdditionalCapability::OneHot]))
+            .unwrap();
+
+        assert_eq!(instance, original);
+        assert_eq!(instance.to_v2_bytes(), original_bytes);
+        assert_eq!(
+            result.restored_capabilities(),
+            &requested([AdditionalCapability::OneHot])
+        );
+        assert_eq!(result.before_variable_ids(), result.after_variable_ids());
+        for state in [
+            v1::State::from_iter([(0, 1.0), (1, 0.0)]),
+            v1::State::from_iter([(0, 0.0), (1, 0.0)]),
+        ] {
+            let projected = result.project_state(&state).unwrap();
+            assert_eq!(projected, state);
+            assert_eq!(result.lift_state(&projected).unwrap(), state);
+            assert_eq!(
+                lowered
+                    .evaluate(&state, crate::ATol::default())
+                    .unwrap()
+                    .feasible(),
+                instance
+                    .evaluate(&projected, crate::ATol::default())
+                    .unwrap()
+                    .feasible()
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_one_hot_rolls_back_an_earlier_sos1_restoration() {
+        let one_hot_id = crate::OneHotConstraintID::from(4);
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(
+                ((linear!(0) + linear!(1)).unwrap() + linear!(2)).unwrap(),
+            ))
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::binary(),
+                VariableID::from(1) => DecisionVariable::binary(),
+                VariableID::from(2) => DecisionVariable::new(
+                    Kind::Continuous,
+                    Bound::new(-1.0, 2.0).unwrap(),
+                    crate::ATol::default(),
+                ).unwrap(),
+            })
+            .constraints(BTreeMap::new())
+            .one_hot_constraints(BTreeMap::from([(
+                one_hot_id,
+                OneHotConstraint::new(BTreeSet::from([VariableID::from(0), VariableID::from(1)]))
+                    .unwrap(),
+            )]))
+            .sos1_constraints(BTreeMap::from([(
+                crate::Sos1ConstraintID::from(5),
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(2)])).unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        instance.reduce_capabilities(&Capabilities::new()).unwrap();
+        let (_, reason) = &instance.removed_one_hot_constraints()[&one_hot_id];
+        let row = crate::ConstraintID::from(
+            reason.parameters[super::super::ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER]
+                .parse::<u64>()
+                .unwrap(),
+        );
+        instance
+            .insert_constraint(
+                row,
+                Constraint::equal_to_zero(Function::from(
+                    ((linear!(0) + linear!(1)).unwrap() + coeff!(-2.0)).unwrap(),
+                )),
+            )
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let error = instance
+            .restore_lowered_capabilities_checked(&requested([
+                AdditionalCapability::OneHot,
+                AdditionalCapability::Sos1,
+            ]))
             .unwrap_err();
-        assert!(error.to_string().contains("does not yet support"));
+
+        assert!(error.to_string().contains("canonical V1 equality exactly"));
         assert_eq!(instance, before);
         assert_eq!(instance.to_v2_bytes(), before_bytes);
     }

--- a/rust/ommx/src/instance/one_hot.rs
+++ b/rust/ommx/src/instance/one_hot.rs
@@ -1,14 +1,106 @@
-use super::Instance;
+use super::{
+    reduction::AssignmentMap, AdditionalCapability, Capabilities, Instance,
+    ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER, ONE_HOT_LOWERING_REASON,
+};
 use crate::{
     coeff,
     constraint::{ConstraintID, Provenance, RemovedReason},
     linear,
     one_hot_constraint::OneHotConstraintID,
-    Constraint, Function, Linear,
+    Constraint, Function, Linear, VariableIDSet,
 };
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use std::collections::BTreeSet;
+
+/// Private one-shot plan for an exact checked inverse lowering.
+///
+/// OneHot lowering does not change the decision-variable space, so its
+/// assignment map is always the identity. All fallible proof and storage work
+/// is nevertheless applied to `staged`, matching the other family inverses.
+struct OneHotInversePlan {
+    staged: Instance,
+    assignment_map: AssignmentMap,
+}
+
+impl OneHotInversePlan {
+    fn commit(self, target: &mut Instance) -> AssignmentMap {
+        *target = self.staged;
+        self.assignment_map
+    }
+}
 
 impl Instance {
+    /// Restore one OneHot constraint that this Instance previously lowered,
+    /// after exact V1 content and context verification.
+    pub(super) fn restore_one_hot_from_lowering_checked(
+        &mut self,
+        id: OneHotConstraintID,
+        permitted_additions: &Capabilities,
+    ) -> Result<AssignmentMap> {
+        let plan = self.plan_one_hot_inverse(id, permitted_additions)?;
+        Ok(plan.commit(self))
+    }
+
+    fn plan_one_hot_inverse(
+        &self,
+        id: OneHotConstraintID,
+        permitted_additions: &Capabilities,
+    ) -> Result<OneHotInversePlan> {
+        if !permitted_additions.contains(&AdditionalCapability::OneHot) {
+            bail!(
+                "Restoring OneHot constraint {id:?} requires explicit OneHot capability permission"
+            );
+        }
+
+        let verified = crate::proof::verify_one_hot_v1(self, id)?;
+        debug_assert_eq!(verified.source_id(), id);
+        for &member in &verified.source().variables {
+            if !self.decision_variables.contains_key(&member) {
+                bail!(
+                    "Cannot restore OneHot constraint {id:?}: member {member:?} is not registered"
+                );
+            }
+            if self.decision_variable_dependency.get(&member).is_some() {
+                bail!(
+                    "Cannot restore OneHot constraint {id:?}: member {member:?} is a dependency target"
+                );
+            }
+            if self.fixed_decision_variable_values().contains_key(&member) {
+                bail!("Cannot restore OneHot constraint {id:?}: member {member:?} is fixed");
+            }
+        }
+
+        let generated_rows = BTreeSet::from([verified.generated_row()]);
+        let assignment_map =
+            AssignmentMap::identity(self.decision_variables.keys().copied().collect());
+        let mut staged = self.clone();
+        staged
+            .constraint_collection
+            .consume_active_rows(&generated_rows)?;
+        staged
+            .one_hot_constraint_collection
+            .restore_removed_row(id, verified.source().clone())?;
+        let staged_variable_ids = staged
+            .decision_variables
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>();
+        debug_assert_eq!(&staged_variable_ids, assignment_map.target_ids());
+        debug_assert!(staged.constraint_collection.validate_context_ids().is_ok());
+        debug_assert!(staged
+            .one_hot_constraint_collection
+            .validate_context_ids()
+            .is_ok());
+        debug_assert!(staged
+            .required_capabilities()
+            .contains(&AdditionalCapability::OneHot));
+
+        Ok(OneHotInversePlan {
+            staged,
+            assignment_map,
+        })
+    }
+
     #[cfg_attr(doc, katexit::katexit)]
     /// Convert a one-hot constraint to a regular equality constraint.
     ///
@@ -58,11 +150,14 @@ impl Instance {
         )?;
 
         let mut parameters = fnv::FnvHashMap::default();
-        parameters.insert("constraint_id".to_string(), new_id.into_inner().to_string());
+        parameters.insert(
+            ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER.to_string(),
+            new_id.into_inner().to_string(),
+        );
         self.one_hot_constraint_collection.relax(
             id,
             RemovedReason {
-                reason: "ommx.Instance.convert_one_hot_to_constraint".to_string(),
+                reason: ONE_HOT_LOWERING_REASON.to_string(),
                 parameters,
             },
         )?;
@@ -92,8 +187,8 @@ impl Instance {
 mod tests {
     use super::*;
     use crate::{
-        constraint::Equality, one_hot_constraint::OneHotConstraint, DecisionVariable, Sense,
-        VariableID,
+        constraint::Equality, one_hot_constraint::OneHotConstraint, DecisionVariable,
+        ModelingLabel, Sense, Sos1ConstraintID, VariableID,
     };
     use std::collections::{BTreeMap, BTreeSet};
 
@@ -208,5 +303,83 @@ mod tests {
         for id in new_ids {
             assert!(instance.constraints().contains_key(&id));
         }
+    }
+
+    #[test]
+    fn checked_inverse_restores_exact_one_hot_and_context() {
+        let id = OneHotConstraintID::from(7);
+        let mut instance = instance_with_one_one_hot();
+        instance
+            .set_one_hot_constraint_context(
+                id,
+                crate::ConstraintContext {
+                    label: ModelingLabel {
+                        name: Some("choose".to_string()),
+                        subscripts: vec![4],
+                        ..Default::default()
+                    },
+                    provenance: vec![Provenance::Sos1Constraint(Sos1ConstraintID::from(9))],
+                },
+            )
+            .unwrap();
+        let original = instance.clone();
+        let original_bytes = instance.to_v2_bytes();
+        instance.convert_one_hot_to_constraint(id).unwrap();
+        let lowered_ids = instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .collect::<crate::VariableIDSet>();
+
+        let map = instance
+            .restore_one_hot_from_lowering_checked(
+                id,
+                &Capabilities::from([AdditionalCapability::OneHot]),
+            )
+            .unwrap();
+
+        assert_eq!(instance, original);
+        assert_eq!(instance.to_v2_bytes(), original_bytes);
+        assert_eq!(map.source_ids(), &lowered_ids);
+        assert_eq!(map.target_ids(), &lowered_ids);
+        let state = crate::v1::State::from_iter([(1, 1.0), (2, 0.0)]);
+        assert_eq!(map.project_state(&state).unwrap(), state);
+        assert_eq!(map.lift_state(&state).unwrap(), state);
+    }
+
+    #[test]
+    fn checked_inverse_requires_permission_and_is_atomic_on_changed_row() {
+        let id = OneHotConstraintID::from(7);
+        let mut instance = instance_with_one_one_hot();
+        let generated = instance.convert_one_hot_to_constraint(id).unwrap();
+        let lowered = instance.clone();
+
+        let error = instance
+            .restore_one_hot_from_lowering_checked(id, &Capabilities::new())
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("explicit OneHot capability permission"));
+        assert_eq!(instance, lowered);
+
+        instance
+            .insert_constraint(
+                generated,
+                Constraint::equal_to_zero(Function::from(
+                    ((linear!(1) + linear!(2)).unwrap() + coeff!(-2.0)).unwrap(),
+                )),
+            )
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+        let error = instance
+            .restore_one_hot_from_lowering_checked(
+                id,
+                &Capabilities::from([AdditionalCapability::OneHot]),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("canonical V1 equality exactly"));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
     }
 }

--- a/rust/ommx/src/proof/linear.rs
+++ b/rust/ommx/src/proof/linear.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 mod activity;
 mod candidate;
 
-pub(crate) use candidate::{verify_indicator_big_m_v1, verify_sos1_big_m_v1};
+pub(crate) use candidate::{verify_indicator_big_m_v1, verify_one_hot_v1, verify_sos1_big_m_v1};
 
 const FINGERPRINT_DOMAIN: &[u8] = b"org.ommx.proof.linear-relaxation\0";
 const FINGERPRINT_VERSION: u32 = 1;

--- a/rust/ommx/src/proof/linear/candidate.rs
+++ b/rust/ommx/src/proof/linear/candidate.rs
@@ -1,14 +1,17 @@
 use super::{
-    ExactAffine, ExactRational, InequalityRef, LinearProofError, LinearRelaxationFingerprint,
+    EqualityRef, ExactAffine, ExactRational, InequalityRef, LinearProofError,
+    LinearRelaxationFingerprint,
 };
 use crate::{
-    constraint::{Provenance, RemovedReason},
+    constraint::{ConstraintContext, Provenance, RemovedReason},
     instance::{
-        GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON, SOS1_LOWERING_REASON,
+        GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON,
+        ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER, ONE_HOT_LOWERING_REASON, SOS1_LOWERING_REASON,
     },
     proof::exact::from_f64,
     Bound, ConstraintID, Equality, IndicatorConstraint, IndicatorConstraintID, Instance, Kind,
-    ModelingLabel, Sos1Constraint, Sos1ConstraintID, VariableID,
+    ModelingLabel, OneHotConstraint, OneHotConstraintID, Sos1Constraint, Sos1ConstraintID,
+    VariableID,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -19,6 +22,15 @@ use std::collections::{BTreeMap, BTreeSet};
 struct IndicatorBigMV1 {
     source: IndicatorConstraintID,
     generated_rows: Vec<ConstraintID>,
+    representation: LinearRelaxationFingerprint,
+}
+
+/// Untrusted, versioned lookup result for one historical OneHot lowering.
+/// The generated equality and transferred context remain to be verified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OneHotV1 {
+    source: OneHotConstraintID,
+    generated_row: ConstraintID,
     representation: LinearRelaxationFingerprint,
 }
 
@@ -59,6 +71,30 @@ impl VerifiedIndicatorBigMV1 {
     }
 }
 
+/// Exact, representation-bound fact that one retained removed OneHot
+/// constraint is represented by the current canonical V1 equality.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct VerifiedOneHotV1 {
+    source_id: OneHotConstraintID,
+    source: OneHotConstraint,
+    generated_row: ConstraintID,
+    representation: LinearRelaxationFingerprint,
+}
+
+impl VerifiedOneHotV1 {
+    pub(crate) fn source_id(&self) -> OneHotConstraintID {
+        self.source_id
+    }
+
+    pub(crate) fn source(&self) -> &OneHotConstraint {
+        &self.source
+    }
+
+    pub(crate) fn generated_row(&self) -> ConstraintID {
+        self.generated_row
+    }
+}
+
 /// Exact, representation-bound fact that the recorded regular rows are the
 /// complete current V1 lowering of one retained removed SOS1 constraint.
 ///
@@ -96,6 +132,8 @@ impl VerifiedSos1BigMV1 {
 enum InverseLoweringCandidateError {
     #[error("removed Indicator constraint {id:?} was not found")]
     MissingRemovedIndicator { id: IndicatorConstraintID },
+    #[error("removed OneHot constraint {id:?} was not found")]
+    MissingRemovedOneHot { id: OneHotConstraintID },
     #[error("removed SOS1 constraint {id:?} was not found")]
     MissingRemovedSos1 { id: Sos1ConstraintID },
     #[error("expected lowering reason {expected}, found {actual}")]
@@ -105,6 +143,10 @@ enum InverseLoweringCandidateError {
     },
     #[error("lowering reason is missing the {GENERATED_CONSTRAINT_IDS_PARAMETER} parameter")]
     MissingGeneratedConstraintIds,
+    #[error(
+        "lowering reason is missing the {ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER} parameter"
+    )]
+    MissingOneHotGeneratedConstraintId,
     #[error("lowering reason contains unsupported V1 parameter {key:?}")]
     UnexpectedRemovalParameter { key: String },
     #[error("generated constraint ID token {token:?} is not canonical u64 text")]
@@ -117,6 +159,8 @@ enum InverseLoweringCandidateError {
     ProvenanceMismatch { id: ConstraintID },
     #[error("generated regular constraint {id:?} has a modeling label that would be discarded")]
     GeneratedConstraintHasModelingLabel { id: ConstraintID },
+    #[error("generated regular constraint {id:?} does not have the exact transferred context")]
+    GeneratedConstraintContextMismatch { id: ConstraintID },
     #[error("active regular constraint {id:?} claims the lowering provenance but is not recorded")]
     UnrecordedGeneratedConstraint { id: ConstraintID },
     #[error(transparent)]
@@ -138,6 +182,34 @@ impl Instance {
         Ok(IndicatorBigMV1 {
             source: id,
             generated_rows,
+            representation,
+        })
+    }
+
+    fn one_hot_candidate_v1(
+        &self,
+        id: OneHotConstraintID,
+    ) -> Result<OneHotV1, InverseLoweringCandidateError> {
+        let (_, reason) = self
+            .removed_one_hot_constraints()
+            .get(&id)
+            .ok_or(InverseLoweringCandidateError::MissingRemovedOneHot { id })?;
+        let generated_row = parse_one_hot_constraint_id(reason)?;
+
+        // OneHot lowering transfers the source's complete modeling context to
+        // the regular row and appends exactly one lineage step. Unlike the
+        // Indicator/SOS1 lowerers, a non-default generated label is expected.
+        let mut expected_context = self.one_hot_constraint_context().collect_for(id);
+        let expected_provenance = Provenance::OneHotConstraint(id);
+        expected_context
+            .provenance
+            .push(expected_provenance.clone());
+        self.validate_one_hot_candidate_row(generated_row, &expected_context, expected_provenance)?;
+
+        let representation = self.certified_linear_relaxation()?.fingerprint();
+        Ok(OneHotV1 {
+            source: id,
+            generated_row,
             representation,
         })
     }
@@ -193,6 +265,107 @@ impl Instance {
         }
         Ok(())
     }
+
+    fn validate_one_hot_candidate_row(
+        &self,
+        generated_row: ConstraintID,
+        expected_context: &ConstraintContext,
+        expected_provenance: Provenance,
+    ) -> Result<(), InverseLoweringCandidateError> {
+        if !self.constraints().contains_key(&generated_row) {
+            return Err(InverseLoweringCandidateError::MissingGeneratedConstraint {
+                id: generated_row,
+            });
+        }
+        if self.constraint_context().collect_for(generated_row) != *expected_context {
+            return Err(
+                InverseLoweringCandidateError::GeneratedConstraintContextMismatch {
+                    id: generated_row,
+                },
+            );
+        }
+        for id in self.constraints().keys() {
+            if *id != generated_row
+                && self
+                    .constraint_context()
+                    .provenance(*id)
+                    .contains(&expected_provenance)
+            {
+                return Err(
+                    InverseLoweringCandidateError::UnrecordedGeneratedConstraint { id: *id },
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Verify the complete current V1 OneHot lowering exactly.
+///
+/// The single generated row must be the canonical equality
+/// `sum(member) - 1 = 0`, every member must retain a binary domain, and the
+/// row's context must be the exact source context plus the lowering lineage
+/// step. Scalar multiples are deliberately rejected: this verifier consumes a
+/// current OMMX history rather than recognizing arbitrary flat models.
+pub(crate) fn verify_one_hot_v1(
+    instance: &Instance,
+    id: OneHotConstraintID,
+) -> crate::Result<VerifiedOneHotV1> {
+    let candidate = instance.one_hot_candidate_v1(id)?;
+    let snapshot = instance.certified_linear_relaxation()?;
+    if candidate.representation != snapshot.fingerprint() {
+        crate::bail!(
+            { ?id },
+            "OneHot inverse-lowering candidate {id:?} is bound to a stale representation"
+        );
+    }
+
+    let (source, _) = instance
+        .removed_one_hot_constraints()
+        .get(&id)
+        .expect("candidate lookup proved that the removed source exists");
+    if source.variables.is_empty() {
+        crate::bail!({ ?id }, "Removed OneHot constraint {id:?} has no members");
+    }
+    for &member in &source.variables {
+        let Some(variable) = instance.decision_variables().get(&member) else {
+            crate::bail!(
+                { ?id, ?member },
+                "OneHot member {member:?} is not registered"
+            );
+        };
+        if variable.kind() != Kind::Binary {
+            crate::bail!(
+                { ?id, ?member, kind = ?variable.kind() },
+                "OneHot member {member:?} is not binary"
+            );
+        }
+    }
+
+    let actual = snapshot.equality(EqualityRef::RegularConstraint(candidate.generated_row))?;
+    let one = ExactRational::from_integer(1.into());
+    let expected = ExactAffine {
+        coefficients: source
+            .variables
+            .iter()
+            .copied()
+            .map(|member| (member, one.clone()))
+            .collect(),
+        constant: ExactRational::from_integer((-1).into()),
+    };
+    if actual != expected {
+        crate::bail!(
+            { ?id, row_id = ?candidate.generated_row },
+            "Generated OneHot row does not match the canonical V1 equality exactly"
+        );
+    }
+
+    Ok(VerifiedOneHotV1 {
+        source_id: candidate.source,
+        source: source.clone(),
+        generated_row: candidate.generated_row,
+        representation: candidate.representation,
+    })
 }
 
 /// Verify the current V1 Indicator Big-M history exactly.
@@ -560,6 +733,42 @@ fn equality_roles_cover(roles: &[(bool, bool)], upper_implied: bool, lower_impli
     false
 }
 
+fn parse_one_hot_constraint_id(
+    reason: &RemovedReason,
+) -> Result<ConstraintID, InverseLoweringCandidateError> {
+    if reason.reason != ONE_HOT_LOWERING_REASON {
+        return Err(InverseLoweringCandidateError::UnexpectedRemovalReason {
+            expected: ONE_HOT_LOWERING_REASON,
+            actual: reason.reason.clone(),
+        });
+    }
+    if let Some(key) = reason
+        .parameters
+        .keys()
+        .filter(|key| key.as_str() != ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER)
+        .min()
+    {
+        return Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { key: key.clone() });
+    }
+    let token = reason
+        .parameters
+        .get(ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER)
+        .ok_or(InverseLoweringCandidateError::MissingOneHotGeneratedConstraintId)?;
+    let value = token.parse::<u64>().map_err(|_| {
+        InverseLoweringCandidateError::InvalidGeneratedConstraintId {
+            token: token.clone(),
+        }
+    })?;
+    if token != &value.to_string() {
+        return Err(
+            InverseLoweringCandidateError::InvalidGeneratedConstraintId {
+                token: token.clone(),
+            },
+        );
+    }
+    Ok(ConstraintID::from(value))
+}
+
 fn parse_generated_constraint_ids(
     reason: &RemovedReason,
     expected_reason: &'static str,
@@ -615,8 +824,8 @@ mod tests {
     use super::*;
     use crate::{
         coeff, linear, Bound, Constraint, ConstraintContextStore, DecisionVariable, Equality,
-        Function, IndicatorConstraint, Kind, ModelingLabel, Sense, Sos1Constraint, VariableID,
-        VariableLabelStore,
+        Function, IndicatorConstraint, Kind, ModelingLabel, OneHotConstraint, Sense,
+        Sos1Constraint, VariableID, VariableLabelStore,
     };
     use fnv::FnvHashMap;
     use std::collections::{BTreeMap, BTreeSet};
@@ -683,6 +892,139 @@ mod tests {
             )]))
             .build()
             .unwrap()
+    }
+
+    fn current_one_hot_history() -> (Instance, ConstraintID) {
+        let one_hot_id = OneHotConstraintID::from(7);
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), DecisionVariable::binary()),
+                (VariableID::from(2), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .one_hot_constraints(BTreeMap::from([(
+                one_hot_id,
+                OneHotConstraint::new(BTreeSet::from([VariableID::from(1), VariableID::from(2)]))
+                    .unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        instance
+            .set_one_hot_constraint_context(
+                one_hot_id,
+                ConstraintContext {
+                    label: ModelingLabel {
+                        name: Some("choose".to_string()),
+                        ..Default::default()
+                    },
+                    provenance: vec![Provenance::Sos1Constraint(Sos1ConstraintID::from(3))],
+                },
+            )
+            .unwrap();
+        let generated = instance.convert_one_hot_to_constraint(one_hot_id).unwrap();
+        (instance, generated)
+    }
+
+    #[test]
+    fn verifies_current_one_hot_lowering_with_exact_transferred_context() {
+        let (instance, generated) = current_one_hot_history();
+        let candidate = instance
+            .one_hot_candidate_v1(OneHotConstraintID::from(7))
+            .unwrap();
+        assert_eq!(candidate.source, OneHotConstraintID::from(7));
+        assert_eq!(candidate.generated_row, generated);
+
+        let verified = verify_one_hot_v1(&instance, OneHotConstraintID::from(7)).unwrap();
+        assert_eq!(verified.source_id(), OneHotConstraintID::from(7));
+        assert_eq!(verified.generated_row(), generated);
+        assert_eq!(
+            verified.source().variables,
+            BTreeSet::from([VariableID::from(1), VariableID::from(2)])
+        );
+    }
+
+    #[test]
+    fn rejects_one_hot_scalar_multiple_and_context_edits() {
+        let (instance, generated) = current_one_hot_history();
+
+        let mut scaled = instance.clone();
+        scaled
+            .insert_constraint(
+                generated,
+                Constraint::equal_to_zero(Function::from(
+                    (((coeff!(2.0) * linear!(1)).unwrap() + (coeff!(2.0) * linear!(2)).unwrap())
+                        .unwrap()
+                        + coeff!(-2.0))
+                    .unwrap(),
+                )),
+            )
+            .unwrap();
+        let error = verify_one_hot_v1(&scaled, OneHotConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains("canonical V1 equality exactly"));
+
+        let mut relabeled = instance;
+        let mut context = relabeled.constraint_context().collect_for(generated);
+        context.label.name = Some("presolver-edited".to_string());
+        relabeled
+            .set_constraint_context(generated, context)
+            .unwrap();
+        let error = verify_one_hot_v1(&relabeled, OneHotConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains("exact transferred context"));
+    }
+
+    #[test]
+    fn rejects_unrecorded_one_hot_provenance_and_malformed_parameters() {
+        let (mut instance, _) = current_one_hot_history();
+        let extra = instance
+            .add_constraint(
+                Constraint::equal_to_zero(Function::zero()),
+                ConstraintContext {
+                    label: Default::default(),
+                    provenance: vec![Provenance::OneHotConstraint(OneHotConstraintID::from(7))],
+                },
+            )
+            .unwrap();
+        let error = verify_one_hot_v1(&instance, OneHotConstraintID::from(7)).unwrap_err();
+        assert!(error.to_string().contains(&format!("{extra:?}")));
+        assert!(error.to_string().contains("not recorded"));
+
+        let missing = RemovedReason {
+            reason: ONE_HOT_LOWERING_REASON.to_string(),
+            parameters: FnvHashMap::default(),
+        };
+        assert!(matches!(
+            parse_one_hot_constraint_id(&missing),
+            Err(InverseLoweringCandidateError::MissingOneHotGeneratedConstraintId)
+        ));
+        for token in ["01", "1,2", "-1"] {
+            let reason = RemovedReason {
+                reason: ONE_HOT_LOWERING_REASON.to_string(),
+                parameters: FnvHashMap::from_iter([(
+                    ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER.to_string(),
+                    token.to_string(),
+                )]),
+            };
+            assert!(matches!(
+                parse_one_hot_constraint_id(&reason),
+                Err(InverseLoweringCandidateError::InvalidGeneratedConstraintId { .. })
+            ));
+        }
+        let extra_parameter = RemovedReason {
+            reason: ONE_HOT_LOWERING_REASON.to_string(),
+            parameters: FnvHashMap::from_iter([
+                (
+                    ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER.to_string(),
+                    "1".to_string(),
+                ),
+                ("future".to_string(), "value".to_string()),
+            ]),
+        };
+        assert!(matches!(
+            parse_one_hot_constraint_id(&extra_parameter),
+            Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { .. })
+        ));
     }
 
     #[test]

--- a/rust/ommx/src/proof/mod.rs
+++ b/rust/ommx/src/proof/mod.rs
@@ -13,4 +13,4 @@
 mod exact;
 mod linear;
 
-pub(crate) use linear::{verify_indicator_big_m_v1, verify_sos1_big_m_v1};
+pub(crate) use linear::{verify_indicator_big_m_v1, verify_one_hot_v1, verify_sos1_big_m_v1};


### PR DESCRIPTION
Stacked on #1066.

## Summary

- reconstruct the exact current OneHot lowering history from its retained source, generated equality, and transferred context
- require the canonical `sum(x) - 1 = 0` row over registered binary members, rejecting scalar multiples and modified lineage
- restore the OneHot constraint on a staged root with an identity assignment map
- extend the private bulk coordinator to reverse all three capability lowerings in `SOS1 -> OneHot -> Indicator` order

This remains a crate-private history inverse. It does not introduce flat-model recognition, a public promotion API, or a durable transformation receipt.
