### PR TITLE
Drop Python 3.13t wheels from dev-2.x releases

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -25,7 +25,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.10 3.13t 3.14t
+          args: --release --out dist --interpreter 3.10 3.14t
           target: ${{ matrix.target }}
           working-directory: ./python/ommx
           manylinux: manylinux_2_28
@@ -47,7 +47,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.10 3.13t 3.14t
+          args: --release --out dist --interpreter 3.10 3.14t
           working-directory: ./python/ommx
 
       - name: Upload wheels
@@ -66,13 +66,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.13t
+          python-version: "3.10"
           cache: "pip"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --out dist --interpreter 3.10 3.13t
+          args: --release --out dist --interpreter 3.10
           working-directory: ./python/ommx
 
       - name: Upload wheels


### PR DESCRIPTION
## Summary

- Remove CPython 3.13 free-threaded targets from the Linux and macOS release wheel builds.
- Return the Windows release wheel build to its CPython 3.10-only setup.
- Keep CPython 3.14 free-threaded wheels enabled on Linux and macOS.

## Root cause

The `dev-2.x` release workflow still requested the experimental CPython 3.13 free-threaded interpreter after upstream manylinux and cibuildwheel support was removed. The current `maturin` release rejects the stale `3.13t` interpreter target, causing the Linux and macOS release jobs to fail before wheel compilation.

## Impact

Future `dev-2.x` Python releases use the supported interpreter set and no longer fail while resolving the removed `3.13t` target.