### PR TITLE
Add public capability recovery API

### DIFF
--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -573,6 +573,33 @@ Append user-visible updates within the 3.0 release line here. Each entry should
 describe only what changed since the previous 3.0.x release; broader redesigns
 should start a new minor-line page such as `3.1.md`.
 
+### Proof-checked recovery after capability reduction ([#1068](https://github.com/Jij-Inc/ommx/pull/1068))
+
+[`Instance::reduce_capabilities_with_recovery`](crate::Instance::reduce_capabilities_with_recovery)
+converts unsupported Indicator, OneHot, and SOS1 constraints for an external
+pass while returning an opaque [`CapabilityReduction`](crate::CapabilityReduction)
+handle for exactly that lowering batch. After the pass,
+[`Instance::recover_capability_reduction`](crate::Instance::recover_capability_reduction)
+re-verifies each generated representation against the current `Instance` and
+restores only the sources whose exact lowering proof still holds.
+
+```rust,ignore
+let reduction = instance.reduce_capabilities_with_recovery(&Capabilities::new())?;
+external_presolve(&mut instance)?;
+let recovery = instance.recover_capability_reduction(reduction)?;
+
+for skipped in recovery.skipped() {
+    eprintln!("kept {:?} lowered: {}", skipped.constraint_id(), skipped.reason());
+}
+```
+
+The handle is runtime-only and is an untrusted candidate locator, not a
+certificate or serialized receipt. Recovery is best effort for candidates
+changed by the external pass, but operation-level failures leave the whole
+`Instance` unchanged. [`CapabilityRecovery`](crate::CapabilityRecovery) also
+provides exact `project_state` and `lift_state` transforms for complete finite
+raw states that cross the recovery boundary.
+
 ### Experiment Sampling records ([#1055](https://github.com/Jij-Inc/ommx/pull/1055))
 
 [`Run::log_finished_sample`](crate::experiment::Run::log_finished_sample) and

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -417,6 +417,32 @@ impl<T: ConstraintType> ConstraintCollection<T> {
         &self.removed
     }
 
+    /// Add one parent-owned metadata parameter to an existing removal reason.
+    ///
+    /// This is a narrow storage operation for root-level transformations that
+    /// need to bind a just-removed row to runtime metadata. The collection
+    /// validates lifecycle membership and refuses to overwrite an existing
+    /// parameter; interpretation of the key and value remains the enclosing
+    /// root object's responsibility.
+    pub(crate) fn add_removed_reason_parameter(
+        &mut self,
+        id: T::ID,
+        key: &'static str,
+        value: String,
+    ) -> crate::Result<()> {
+        let Some((_, reason)) = self.removed.get_mut(&id) else {
+            crate::bail!({ ?id }, "Removed constraint with ID {id:?} not found");
+        };
+        if reason.parameters.contains_key(key) {
+            crate::bail!(
+                { ?id, key },
+                "Removal reason for constraint {id:?} already contains parameter {key:?}",
+            );
+        }
+        reason.parameters.insert(key.to_string(), value);
+        Ok(())
+    }
+
     /// Return whether `id` belongs to either active or removed constraints.
     fn contains_id(&self, id: T::ID) -> bool {
         self.active.contains_key(&id) || self.removed.contains_key(&id)

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -33,6 +33,9 @@ mod unary_encode;
 pub use analysis::*;
 pub use arbitrary::{InstanceParameters, InstanceSpace};
 pub use builder::*;
+pub use inverse_lowering::{
+    CapabilityRecovery, CapabilityReduction, LoweredConstraintID, SkippedLowering,
+};
 pub use parametric_builder::*;
 pub use stats::*;
 
@@ -52,6 +55,8 @@ use crate::{
 use std::collections::{BTreeMap, HashMap};
 
 pub(crate) const GENERATED_CONSTRAINT_IDS_PARAMETER: &str = "constraint_ids";
+pub(crate) const CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER: &str =
+    "ommx.capability_reduction_batch_token";
 pub(crate) const INDICATOR_LOWERING_REASON: &str = "ommx.Instance.convert_indicator_to_constraint";
 pub(crate) const ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER: &str = "constraint_id";
 pub(crate) const ONE_HOT_LOWERING_REASON: &str = "ommx.Instance.convert_one_hot_to_constraint";

--- a/rust/ommx/src/instance/indicator.rs
+++ b/rust/ommx/src/instance/indicator.rs
@@ -1,6 +1,6 @@
 use super::{
-    reduction::AssignmentMap, AdditionalCapability, Capabilities, Instance,
-    GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON,
+    inverse_lowering::InverseLoweringError, reduction::AssignmentMap, AdditionalCapability,
+    Capabilities, Instance, GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON,
 };
 use crate::{
     constraint::{ConstraintContext, ConstraintID, Equality, Provenance, RemovedReason},
@@ -45,7 +45,7 @@ impl Instance {
         &mut self,
         id: IndicatorConstraintID,
         permitted_additions: &Capabilities,
-    ) -> Result<AssignmentMap> {
+    ) -> std::result::Result<AssignmentMap, InverseLoweringError> {
         let plan = self.plan_indicator_inverse(id, permitted_additions)?;
         Ok(plan.commit(self))
     }
@@ -54,37 +54,38 @@ impl Instance {
         &self,
         id: IndicatorConstraintID,
         permitted_additions: &Capabilities,
-    ) -> Result<IndicatorInversePlan> {
+    ) -> std::result::Result<IndicatorInversePlan, InverseLoweringError> {
         if !permitted_additions.contains(&AdditionalCapability::Indicator) {
-            bail!(
+            return Err(InverseLoweringError::operation_message(format!(
                 "Restoring Indicator constraint {id:?} requires explicit Indicator capability permission"
-            );
+            )));
         }
 
-        let verified = crate::proof::verify_indicator_big_m_v1(self, id)?;
+        let verified = crate::proof::verify_indicator_big_m_v1(self, id)
+            .map_err(InverseLoweringError::not_recoverable)?;
         debug_assert_eq!(verified.source_id(), id);
         for variable_id in verified.source().required_ids() {
             if !self.decision_variables.contains_key(&variable_id) {
-                bail!(
+                return Err(InverseLoweringError::not_recoverable_message(format!(
                     "Cannot restore Indicator constraint {id:?}: variable {variable_id:?} is not registered"
-                );
+                )));
             }
             if self
                 .decision_variable_dependency
                 .get(&variable_id)
                 .is_some()
             {
-                bail!(
+                return Err(InverseLoweringError::not_recoverable_message(format!(
                     "Cannot restore Indicator constraint {id:?}: variable {variable_id:?} is a dependency target"
-                );
+                )));
             }
             if self
                 .fixed_decision_variable_values()
                 .contains_key(&variable_id)
             {
-                bail!(
+                return Err(InverseLoweringError::not_recoverable_message(format!(
                     "Cannot restore Indicator constraint {id:?}: variable {variable_id:?} is fixed"
-                );
+                )));
             }
         }
 
@@ -94,10 +95,12 @@ impl Instance {
         let mut staged = self.clone();
         staged
             .constraint_collection
-            .consume_active_rows(&generated_rows)?;
+            .consume_active_rows(&generated_rows)
+            .map_err(InverseLoweringError::operation)?;
         staged
             .indicator_constraint_collection
-            .restore_removed_row(id, verified.source().clone())?;
+            .restore_removed_row(id, verified.source().clone())
+            .map_err(InverseLoweringError::operation)?;
         debug_assert!(staged.constraint_collection.validate_context_ids().is_ok());
         debug_assert!(staged
             .indicator_constraint_collection

--- a/rust/ommx/src/instance/inverse_lowering.rs
+++ b/rust/ommx/src/instance/inverse_lowering.rs
@@ -1,8 +1,9 @@
-//! Crate-private end-to-end coordination for checked inverse lowering.
+//! Proof-checked recovery of capability reductions.
 //!
-//! The generic SDK surface remains deliberately unfrozen. This module proves
-//! that the family-specific Indicator, OneHot, and SOS1 consumers compose at the root
-//! `Instance` boundary without making the result/map vocabulary public.
+//! The public surface exposes only an opaque, runtime-only handle for one
+//! capability-reduction call and the report/state transform produced by
+//! recovering that handle. Family-specific proof objects, mutation plans, and
+//! assignment-map representation remain private implementation details.
 //! General lifecycle reactivation such as `restore_indicator_constraint`
 //! remains a distinct, potentially semantics-changing operation and is not an
 //! alias for this proof-preserving inverse.
@@ -11,9 +12,340 @@
 
 use super::{
     reduction::AssignmentMap, AdditionalCapability, Capabilities, Instance,
-    INDICATOR_LOWERING_REASON, ONE_HOT_LOWERING_REASON, SOS1_LOWERING_REASON,
+    CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER, INDICATOR_LOWERING_REASON, ONE_HOT_LOWERING_REASON,
+    SOS1_LOWERING_REASON,
 };
-use crate::{v1, VariableIDSet};
+use crate::{v1, IndicatorConstraintID, OneHotConstraintID, Sos1ConstraintID, VariableIDSet};
+use std::fmt;
+use uuid::Uuid;
+
+/// The source ID of one special constraint lowered by a capability reduction.
+///
+/// IDs of different special-constraint families occupy distinct namespaces;
+/// the enum preserves that family information without exposing any lowering
+/// history, generated-row ID, proof object, or mutation plan.
+///
+/// Values returned by [`CapabilityReduction::lowered_constraints`] appear in
+/// the exact order in which OMMX lowered them: Indicator IDs in ascending
+/// order, followed by OneHot IDs in ascending order, followed by SOS1 IDs in
+/// ascending order.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LoweredConstraintID {
+    /// An Indicator constraint source.
+    Indicator(IndicatorConstraintID),
+    /// A OneHot constraint source.
+    OneHot(OneHotConstraintID),
+    /// A SOS1 constraint source.
+    Sos1(Sos1ConstraintID),
+}
+
+impl LoweredConstraintID {
+    /// Return the special-constraint capability represented by this source ID.
+    pub fn capability(self) -> AdditionalCapability {
+        match self {
+            Self::Indicator(_) => AdditionalCapability::Indicator,
+            Self::OneHot(_) => AdditionalCapability::OneHot,
+            Self::Sos1(_) => AdditionalCapability::Sos1,
+        }
+    }
+}
+
+/// Runtime handle for exactly one call to
+/// [`Instance::reduce_capabilities_with_recovery`].
+///
+/// This is an untrusted candidate locator, not a certificate. It records only
+/// the exact special-constraint source IDs lowered by that call and their
+/// lowering order. [`Instance::recover_capability_reduction`] consumes the
+/// handle and re-verifies every candidate against the current
+/// `Instance`, including its removal reason, generated rows, provenance,
+/// exact row content, and variable-use invariants.
+///
+/// The handle is intentionally runtime-only: it is not cloneable or
+/// serializable and has no public constructor. A future durable receipt is a
+/// separate versioned format rather than a serialization of this type.
+#[must_use = "retain this handle to recover exactly this capability-reduction batch"]
+#[derive(Debug)]
+pub struct CapabilityReduction {
+    batch_token: Uuid,
+    converted_capabilities: Capabilities,
+    lowered_constraints: Vec<LoweredConstraintID>,
+}
+
+impl CapabilityReduction {
+    /// Capabilities that this reduction converted to regular constraints.
+    pub fn converted_capabilities(&self) -> &Capabilities {
+        &self.converted_capabilities
+    }
+
+    /// Exact source IDs lowered by this call, in actual lowering order.
+    ///
+    /// Pre-existing removed constraints are never included.
+    pub fn lowered_constraints(&self) -> &[LoweredConstraintID] {
+        &self.lowered_constraints
+    }
+
+    /// Return whether this reduction lowered no special constraints.
+    pub fn is_empty(&self) -> bool {
+        self.lowered_constraints.is_empty()
+    }
+}
+
+/// A tracked lowering that could not be proved recoverable from the current
+/// `Instance`.
+///
+/// Skipping is a normal best-effort outcome after presolve: the presolver may
+/// have removed a generated row, changed its exact content, fixed or
+/// substituted a source variable, or introduced another use of a private SOS1
+/// selector. The original lowered representation is left untouched for this
+/// source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedLowering {
+    constraint_id: LoweredConstraintID,
+    reason: String,
+}
+
+impl SkippedLowering {
+    /// Source ID that was not recovered.
+    pub fn constraint_id(&self) -> LoweredConstraintID {
+        self.constraint_id
+    }
+
+    /// Human-readable verifier diagnostic.
+    ///
+    /// This text is intended for logging and inspection, not stable
+    /// machine-readable branching.
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+/// Result of best-effort recovery for one [`CapabilityReduction`].
+///
+/// The result owns the exact raw-state transform between the `Instance`
+/// immediately before and after recovery. Its representation is intentionally
+/// opaque so callers cannot construct or compose unchecked mutation plans.
+/// Candidate reports retain the original lowering order even though recovery
+/// itself is attempted in reverse order.
+///
+/// State transformation requires a complete finite [`v1::State`] whose keys
+/// exactly match the corresponding variable-ID set. The transform is exact
+/// mathematical bookkeeping, not a tolerance-based feasibility classifier.
+#[must_use = "inspect skipped lowerings and retain the state transform when solutions cross this reduction boundary"]
+#[derive(Debug)]
+pub struct CapabilityRecovery {
+    restored_capabilities: Capabilities,
+    recovered: Vec<LoweredConstraintID>,
+    skipped: Vec<SkippedLowering>,
+    assignment_map: AssignmentMap,
+}
+
+impl CapabilityRecovery {
+    /// Capabilities for which at least one source was recovered.
+    ///
+    /// Use [`Self::recovered`] and [`Self::skipped`] when individual source
+    /// completeness matters.
+    pub fn restored_capabilities(&self) -> &Capabilities {
+        &self.restored_capabilities
+    }
+
+    /// Sources recovered successfully, in their original lowering order.
+    pub fn recovered(&self) -> &[LoweredConstraintID] {
+        &self.recovered
+    }
+
+    /// Tracked sources that did not pass batch or current-content verification.
+    pub fn skipped(&self) -> &[SkippedLowering] {
+        &self.skipped
+    }
+
+    /// Complete variable-ID set immediately before recovery.
+    pub fn before_variable_ids(&self) -> &VariableIDSet {
+        self.assignment_map.source_ids()
+    }
+
+    /// Complete variable-ID set immediately after recovery.
+    pub fn after_variable_ids(&self) -> &VariableIDSet {
+        self.assignment_map.target_ids()
+    }
+
+    /// Project a complete finite state of the pre-recovery lowered `Instance`
+    /// to the post-recovery `Instance`.
+    pub fn project_state(&self, before: &v1::State) -> crate::Result<v1::State> {
+        Ok(self.assignment_map.project_state(before)?)
+    }
+
+    /// Lift a complete finite state of the post-recovery `Instance` to the
+    /// pre-recovery lowered `Instance`.
+    ///
+    /// Fresh SOS1 selectors use mathematical exact zero: a selector is zero
+    /// exactly when its member value equals `0.0`. This does not promise
+    /// preservation of every tolerance-based `Evaluate(ATol)` classification.
+    pub fn lift_state(&self, after: &v1::State) -> crate::Result<v1::State> {
+        Ok(self.assignment_map.lift_state(after)?)
+    }
+}
+
+fn lowering_sources(instance: &Instance, supported: &Capabilities) -> Vec<LoweredConstraintID> {
+    let mut sources = Vec::new();
+    if !supported.contains(&AdditionalCapability::Indicator) {
+        sources.extend(
+            instance
+                .indicator_constraints()
+                .keys()
+                .copied()
+                .map(LoweredConstraintID::Indicator),
+        );
+    }
+    if !supported.contains(&AdditionalCapability::OneHot) {
+        sources.extend(
+            instance
+                .one_hot_constraints()
+                .keys()
+                .copied()
+                .map(LoweredConstraintID::OneHot),
+        );
+    }
+    if !supported.contains(&AdditionalCapability::Sos1) {
+        sources.extend(
+            instance
+                .sos1_constraints()
+                .keys()
+                .copied()
+                .map(LoweredConstraintID::Sos1),
+        );
+    }
+    sources
+}
+
+fn bind_lowered_sources_to_batch(
+    instance: &mut Instance,
+    sources: &[LoweredConstraintID],
+    batch_token: Uuid,
+) -> crate::Result<()> {
+    let value = batch_token.hyphenated().to_string();
+    for source in sources {
+        match *source {
+            LoweredConstraintID::Indicator(id) => instance
+                .indicator_constraint_collection
+                .add_removed_reason_parameter(
+                    id,
+                    CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER,
+                    value.clone(),
+                )?,
+            LoweredConstraintID::OneHot(id) => instance
+                .one_hot_constraint_collection
+                .add_removed_reason_parameter(
+                    id,
+                    CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER,
+                    value.clone(),
+                )?,
+            LoweredConstraintID::Sos1(id) => instance
+                .sos1_constraint_collection
+                .add_removed_reason_parameter(
+                    id,
+                    CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER,
+                    value.clone(),
+                )?,
+        }
+    }
+    Ok(())
+}
+
+fn verify_source_batch(
+    instance: &Instance,
+    source: LoweredConstraintID,
+    expected_batch_token: Uuid,
+) -> Result<(), InverseLoweringError> {
+    let reason = match source {
+        LoweredConstraintID::Indicator(id) => instance
+            .removed_indicator_constraints()
+            .get(&id)
+            .map(|(_, reason)| reason),
+        LoweredConstraintID::OneHot(id) => instance
+            .removed_one_hot_constraints()
+            .get(&id)
+            .map(|(_, reason)| reason),
+        LoweredConstraintID::Sos1(id) => instance
+            .removed_sos1_constraints()
+            .get(&id)
+            .map(|(_, reason)| reason),
+    }
+    .ok_or_else(|| {
+        InverseLoweringError::not_recoverable_message(format!(
+            "Removed lowering source {source:?} was not found"
+        ))
+    })?;
+    let token = reason
+        .parameters
+        .get(CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER)
+        .ok_or_else(|| {
+            InverseLoweringError::not_recoverable_message(format!(
+                "Removed lowering source {source:?} is not bound to a capability-reduction batch"
+            ))
+        })?;
+    let actual_batch_token = Uuid::parse_str(token).map_err(|_| {
+        InverseLoweringError::not_recoverable_message(format!(
+            "Removed lowering source {source:?} has non-canonical capability-reduction batch token {token:?}"
+        ))
+    })?;
+    if token != &actual_batch_token.hyphenated().to_string() {
+        return Err(InverseLoweringError::not_recoverable_message(format!(
+            "Removed lowering source {source:?} has non-canonical capability-reduction batch token {token:?}"
+        )));
+    }
+    if actual_batch_token != expected_batch_token {
+        return Err(InverseLoweringError::not_recoverable_message(format!(
+            "Removed lowering source {source:?} belongs to capability-reduction batch {actual_batch_token}, not handle batch {expected_batch_token}"
+        )));
+    }
+    Ok(())
+}
+
+/// Internal outcome boundary for one checked inverse-lowering attempt.
+///
+/// Candidate, lifecycle, and selector-isolation rejection is an expected
+/// best-effort outcome. Storage, assignment-map, and coordinator failures are
+/// operation errors and must abort the root-owned atomic batch.
+#[derive(Debug)]
+pub(super) enum InverseLoweringError {
+    NotRecoverable(crate::Error),
+    Operation(crate::Error),
+}
+
+impl InverseLoweringError {
+    pub(super) fn not_recoverable(error: impl Into<crate::Error>) -> Self {
+        Self::NotRecoverable(error.into())
+    }
+
+    pub(super) fn not_recoverable_message(message: impl Into<String>) -> Self {
+        Self::NotRecoverable(crate::Error::msg(message.into()))
+    }
+
+    pub(super) fn operation(error: impl Into<crate::Error>) -> Self {
+        Self::Operation(error.into())
+    }
+
+    pub(super) fn operation_message(message: impl Into<String>) -> Self {
+        Self::Operation(crate::Error::msg(message.into()))
+    }
+}
+
+impl fmt::Display for InverseLoweringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotRecoverable(error) | Self::Operation(error) => write!(f, "{error:#}"),
+        }
+    }
+}
+
+impl std::error::Error for InverseLoweringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NotRecoverable(error) | Self::Operation(error) => Some(error.as_ref()),
+        }
+    }
+}
 
 /// Result of one checked, root-owned inverse-lowering batch.
 ///
@@ -57,6 +389,129 @@ impl InverseLoweringResult {
 }
 
 impl Instance {
+    /// Convert unsupported special constraints while retaining a one-shot
+    /// handle for proof-checked recovery after an external transformation.
+    ///
+    /// The conversion rule and deterministic order are the same as
+    /// [`Self::reduce_capabilities`]. Unlike that legacy method, this operation
+    /// is atomic across capability families: all conversions are applied to a
+    /// staged clone and the receiver is replaced only after every requested
+    /// lowering succeeds. On error, `self` is byte-for-byte unchanged and no
+    /// incomplete recovery handle is produced.
+    ///
+    /// The returned [`CapabilityReduction`] contains exactly the active source
+    /// IDs lowered by this call. It does not scan or adopt pre-existing removed
+    /// histories. Retain the handle while a presolver or other external pass
+    /// operates on the lowered `Instance`, then pass it to
+    /// [`Self::recover_capability_reduction`].
+    ///
+    /// The handle is not evidence that recovery remains valid. Every source is
+    /// treated as untrusted and re-verified against the post-pass `Instance`.
+    #[tracing::instrument(skip_all)]
+    pub fn reduce_capabilities_with_recovery(
+        &mut self,
+        supported: &Capabilities,
+    ) -> crate::Result<CapabilityReduction> {
+        let batch_token = Uuid::new_v4();
+        let lowered_constraints = lowering_sources(self, supported);
+        let mut staged = self.clone();
+        let converted_capabilities = staged.reduce_capabilities(supported)?;
+        bind_lowered_sources_to_batch(&mut staged, &lowered_constraints, batch_token)?;
+        debug_assert_eq!(
+            converted_capabilities,
+            lowered_constraints
+                .iter()
+                .map(|source| source.capability())
+                .collect()
+        );
+        *self = staged;
+        Ok(CapabilityReduction {
+            batch_token,
+            converted_capabilities,
+            lowered_constraints,
+        })
+    }
+
+    /// Best-effort recovery of exactly one capability-reduction batch.
+    ///
+    /// `reduction` must be the runtime handle returned by
+    /// [`Self::reduce_capabilities_with_recovery`]. It is consumed so one batch
+    /// is not accidentally recovered repeatedly. Every source in the handle is
+    /// attempted; its converted capabilities are the explicit permission to
+    /// add those semantic capabilities to the current `Instance`.
+    ///
+    /// Sources are attempted in the reverse of their actual lowering order.
+    /// Each source's globally unique batch token is matched before its current
+    /// content is re-verified. A source that belongs to another reduction batch
+    /// or that a presolver changed is reported through
+    /// [`CapabilityRecovery::skipped`], and its lowered representation remains
+    /// untouched. No unrelated removed history is inspected or recovered.
+    ///
+    /// Successful source plans and their state maps are composed on one staged
+    /// clone, then committed to `self` once. Candidate rejection is a normal
+    /// successful result. An operation-level error, such as an internal map
+    /// composition inconsistency, leaves `self` byte-for-byte unchanged.
+    pub fn recover_capability_reduction(
+        &mut self,
+        reduction: CapabilityReduction,
+    ) -> crate::Result<CapabilityRecovery> {
+        let CapabilityReduction {
+            batch_token,
+            converted_capabilities,
+            lowered_constraints,
+        } = reduction;
+        let mut assignment_map =
+            AssignmentMap::identity(self.decision_variables.keys().copied().collect());
+        let mut staged = self.clone();
+        let mut restored_capabilities = Capabilities::new();
+        let mut recovered = Vec::new();
+        let mut skipped = Vec::new();
+
+        for source in lowered_constraints.into_iter().rev() {
+            let step =
+                verify_source_batch(&staged, source, batch_token).and_then(|()| match source {
+                    LoweredConstraintID::Indicator(id) => {
+                        staged.restore_indicator_from_lowering_checked(id, &converted_capabilities)
+                    }
+                    LoweredConstraintID::OneHot(id) => {
+                        staged.restore_one_hot_from_lowering_checked(id, &converted_capabilities)
+                    }
+                    LoweredConstraintID::Sos1(id) => {
+                        staged.restore_sos1_from_lowering_checked(id, &converted_capabilities)
+                    }
+                });
+            match step {
+                Ok(step) => {
+                    assignment_map = assignment_map.then(step)?;
+                    restored_capabilities.insert(source.capability());
+                    recovered.push(source);
+                }
+                Err(InverseLoweringError::NotRecoverable(error)) => skipped.push(SkippedLowering {
+                    constraint_id: source,
+                    reason: format!("{error:#}"),
+                }),
+                Err(InverseLoweringError::Operation(error)) => return Err(error),
+            }
+        }
+
+        recovered.reverse();
+        skipped.reverse();
+        let staged_variable_ids = staged
+            .decision_variables
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>();
+        debug_assert_eq!(assignment_map.target_ids(), &staged_variable_ids);
+        *self = staged;
+
+        Ok(CapabilityRecovery {
+            restored_capabilities,
+            recovered,
+            skipped,
+            assignment_map,
+        })
+    }
+
     /// Restore every current OMMX V1 Indicator/OneHot/SOS1 lowering history in the
     /// requested families, or leave the Instance entirely unchanged.
     ///
@@ -629,6 +1084,544 @@ mod tests {
 
         assert!(error.to_string().contains(&format!("{extra_id:?}")));
         assert!(error.to_string().contains("not recorded"));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+    }
+
+    fn two_one_hot_instance() -> Instance {
+        let members = BTreeSet::from([VariableID::from(0), VariableID::from(1)]);
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::binary(),
+                VariableID::from(1) => DecisionVariable::binary(),
+            })
+            .constraints(BTreeMap::new())
+            .one_hot_constraints(BTreeMap::from([
+                (
+                    crate::OneHotConstraintID::from(1),
+                    OneHotConstraint::new(members.clone()).unwrap(),
+                ),
+                (
+                    crate::OneHotConstraintID::from(2),
+                    OneHotConstraint::new(members).unwrap(),
+                ),
+            ]))
+            .build()
+            .unwrap()
+    }
+
+    fn one_hot_generated_row(instance: &Instance, id: u64) -> crate::ConstraintID {
+        crate::ConstraintID::from(
+            instance.removed_one_hot_constraints()[&crate::OneHotConstraintID::from(id)]
+                .1
+                .parameters[super::super::ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER]
+                .parse::<u64>()
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn public_reduction_handle_does_not_adopt_pre_existing_history() {
+        let mut instance = two_one_hot_instance();
+        instance
+            .convert_one_hot_to_constraint(crate::OneHotConstraintID::from(1))
+            .unwrap();
+
+        let reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        assert_eq!(
+            reduction.lowered_constraints(),
+            &[LoweredConstraintID::OneHot(
+                crate::OneHotConstraintID::from(2)
+            )]
+        );
+
+        let recovery = instance.recover_capability_reduction(reduction).unwrap();
+
+        assert_eq!(
+            recovery.recovered(),
+            &[LoweredConstraintID::OneHot(
+                crate::OneHotConstraintID::from(2)
+            )]
+        );
+        assert!(recovery.skipped().is_empty());
+        assert!(instance
+            .one_hot_constraints()
+            .contains_key(&crate::OneHotConstraintID::from(2)));
+        assert!(!instance
+            .one_hot_constraints()
+            .contains_key(&crate::OneHotConstraintID::from(1)));
+        assert!(instance
+            .removed_one_hot_constraints()
+            .contains_key(&crate::OneHotConstraintID::from(1)));
+    }
+
+    #[test]
+    fn public_recovery_is_best_effort_per_recorded_source() {
+        let mut instance = two_one_hot_instance();
+        let reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        let corrupted = one_hot_generated_row(&instance, 1);
+        instance
+            .insert_constraint(
+                corrupted,
+                Constraint::equal_to_zero(Function::from(
+                    ((linear!(0) + linear!(1)).unwrap() + coeff!(-2.0)).unwrap(),
+                )),
+            )
+            .unwrap();
+
+        let recovery = instance.recover_capability_reduction(reduction).unwrap();
+
+        assert_eq!(
+            recovery.recovered(),
+            &[LoweredConstraintID::OneHot(
+                crate::OneHotConstraintID::from(2)
+            )]
+        );
+        assert_eq!(recovery.skipped().len(), 1);
+        assert_eq!(
+            recovery.skipped()[0].constraint_id(),
+            LoweredConstraintID::OneHot(crate::OneHotConstraintID::from(1))
+        );
+        assert!(recovery.skipped()[0]
+            .reason()
+            .contains("canonical V1 equality exactly"));
+        assert_eq!(
+            recovery.restored_capabilities(),
+            &requested([AdditionalCapability::OneHot])
+        );
+        assert!(instance
+            .one_hot_constraints()
+            .contains_key(&crate::OneHotConstraintID::from(2)));
+        assert!(instance
+            .removed_one_hot_constraints()
+            .contains_key(&crate::OneHotConstraintID::from(1)));
+    }
+
+    #[test]
+    fn public_handle_and_report_preserve_lowering_order() {
+        let one_hot_members = BTreeSet::from([VariableID::from(0), VariableID::from(2)]);
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::binary(),
+                VariableID::from(1) => DecisionVariable::new(
+                    Kind::Continuous,
+                    Bound::new(0.0, 5.0).unwrap(),
+                    crate::ATol::default(),
+                ).unwrap(),
+                VariableID::from(2) => DecisionVariable::binary(),
+                VariableID::from(3) => DecisionVariable::new(
+                    Kind::Integer,
+                    Bound::new(-2.0, 3.0).unwrap(),
+                    crate::ATol::default(),
+                ).unwrap(),
+            })
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                crate::IndicatorConstraintID::from(7),
+                IndicatorConstraint::new(
+                    VariableID::from(0),
+                    Equality::LessThanOrEqualToZero,
+                    Function::from((linear!(1) + coeff!(-2.0)).unwrap()),
+                ),
+            )]))
+            .one_hot_constraints(BTreeMap::from([
+                (
+                    crate::OneHotConstraintID::from(5),
+                    OneHotConstraint::new(one_hot_members.clone()).unwrap(),
+                ),
+                (
+                    crate::OneHotConstraintID::from(3),
+                    OneHotConstraint::new(one_hot_members).unwrap(),
+                ),
+            ]))
+            .sos1_constraints(BTreeMap::from([(
+                crate::Sos1ConstraintID::from(9),
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(2), VariableID::from(3)]))
+                    .unwrap(),
+            )]))
+            .build()
+            .unwrap();
+
+        let expected = vec![
+            LoweredConstraintID::Indicator(crate::IndicatorConstraintID::from(7)),
+            LoweredConstraintID::OneHot(crate::OneHotConstraintID::from(3)),
+            LoweredConstraintID::OneHot(crate::OneHotConstraintID::from(5)),
+            LoweredConstraintID::Sos1(crate::Sos1ConstraintID::from(9)),
+        ];
+        let reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        assert_eq!(reduction.lowered_constraints(), expected);
+        assert_eq!(
+            reduction.converted_capabilities(),
+            &requested([
+                AdditionalCapability::Indicator,
+                AdditionalCapability::OneHot,
+                AdditionalCapability::Sos1,
+            ])
+        );
+
+        let recovery = instance.recover_capability_reduction(reduction).unwrap();
+        assert_eq!(recovery.recovered(), expected);
+        assert!(recovery.skipped().is_empty());
+    }
+
+    #[test]
+    fn public_recovery_owns_the_composed_exact_state_map() {
+        let mut instance = combined_instance();
+        let original_ids = instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>();
+        let reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        let lowered_ids = instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>();
+        let selector = *lowered_ids
+            .difference(&original_ids)
+            .next()
+            .expect("SOS1 lowering introduces one fresh selector");
+
+        let recovery = instance.recover_capability_reduction(reduction).unwrap();
+        assert_eq!(recovery.before_variable_ids(), &lowered_ids);
+        assert_eq!(recovery.after_variable_ids(), &original_ids);
+        assert_eq!(
+            recovery.recovered(),
+            &[
+                LoweredConstraintID::Indicator(crate::IndicatorConstraintID::from(7)),
+                LoweredConstraintID::Sos1(crate::Sos1ConstraintID::from(9)),
+            ]
+        );
+
+        let lowered_state = v1::State::from_iter([
+            (0, 1.0),
+            (1, 2.0),
+            (2, 0.0),
+            (3, 1.0),
+            (selector.into_inner(), 1.0),
+        ]);
+        let recovered_state = recovery.project_state(&lowered_state).unwrap();
+        assert!(!recovered_state.entries.contains_key(&selector.into_inner()));
+        assert_eq!(
+            recovery.lift_state(&recovered_state).unwrap(),
+            lowered_state
+        );
+        assert!(recovery
+            .project_state(&v1::State::from_iter([(0, 1.0)]))
+            .is_err());
+    }
+
+    #[test]
+    fn public_reduction_is_atomic_across_capability_families() {
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::binary(),
+                VariableID::from(1) => DecisionVariable::new(
+                    Kind::Continuous,
+                    Bound::new(0.0, 2.0).unwrap(),
+                    crate::ATol::default(),
+                ).unwrap(),
+                VariableID::from(2) => DecisionVariable::continuous(),
+            })
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                crate::IndicatorConstraintID::from(1),
+                IndicatorConstraint::new(
+                    VariableID::from(0),
+                    Equality::LessThanOrEqualToZero,
+                    Function::from((linear!(1) + coeff!(-1.0)).unwrap()),
+                ),
+            )]))
+            .sos1_constraints(BTreeMap::from([(
+                crate::Sos1ConstraintID::from(2),
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(2)])).unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let error = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap_err();
+
+        assert!(error.to_string().contains("non-finite bound"));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+    }
+
+    #[test]
+    fn capability_reduction_handle_rejects_another_instances_batch() {
+        let mut first = two_one_hot_instance();
+        let first_reduction = first
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+
+        let mut second = two_one_hot_instance();
+        let second_reduction = second
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        assert_ne!(first_reduction.batch_token, second_reduction.batch_token);
+        let before = second.clone();
+        let before_bytes = second.to_v2_bytes();
+
+        let recovery = second
+            .recover_capability_reduction(first_reduction)
+            .unwrap();
+
+        assert!(recovery.recovered().is_empty());
+        assert_eq!(recovery.skipped().len(), 2);
+        assert!(recovery
+            .skipped()
+            .iter()
+            .all(|skipped| skipped.reason().contains("not handle batch")));
+        assert_eq!(second, before);
+        assert_eq!(second.to_v2_bytes(), before_bytes);
+
+        let recovery = second
+            .recover_capability_reduction(second_reduction)
+            .unwrap();
+        assert_eq!(recovery.recovered().len(), 2);
+        assert!(recovery.skipped().is_empty());
+    }
+
+    #[test]
+    fn stale_handle_does_not_recover_a_later_relowering_of_the_same_ids() {
+        let mut instance = two_one_hot_instance();
+        let stale = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        instance
+            .restore_lowered_capabilities_checked(&requested([AdditionalCapability::OneHot]))
+            .unwrap();
+
+        let current = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let stale_recovery = instance.recover_capability_reduction(stale).unwrap();
+        assert!(stale_recovery.recovered().is_empty());
+        assert_eq!(stale_recovery.skipped().len(), 2);
+        assert!(stale_recovery
+            .skipped()
+            .iter()
+            .all(|skipped| skipped.reason().contains("not handle batch")));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+
+        let current_recovery = instance.recover_capability_reduction(current).unwrap();
+        assert_eq!(current_recovery.recovered().len(), 2);
+        assert!(current_recovery.skipped().is_empty());
+    }
+
+    #[test]
+    fn cloned_instance_preserves_the_runtime_batch_binding() {
+        let mut instance = two_one_hot_instance();
+        let reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        let mut cloned = instance.clone();
+
+        let recovery = cloned.recover_capability_reduction(reduction).unwrap();
+
+        assert_eq!(recovery.recovered().len(), 2);
+        assert!(recovery.skipped().is_empty());
+        assert_eq!(
+            cloned.required_capabilities(),
+            requested([AdditionalCapability::OneHot])
+        );
+    }
+
+    #[test]
+    fn partial_sos1_recovery_removes_only_the_proved_selector() {
+        let continuous = || {
+            DecisionVariable::new(
+                Kind::Continuous,
+                Bound::new(-1.0, 2.0).unwrap(),
+                crate::ATol::default(),
+            )
+            .unwrap()
+        };
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(btreemap! {
+                VariableID::from(0) => continuous(),
+                VariableID::from(1) => continuous(),
+            })
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([
+                (
+                    crate::Sos1ConstraintID::from(1),
+                    Sos1Constraint::new(BTreeSet::from([VariableID::from(0)])).unwrap(),
+                ),
+                (
+                    crate::Sos1ConstraintID::from(2),
+                    Sos1Constraint::new(BTreeSet::from([VariableID::from(1)])).unwrap(),
+                ),
+            ]))
+            .build()
+            .unwrap();
+        let original_ids = instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>();
+        let reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        let lowered_ids = instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>();
+        let selectors = lowered_ids
+            .difference(&original_ids)
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(selectors.len(), 2);
+        let skipped_selector = selectors[0];
+        let recovered_selector = selectors[1];
+
+        let damaged_row = first_recorded_constraint_id(
+            &instance.removed_sos1_constraints()[&crate::Sos1ConstraintID::from(1)].1,
+        );
+        instance
+            .relax_constraint(damaged_row, "presolver removed row".to_string(), [])
+            .unwrap();
+
+        let recovery = instance.recover_capability_reduction(reduction).unwrap();
+        let expected_after_ids = original_ids
+            .iter()
+            .copied()
+            .chain([skipped_selector])
+            .collect::<VariableIDSet>();
+        assert_eq!(recovery.before_variable_ids(), &lowered_ids);
+        assert_eq!(recovery.after_variable_ids(), &expected_after_ids);
+        assert_eq!(
+            recovery.recovered(),
+            &[LoweredConstraintID::Sos1(crate::Sos1ConstraintID::from(2))]
+        );
+        assert_eq!(recovery.skipped().len(), 1);
+        assert_eq!(
+            recovery.skipped()[0].constraint_id(),
+            LoweredConstraintID::Sos1(crate::Sos1ConstraintID::from(1))
+        );
+        assert!(recovery.skipped()[0].reason().contains("is not active"));
+        assert!(instance
+            .decision_variables()
+            .contains_key(&skipped_selector));
+        assert!(!instance
+            .decision_variables()
+            .contains_key(&recovered_selector));
+
+        let before = v1::State::from_iter([
+            (0, 0.0),
+            (1, 1.5),
+            (skipped_selector.into_inner(), 0.0),
+            (recovered_selector.into_inner(), 1.0),
+        ]);
+        let after = recovery.project_state(&before).unwrap();
+        assert!(after.entries.contains_key(&skipped_selector.into_inner()));
+        assert!(!after.entries.contains_key(&recovered_selector.into_inner()));
+        assert_eq!(recovery.lift_state(&after).unwrap(), before);
+    }
+
+    #[test]
+    fn public_sos1_selector_isolation_failure_is_skipped() {
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::zero())
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::new(
+                    Kind::Continuous,
+                    Bound::new(-1.0, 2.0).unwrap(),
+                    crate::ATol::default(),
+                ).unwrap(),
+            })
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(
+                crate::Sos1ConstraintID::from(1),
+                Sos1Constraint::new(BTreeSet::from([VariableID::from(0)])).unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        let original_ids = instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>();
+        let reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        let selector = *instance
+            .decision_variables()
+            .keys()
+            .copied()
+            .collect::<VariableIDSet>()
+            .difference(&original_ids)
+            .next()
+            .expect("SOS1 lowering introduces one fresh selector");
+        instance
+            .add_constraint(
+                Constraint::equal_to_zero(Function::from(linear!(selector.into_inner()))),
+                Default::default(),
+            )
+            .unwrap();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let recovery = instance.recover_capability_reduction(reduction).unwrap();
+
+        assert!(recovery.recovered().is_empty());
+        assert_eq!(recovery.skipped().len(), 1);
+        assert_eq!(
+            recovery.skipped()[0].constraint_id(),
+            LoweredConstraintID::Sos1(crate::Sos1ConstraintID::from(1))
+        );
+        assert!(recovery.skipped()[0]
+            .reason()
+            .contains("used by active regular constraint"));
+        assert_eq!(instance, before);
+        assert_eq!(instance.to_v2_bytes(), before_bytes);
+    }
+
+    #[test]
+    fn public_operation_error_is_propagated_and_atomic() {
+        let mut instance = two_one_hot_instance();
+        let mut reduction = instance
+            .reduce_capabilities_with_recovery(&Capabilities::new())
+            .unwrap();
+        // The handle is opaque to SDK callers. Corrupt its internal permission
+        // only here to exercise the operation-error branch deterministically.
+        reduction.converted_capabilities.clear();
+        let before = instance.clone();
+        let before_bytes = instance.to_v2_bytes();
+
+        let error = instance
+            .recover_capability_reduction(reduction)
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("requires explicit OneHot capability permission"));
         assert_eq!(instance, before);
         assert_eq!(instance.to_v2_bytes(), before_bytes);
     }

--- a/rust/ommx/src/instance/one_hot.rs
+++ b/rust/ommx/src/instance/one_hot.rs
@@ -1,6 +1,6 @@
 use super::{
-    reduction::AssignmentMap, AdditionalCapability, Capabilities, Instance,
-    ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER, ONE_HOT_LOWERING_REASON,
+    inverse_lowering::InverseLoweringError, reduction::AssignmentMap, AdditionalCapability,
+    Capabilities, Instance, ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER, ONE_HOT_LOWERING_REASON,
 };
 use crate::{
     coeff,
@@ -9,7 +9,7 @@ use crate::{
     one_hot_constraint::OneHotConstraintID,
     Constraint, Function, Linear, VariableIDSet,
 };
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use std::collections::BTreeSet;
 
 /// Private one-shot plan for an exact checked inverse lowering.
@@ -36,7 +36,7 @@ impl Instance {
         &mut self,
         id: OneHotConstraintID,
         permitted_additions: &Capabilities,
-    ) -> Result<AssignmentMap> {
+    ) -> std::result::Result<AssignmentMap, InverseLoweringError> {
         let plan = self.plan_one_hot_inverse(id, permitted_additions)?;
         Ok(plan.commit(self))
     }
@@ -45,28 +45,31 @@ impl Instance {
         &self,
         id: OneHotConstraintID,
         permitted_additions: &Capabilities,
-    ) -> Result<OneHotInversePlan> {
+    ) -> std::result::Result<OneHotInversePlan, InverseLoweringError> {
         if !permitted_additions.contains(&AdditionalCapability::OneHot) {
-            bail!(
+            return Err(InverseLoweringError::operation_message(format!(
                 "Restoring OneHot constraint {id:?} requires explicit OneHot capability permission"
-            );
+            )));
         }
 
-        let verified = crate::proof::verify_one_hot_v1(self, id)?;
+        let verified = crate::proof::verify_one_hot_v1(self, id)
+            .map_err(InverseLoweringError::not_recoverable)?;
         debug_assert_eq!(verified.source_id(), id);
         for &member in &verified.source().variables {
             if !self.decision_variables.contains_key(&member) {
-                bail!(
+                return Err(InverseLoweringError::not_recoverable_message(format!(
                     "Cannot restore OneHot constraint {id:?}: member {member:?} is not registered"
-                );
+                )));
             }
             if self.decision_variable_dependency.get(&member).is_some() {
-                bail!(
+                return Err(InverseLoweringError::not_recoverable_message(format!(
                     "Cannot restore OneHot constraint {id:?}: member {member:?} is a dependency target"
-                );
+                )));
             }
             if self.fixed_decision_variable_values().contains_key(&member) {
-                bail!("Cannot restore OneHot constraint {id:?}: member {member:?} is fixed");
+                return Err(InverseLoweringError::not_recoverable_message(format!(
+                    "Cannot restore OneHot constraint {id:?}: member {member:?} is fixed"
+                )));
             }
         }
 
@@ -76,10 +79,12 @@ impl Instance {
         let mut staged = self.clone();
         staged
             .constraint_collection
-            .consume_active_rows(&generated_rows)?;
+            .consume_active_rows(&generated_rows)
+            .map_err(InverseLoweringError::operation)?;
         staged
             .one_hot_constraint_collection
-            .restore_removed_row(id, verified.source().clone())?;
+            .restore_removed_row(id, verified.source().clone())
+            .map_err(InverseLoweringError::operation)?;
         let staged_variable_ids = staged
             .decision_variables
             .keys()

--- a/rust/ommx/src/instance/reduction.rs
+++ b/rust/ommx/src/instance/reduction.rs
@@ -251,12 +251,12 @@ impl Instance {
     ) -> crate::Result<()> {
         for id in private_ids {
             if !self.decision_variables.contains_key(id) {
-                crate::bail!({ ?id }, "Private decision variable {id:?} is not registered");
+                anyhow::bail!("Private decision variable {id:?} is not registered");
             }
         }
         for id in consumed_regular_rows {
             if !self.constraints().contains_key(id) {
-                crate::bail!({ ?id }, "Consumed regular constraint {id:?} is not active");
+                anyhow::bail!("Consumed regular constraint {id:?} is not active");
             }
         }
 
@@ -329,10 +329,7 @@ impl Instance {
         }
         for (id, function) in self.decision_variable_dependency().iter() {
             if private_ids.contains(id) {
-                crate::bail!(
-                    { ?id },
-                    "Private decision variable {id:?} is a dependency target"
-                );
+                anyhow::bail!("Private decision variable {id:?} is a dependency target");
             }
             reject_required_ids(
                 private_ids,
@@ -344,7 +341,7 @@ impl Instance {
             .iter()
             .find(|id| self.fixed_decision_variable_values().contains_key(id))
         {
-            crate::bail!({ ?id }, "Private decision variable {id:?} is fixed");
+            anyhow::bail!("Private decision variable {id:?} is fixed");
         }
         Ok(())
     }
@@ -356,7 +353,7 @@ fn reject_required_ids(
     location: &str,
 ) -> crate::Result<()> {
     if let Some(id) = private_ids.intersection(required_ids).next() {
-        crate::bail!({ ?id, location }, "Private decision variable {id:?} is used by {location}");
+        anyhow::bail!("Private decision variable {id:?} is used by {location}");
     }
     Ok(())
 }
@@ -507,17 +504,15 @@ mod tests {
             Err(AssignmentMapError::MissingFreshSelector { selector })
                 if selector == VariableID::from(99)
         ));
-        assert!(matches!(
-            AssignmentMap::sos1_selectors(
-                source.clone(),
-                Sos1ConstraintID::from(7),
-                BTreeMap::from([(
-                    VariableID::from(1),
-                    SelectorRole::Fresh(VariableID::from(2)),
-                )]),
-            ),
-            Ok(_)
-        ));
+        assert!(AssignmentMap::sos1_selectors(
+            source.clone(),
+            Sos1ConstraintID::from(7),
+            BTreeMap::from([(
+                VariableID::from(1),
+                SelectorRole::Fresh(VariableID::from(2)),
+            )]),
+        )
+        .is_ok());
         assert!(matches!(
             AssignmentMap::sos1_selectors(
                 source.clone(),

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -1,4 +1,5 @@
 use super::{
+    inverse_lowering::InverseLoweringError,
     reduction::{AssignmentMap, SelectorRole},
     AdditionalCapability, Capabilities, Instance, GENERATED_CONSTRAINT_IDS_PARAMETER,
     SOS1_LOWERING_REASON,
@@ -52,7 +53,7 @@ impl Instance {
         &mut self,
         id: Sos1ConstraintID,
         permitted_additions: &Capabilities,
-    ) -> Result<AssignmentMap> {
+    ) -> std::result::Result<AssignmentMap, InverseLoweringError> {
         let plan = self.plan_sos1_inverse(id, permitted_additions)?;
         Ok(plan.commit(self))
     }
@@ -61,24 +62,31 @@ impl Instance {
         &self,
         id: Sos1ConstraintID,
         permitted_additions: &Capabilities,
-    ) -> Result<Sos1InversePlan> {
+    ) -> std::result::Result<Sos1InversePlan, InverseLoweringError> {
         if !permitted_additions.contains(&AdditionalCapability::Sos1) {
-            bail!("Restoring SOS1 constraint {id:?} requires explicit SOS1 capability permission");
+            return Err(InverseLoweringError::operation_message(format!(
+                "Restoring SOS1 constraint {id:?} requires explicit SOS1 capability permission"
+            )));
         }
 
-        let verified = crate::proof::verify_sos1_big_m_v1(self, id)?;
+        let verified = crate::proof::verify_sos1_big_m_v1(self, id)
+            .map_err(InverseLoweringError::not_recoverable)?;
         debug_assert_eq!(verified.source_id(), id);
         for &member in &verified.source().variables {
             if !self.decision_variables.contains_key(&member) {
-                bail!("Cannot restore SOS1 constraint {id:?}: member {member:?} is not registered");
+                return Err(InverseLoweringError::not_recoverable_message(format!(
+                    "Cannot restore SOS1 constraint {id:?}: member {member:?} is not registered"
+                )));
             }
             if self.decision_variable_dependency.get(&member).is_some() {
-                bail!(
+                return Err(InverseLoweringError::not_recoverable_message(format!(
                     "Cannot restore SOS1 constraint {id:?}: member {member:?} is a dependency target"
-                );
+                )));
             }
             if self.fixed_decision_variable_values().contains_key(&member) {
-                bail!("Cannot restore SOS1 constraint {id:?}: member {member:?} is fixed");
+                return Err(InverseLoweringError::not_recoverable_message(format!(
+                    "Cannot restore SOS1 constraint {id:?}: member {member:?} is fixed"
+                )));
             }
         }
 
@@ -107,23 +115,28 @@ impl Instance {
             .copied()
             .collect::<BTreeSet<_>>();
 
-        self.ensure_variables_isolated_for_removal(&fresh_selectors, &generated_rows)?;
+        self.ensure_variables_isolated_for_removal(&fresh_selectors, &generated_rows)
+            .map_err(InverseLoweringError::not_recoverable)?;
         let assignment_map = AssignmentMap::sos1_selectors(
             self.decision_variables.keys().copied().collect(),
             id,
             selector_roles,
-        )?;
+        )
+        .map_err(InverseLoweringError::operation)?;
 
         let mut staged = self.clone();
         staged
             .constraint_collection
-            .consume_active_rows(&generated_rows)?;
+            .consume_active_rows(&generated_rows)
+            .map_err(InverseLoweringError::operation)?;
         staged
             .decision_variables
-            .remove_unfixed_rows(&fresh_selectors)?;
+            .remove_unfixed_rows(&fresh_selectors)
+            .map_err(InverseLoweringError::operation)?;
         staged
             .sos1_constraint_collection
-            .restore_removed_row(id, verified.source().clone())?;
+            .restore_removed_row(id, verified.source().clone())
+            .map_err(InverseLoweringError::operation)?;
         let staged_variable_ids = staged
             .decision_variables
             .keys()

--- a/rust/ommx/src/proof/linear/candidate.rs
+++ b/rust/ommx/src/proof/linear/candidate.rs
@@ -5,8 +5,9 @@ use super::{
 use crate::{
     constraint::{ConstraintContext, Provenance, RemovedReason},
     instance::{
-        GENERATED_CONSTRAINT_IDS_PARAMETER, INDICATOR_LOWERING_REASON,
-        ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER, ONE_HOT_LOWERING_REASON, SOS1_LOWERING_REASON,
+        CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER, GENERATED_CONSTRAINT_IDS_PARAMETER,
+        INDICATOR_LOWERING_REASON, ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER,
+        ONE_HOT_LOWERING_REASON, SOS1_LOWERING_REASON,
     },
     proof::exact::from_f64,
     Bound, ConstraintID, Equality, IndicatorConstraint, IndicatorConstraintID, Instance, Kind,
@@ -151,6 +152,8 @@ enum InverseLoweringCandidateError {
     UnexpectedRemovalParameter { key: String },
     #[error("generated constraint ID token {token:?} is not canonical u64 text")]
     InvalidGeneratedConstraintId { token: String },
+    #[error("capability-reduction batch token {token:?} is not canonical UUID text")]
+    InvalidCapabilityReductionBatchToken { token: String },
     #[error("generated constraint ID {id:?} is listed more than once")]
     DuplicateGeneratedConstraintId { id: ConstraintID },
     #[error("generated regular constraint {id:?} is not active")]
@@ -314,8 +317,7 @@ pub(crate) fn verify_one_hot_v1(
     let candidate = instance.one_hot_candidate_v1(id)?;
     let snapshot = instance.certified_linear_relaxation()?;
     if candidate.representation != snapshot.fingerprint() {
-        crate::bail!(
-            { ?id },
+        anyhow::bail!(
             "OneHot inverse-lowering candidate {id:?} is bound to a stale representation"
         );
     }
@@ -325,20 +327,14 @@ pub(crate) fn verify_one_hot_v1(
         .get(&id)
         .expect("candidate lookup proved that the removed source exists");
     if source.variables.is_empty() {
-        crate::bail!({ ?id }, "Removed OneHot constraint {id:?} has no members");
+        anyhow::bail!("Removed OneHot constraint {id:?} has no members");
     }
     for &member in &source.variables {
         let Some(variable) = instance.decision_variables().get(&member) else {
-            crate::bail!(
-                { ?id, ?member },
-                "OneHot member {member:?} is not registered"
-            );
+            anyhow::bail!("OneHot member {member:?} is not registered");
         };
         if variable.kind() != Kind::Binary {
-            crate::bail!(
-                { ?id, ?member, kind = ?variable.kind() },
-                "OneHot member {member:?} is not binary"
-            );
+            anyhow::bail!("OneHot member {member:?} is not binary");
         }
     }
 
@@ -354,10 +350,7 @@ pub(crate) fn verify_one_hot_v1(
         constant: ExactRational::from_integer((-1).into()),
     };
     if actual != expected {
-        crate::bail!(
-            { ?id, row_id = ?candidate.generated_row },
-            "Generated OneHot row does not match the canonical V1 equality exactly"
-        );
+        anyhow::bail!("Generated OneHot row does not match the canonical V1 equality exactly");
     }
 
     Ok(VerifiedOneHotV1 {
@@ -382,8 +375,7 @@ pub(crate) fn verify_indicator_big_m_v1(
     let candidate = instance.indicator_big_m_candidate_v1(id)?;
     let snapshot = instance.certified_linear_relaxation()?;
     if candidate.representation != snapshot.fingerprint() {
-        crate::bail!(
-            { ?id },
+        anyhow::bail!(
             "Indicator inverse-lowering candidate {id:?} is bound to a stale representation"
         );
     }
@@ -394,23 +386,14 @@ pub(crate) fn verify_indicator_big_m_v1(
         .expect("candidate lookup proved that the removed source exists");
     let indicator_variable = source.indicator_variable;
     let Some(indicator) = instance.decision_variables().get(&indicator_variable) else {
-        crate::bail!(
-            { ?id, ?indicator_variable },
-            "Indicator variable {indicator_variable:?} is not registered"
-        );
+        anyhow::bail!("Indicator variable {indicator_variable:?} is not registered");
     };
     if indicator.kind() != Kind::Binary {
-        crate::bail!(
-            { ?id, ?indicator_variable },
-            "Indicator variable {indicator_variable:?} is not binary"
-        );
+        anyhow::bail!("Indicator variable {indicator_variable:?} is not binary");
     }
 
     let body = ExactAffine::from_function(source.function())?.ok_or_else(|| {
-        crate::error!(
-            { ?id },
-            "Removed Indicator constraint {id:?} has a nonlinear body"
-        )
+        anyhow::anyhow!("Removed Indicator constraint {id:?} has a nonlinear body")
     })?;
     let zero = ExactRational::from_integer(0.into());
     let one = ExactRational::from_integer(1.into());
@@ -422,8 +405,7 @@ pub(crate) fn verify_indicator_big_m_v1(
         let row = snapshot.inequality(InequalityRef::RegularConstraint(*row_id))?;
         let inactive = row.substitute(indicator_variable, &zero);
         if !snapshot.variable_facts_imply_nonpositive(&inactive)? {
-            crate::bail!(
-                { ?id, ?row_id },
+            anyhow::bail!(
                 "Generated Indicator row {row_id:?} is not redundant on the inactive branch"
             );
         }
@@ -435,36 +417,27 @@ pub(crate) fn verify_indicator_big_m_v1(
     match source.equality {
         Equality::LessThanOrEqualToZero => {
             if roles.len() > 1 {
-                crate::bail!(
-                    { ?id, generated_rows = roles.len() },
-                    "Inequality Indicator {id:?} has more than one generated row"
-                );
+                anyhow::bail!("Inequality Indicator {id:?} has more than one generated row");
             }
             if let Some((matches_upper, _)) = roles.first() {
                 if !matches_upper {
-                    crate::bail!(
-                        { ?id, row_id = ?candidate.generated_rows[0] },
+                    anyhow::bail!(
                         "Generated Indicator row does not equal the active upper side exactly"
                     );
                 }
             } else if !upper_implied {
-                crate::bail!(
-                    { ?id },
+                anyhow::bail!(
                     "Missing Indicator upper side is not implied by exact variable facts"
                 );
             }
         }
         Equality::EqualToZero => {
             if roles.len() > 2 {
-                crate::bail!(
-                    { ?id, generated_rows = roles.len() },
-                    "Equality Indicator {id:?} has more than two generated rows"
-                );
+                anyhow::bail!("Equality Indicator {id:?} has more than two generated rows");
             }
             let lower_implied = snapshot.variable_facts_imply_nonpositive(&active_lower)?;
             if !equality_roles_cover(&roles, upper_implied, lower_implied) {
-                crate::bail!(
-                    { ?id },
+                anyhow::bail!(
                     "Generated Indicator rows do not provide independent exact upper and lower active sides"
                 );
             }
@@ -502,10 +475,7 @@ pub(crate) fn verify_sos1_big_m_v1(
     let candidate = instance.sos1_big_m_candidate_v1(id)?;
     let snapshot = instance.certified_linear_relaxation()?;
     if candidate.representation != snapshot.fingerprint() {
-        crate::bail!(
-            { ?id },
-            "SOS1 inverse-lowering candidate {id:?} is bound to a stale representation"
-        );
+        anyhow::bail!("SOS1 inverse-lowering candidate {id:?} is bound to a stale representation");
     }
 
     let (source, _) = instance
@@ -517,26 +487,22 @@ pub(crate) fn verify_sos1_big_m_v1(
     let mut expected_row_count = 1usize; // The final cardinality row.
 
     for &member in &source.variables {
-        let variable = instance.decision_variables().get(&member).ok_or_else(|| {
-            crate::error!(
-                { ?id, ?member },
-                "SOS1 member {member:?} is not registered"
-            )
-        })?;
+        let variable = instance
+            .decision_variables()
+            .get(&member)
+            .ok_or_else(|| anyhow::anyhow!("SOS1 member {member:?} is not registered"))?;
         let bound = variable.bound();
         if variable.kind() == Kind::Binary && bound == Bound::of_binary() {
             selectors.insert(member, member);
             continue;
         }
         if matches!(variable.kind(), Kind::SemiContinuous | Kind::SemiInteger) {
-            crate::bail!(
-                { ?id, ?member, kind = ?variable.kind() },
+            anyhow::bail!(
                 "SOS1 member {member:?} has a semi-variable kind unsupported by V1 lowering"
             );
         }
         if !bound.is_finite() || bound.lower() > 0.0 || bound.upper() < 0.0 {
-            crate::bail!(
-                { ?id, ?member, ?bound },
+            anyhow::bail!(
                 "SOS1 member {member:?} does not have a finite V1 Big-M domain containing zero"
             );
         }
@@ -546,14 +512,7 @@ pub(crate) fn verify_sos1_big_m_v1(
     }
 
     if candidate.generated_rows.len() != expected_row_count {
-        crate::bail!(
-            {
-                ?id,
-                actual = candidate.generated_rows.len(),
-                expected = expected_row_count
-            },
-            "SOS1 lowering has an unexpected number of generated rows"
-        );
+        anyhow::bail!("SOS1 lowering has an unexpected number of generated rows");
     }
 
     // The V1 lowerer emits cardinality last. Read selector candidates only
@@ -573,18 +532,12 @@ pub(crate) fn verify_sos1_big_m_v1(
             .values()
             .any(|coefficient| coefficient != &one)
     {
-        crate::bail!(
-            { ?id, ?cardinality_id },
-            "Generated SOS1 cardinality row does not have canonical V1 shape"
-        );
+        anyhow::bail!("Generated SOS1 cardinality row does not have canonical V1 shape");
     }
     for (&member, &selector) in &selectors {
         debug_assert_eq!(member, selector);
         if !cardinality.coefficients().contains_key(&selector) {
-            crate::bail!(
-                { ?id, ?member, ?cardinality_id },
-                "Generated SOS1 cardinality row is missing reused member {member:?}"
-            );
+            anyhow::bail!("Generated SOS1 cardinality row is missing reused member {member:?}");
         }
     }
 
@@ -599,10 +552,7 @@ pub(crate) fn verify_sos1_big_m_v1(
             .iter()
             .any(|selector| source.variables.contains(selector))
     {
-        crate::bail!(
-            { ?id, ?cardinality_id },
-            "Generated SOS1 cardinality row has an invalid fresh-selector set"
-        );
+        anyhow::bail!("Generated SOS1 cardinality row has an invalid fresh-selector set");
     }
 
     for &member in fresh_member_bounds.keys() {
@@ -613,10 +563,7 @@ pub(crate) fn verify_sos1_big_m_v1(
             .filter(|selector| instance.variable_labels().collect_for(*selector) == expected_label)
             .collect::<Vec<_>>();
         let [selector] = matching_selectors.as_slice() else {
-            crate::bail!(
-                { ?id, ?member, matches = matching_selectors.len() },
-                "SOS1 member {member:?} does not have exactly one canonical V1 selector"
-            );
+            anyhow::bail!("SOS1 member {member:?} does not have exactly one canonical V1 selector");
         };
         let selector = *selector;
         let selector_variable = instance
@@ -626,16 +573,10 @@ pub(crate) fn verify_sos1_big_m_v1(
         if selector_variable.kind() != Kind::Binary
             || selector_variable.bound() != Bound::of_binary()
         {
-            crate::bail!(
-                { ?id, ?member, ?selector },
-                "SOS1 selector {selector:?} does not have the canonical binary domain"
-            );
+            anyhow::bail!("SOS1 selector {selector:?} does not have the canonical binary domain");
         }
         if selectors.values().any(|existing| *existing == selector) {
-            crate::bail!(
-                { ?id, ?member, ?selector },
-                "SOS1 selector {selector:?} is assigned to more than one member"
-            );
+            anyhow::bail!("SOS1 selector {selector:?} is assigned to more than one member");
         }
         selectors.insert(member, selector);
     }
@@ -682,9 +623,8 @@ pub(crate) fn verify_sos1_big_m_v1(
     {
         let actual = snapshot.inequality(InequalityRef::RegularConstraint(row_id))?;
         if actual != *expected {
-            crate::bail!(
-                { ?id, ?row_id, index },
-                "Generated SOS1 row {row_id:?} does not match the canonical V1 content exactly"
+            anyhow::bail!(
+                "Generated SOS1 row {row_id:?} at index {index} does not match the canonical V1 content exactly"
             );
         }
     }
@@ -745,11 +685,15 @@ fn parse_one_hot_constraint_id(
     if let Some(key) = reason
         .parameters
         .keys()
-        .filter(|key| key.as_str() != ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER)
+        .filter(|key| {
+            key.as_str() != ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER
+                && key.as_str() != CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER
+        })
         .min()
     {
         return Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { key: key.clone() });
     }
+    validate_optional_capability_reduction_batch_token(reason)?;
     let token = reason
         .parameters
         .get(ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER)
@@ -782,11 +726,15 @@ fn parse_generated_constraint_ids(
     if let Some(key) = reason
         .parameters
         .keys()
-        .filter(|key| key.as_str() != GENERATED_CONSTRAINT_IDS_PARAMETER)
+        .filter(|key| {
+            key.as_str() != GENERATED_CONSTRAINT_IDS_PARAMETER
+                && key.as_str() != CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER
+        })
         .min()
     {
         return Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { key: key.clone() });
     }
+    validate_optional_capability_reduction_batch_token(reason)?;
     let raw = reason
         .parameters
         .get(GENERATED_CONSTRAINT_IDS_PARAMETER)
@@ -817,6 +765,30 @@ fn parse_generated_constraint_ids(
         ids.push(id);
     }
     Ok(ids)
+}
+
+fn validate_optional_capability_reduction_batch_token(
+    reason: &RemovedReason,
+) -> Result<(), InverseLoweringCandidateError> {
+    let Some(token) = reason
+        .parameters
+        .get(CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER)
+    else {
+        return Ok(());
+    };
+    let value = uuid::Uuid::parse_str(token).map_err(|_| {
+        InverseLoweringCandidateError::InvalidCapabilityReductionBatchToken {
+            token: token.clone(),
+        }
+    })?;
+    if token != &value.hyphenated().to_string() {
+        return Err(
+            InverseLoweringCandidateError::InvalidCapabilityReductionBatchToken {
+                token: token.clone(),
+            },
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1024,6 +996,24 @@ mod tests {
         assert!(matches!(
             parse_one_hot_constraint_id(&extra_parameter),
             Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { .. })
+        ));
+
+        let malformed_batch = RemovedReason {
+            reason: ONE_HOT_LOWERING_REASON.to_string(),
+            parameters: FnvHashMap::from_iter([
+                (
+                    ONE_HOT_GENERATED_CONSTRAINT_ID_PARAMETER.to_string(),
+                    "1".to_string(),
+                ),
+                (
+                    CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER.to_string(),
+                    "550E8400-E29B-41D4-A716-446655440000".to_string(),
+                ),
+            ]),
+        };
+        assert!(matches!(
+            parse_one_hot_constraint_id(&malformed_batch),
+            Err(InverseLoweringCandidateError::InvalidCapabilityReductionBatchToken { .. })
         ));
     }
 
@@ -1512,6 +1502,16 @@ mod tests {
             parse_generated_constraint_ids(&extra_parameter, INDICATOR_LOWERING_REASON),
             Err(InverseLoweringCandidateError::UnexpectedRemovalParameter { .. })
         ));
+
+        let mut malformed_batch = removed_reason(INDICATOR_LOWERING_REASON, "1");
+        malformed_batch.parameters.insert(
+            CAPABILITY_REDUCTION_BATCH_TOKEN_PARAMETER.to_string(),
+            "not-a-uuid".to_string(),
+        );
+        assert!(matches!(
+            parse_generated_constraint_ids(&malformed_batch, INDICATOR_LOWERING_REASON),
+            Err(InverseLoweringCandidateError::InvalidCapabilityReductionBatchToken { .. })
+        ));
     }
 
     fn forged_indicator_history(
@@ -1520,14 +1520,14 @@ mod tests {
         include_row: bool,
     ) -> Instance {
         let row_id = ConstraintID::from(10);
-        let constraints = include_row
-            .then(|| {
-                BTreeMap::from([(
-                    row_id,
-                    Constraint::less_than_or_equal_to_zero(Function::from(linear!(1))),
-                )])
-            })
-            .unwrap_or_default();
+        let constraints = if include_row {
+            BTreeMap::from([(
+                row_id,
+                Constraint::less_than_or_equal_to_zero(Function::from(linear!(1))),
+            )])
+        } else {
+            BTreeMap::new()
+        };
         let mut context = ConstraintContextStore::default();
         if include_row {
             context.set_provenance(row_id, provenance);

--- a/rust/ommx/tests/capability_recovery.rs
+++ b/rust/ommx/tests/capability_recovery.rs
@@ -1,0 +1,46 @@
+use ommx::{
+    v1, AdditionalCapability, Capabilities, DecisionVariable, Function, Instance,
+    LoweredConstraintID, OneHotConstraint, OneHotConstraintID, Sense, VariableID,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[test]
+fn public_capability_recovery_surface_is_usable_outside_the_crate() {
+    let one_hot_id = OneHotConstraintID::from(4);
+    let mut instance = Instance::builder()
+        .sense(Sense::Minimize)
+        .objective(Function::zero())
+        .decision_variables(BTreeMap::from([
+            (VariableID::from(0), DecisionVariable::binary()),
+            (VariableID::from(1), DecisionVariable::binary()),
+        ]))
+        .constraints(BTreeMap::new())
+        .one_hot_constraints(BTreeMap::from([(
+            one_hot_id,
+            OneHotConstraint::new(BTreeSet::from([VariableID::from(0), VariableID::from(1)]))
+                .unwrap(),
+        )]))
+        .build()
+        .unwrap();
+
+    let reduction = instance
+        .reduce_capabilities_with_recovery(&Capabilities::new())
+        .unwrap();
+    assert_eq!(
+        reduction.lowered_constraints(),
+        &[LoweredConstraintID::OneHot(one_hot_id)]
+    );
+
+    let requested = Capabilities::from([AdditionalCapability::OneHot]);
+    let recovery = instance.recover_capability_reduction(reduction).unwrap();
+    assert_eq!(
+        recovery.recovered(),
+        &[LoweredConstraintID::OneHot(one_hot_id)]
+    );
+    assert!(recovery.skipped().is_empty());
+    assert_eq!(instance.required_capabilities(), requested);
+
+    let state = v1::State::from_iter([(0, 1.0), (1, 0.0)]);
+    assert_eq!(recovery.project_state(&state).unwrap(), state);
+    assert_eq!(recovery.lift_state(&state).unwrap(), state);
+}


### PR DESCRIPTION
Stacked on #1067.

## Summary

- add an atomic tracked alternative to `reduce_capabilities` that returns a runtime-only handle scoped to exactly one lowering batch
- bind each newly lowered Indicator, OneHot, and SOS1 source to a globally unique batch token and re-verify current content after external presolve
- recover verifiable sources in reverse lowering order while reporting changed candidates as skipped
- expose an opaque exact raw-state projection/lift result without exposing proof objects, mutation plans, selector roles, or durable receipt serialization

This is the first public Rust history-recovery surface intended for external presolvers such as JijPresolve. It is not flat-model recognition and does not add Python or protobuf APIs.

## Consumer

JijPresolve uses this API around its high-level PaPILO pipeline. It temporarily lowers active Indicator, OneHot, and SOS1 constraints, writes PaPILO reductions back, then recovers only the histories that still pass the exact OMMX verifier. The corresponding integration remains in development until this stack is merged and published as an OMMX Rust SDK version.
