### PR TITLE
Fix parameter arithmetic with function expressions

### DIFF
--- a/python/ommx-tests/tests/test_function.py
+++ b/python/ommx-tests/tests/test_function.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from ommx import _ommx_rust
 from ommx.v1 import (
     DecisionVariable,
     Function,
@@ -78,6 +79,17 @@ def test_quadratic():
             columns=[1], rows=[2], values=[1.0], linear=Linear(terms={1: 1}, constant=0)
         ),
     )
+
+    rust_linear = _ommx_rust.Linear(terms={2: 3.0}, constant=1.0)
+    public_linear = Linear(terms={1: 1.0})
+    expected_from_rust_linear = Quadratic(
+        columns=[1],
+        rows=[2],
+        values=[3.0],
+        linear=Linear(terms={1: 1.0}),
+    )
+    assert_eq(public_linear * rust_linear, expected_from_rust_linear)
+    assert_eq(rust_linear * public_linear, expected_from_rust_linear)
 
     assert_eq(
         x1 * x2 + 2,

--- a/python/ommx-tests/tests/test_function.py
+++ b/python/ommx-tests/tests/test_function.py
@@ -1,5 +1,7 @@
 # FIXME: Use test case generator like Hypothesis
 
+import pytest
+
 from ommx.v1 import (
     DecisionVariable,
     Function,
@@ -159,19 +161,28 @@ def test_parameter_multiplication():
     assert_eq(w * h, expected_quadratic)
     assert_eq(h * w, expected_quadratic)
 
-    assert_eq(
-        w * (h - eps) * (h - eps),
-        Polynomial(
-            terms={
-                (0, 0, w.id): 1.0,
-                (0, 1, w.id): 4.0,
-                (0, w.id, eps.id): -2.0,
-                (1, 1, w.id): 4.0,
-                (1, w.id, eps.id): -4.0,
-                (w.id, eps.id, eps.id): 1.0,
-            }
-        ),
+    expected_polynomial = Polynomial(
+        terms={
+            (0, 0, w.id): 1.0,
+            (0, 1, w.id): 4.0,
+            (0, w.id, eps.id): -2.0,
+            (1, 1, w.id): 4.0,
+            (1, w.id, eps.id): -4.0,
+            (w.id, eps.id, eps.id): 1.0,
+        }
     )
+    shifted = h - eps
+    quadratic = shifted * shifted
+    polynomial = quadratic * shifted
+
+    assert_eq(w * shifted * shifted, expected_polynomial)
+    assert_eq(quadratic * w, expected_polynomial)
+    assert_eq(w * quadratic, expected_polynomial)
+    assert_eq(polynomial * w, w * polynomial)
+    assert_eq(Function(quadratic) * w, w * Function(quadratic))
+
+    with pytest.raises(TypeError):
+        _ = object() * h
 
 
 def test_polynomial():

--- a/python/ommx-tests/tests/test_function.py
+++ b/python/ommx-tests/tests/test_function.py
@@ -1,6 +1,13 @@
 # FIXME: Use test case generator like Hypothesis
 
-from ommx.v1 import Linear, DecisionVariable, Quadratic, Polynomial, Function
+from ommx.v1 import (
+    DecisionVariable,
+    Function,
+    Linear,
+    Parameter,
+    Polynomial,
+    Quadratic,
+)
 
 
 def assert_eq(lhs, rhs):
@@ -135,6 +142,36 @@ def test_quadratic():
     quad_instance += Quadratic(columns=[3], rows=[4], values=[3.0])
     assert id(quad_instance) == original_id  # Verify it's the same object
     assert_eq(quad_instance, Quadratic(columns=[1, 3], rows=[2, 4], values=[2.0, 3.0]))
+
+
+def test_parameter_multiplication():
+    x1 = DecisionVariable.binary(0, name="x1")
+    x2 = DecisionVariable.binary(1, name="x2")
+    w = Parameter.new(1_000_000, name="w")
+    eps = Parameter.new(1_000_001, name="eps")
+    h = x1 + 2.0 * x2
+
+    expected_quadratic = Quadratic(
+        columns=[0, 1],
+        rows=[w.id, w.id],
+        values=[1.0, 2.0],
+    )
+    assert_eq(w * h, expected_quadratic)
+    assert_eq(h * w, expected_quadratic)
+
+    assert_eq(
+        w * (h - eps) * (h - eps),
+        Polynomial(
+            terms={
+                (0, 0, w.id): 1.0,
+                (0, 1, w.id): 4.0,
+                (0, w.id, eps.id): -2.0,
+                (1, 1, w.id): 4.0,
+                (1, w.id, eps.id): -4.0,
+                (w.id, eps.id, eps.id): 1.0,
+            }
+        ),
+    )
 
 
 def test_polynomial():

--- a/python/ommx-tests/tests/test_function.py
+++ b/python/ommx-tests/tests/test_function.py
@@ -4,9 +4,11 @@ import pytest
 
 from ommx import _ommx_rust
 from ommx.v1 import (
+    Constraint,
     DecisionVariable,
     Function,
     Linear,
+    NamedFunction,
     Parameter,
     Polynomial,
     Quadratic,
@@ -195,6 +197,42 @@ def test_parameter_multiplication():
 
     with pytest.raises(TypeError):
         _ = object() * h
+
+
+def test_parameter_addition_with_higher_degree_functions():
+    x = DecisionVariable.binary(0)
+    parameter = Parameter.new(1_000_000)
+    parameter_linear = Linear(terms={parameter.id: 1.0})
+    linear = x + 1
+    quadratic = linear * linear
+    polynomial = quadratic * linear
+    function = Function(polynomial)
+    named_function = NamedFunction(id=0, function=function)
+
+    for expression, function_expression in [
+        (quadratic, quadratic),
+        (polynomial, polynomial),
+        (function, function),
+        (named_function, function),
+    ]:
+        assert_eq(parameter + expression, parameter_linear + function_expression)
+        assert_eq(expression + parameter, function_expression + parameter_linear)
+        assert_eq(parameter - expression, parameter_linear - function_expression)
+        assert_eq(expression - parameter, function_expression - parameter_linear)
+
+        assert isinstance(parameter == expression, Constraint)
+        assert isinstance(parameter <= expression, Constraint)
+        assert isinstance(parameter >= expression, Constraint)
+        assert isinstance(expression == parameter, Constraint)
+        assert isinstance(expression <= parameter, Constraint)
+        assert isinstance(expression >= parameter, Constraint)
+
+    quadratic += parameter
+    polynomial += parameter
+    function += parameter
+    assert_eq(quadratic, linear * linear + parameter_linear)
+    assert_eq(polynomial, linear * linear * linear + parameter_linear)
+    assert_eq(function, Function(linear * linear * linear) + parameter_linear)
 
 
 def test_polynomial():

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -2307,7 +2307,7 @@ class VariableBase(ABC):
         return Linear(terms={self.id: -1})
 
     def __radd__(self, other) -> Linear:
-        return self + other
+        return self.__add__(other)
 
     def __rsub__(self, other) -> Linear:
         return -self + other
@@ -3286,7 +3286,7 @@ class Linear(AsConstraint):
             return NotImplemented
 
     def __radd__(self, other):
-        return self + other
+        return self.__add__(other)
 
     def __iadd__(
         self, rhs: int | float | VariableBase | _ommx_rust.Linear | Linear
@@ -3498,12 +3498,12 @@ class Quadratic(AsConstraint):
         return self.raw.__repr__()
 
     def __add__(
-        self, other: int | float | DecisionVariable | Linear | Quadratic
+        self, other: int | float | VariableBase | Linear | Quadratic
     ) -> Quadratic:
         if isinstance(other, float) or isinstance(other, int):
             return Quadratic.from_raw(self.raw.add_scalar(other))
-        if isinstance(other, DecisionVariable):
-            other_linear = Linear(terms={other.raw.id: 1}, constant=0)
+        if isinstance(other, VariableBase):
+            other_linear = Linear(terms={other.id: 1}, constant=0)
             return Quadratic.from_raw(self.raw.add_linear(other_linear.raw))
         if isinstance(other, Linear):
             return Quadratic.from_raw(self.raw.add_linear(other.raw))
@@ -3512,10 +3512,10 @@ class Quadratic(AsConstraint):
         return NotImplemented
 
     def __radd__(self, other):
-        return self + other
+        return self.__add__(other)
 
     def __iadd__(
-        self, rhs: int | float | DecisionVariable | Linear | Quadratic
+        self, rhs: int | float | VariableBase | Linear | Quadratic
     ) -> Quadratic:
         if isinstance(rhs, Quadratic):
             self.raw.add_assign(rhs.raw)
@@ -3527,7 +3527,7 @@ class Quadratic(AsConstraint):
             return self
 
     def __sub__(
-        self, other: int | float | DecisionVariable | Linear | Quadratic
+        self, other: int | float | VariableBase | Linear | Quadratic
     ) -> Quadratic:
         return self + (-other)
 
@@ -3676,12 +3676,12 @@ class Polynomial(AsConstraint):
         return self.raw.__repr__()
 
     def __add__(
-        self, other: int | float | DecisionVariable | Linear | Quadratic | Polynomial
+        self, other: int | float | VariableBase | Linear | Quadratic | Polynomial
     ) -> Polynomial:
         if isinstance(other, float) or isinstance(other, int):
             return Polynomial.from_raw(self.raw.add_scalar(other))
-        if isinstance(other, DecisionVariable):
-            other_linear = Linear(terms={other.raw.id: 1}, constant=0)
+        if isinstance(other, VariableBase):
+            other_linear = Linear(terms={other.id: 1}, constant=0)
             return Polynomial.from_raw(self.raw.add_linear(other_linear.raw))
         if isinstance(other, Linear):
             return Polynomial.from_raw(self.raw.add_linear(other.raw))
@@ -3692,10 +3692,10 @@ class Polynomial(AsConstraint):
         return NotImplemented
 
     def __radd__(self, other):
-        return self + other
+        return self.__add__(other)
 
     def __iadd__(
-        self, rhs: int | float | DecisionVariable | Linear | Quadratic | Polynomial
+        self, rhs: int | float | VariableBase | Linear | Quadratic | Polynomial
     ) -> Polynomial:
         if isinstance(rhs, Polynomial):
             self.raw.add_assign(rhs.raw)
@@ -3707,11 +3707,9 @@ class Polynomial(AsConstraint):
             return self
 
     def __sub__(
-        self, other: int | float | DecisionVariable | Linear | Quadratic | Polynomial
+        self, other: int | float | VariableBase | Linear | Quadratic | Polynomial
     ) -> Polynomial:
-        if isinstance(
-            other, (int, float, DecisionVariable, Linear, Quadratic, Polynomial)
-        ):
+        if isinstance(other, (int, float, VariableBase, Linear, Quadratic, Polynomial)):
             return self + (-other)
         return NotImplemented
 
@@ -4111,19 +4109,13 @@ class Function(AsConstraint):
 
     def __add__(
         self,
-        other: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         if isinstance(other, float) or isinstance(other, int):
             rhs = _ommx_rust.Function.from_scalar(other)
-        elif isinstance(other, DecisionVariable):
+        elif isinstance(other, VariableBase):
             rhs = _ommx_rust.Function.from_linear(
-                _ommx_rust.Linear.single_term(other.raw.id, 1)
+                _ommx_rust.Linear.single_term(other.id, 1)
             )
         elif isinstance(other, Linear):
             rhs = _ommx_rust.Function.from_linear(other.raw)
@@ -4138,17 +4130,11 @@ class Function(AsConstraint):
         return Function.from_raw(self.raw + rhs)
 
     def __radd__(self, other):
-        return self + other
+        return self.__add__(other)
 
     def __iadd__(
         self,
-        rhs: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        rhs: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         if isinstance(rhs, Function):
             self.raw.add_assign(rhs.raw)
@@ -4161,13 +4147,7 @@ class Function(AsConstraint):
 
     def __sub__(
         self,
-        other: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         return self + (-other)
 
@@ -4498,73 +4478,37 @@ class NamedFunction(AsConstraint):
 
     def __add__(
         self,
-        other: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         return self.function + other
 
     def __radd__(
         self,
-        other: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
-        return self.function + other
+        return self.function.__add__(other)
 
     def __sub__(
         self,
-        other: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         return self.function - other
 
     def __rsub__(
         self,
-        other: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         return -self.function + other
 
     def __mul__(
         self,
-        other: int
-        | float
-        | VariableBase
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         return self.function * other
 
     def __rmul__(
         self,
-        other: int
-        | float
-        | VariableBase
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Function:
         return self.function * other
 
@@ -4573,13 +4517,7 @@ class NamedFunction(AsConstraint):
 
     def __eq__(  # type: ignore[reportIncompatibleMethodOverride]
         self,
-        other: int
-        | float
-        | DecisionVariable
-        | Linear
-        | Quadratic
-        | Polynomial
-        | Function,
+        other: int | float | VariableBase | Linear | Quadratic | Polynomial | Function,
     ) -> Constraint:
         return Constraint(
             function=self.function - other, equality=Constraint.EQUAL_TO_ZERO

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -3143,7 +3143,7 @@ class Linear(AsConstraint):
 
     @classmethod
     def from_object(
-        cls, obj: float | int | DecisionVariable | _ommx_rust.Linear | Linear
+        cls, obj: float | int | VariableBase | _ommx_rust.Linear | Linear
     ) -> Linear:
         if isinstance(obj, Linear):
             return obj
@@ -3153,8 +3153,8 @@ class Linear(AsConstraint):
             return new
         elif isinstance(obj, (float, int)):
             return cls.from_raw(_ommx_rust.Linear.constant(obj))
-        elif isinstance(obj, DecisionVariable):
-            return cls.from_raw(_ommx_rust.Linear.single_term(obj.raw.id, 1))
+        elif isinstance(obj, VariableBase):
+            return cls.from_raw(_ommx_rust.Linear.single_term(obj.id, 1))
         else:
             raise TypeError(f"Cannot create Linear from {type(obj).__name__}. ")
 
@@ -3314,14 +3314,14 @@ class Linear(AsConstraint):
     def __mul__(self, other: int | float) -> Linear: ...
 
     @overload
-    def __mul__(self, other: DecisionVariable | Linear) -> Quadratic: ...
+    def __mul__(self, other: VariableBase | Linear) -> Quadratic: ...
 
     def __mul__(
-        self, other: int | float | DecisionVariable | _ommx_rust.Linear | Linear
+        self, other: int | float | VariableBase | _ommx_rust.Linear | Linear
     ) -> Linear | Quadratic:
         if isinstance(other, (float, int)):
             return Linear.from_raw(self.raw.mul_scalar(other))
-        if isinstance(other, (DecisionVariable, Linear)):
+        if isinstance(other, (VariableBase, Linear)):
             rhs = Linear.from_object(other)
             return Quadratic.from_raw(self.raw * rhs.raw)
         return NotImplemented

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -3314,17 +3314,20 @@ class Linear(AsConstraint):
     def __mul__(self, other: int | float) -> Linear: ...
 
     @overload
-    def __mul__(self, other: VariableBase | Linear) -> Quadratic: ...
+    def __mul__(
+        self, other: VariableBase | _ommx_rust.Linear | Linear
+    ) -> Quadratic: ...
 
     def __mul__(
         self, other: int | float | VariableBase | _ommx_rust.Linear | Linear
     ) -> Linear | Quadratic:
         if isinstance(other, (float, int)):
             return Linear.from_raw(self.raw.mul_scalar(other))
-        if isinstance(other, (VariableBase, Linear)):
+        try:
             rhs = Linear.from_object(other)
-            return Quadratic.from_raw(self.raw * rhs.raw)
-        return NotImplemented
+        except TypeError:
+            return NotImplemented
+        return Quadratic.from_raw(self.raw * rhs.raw)
 
     def __rmul__(self, other):
         return self.__mul__(other)

--- a/python/ommx/ommx/v1/__init__.py
+++ b/python/ommx/ommx/v1/__init__.py
@@ -2326,7 +2326,7 @@ class VariableBase(ABC):
         return NotImplemented
 
     def __rmul__(self, other):
-        return self * other
+        return self.__mul__(other)
 
     def __le__(self, other) -> Constraint:
         return Constraint(
@@ -3277,7 +3277,7 @@ class Linear(AsConstraint):
         return self.raw.__repr__()
 
     def __add__(
-        self, rhs: int | float | DecisionVariable | _ommx_rust.Linear | Linear
+        self, rhs: int | float | VariableBase | _ommx_rust.Linear | Linear
     ) -> Linear:
         try:
             rhs = Linear.from_object(rhs)
@@ -3289,7 +3289,7 @@ class Linear(AsConstraint):
         return self + other
 
     def __iadd__(
-        self, rhs: int | float | DecisionVariable | _ommx_rust.Linear | Linear
+        self, rhs: int | float | VariableBase | _ommx_rust.Linear | Linear
     ) -> Linear:
         try:
             rhs = Linear.from_object(rhs)
@@ -3299,7 +3299,7 @@ class Linear(AsConstraint):
             return NotImplemented
 
     def __sub__(
-        self, rhs: int | float | DecisionVariable | _ommx_rust.Linear | Linear
+        self, rhs: int | float | VariableBase | _ommx_rust.Linear | Linear
     ) -> Linear:
         try:
             rhs = Linear.from_object(rhs)
@@ -3327,7 +3327,7 @@ class Linear(AsConstraint):
         return NotImplemented
 
     def __rmul__(self, other):
-        return self * other
+        return self.__mul__(other)
 
     def __neg__(self) -> Linear:
         return -1 * self
@@ -3535,15 +3535,15 @@ class Quadratic(AsConstraint):
     def __mul__(self, other: int | float) -> Quadratic: ...
 
     @overload
-    def __mul__(self, other: DecisionVariable | Linear | Quadratic) -> Polynomial: ...
+    def __mul__(self, other: VariableBase | Linear | Quadratic) -> Polynomial: ...
 
     def __mul__(
-        self, other: int | float | DecisionVariable | Linear | Quadratic
+        self, other: int | float | VariableBase | Linear | Quadratic
     ) -> Quadratic | Polynomial:
         if isinstance(other, float) or isinstance(other, int):
             return Quadratic.from_raw(self.raw.mul_scalar(other))
-        if isinstance(other, DecisionVariable):
-            other_linear = Linear(terms={other.raw.id: 1}, constant=0)
+        if isinstance(other, VariableBase):
+            other_linear = Linear(terms={other.id: 1}, constant=0)
             return Polynomial.from_raw(self.raw.mul_linear(other_linear.raw))
         if isinstance(other, Linear):
             return Polynomial.from_raw(self.raw.mul_linear(other.raw))
@@ -3552,9 +3552,9 @@ class Quadratic(AsConstraint):
         return NotImplemented
 
     def __rmul__(self, other):
-        return self * other
+        return self.__mul__(other)
 
-    def __neg__(self) -> Linear:
+    def __neg__(self) -> Quadratic:
         return -1 * self
 
     def __eq__(self, other) -> Constraint:  # type: ignore[reportIncompatibleMethodOverride]
@@ -3716,12 +3716,12 @@ class Polynomial(AsConstraint):
         return -self + other
 
     def __mul__(
-        self, other: int | float | DecisionVariable | Linear | Quadratic | Polynomial
+        self, other: int | float | VariableBase | Linear | Quadratic | Polynomial
     ) -> Polynomial:
         if isinstance(other, float) or isinstance(other, int):
             return Polynomial.from_raw(self.raw.mul_scalar(other))
-        if isinstance(other, DecisionVariable):
-            other_linear = Linear(terms={other.raw.id: 1}, constant=0)
+        if isinstance(other, VariableBase):
+            other_linear = Linear(terms={other.id: 1}, constant=0)
             return Polynomial.from_raw(self.raw.mul_linear(other_linear.raw))
         if isinstance(other, Linear):
             return Polynomial.from_raw(self.raw.mul_linear(other.raw))
@@ -3732,9 +3732,9 @@ class Polynomial(AsConstraint):
         return NotImplemented
 
     def __rmul__(self, other):
-        return self * other
+        return self.__mul__(other)
 
-    def __neg__(self) -> Linear:
+    def __neg__(self) -> Polynomial:
         return -1 * self
 
     def __eq__(self, other) -> Constraint:  # type: ignore[reportIncompatibleMethodOverride]
@@ -4174,14 +4174,14 @@ class Function(AsConstraint):
     def __mul__(
         self,
         other: (
-            int | float | DecisionVariable | Linear | Quadratic | Polynomial | Function
+            int | float | VariableBase | Linear | Quadratic | Polynomial | Function
         ),
     ) -> Function:
         if isinstance(other, float) or isinstance(other, int):
             rhs = _ommx_rust.Function.from_scalar(other)
-        elif isinstance(other, DecisionVariable):
+        elif isinstance(other, VariableBase):
             rhs = _ommx_rust.Function.from_linear(
-                _ommx_rust.Linear.single_term(other.raw.id, 1)
+                _ommx_rust.Linear.single_term(other.id, 1)
             )
         elif isinstance(other, Linear):
             rhs = _ommx_rust.Function.from_linear(other.raw)
@@ -4196,7 +4196,7 @@ class Function(AsConstraint):
         return Function.from_raw(self.raw * rhs)
 
     def __rmul__(self, other):
-        return self * other
+        return self.__mul__(other)
 
     def __neg__(self) -> Function:
         return -1 * self
@@ -4545,7 +4545,7 @@ class NamedFunction(AsConstraint):
         self,
         other: int
         | float
-        | DecisionVariable
+        | VariableBase
         | Linear
         | Quadratic
         | Polynomial
@@ -4557,7 +4557,7 @@ class NamedFunction(AsConstraint):
         self,
         other: int
         | float
-        | DecisionVariable
+        | VariableBase
         | Linear
         | Quadratic
         | Polynomial


### PR DESCRIPTION
## Summary

- treat `Parameter` consistently with other `VariableBase` values across addition, subtraction, multiplication, comparisons, and in-place addition for linear, quadratic, polynomial, function, and named-function expressions
- make reflected addition and multiplication call their implementations directly so unsupported operands produce a normal `TypeError` instead of recursively redispatching
- normalize Python and Rust-backed linear operands through `Linear.from_object` so mixed linear multiplication works in either order
- align the affected public type annotations and negation return types with runtime behavior
- add regression coverage for both operand orders, the reported cubic penalty expression, higher-degree expressions, constraints, in-place addition, Rust-backed linear operands, and unsupported operands

## Root cause

The expression wrappers accepted `DecisionVariable` explicitly but excluded the other `VariableBase` subtype, `Parameter`. When neither operand accepted the other, their reflected operators re-entered Python's binary-operator dispatch, repeatedly returning `NotImplemented` and delegating back to each other until `RecursionError`. The same dispatch loop affected parameter addition with higher-degree expressions, and therefore parameter subtraction and comparisons built on that addition path.

Separately, `Linear.__mul__` included `_ommx_rust.Linear` in its implementation signature but excluded it from both the overload and runtime conversion path, despite `Linear.from_object` already supporting that representation.

## Impact

Parametric expressions now support arithmetic consistently regardless of operand order or expression degree. Expressions such as `w * (h - eps) * (h - eps)` and `(h - eps) * (h - eps) * w` produce the expected polynomial, while parameter addition, subtraction, comparisons, and in-place addition work with higher-degree expressions. Python `Linear` values can also be multiplied with Rust-backed linear values in either order.