### PR TITLE
Preserve Rust prerelease channel after releases

### DIFF
--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -139,8 +139,19 @@ jobs:
 
       - name: Bump version
         run: |
-          cargo set-version --bump patch
-          echo "NEW_VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version')" >> "$GITHUB_ENV"
+          CURRENT_VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name == "ommx") | .version')
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            PRERELEASE=${CURRENT_VERSION#*-}
+            CHANNEL=${PRERELEASE%%.*}
+            case "$CHANNEL" in
+              alpha|beta|rc) ;;
+              *) echo "Unsupported prerelease channel: $CHANNEL" >&2; exit 1 ;;
+            esac
+            cargo set-version --bump "$CHANNEL"
+          else
+            cargo set-version --bump patch
+          fi
+          echo "NEW_VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name == "ommx") | .version')" >> "$GITHUB_ENV"
 
       - uses: actions/create-github-app-token@v3
         id: app-token


### PR DESCRIPTION
## Summary

- detect the current Rust SDK prerelease channel in the release workflow
- increment `alpha`, `beta`, and `rc` versions within the same channel
- retain patch bumps for stable releases and fail explicitly for unsupported prerelease channels

## Background

The release workflow always used a patch bump after publishing. For a prerelease such as `3.0.0-beta.1`, that promotes the version directly to `3.0.0` instead of starting development on `3.0.0-beta.2`.

This change derives the channel from the current `ommx` package version and passes it to `cargo set-version`, keeping prerelease development on the intended channel.