### PR TITLE
Add policy-driven SolverAdapter preparation

### DIFF
--- a/docs/en/migration/python_sdk_v2_to_v3.md
+++ b/docs/en/migration/python_sdk_v2_to_v3.md
@@ -400,13 +400,13 @@ parametric_instance.parameters_df()       # -> pandas.DataFrame  (method, not pr
 - `Parameters` / `OneHot` / `Sos1` / `ConstraintHints` — see §1.2.
 - `Artifact` low-level types (`ArtifactArchive`, `ArtifactDir`, `ArtifactArchiveBuilder`, `ArtifactDirBuilder`) — replaced by unified `Artifact` / `ArtifactDraft`.
 - `ommx_openjij_adapter.response_to_samples(response)` — use `decode_to_samples(response)`.
-- `ommx_openjij_adapter.sample_qubo_sa(...)` — use `OMMXOpenJijSAAdapter.sample(...)` for a directly applicable input. The replacement returns an evaluated `SampleSet`, rather than raw `Samples`. When preparation is required, call `OMMXOpenJijSAAdapter.prepare(...)`, sample `preparation.input`, and use `preparation.evaluate_source(...)` to evaluate the samples against the source instance.
+- `ommx_openjij_adapter.sample_qubo_sa(...)` — use `OMMXOpenJijSAAdapter.sample(...)` for a directly applicable input. The replacement returns an evaluated `SampleSet`, rather than raw `Samples`. When preparation is required, call `OMMXOpenJijSAAdapter.prepare(...)`, sample `preparation.input`, and use `preparation.decode(...)` to evaluate the samples against the source instance.
 
 In v2, the OpenJij Adapter constructor, `sample()`, and `solve()` accepted
 `uniform_penalty_weight`, `penalty_weights`, and
 `inequality_integer_slack_max_range` directly and performed preparation
 implicitly. In v3, move those settings into one immutable
-`OpenJijPreparationConfig`, pass it to `prepare()` through `config=`, and sample
+`OpenJijPreparationPolicy`, pass it to `prepare()` through `policy=`, and sample
 the resulting `preparation.input`. Use `penalty_weights` instead of
 `uniform_penalty_weight` when each regular constraint needs its own weight. v2
 also selected a uniform weight of `1.0` when neither penalty setting was
@@ -421,21 +421,21 @@ default preparation path uses only available exact operations.
 ```python
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
-config = OpenJijPreparationConfig(
+policy = OpenJijPreparationPolicy(
     uniform_penalty_weight=20.0,
     inequality_integer_slack_max_range=32,
     allow_approximate_integer_slack=True,  # Retain v2's approximation fallback.
 )
-preparation = OMMXOpenJijSAAdapter.prepare(source, config=config)
+preparation = OMMXOpenJijSAAdapter.prepare(source, policy=policy)
 ```
 
-`preparation.report.config` records the normalized, immutable settings actually
+`preparation.report.policy` records the normalized, immutable settings actually
 used. The remaining fields encode one of four terminal states: source rejected,
 preparation phase rejected, prepared candidate rejected by Adapter
-applicability, or success. `steps` is the prefix of operations completed before
+applicability, or success. `transforms` is the prefix of transformations completed before
 that terminal state, not a separate outcome.
 
 ```python

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -67,15 +67,15 @@ the source model when source semantics are required:
 ```python
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
-config = OpenJijPreparationConfig(
+policy = OpenJijPreparationPolicy(
     uniform_penalty_weight=20.0,
 )
-preparation = OMMXOpenJijSAAdapter.prepare(source, config=config)
+preparation = OMMXOpenJijSAAdapter.prepare(source, policy=policy)
 prepared_samples = OMMXOpenJijSAAdapter.sample(preparation.input)
-source_samples = preparation.evaluate_source(prepared_samples)
+source_samples = preparation.decode(prepared_samples)
 ```
 
 Finite penalties and approximate integer slack now require explicit opt-in.

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,6 +8,22 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
+### 🆕 Policy-driven SolverAdapter preparation ([#1137](https://github.com/Jij-Inc/ommx/pull/1137))
+
+{meth}`SolverAdapter.prepare <ommx.adapter.SolverAdapter.prepare>` now provides
+an explicit common workflow for producing an applicable Adapter input without
+changing direct `solve()` or `sample()` behavior. A
+{class}`~ommx.adapter.PreparationPolicy` can restrict the Adapter-declared
+special-constraint lowerings, and the returned
+{class}`~ommx.adapter.Preparation` records applied Transforms and decodes
+Adapter outputs by reevaluating them against the source instance.
+
+HiGHS preparation now lowers active Indicator, OneHot, and SOS1 constraints
+through the existing exact SDK Transforms before rechecking applicability.
+OpenJij's existing pipeline uses the same `Preparation`, Transform, policy, and
+`decode()` vocabulary, with OpenJij-specific settings in
+`OpenJijPreparationPolicy`.
+
 ### 🛠 Model errors follow caller ownership ([#1104](https://github.com/Jij-Inc/ommx/pull/1104), [#1105](https://github.com/Jij-Inc/ommx/pull/1105))
 
 Function, polynomial, constraint, named-function, and `Instance` evaluation

--- a/docs/en/tutorial/implement_adapter.md
+++ b/docs/en/tutorial/implement_adapter.md
@@ -284,6 +284,8 @@ Finally, create a class that inherits `ommx.adapter.SolverAdapter` to standardiz
 class SolverAdapter(ABC):
     # OMMX-defined structural condition for adapter applicability.
     INPUT_CLASS: InstanceClass | None = None
+    # Canonical special-constraint families this Adapter permits prepare() to lower.
+    PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS: tuple[SpecialConstraintKind, ...] = ()
 
     @classmethod
     @abstractmethod
@@ -312,11 +314,13 @@ This abstract base class assumes the following two use cases:
 
 The `solve` class method may define additional adapter-specific keyword options in concrete adapters. The reserved `diagnostics` keyword is owned by `Run.log_solve`. When `Run.log_solve(..., store_diagnostics=True)` is used, adapters may record adapter-defined diagnostic reports into that sink; `None` means diagnostics are disabled.
 
-#### Input Class and Explicit Constraint Lowering
+#### Input Class and Preparation
 
 An adapter declares the structural set of exact `Instance` values it can receive with `INPUT_CLASS`. `check_applicability()` evaluates membership first and then adapter-owned preconditions without mutating the caller's instance; `require_applicable()` raises with the same structured report when either condition fails.
 
-`SolverAdapter` does not prescribe how a concrete adapter processes an accepted input and does not mutate the instance in a base constructor. A concrete adapter may explicitly call {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` as an implementation detail. Its `kinds_to_lower` argument uses these special-constraint family selectors:
+Direct constructors, `solve()`, and `sample()` receive only applicable inputs and never prepare them implicitly. Separately, an Adapter may declare the canonical ordered special-constraint families it permits with `PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS`. The inherited {meth}`SolverAdapter.prepare <ommx.adapter.SolverAdapter.prepare>` intersects that family list with the caller's {class}`~ommx.adapter.PreparationPolicy`, lowers the selected active families together on an isolated copy, and checks the produced input again. This first common slice is not a general alternative-path search API.
+
+The Adapter declaration and the root-owned {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` Transform use these special-constraint family selectors:
 
 - `SpecialConstraintKind.Indicator`: Indicator constraints (`binvar = 1 → f(x) <= 0`)
 - `SpecialConstraintKind.OneHot`: Exactly one of a set of binary variables is 1
@@ -325,23 +329,46 @@ An adapter declares the structural set of exact `Instance` values it can receive
 Use {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` to inspect the currently active families. `lower_special_constraints` converts each selected active family into regular constraints (Big-M for indicator / SOS1, linear equality for one-hot), mutates the instance in place, and logs each lowering at `INFO` level. Neither this property nor lowering establishes `INPUT_CLASS` membership or adapter applicability.
 
 ```{important}
-`INPUT_CLASS` describes the exact value received by the adapter, regardless of its internal implementation. If a caller explicitly lowers an instance before choosing an adapter, the result is a different input value and must be checked again with `check_applicability()` or `require_applicable()`.
+`INPUT_CLASS` describes the exact value received by the adapter. `prepare(source)` is an explicit operation that returns a separate {class}`~ommx.adapter.Preparation`; pass `preparation.input` to the direct Adapter API and use `preparation.decode(output)` for a source-evaluated result.
+
+Each {class}`~ommx.adapter.PreparationTransform` in the report is an audit receipt for an applied SDK Transform, not an Adapter-authored exactness proof. The current common decoder is intended for Transform pipelines whose evaluated input state retains or reconstructs every source variable.
 ```
 
 Using the functions prepared so far, you can implement it as follows:
 
 ```{code-cell} ipython3
+from ommx import (
+    DegreeBound,
+    Equality,
+    InstanceClass,
+    InstanceClassClause,
+    Kind,
+    Sense,
+)
 from ommx.adapter import DiagnosticsSink, SolverAdapter
-from ommx import SpecialConstraintKind
 
 class OMMXPySCIPOptAdapter(SolverAdapter):
+    INPUT_CLASS = InstanceClass(
+        [
+            InstanceClassClause(
+                label="tutorial-quadratic-mip",
+                allowed_variable_kinds={Kind.Binary, Kind.Integer, Kind.Continuous},
+                objective_degree_bound=DegreeBound.at_most(2),
+                regular_constraint_degree_bounds={
+                    Equality.EqualToZero: DegreeBound.at_most(2),
+                    Equality.LessThanOrEqualToZero: DegreeBound.at_most(2),
+                },
+                allowed_senses={Sense.Minimize, Sense.Maximize},
+            )
+        ]
+    )
+
     def __init__(
         self,
         ommx_instance: Instance,
     ):
-        # This adapter handles Indicator and SOS1 directly, and explicitly
-        # lowers OneHot constraints.
-        ommx_instance.lower_special_constraints({SpecialConstraintKind.OneHot})
+        # The direct constructor receives an already-applicable input.
+        self.require_applicable(ommx_instance)
         self.instance = ommx_instance
         self.model = pyscipopt.Model()
         self.model.hideOutput()
@@ -606,7 +633,7 @@ sample_set.summary
 In this tutorial, we learned how to implement an OMMX Adapter by connecting to PySCIPOpt as a Solver Adapter and OpenJij as a Sampler Adapter. Here are the key points when implementing an OMMX Adapter:
 
 1. Implement an OMMX Adapter by inheriting the abstract base class `SolverAdapter` or `SamplerAdapter`.
-2. Declare the structural input condition with `INPUT_CLASS`, then use `check_applicability()` or `require_applicable()` to evaluate membership and adapter-owned preconditions. If lowering is needed, make it an explicit concrete-adapter or caller operation; the base Adapter contract never mutates the input.
+2. Declare the structural input condition with `INPUT_CLASS`, then use `check_applicability()` or `require_applicable()` to evaluate membership and adapter-owned preconditions. Declare only Adapter-approved automatic special-constraint families; `prepare()` lowers policy-permitted active families together on an isolated copy, while direct Adapter calls remain preparation-free.
 3. The main steps of the implementation are as follows:
    - Convert `ommx.Instance` into a format that the backend solver can understand.
    - Run the backend solver to obtain a solution.

--- a/docs/en/tutorial/tsp_sampling_with_openjij_adapter.md
+++ b/docs/en/tutorial/tsp_sampling_with_openjij_adapter.md
@@ -136,19 +136,19 @@ the Adapter and evaluate those samples against the source model explicitly.
 ```{code-cell} ipython3
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
-config = OpenJijPreparationConfig(
+policy = OpenJijPreparationPolicy(
     uniform_penalty_weight=20.0,
 )
-prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
+prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
 
 prepared_samples = OMMXOpenJijSAAdapter.sample(
     prepared.input,
     num_reads=16,
 )
-sample_set = prepared.evaluate_source(prepared_samples)
+sample_set = prepared.decode(prepared_samples)
 sample_set.summary
 ```
 
@@ -157,34 +157,34 @@ sample_set.summary
 constraint violations in addition to the decision variable values.
 `SampleSet.summary` displays this information. Its `feasible` column indicates
 feasibility for the source constrained problem because
-`prepared.evaluate_source()` evaluates the prepared-input states against that
+`prepared.decode()` decodes the prepared-input states and evaluates them against that
 source model.
 
-The penalty weight in `config` belongs to the explicit preparation, not to the
+The penalty weight in `policy` belongs to the explicit preparation, not to the
 OpenJij backend sampler. A finite penalty encourages feasibility but does not
 guarantee that every returned sample is feasible for the source problem.
 
 ### Inspecting preparation
 
-`check_preparation` checks the source model and preparation config without
+`check_preparation` checks the source model and preparation policy without
 mutating the instance. `prepare` performs the checked transformations and
 stores an audit report in `prepared.report`:
 
 ```{code-cell} ipython3
 report = prepared.report
-config_used = report.config
+policy_used = report.policy
 final = report.input_applicability
 outcomes = {
     "source_membership": report.source_check.source_membership.is_member,
-    "steps": [step.operation for step in report.steps],
+    "transforms": [transform.name for transform in report.transforms],
     "preparation_failures": report.preparation_failures,
     "input_applicability": None if final is None else final.is_applicable,
 }
-config_used, outcomes
+policy_used, outcomes
 ```
 
-`report.config` records the normalized, immutable preparation settings actually
-used. It is configuration evidence. The other fields encode one terminal state:
+`report.policy` records the normalized, immutable preparation settings actually
+used. It is policy evidence. The other fields encode one terminal state:
 
 | State | `source_check` | `preparation_failures` | `input_applicability` |
 | --- | --- | --- | --- |
@@ -195,14 +195,14 @@ used. It is configuration evidence. The other fields encode one terminal state:
 
 `source_check` is structural source-class membership. Operation availability
 and preparation policy belong to the phase that performs the operation and are
-recorded in `preparation_failures`. `steps` is the prefix of operations that
-completed before the terminal state. It is an operation audit, not a separate
+recorded in `preparation_failures`. `transforms` is the prefix of transformations
+that completed before the terminal state. It is a transform audit, not a separate
 outcome or a composed mathematical guarantee.
-Common preparation policy, guarantees, and automatic selection are tracked in
-[OMMX issue #1111](https://github.com/Jij-Inc/ommx/issues/1111). By default,
+Common preparation policy and automatic selection are provided by
+{py:class}`~ommx.adapter.SolverAdapter`. By default,
 OpenJij preparation uses only the available exact operations. Discrete integer
 slack approximation requires setting `allow_approximate_integer_slack=True` on
-`OpenJijPreparationConfig`; setting `inequality_integer_slack_max_range` alone
+`OpenJijPreparationPolicy`; setting `inequality_integer_slack_max_range` alone
 does not opt into approximation. Configuring `uniform_penalty_weight` or
 `penalty_weights` explicitly selects finite-penalty preparation, which does not
 claim that the Adapter directly or exactly supports constrained input.

--- a/docs/en/user_guide/capability_model.md
+++ b/docs/en/user_guide/capability_model.md
@@ -11,16 +11,18 @@ kernelspec:
   name: python3
 ---
 
-# Adapter Input Classes and Explicit Constraint Lowering
+# Adapter Input Classes, Preparation, and Constraint Lowering
 
-OMMX separates two concepts that were previously described together as adapter capabilities:
+OMMX separates three concepts that were previously described together as adapter capabilities:
 
 - An {class}`~ommx.InstanceClass` describes a set of exact `Instance` values. An adapter declares its structural input condition with `INPUT_CLASS`, then evaluates adapter-owned preconditions to determine applicability.
+- {meth}`SolverAdapter.prepare() <ommx.adapter.SolverAdapter.prepare>` applies an Adapter-declared, policy-permitted Transform to an isolated source and returns an applicable {class}`~ommx.adapter.Preparation` input together with output decoding.
 - {meth}`Instance.lower_special_constraints() <ommx.Instance.lower_special_constraints>` explicitly lowers selected special-constraint families on an instance. It does not declare an input class or establish adapter applicability.
 
 This page covers:
 
 - `InstanceClass` membership and adapter applicability
+- {class}`~ommx.adapter.Preparation`, {class}`~ommx.adapter.PreparationPolicy`, and output decoding
 - {class}`~ommx.SpecialConstraintKind` and {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` as special-constraint family selectors
 - {meth}`Instance.lower_special_constraints() <ommx.Instance.lower_special_constraints>` for explicit lowering
 - Manual conversion APIs per constraint type
@@ -47,6 +49,31 @@ binary_linear_with_one_hot = InstanceClass(
 ```
 
 Adapters declare this first applicability condition as `INPUT_CLASS`. Use `check_applicability()` for a structured result or `require_applicable()` to raise when membership or an adapter-owned precondition fails. Explicit preparation produces another input value, whose applicability must be checked again.
+
+## Policy-driven Adapter preparation
+
+{meth}`SolverAdapter.prepare() <ommx.adapter.SolverAdapter.prepare>` keeps direct Adapter applicability unchanged while providing an explicit preparation workflow. It first prefers identity when the source is already applicable. In the current common slice, it otherwise applies the canonical ordered special-constraint families declared by that Adapter and allowed by the caller's {class}`~ommx.adapter.PreparationPolicy`. Those selected active families are lowered together by the SDK; this tuple is not yet a general alternative-path search API. The source is never mutated, and the produced input is checked again before {class}`~ommx.adapter.Preparation` is returned.
+
+HiGHS declares exact Indicator, OneHot, and SOS1 lowering candidates. A caller can therefore prepare a source with special constraints without manually choosing the active families:
+
+```python
+from ommx.adapter import PreparationPolicy
+from ommx_highs_adapter import OMMXHighsAdapter
+
+source = instance
+preparation = OMMXHighsAdapter.prepare(source)
+input_solution = OMMXHighsAdapter.solve(preparation.input)
+source_solution = preparation.decode(input_solution)
+
+# A policy can restrict, but never broaden, the Adapter's candidates.
+no_automatic_lowering = PreparationPolicy(
+    allowed_special_constraint_lowerings=frozenset()
+)
+```
+
+`preparation.input` and `input_solution` belong to the transformed problem. For the current SDK special lowerings and the OpenJij pipeline, input evaluation retains or reconstructs every source variable. {meth}`Preparation.decode() <ommx.adapter.Preparation.decode>` can therefore select those source variables, remove input-only auxiliaries, and reevaluate the state on `preparation.source`; it does not promote regular constraints back into special constraints. `PreparationTransform` is an applied-transform audit receipt, not a formal proof or a general executable `encode`/`decode` object.
+
+This slice transports successful `Solution` and `SampleSet` values. It does not yet provide a high-level invocation API that transports `InfeasibleDetected` or `UnboundedDetected` across a Preparation. Direct constructors, `solve()`, and `sample()` remain preparation-free and continue to reject non-applicable inputs.
 
 ## SpecialConstraintKind and active_special_constraint_kinds
 
@@ -202,6 +229,8 @@ for cid, c in instance2.constraints.items():
 | Describe a structural set of adapter inputs | {class}`~ommx.InstanceClass` |
 | Declare the first adapter applicability condition | `INPUT_CLASS` |
 | Check membership plus adapter-owned preconditions | `check_applicability()` / `require_applicable()` |
+| Prepare an isolated applicable Adapter input | {meth}`SolverAdapter.prepare <ommx.adapter.SolverAdapter.prepare>` with {class}`~ommx.adapter.PreparationPolicy` |
+| Decode and reevaluate Adapter output on the source | {meth}`Preparation.decode <ommx.adapter.Preparation.decode>` |
 | Inspect active special-constraint families | {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` |
 | Explicitly lower selected special constraints | {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` |
 | Convert individually to regular constraints | `convert_*_to_constraint(s)` / `convert_all_*_to_constraints` |

--- a/docs/en/user_guide/special_constraints.md
+++ b/docs/en/user_guide/special_constraints.md
@@ -25,7 +25,7 @@ The examples below use the PySCIPOpt Adapter, as in [Solving optimization proble
 pip install ommx-pyscipopt-adapter
 ```
 
-The PySCIPOpt Adapter passes Indicator and SOS1 constraints through to SCIP's `addConsIndicator` / `addConsSOS1` (equality indicators are split into two inequality indicators). It does not accept OneHot directly, so callers must explicitly lower OneHot to a regular equality before passing the resulting input to the adapter. This preparation is separate from `INPUT_CLASS` membership and adapter applicability; see [Adapter Input Classes and Explicit Constraint Lowering](./capability_model.md).
+The PySCIPOpt Adapter passes Indicator and SOS1 constraints through to SCIP's `addConsIndicator` / `addConsSOS1` (equality indicators are split into two inequality indicators). It does not accept OneHot directly, so callers must explicitly lower OneHot to a regular equality before passing the resulting input to the adapter. This preparation is separate from `INPUT_CLASS` membership and adapter applicability; see [Adapter Input Classes, Preparation, and Constraint Lowering](./capability_model.md).
 
 ## IndicatorConstraint
 

--- a/docs/ja/migration/python_sdk_v2_to_v3.md
+++ b/docs/ja/migration/python_sdk_v2_to_v3.md
@@ -236,12 +236,12 @@ ids_list: list[int] = sample_set.sample_ids_list
 - `instance.constraint_hints` - `one_hot_constraints` / `sos1_constraints` / `indicator_constraints` に分かれました。
 - `ArtifactArchive` / `ArtifactDir` 系 - `Artifact` / `ArtifactDraft` に統合されました。
 - `ommx_openjij_adapter.response_to_samples(response)` - `decode_to_samples(response)` を使用します（`3.0.0`: [#1087](https://github.com/Jij-Inc/ommx/pull/1087)）。
-- `ommx_openjij_adapter.sample_qubo_sa(...)` - 直接適用可能なinputでは `OMMXOpenJijSAAdapter.sample(...)` を使用します。置き換え後はraw `Samples` ではなく評価済みの `SampleSet` を返します。preparationが必要な場合は `OMMXOpenJijSAAdapter.prepare(...)` を呼び、`preparation.input` をsampleしてから、`preparation.evaluate_source(...)` でsource instanceに対して評価します（`3.0.0`: [#1087](https://github.com/Jij-Inc/ommx/pull/1087)）。
+- `ommx_openjij_adapter.sample_qubo_sa(...)` - 直接適用可能なinputでは `OMMXOpenJijSAAdapter.sample(...)` を使用します。置き換え後はraw `Samples` ではなく評価済みの `SampleSet` を返します。preparationが必要な場合は `OMMXOpenJijSAAdapter.prepare(...)` を呼び、`preparation.input` をsampleしてから、`preparation.decode(...)` でsource instanceに対して評価します（`3.0.0`: [#1087](https://github.com/Jij-Inc/ommx/pull/1087)）。
 
 v2のOpenJij Adapterでは、constructor、`sample()`、`solve()` が
 `uniform_penalty_weight`、`penalty_weights`、
 `inequality_integer_slack_max_range` を直接受け取り、暗黙にpreparationを実行していました。
-v3では、これらを1つの不変な `OpenJijPreparationConfig` にまとめ、`config=` から
+v3では、これらを1つの不変な `OpenJijPreparationPolicy` にまとめ、`policy=` から
 `prepare()` に渡したうえで、得られた `preparation.input` をsampleします。通常制約ごとに
 異なるweightが必要な場合は、`uniform_penalty_weight` の代わりに `penalty_weights` を
 使います。v2はどちらのpenalty設定もない場合に一律weight `1.0` を選びましたが、v3では
@@ -255,21 +255,21 @@ v2はexact integer slackへの変換に失敗すると、離散的なslack近似
 ```python
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
-config = OpenJijPreparationConfig(
+policy = OpenJijPreparationPolicy(
     uniform_penalty_weight=20.0,
     inequality_integer_slack_max_range=32,
     allow_approximate_integer_slack=True,  # v2の近似fallbackを維持
 )
-preparation = OMMXOpenJijSAAdapter.prepare(source, config=config)
+preparation = OMMXOpenJijSAAdapter.prepare(source, policy=policy)
 ```
 
-`preparation.report.config` は、正規化済みで実際に使われた不変の設定を記録します。
+`preparation.report.policy` は、正規化済みで実際に使われた不変の設定を記録します。
 その他のfieldは、source rejected、preparation phase rejected、準備したcandidateが
 Adapter applicabilityでrejected、successの4つの終端状態のいずれかを表します。
-`steps` はその終端状態までに完了したoperationのprefixであり、独立したoutcomeでは
+`transforms` はその終端状態までに完了したtransformのprefixであり、独立したoutcomeでは
 ありません。
 
 ## 8. DataFrame accessor

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -62,15 +62,15 @@ OpenJijの `sample()` / `solve()` は、Integer encoding、sense反転、slack�
 ```python
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
-config = OpenJijPreparationConfig(
+policy = OpenJijPreparationPolicy(
     uniform_penalty_weight=20.0,
 )
-preparation = OMMXOpenJijSAAdapter.prepare(source, config=config)
+preparation = OMMXOpenJijSAAdapter.prepare(source, policy=policy)
 prepared_samples = OMMXOpenJijSAAdapter.sample(preparation.input)
-source_samples = preparation.evaluate_source(prepared_samples)
+source_samples = preparation.decode(prepared_samples)
 ```
 
 有限penaltyとapproximate integer slackは明示的なopt-inが必要です。prepare後の値は

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,6 +8,20 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
+### 🆕 Policyで制御するSolverAdapter preparation ([#1137](https://github.com/Jij-Inc/ommx/pull/1137))
+
+{meth}`SolverAdapter.prepare <ommx.adapter.SolverAdapter.prepare>` に、直接の
+`solve()` / `sample()` の挙動を変えず、applicableなAdapter inputを生成する明示的な
+共通workflowを追加しました。{class}`~ommx.adapter.PreparationPolicy` でAdapterが
+宣言した特殊制約loweringを制限できます。返される
+{class}`~ommx.adapter.Preparation` は、適用したTransformを記録し、Adapter outputを
+source instanceに対して再評価する `decode()` を提供します。
+
+HiGHSのpreparationは、activeなIndicator、OneHot、SOS1制約を既存SDKのexactな
+Transformでloweringしてからapplicabilityを再検査します。OpenJijの既存pipelineも
+共通の `Preparation`、Transform、policy、`decode()` vocabularyを使い、OpenJij固有の
+設定は `OpenJijPreparationPolicy` で指定します。
+
 ### 🛠 Model error を呼び出し側の回復方法に応じて通知 ([#1104](https://github.com/Jij-Inc/ommx/pull/1104)、[#1105](https://github.com/Jij-Inc/ommx/pull/1105))
 
 Function、polynomial、constraint、named function、`Instance` のevaluation APIは、

--- a/docs/ja/tutorial/implement_adapter.md
+++ b/docs/ja/tutorial/implement_adapter.md
@@ -280,6 +280,8 @@ def decode_to_state(model: pyscipopt.Model, instance: Instance) -> State:
 class SolverAdapter(ABC):
     # Adapter applicability の OMMX 定義の構造条件
     INPUT_CLASS: InstanceClass | None = None
+    # prepare()でloweringを許可するcanonicalな特殊制約family
+    PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS: tuple[SpecialConstraintKind, ...] = ()
 
     @classmethod
     @abstractmethod
@@ -308,11 +310,13 @@ class SolverAdapter(ABC):
 
 具体的な adapter の `solve` クラスメソッドは、adapter 固有の keyword option を追加で定義できます。予約済みの `diagnostics` keyword は `Run.log_solve` が管理します。`Run.log_solve(..., store_diagnostics=True)` を使う場合、adapter はその sink に adapter 定義の diagnostic report を記録できます。`None` の場合、diagnostics は無効です。
 
-#### 入力 class と明示的な特殊制約 lowering
+#### 入力 class とPreparation
 
 Adapter は、受け取れる具体的な `Instance` 値の構造的な集合を `INPUT_CLASS` で宣言します。`check_applicability()` は membership、続いて Adapter 固有の precondition を呼び出し元の instance を変更せずに評価します。いずれかを満たさない場合に同じ構造化 report で例外を送出するには `require_applicable()` を使います。
 
-`SolverAdapter` は、受理した入力を具体的な Adapter がどのように処理するかを規定せず、基底 class の constructor で instance を変更しません。具体的な Adapter は、実装上必要であれば {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` を明示的に呼び出せます。`kinds_to_lower` 引数では、以下の特殊制約 family selector を使います：
+直接のconstructor、`solve()`、`sample()` はapplicableな入力だけを受け取り、暗黙のpreparationを行いません。これとは別に、Adapterはloweringを許可する特殊制約familyをcanonicalな順序の `PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS` で宣言できます。継承した {meth}`SolverAdapter.prepare <ommx.adapter.SolverAdapter.prepare>` は、そのfamily listと呼び出し側の {class}`~ommx.adapter.PreparationPolicy` の積を取り、選択したactive familyを隔離したcopy上でまとめてloweringしてから、生成したinputを再検査します。この最初の共通sliceは一般のalternative path探索APIではありません。
+
+Adapter側の宣言と、root所有の {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` Transformでは、以下の特殊制約family selectorを使います。
 
 - `SpecialConstraintKind.Indicator`: インジケーター制約 (`binvar = 1 → f(x) <= 0`)
 - `SpecialConstraintKind.OneHot`: バイナリ変数集合のうち丁度1つが1
@@ -321,23 +325,46 @@ Adapter は、受け取れる具体的な `Instance` 値の構造的な集合を
 `Instance` が現在保持する family は {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` で確認できます。`lower_special_constraints` は選択した active な family を通常制約へ変換し（indicator/SOS1 は Big-M、one-hot は線形等式）、instance を in-place に変更して、各 lowering を `INFO` level で記録します。この property も lowering も、`INPUT_CLASS` の membership や Adapter applicability を保証しません。
 
 ```{important}
-`INPUT_CLASS` は Adapter の内部実装にかかわらず、Adapter が受け取る時点の入力値そのものを記述します。呼び出し側が Adapter を選ぶ前に instance を明示的に lowering した場合、結果は別の入力値なので、`check_applicability()` または `require_applicable()` で再評価する必要があります。
+`INPUT_CLASS` はAdapterが受け取る時点の入力値そのものを記述します。`prepare(source)` は別の {class}`~ommx.adapter.Preparation` を返す明示的な操作です。`preparation.input` を直接のAdapter APIへ渡し、source側で評価した結果には `preparation.decode(output)` を使います。
+
+report内の各 {class}`~ommx.adapter.PreparationTransform` は、適用したSDK Transformの監査receiptであり、Adapterが作るexactness proofではありません。現在の共通decoderは、評価済みinput stateがすべてのsource変数を保持または再構築するTransform pipelineを対象にしています。
 ```
 
 ここまでで用意した関数を使って次のように実装することができます：
 
 ```{code-cell} ipython3
+from ommx import (
+    DegreeBound,
+    Equality,
+    InstanceClass,
+    InstanceClassClause,
+    Kind,
+    Sense,
+)
 from ommx.adapter import DiagnosticsSink, SolverAdapter
-from ommx import SpecialConstraintKind
 
 class OMMXPySCIPOptAdapter(SolverAdapter):
+    INPUT_CLASS = InstanceClass(
+        [
+            InstanceClassClause(
+                label="tutorial-quadratic-mip",
+                allowed_variable_kinds={Kind.Binary, Kind.Integer, Kind.Continuous},
+                objective_degree_bound=DegreeBound.at_most(2),
+                regular_constraint_degree_bounds={
+                    Equality.EqualToZero: DegreeBound.at_most(2),
+                    Equality.LessThanOrEqualToZero: DegreeBound.at_most(2),
+                },
+                allowed_senses={Sense.Minimize, Sense.Maximize},
+            )
+        ]
+    )
+
     def __init__(
         self,
         ommx_instance: Instance,
     ):
-        # この Adapter は Indicator と SOS1 を直接処理し、OneHot を
-        # 明示的に lowering する
-        ommx_instance.lower_special_constraints({SpecialConstraintKind.OneHot})
+        # 直接のconstructorは、すでにapplicableなinputを受け取る
+        self.require_applicable(ommx_instance)
         self.instance = ommx_instance
         self.model = pyscipopt.Model()
         self.model.hideOutput()
@@ -600,7 +627,7 @@ sample_set.summary
 このチュートリアルでは、PySCIPOptと接続するSolver Adapterの実装とOpenJijと接続するSampler Adapterの実装を通して、OMMX Adapterの実装方法について学びました。以下がOMMX Adapterを実装する際の重要なポイントです：
 
 1. OMMX Adapterは `SolverAdapter` または `SamplerAdapter` の抽象基底クラスを継承することで実装します
-2. `INPUT_CLASS` で構造的な入力条件を宣言し、`check_applicability()` または `require_applicable()` で membership と Adapter 固有の precondition を評価します。lowering が必要な場合は具体的な Adapter または呼び出し側の明示的な操作とし、基底 Adapter の契約では入力を変更しません
+2. `INPUT_CLASS` で構造的な入力条件を宣言し、`check_applicability()` または `require_applicable()` で membership と Adapter 固有の precondition を評価します。Adapterが許可する特殊制約familyだけを宣言し、`prepare()` はpolicyで許可されたactive familyを隔離したcopy上でまとめてloweringします。直接のAdapter callはpreparation-freeのままです
 3. 実装の主なステップは以下の通りです：
    - `ommx.Instance` をバックエンドソルバーが理解できる形式に変換する
    - バックエンドソルバーを実行して解を取得する

--- a/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.md
+++ b/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.md
@@ -136,53 +136,53 @@ instance = Instance.from_components(
 ```{code-cell} ipython3
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
-config = OpenJijPreparationConfig(
+policy = OpenJijPreparationPolicy(
     uniform_penalty_weight=20.0,
 )
-prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
+prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
 
 prepared_samples = OMMXOpenJijSAAdapter.sample(
     prepared.input,
     num_reads=16,
 )
-sample_set = prepared.evaluate_source(prepared_samples)
+sample_set = prepared.decode(prepared_samples)
 sample_set.summary
 ```
 
 {py:meth}`~ommx_openjij_adapter.OMMXOpenJijSAAdapter.sample` は
 {py:class}`~ommx.SampleSet` を返します。これは決定変数のサンプル値に加えて、
 評価した目的関数値と制約違反を保持します。`SampleSet.summary` はこの情報の要約を
-表示します。`prepared.evaluate_source()` が準備済み入力のsampleを変換元モデルに
+表示します。`prepared.decode()` が準備済み入力のsampleをdecodeし、変換元モデルに
 対して評価するため、その `feasible` 列は変換元の制約付き問題に対する実行可能性を
 示します。
 
-`config` のペナルティ重みはOpenJij backend samplerのパラメータではなく、明示的な
+`policy` のペナルティ重みはOpenJij backend samplerのパラメータではなく、明示的な
 準備に対する指定です。有限ペナルティは実行可能なサンプルを得やすくしますが、
 すべてのサンプルが変換元の問題に対して実行可能になることを保証しません。
 
 ### 準備内容の確認
 
-`check_preparation` はインスタンスを変更せずに、変換元モデルと準備configを
+`check_preparation` はインスタンスを変更せずに、変換元モデルと準備policyを
 検査します。`prepare` は検査した変換を実行し、監査用レポートを
 `prepared.report` に保存します。
 
 ```{code-cell} ipython3
 report = prepared.report
-config_used = report.config
+policy_used = report.policy
 final = report.input_applicability
 outcomes = {
     "source_membership": report.source_check.source_membership.is_member,
-    "steps": [step.operation for step in report.steps],
+    "transforms": [transform.name for transform in report.transforms],
     "preparation_failures": report.preparation_failures,
     "input_applicability": None if final is None else final.is_applicable,
 }
-config_used, outcomes
+policy_used, outcomes
 ```
 
-`report.config` は、正規化済みで実際に使われた不変のpreparation設定を記録します。
+`report.policy` は、正規化済みで実際に使われた不変のpreparation設定を記録します。
 これは設定の監査記録です。その他のfieldは、次のいずれか1つの終端状態を表します。
 
 | 状態 | `source_check` | `preparation_failures` | `input_applicability` |
@@ -194,14 +194,14 @@ config_used, outcomes
 
 `source_check` は構造的なsource-class membershipです。operation availabilityと
 preparation policyは、そのoperationを実行するphaseが所有し、
-`preparation_failures` に記録します。`steps` は終端状態までに完了したoperationの
+`preparation_failures` に記録します。`transforms` は終端状態までに完了したtransformの
 prefixです。独立したoutcomeや、合成された数学的guaranteeではありません。
-共通のpreparation policy、guarantee、自動選択は
-[OMMX issue #1111](https://github.com/Jij-Inc/ommx/issues/1111) で扱います。このprototype
-が既定で使うのは、利用可能な厳密operationだけです。離散的なinteger slack近似には
-`OpenJijPreparationConfig` で `allow_approximate_integer_slack=True` を設定する必要が
+共通のpreparation policyと自動選択は
+{py:class}`~ommx.adapter.SolverAdapter` が提供します。既定で使うのは、利用可能な厳密
+operationだけです。離散的なinteger slack近似には
+`OpenJijPreparationPolicy` で `allow_approximate_integer_slack=True` を設定する必要が
 あり、`inequality_integer_slack_max_range` の指定だけでは近似への同意になりません。
-同じConfigで `uniform_penalty_weight` または `penalty_weights` を明示的に設定すると
+同じpolicyで `uniform_penalty_weight` または `penalty_weights` を明示的に設定すると
 finite-penalty preparationが選択されますが、制約付き入力をAdapterが直接または厳密に
 サポートするという意味ではありません。
 

--- a/docs/ja/user_guide/capability_model.md
+++ b/docs/ja/user_guide/capability_model.md
@@ -11,16 +11,18 @@ kernelspec:
   name: python3
 ---
 
-# Adapter の入力 class と明示的な特殊制約 lowering
+# Adapter の入力 class、Preparation、特殊制約 lowering
 
-OMMX では、従来 Adapter Capability として一緒に説明されていた次の2つの概念を分けて扱います。
+OMMX では、従来 Adapter Capability として一緒に説明されていた次の3つの概念を分けて扱います。
 
 - {class}`~ommx.InstanceClass` は、具体的な `Instance` 値の集合です。Adapter は構造的な入力条件を `INPUT_CLASS` で宣言し、その後に Adapter 固有の precondition を評価して applicability を判定します。
+- {meth}`SolverAdapter.prepare() <ommx.adapter.SolverAdapter.prepare>` は、Adapter が宣言しpolicyで許可されたTransformを隔離したsourceに適用し、applicableな {class}`~ommx.adapter.Preparation` inputとoutputのdecodeを提供します。
 - {meth}`Instance.lower_special_constraints() <ommx.Instance.lower_special_constraints>` は、Instance 上で選択した特殊制約 family を明示的に lowering します。入力 class の宣言でも、Adapter applicability の証明でもありません。
 
 本ページでは以下を説明します。
 
 - `InstanceClass` の membership と Adapter applicability
+- {class}`~ommx.adapter.Preparation`、{class}`~ommx.adapter.PreparationPolicy`、outputのdecode
 - 特殊制約 family selector としての {class}`~ommx.SpecialConstraintKind` と {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>`
 - {meth}`Instance.lower_special_constraints() <ommx.Instance.lower_special_constraints>` による明示的な lowering
 - 手動で通常制約に変換するための API
@@ -47,6 +49,31 @@ binary_linear_with_one_hot = InstanceClass(
 ```
 
 Adapter は applicability の最初の条件を `INPUT_CLASS` として宣言します。構造化された結果を得るには `check_applicability()`、membership または Adapter 固有の precondition が満たされない場合に例外を送出するには `require_applicable()` を使います。明示的な preparation で別の入力値を作った場合は、その値で applicability を再評価します。
+
+## Policyに基づくAdapter Preparation
+
+{meth}`SolverAdapter.prepare() <ommx.adapter.SolverAdapter.prepare>` は、直接のAdapter applicabilityを変えずに、明示的なpreparation workflowを提供します。sourceがすでにapplicableならidentityを優先します。現在の共通sliceでは、それ以外の場合に、そのAdapterがcanonicalな順序で宣言し、呼び出し側の {class}`~ommx.adapter.PreparationPolicy` が許可した特殊制約familyを適用します。選択したactive familyはSDKがまとめてloweringするため、このtupleはまだ一般のalternative path探索APIではありません。sourceは変更せず、生成したinputのapplicabilityを再検査してから {class}`~ommx.adapter.Preparation` を返します。
+
+HiGHSはIndicator、OneHot、SOS1のexact loweringを候補として宣言しています。そのため、呼び出し側がactive familyを手作業で選ばなくても、特殊制約を持つsourceを準備できます。
+
+```python
+from ommx.adapter import PreparationPolicy
+from ommx_highs_adapter import OMMXHighsAdapter
+
+source = instance
+preparation = OMMXHighsAdapter.prepare(source)
+input_solution = OMMXHighsAdapter.solve(preparation.input)
+source_solution = preparation.decode(input_solution)
+
+# policyはAdapterの候補を制限できますが、広げることはできません。
+no_automatic_lowering = PreparationPolicy(
+    allowed_special_constraint_lowerings=frozenset()
+)
+```
+
+`preparation.input` と `input_solution` は変換後の問題に属します。現在のSDK特殊制約loweringとOpenJij pipelineでは、inputのevaluationがすべてのsource変数を保持または再構築します。そのため {meth}`Preparation.decode() <ommx.adapter.Preparation.decode>` はsource変数だけを選び、input固有の補助変数を除いて、`preparation.source` 上でstateを再評価できます。通常制約を特殊制約へ昇格し直す操作ではありません。`PreparationTransform` は適用済みTransformの監査receiptであり、形式証明でも一般の実行可能な `encode` / `decode` objectでもありません。
+
+このsliceがtransportするのは正常に返った `Solution` と `SampleSet` です。`InfeasibleDetected` や `UnboundedDetected` をPreparation越しにtransportするhigh-level invocation APIはまだ提供しません。直接のconstructor、`solve()`、`sample()` はpreparation-freeのままであり、non-applicableな入力を引き続き拒否します。
 
 ## SpecialConstraintKind と active_special_constraint_kinds
 
@@ -202,6 +229,8 @@ for cid, c in instance2.constraints.items():
 | Adapter 入力の構造的な集合を記述する | {class}`~ommx.InstanceClass` |
 | Adapter applicability の最初の条件を宣言する | `INPUT_CLASS` |
 | membership と Adapter 固有の precondition を検査する | `check_applicability()` / `require_applicable()` |
+| 隔離したapplicableなAdapter inputを準備する | {meth}`SolverAdapter.prepare <ommx.adapter.SolverAdapter.prepare>` と {class}`~ommx.adapter.PreparationPolicy` |
+| Adapter outputをdecodeしてsource上で再評価する | {meth}`Preparation.decode <ommx.adapter.Preparation.decode>` |
 | active な特殊制約 family を調べる | {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` |
 | 選択した特殊制約を明示的に lowering する | {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` |
 | 個別に通常制約に変換する | `convert_*_to_constraint(s)` / `convert_all_*_to_constraints` |

--- a/docs/ja/user_guide/special_constraints.md
+++ b/docs/ja/user_guide/special_constraints.md
@@ -25,7 +25,7 @@ OMMX は通常の制約（{class}`~ommx.Constraint`、等式・不等式を持�
 pip install ommx-pyscipopt-adapter
 ```
 
-PySCIPOpt Adapter は Indicator と SOS1 を SCIP の `addConsIndicator` / `addConsSOS1` にそのまま渡します（等式 Indicator は上下2本の不等式 Indicator に分解されます）。OneHot は直接受け入れないため、呼び出し側が通常の等式制約へ明示的に lowering してから、得られた入力を Adapter に渡す必要があります。この preparation は `INPUT_CLASS` の membership や Adapter applicability とは別です。詳しくは [Adapter の入力 class と明示的な特殊制約 lowering](./capability_model.md) を参照してください。
+PySCIPOpt Adapter は Indicator と SOS1 を SCIP の `addConsIndicator` / `addConsSOS1` にそのまま渡します（等式 Indicator は上下2本の不等式 Indicator に分解されます）。OneHot は直接受け入れないため、呼び出し側が通常の等式制約へ明示的に lowering してから、得られた入力を Adapter に渡す必要があります。この preparation は `INPUT_CLASS` の membership や Adapter applicability とは別です。詳しくは [Adapter の入力 class、Preparation、特殊制約 lowering](./capability_model.md) を参照してください。
 
 ## IndicatorConstraint
 

--- a/python/ommx-highs-adapter/README.md
+++ b/python/ommx-highs-adapter/README.md
@@ -29,3 +29,20 @@ ommx_solution = OMMXHighsAdapter.solve(ommx_instance)
 
 print(ommx_solution)
 ```
+
+`solve()` remains a direct-input API and does not transform its argument. When
+the source contains Indicator, OneHot, or SOS1 constraints, use the explicit
+Preparation workflow. HiGHS declares exact lowering for those three families;
+the produced input is checked again before it is returned.
+
+```python
+preparation = OMMXHighsAdapter.prepare(source)
+input_solution = OMMXHighsAdapter.solve(preparation.input)
+source_solution = preparation.decode(input_solution)
+```
+
+`input_solution` belongs to the lowered input. `decode()` removes any auxiliary
+variables introduced by lowering and reevaluates the state against the retained
+source instance. A caller can restrict automatic lowering with
+`ommx.adapter.PreparationPolicy`; a policy never adds candidates that HiGHS did
+not declare.

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -21,6 +21,7 @@ from ommx import (
     Kind,
     Sense,
     Solution,
+    SpecialConstraintKind,
     State,
 )
 from ommx.adapter import (
@@ -584,6 +585,14 @@ class OMMXHighsAdapter(SolverAdapter):
                 allowed_senses={Sense.Minimize, Sense.Maximize},
             )
         ]
+    )
+
+    PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS: ClassVar[
+        tuple[SpecialConstraintKind, ...]
+    ] = (
+        SpecialConstraintKind.Indicator,
+        SpecialConstraintKind.OneHot,
+        SpecialConstraintKind.Sos1,
     )
 
     def __init__(self, ommx_instance: Instance, *, verbose: bool = False):

--- a/python/ommx-highs-adapter/tests/test_preparation.py
+++ b/python/ommx-highs-adapter/tests/test_preparation.py
@@ -1,0 +1,119 @@
+import pytest
+
+from ommx import (
+    DecisionVariable,
+    Equality,
+    IndicatorConstraint,
+    Instance,
+    OneHotConstraint,
+    Sense,
+    Solution,
+    Sos1Constraint,
+    SpecialConstraintKind,
+)
+from ommx.adapter import PreparationError, PreparationPolicy
+
+from ommx_highs_adapter import OMMXHighsAdapter
+
+
+def _indicator_instance() -> Instance:
+    x = DecisionVariable.continuous(0, lower=0, upper=2)
+    trigger = DecisionVariable.binary(1)
+    return Instance.from_components(
+        decision_variables=[x, trigger],
+        objective=x,
+        constraints={},
+        sense=Sense.Minimize,
+        indicator_constraints={
+            10: IndicatorConstraint(
+                indicator_variable=trigger,
+                function=x - 1,
+                equality=Equality.LessThanOrEqualToZero,
+            )
+        },
+    )
+
+
+def _one_hot_instance() -> Instance:
+    x = [DecisionVariable.binary(i) for i in range(2)]
+    return Instance.from_components(
+        decision_variables=x,
+        objective=x[0] + 2 * x[1],
+        constraints={},
+        sense=Sense.Minimize,
+        one_hot_constraints={20: OneHotConstraint(variables=x)},
+    )
+
+
+def _sos1_instance() -> Instance:
+    x = [
+        DecisionVariable.continuous(0, lower=0, upper=2),
+        DecisionVariable.continuous(1, lower=0, upper=3),
+    ]
+    return Instance.from_components(
+        decision_variables=x,
+        objective=-x[0] - 2 * x[1],
+        constraints={},
+        sense=Sense.Minimize,
+        sos1_constraints={30: Sos1Constraint(variables=x)},
+    )
+
+
+@pytest.mark.parametrize(
+    ("make_source", "kind", "transform_name"),
+    [
+        (_indicator_instance, SpecialConstraintKind.Indicator, "indicator_lowering"),
+        (_one_hot_instance, SpecialConstraintKind.OneHot, "one_hot_lowering"),
+        (_sos1_instance, SpecialConstraintKind.Sos1, "sos1_lowering"),
+    ],
+)
+def test_prepare_lowers_declared_exact_special_constraint(
+    make_source, kind, transform_name
+):
+    source = make_source()
+    before = source.to_v2_bytes()
+
+    preparation = OMMXHighsAdapter.prepare(source)
+
+    assert OMMXHighsAdapter.PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS == (
+        SpecialConstraintKind.Indicator,
+        SpecialConstraintKind.OneHot,
+        SpecialConstraintKind.Sos1,
+    )
+    assert preparation.source.to_v2_bytes() == before
+    assert source.to_v2_bytes() == before
+    assert kind not in preparation.input.active_special_constraint_kinds
+    assert OMMXHighsAdapter.check_applicability(preparation.input).is_applicable
+    assert [transform.name for transform in preparation.report.transforms] == [
+        transform_name
+    ]
+
+
+def test_sos1_preparation_decodes_target_solution_to_source_solution():
+    source = _sos1_instance()
+    preparation = OMMXHighsAdapter.prepare(source)
+
+    target_solution = OMMXHighsAdapter.solve(preparation.input)
+    source_solution = preparation.decode(target_solution)
+
+    assert source_solution.feasible
+    assert source_solution.optimality == Solution.OPTIMAL
+    assert source_solution.objective == pytest.approx(-6)
+    assert source_solution.state.entries == pytest.approx({0: 0, 1: 3})
+
+
+def test_empty_policy_rejects_lowering_without_mutating_source():
+    source = _one_hot_instance()
+    before = source.to_v2_bytes()
+    policy = PreparationPolicy(allowed_special_constraint_lowerings=frozenset())
+
+    with pytest.raises(PreparationError) as exc_info:
+        OMMXHighsAdapter.prepare(source, policy=policy)
+
+    [failure] = exc_info.value.report.preparation_failures
+    assert failure.name == "special_constraint_lowering"
+    assert failure.reason == (
+        "preparation.policy.special_constraint_lowering_not_allowed"
+    )
+    assert exc_info.value.report.transforms == ()
+    assert source.to_v2_bytes() == before

--- a/python/ommx-openjij-adapter/README.md
+++ b/python/ommx-openjij-adapter/README.md
@@ -18,7 +18,7 @@ this adapter. Prepare a constrained model explicitly before sampling it:
 from ommx import DecisionVariable, Instance
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
 x = DecisionVariable.binary(0, name="x")
@@ -29,22 +29,22 @@ instance = Instance.from_components(
     sense=Instance.MINIMIZE,
 )
 
-config = OpenJijPreparationConfig(
+policy = OpenJijPreparationPolicy(
     uniform_penalty_weight=2.0,
 )
-prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
+prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
 
 prepared_samples = OMMXOpenJijSAAdapter.sample(
     prepared.input,
     num_reads=16,
 )
-sample_set = prepared.evaluate_source(prepared_samples)
+sample_set = prepared.decode(prepared_samples)
 
 print(sample_set.summary)
 ```
 
-The finite penalty weight is a field of the `OpenJijPreparationConfig` passed to
-`prepare` through `config=`, not an OpenJij backend sampler parameter. It must be
+The finite penalty weight is a field of the `OpenJijPreparationPolicy` passed to
+`prepare` through `policy=`, not an OpenJij backend sampler parameter. It must be
 chosen explicitly when constraints remain after exact preparation. A finite
 penalty does not guarantee that every returned sample is feasible for the source
 model; inspect the feasibility recorded in the decoded `SampleSet`.
@@ -69,31 +69,39 @@ and `prepare()`.
 
 `sample()` and `solve()` keep the common adapter contract and accept an
 `Instance` only. Explicit preparation therefore returns an
-`OpenJijPreparation`: pass its `input` `Instance` to the adapter, then use
-`evaluate_source()` to evaluate the resulting samples against the source
-model. The preparation itself is not an Adapter input. The report's `config`
+`ommx.adapter.Preparation`: pass its `input` `Instance` to the adapter, then use
+`decode()` to evaluate the resulting samples against the source
+model. The preparation itself is not an Adapter input. The report's `policy`
 field records the normalized, immutable preparation settings actually used.
 The remaining fields represent one of four terminal states:
 
 | State | `source_check` | `preparation_failures` | `input_applicability` |
 | --- | --- | --- | --- |
 | Source rejected | outside the preparation source class | empty | `None` |
-| Phase rejected | accepted | non-empty, with the owning `operation` | `None` |
+| Phase rejected | accepted | non-empty, with the owning transform `name` | `None` |
 | Candidate rejected | accepted | empty | non-applicable report |
 | Success | accepted | empty | applicable report |
 
-`source_check` is structural source-class membership. Operation availability
+`source_check` is structural source-class membership. Transform availability
 and preparation policy are checked by the phase that owns them and appear in
-`preparation_failures`. `steps` is the prefix of OpenJij-specific operations
-that completed before the terminal state; it is an operation audit, not a
-separate outcome or a composed mathematical guarantee.
-Common preparation policy, guarantees, and automatic selection are tracked in
-[OMMX issue #1111](https://github.com/Jij-Inc/ommx/issues/1111). By default,
-this prototype applies only the available exact operations. Discrete integer
+`preparation_failures`. `transforms` is the prefix of OpenJij-specific operations
+that completed before the terminal state. Each common
+`ommx.adapter.PreparationTransform` is an applied-transform audit receipt, not
+an executable transform or formal proof object.
+
+`OMMXOpenJijSAAdapter.PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS` declares the
+ordered Indicator, OneHot, and SOS1 lowerings that this adapter may apply.
+`OpenJijPreparationPolicy.allowed_special_constraint_lowerings=None` leaves
+those candidates unrestricted; a concrete set permits only the selected
+families, and an empty set forbids all special-constraint lowering. A forbidden
+active family produces a structured `PreparationFailure` instead of being
+lowered silently.
+
+By default, preparation applies only the available exact operations. Discrete integer
 slack approximation requires setting `allow_approximate_integer_slack=True` on
-`OpenJijPreparationConfig`; setting `inequality_integer_slack_max_range` alone
+`OpenJijPreparationPolicy`; setting `inequality_integer_slack_max_range` alone
 does not opt into approximation. Finite penalties remain an explicit operation
-selected through `uniform_penalty_weight` or `penalty_weights` on that Config,
+selected through `uniform_penalty_weight` or `penalty_weights` on that policy,
 and do not assert exact constrained support.
 
 Per-constraint penalty weights use regular constraint IDs. A model containing

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/__init__.py
@@ -1,12 +1,9 @@
 from .adapter import OMMXOpenJijSAAdapter as _OMMXOpenJijSAAdapter
 from ._preparation import (
-    OpenJijPreparation,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
     OpenJijPreparationError,
-    OpenJijPreparationFailure,
     OpenJijPreparationReport,
     OpenJijPreparationSourceCheck,
-    OpenJijPreparationStep,
 )
 from ._decode import decode_to_samples
 
@@ -22,19 +19,16 @@ class OMMXOpenJijSAAdapter(_OMMXOpenJijSAAdapter):
 
     Integer encoding, sense reversal, slack introduction, and finite constraint
     penalties are explicit preparation operations, not part of the declared
-    input class. Pass :attr:`OpenJijPreparation.input` back to this Adapter
+    input class. Pass :attr:`ommx.adapter.Preparation.input` back to this Adapter
     as a separate :class:`ommx.Instance` value.
     """
 
 
 __all__ = [
     "OMMXOpenJijSAAdapter",
-    "OpenJijPreparation",
-    "OpenJijPreparationConfig",
+    "OpenJijPreparationPolicy",
     "OpenJijPreparationError",
-    "OpenJijPreparationFailure",
     "OpenJijPreparationReport",
     "OpenJijPreparationSourceCheck",
-    "OpenJijPreparationStep",
     "decode_to_samples",
 ]

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
-import copy
 from collections.abc import Iterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from math import isfinite
 from types import MappingProxyType
 
-from ommx import Instance, InstanceClassMembershipReport, Samples, SampleSet, State
+from ommx import InstanceClassMembershipReport
 from ommx.adapter import (
     AdapterApplicabilityReport,
-    ConstraintRef,
+    PreparationError,
+    PreparationFailure,
+    PreparationPolicy,
+    PreparationTransform,
 )
 
-PreparationDiagnosticValue = str | int | float | bool | None
 _MAX_U64 = 2**64 - 1
 
 
@@ -64,7 +65,7 @@ def _is_positive_finite(value: float) -> bool:
 
 
 @dataclass(frozen=True, slots=True)
-class OpenJijPreparationConfig:
+class OpenJijPreparationPolicy(PreparationPolicy):
     """User-selected settings for one OpenJij preparation operation.
 
     The two penalty modes are mutually exclusive. Every configured penalty
@@ -80,6 +81,7 @@ class OpenJijPreparationConfig:
     allow_approximate_integer_slack: bool = False
 
     def __post_init__(self) -> None:
+        PreparationPolicy.__post_init__(self)
         if self.uniform_penalty_weight is not None and self.penalty_weights is not None:
             raise ValueError(
                 "uniform_penalty_weight and penalty_weights are mutually exclusive"
@@ -131,20 +133,6 @@ class OpenJijPreparationConfig:
 
 
 @dataclass(frozen=True, slots=True)
-class OpenJijPreparationStep:
-    """One OpenJij-specific operation recorded for preparation auditing.
-
-    This record is not a composed mathematical guarantee. The common guarantee
-    and policy contracts are tracked separately in OMMX issue #1111.
-    """
-
-    operation: str
-    description: str
-    variable_ids: frozenset[int] = field(default_factory=frozenset)
-    constraint_refs: frozenset[ConstraintRef] = field(default_factory=frozenset)
-
-
-@dataclass(frozen=True, slots=True)
 class OpenJijPreparationSourceCheck:
     """Structural membership evidence for a preparation source."""
 
@@ -156,43 +144,24 @@ class OpenJijPreparationSourceCheck:
 
 
 @dataclass(frozen=True, slots=True)
-class OpenJijPreparationFailure:
-    """One failure discovered while materializing an accepted source."""
-
-    operation: str
-    reason: str
-    description: str
-    variable_ids: frozenset[int] = field(default_factory=frozenset)
-    constraint_refs: frozenset[ConstraintRef] = field(default_factory=frozenset)
-    observed: PreparationDiagnosticValue = None
-    expected: PreparationDiagnosticValue = None
-
-    def __post_init__(self) -> None:
-        if not self.operation:
-            raise ValueError("preparation failure operation must not be empty")
-        if not self.reason:
-            raise ValueError("preparation failure reason must not be empty")
-
-
-@dataclass(frozen=True, slots=True)
 class OpenJijPreparationReport:
-    """The Config used and four outcomes of one preparation attempt.
+    """The Policy used and four outcomes of one preparation attempt.
 
-    ``config`` is the immutable settings audit. The outcome fields separately
-    record the source check, applied steps, materialization failures, and
+    ``policy`` is the immutable settings audit. The outcome fields separately
+    record the source check, applied transforms, materialization failures, and
     produced-input applicability.
     """
 
-    config: OpenJijPreparationConfig
+    policy: OpenJijPreparationPolicy
     source_check: OpenJijPreparationSourceCheck
-    steps: tuple[OpenJijPreparationStep, ...]
-    preparation_failures: tuple[OpenJijPreparationFailure, ...] = ()
+    transforms: tuple[PreparationTransform, ...]
+    preparation_failures: tuple[PreparationFailure, ...] = ()
     input_applicability: AdapterApplicabilityReport | None = None
 
     def __post_init__(self) -> None:
         if not self.source_check.conditions_hold:
             if (
-                self.steps
+                self.transforms
                 or self.preparation_failures
                 or self.input_applicability is not None
             ):
@@ -221,68 +190,7 @@ class OpenJijPreparationReport:
         )
 
 
-@dataclass(frozen=True, slots=True, init=False)
-class OpenJijPreparation:
-    """A separate Adapter input together with source-state reevaluation.
-
-    Values are created by :meth:`OMMXOpenJijSAAdapter.prepare`; callers cannot
-    pair an arbitrary input with unrelated preparation evidence.
-    """
-
-    _input: Instance = field(repr=False)
-    _source_instance: Instance = field(repr=False)
-    report: OpenJijPreparationReport
-
-    def __init__(self) -> None:
-        raise TypeError("OpenJijPreparation is created only by prepare()")
-
-    @property
-    def input(self) -> Instance:
-        """Return an isolated copy of the Binary, unconstrained minimization input."""
-        return copy.deepcopy(self._input)
-
-    def evaluate_source(self, sample_set: SampleSet) -> SampleSet:
-        """Reevaluate input-side sample states against the source Instance.
-
-        ``sample_set`` must have been evaluated against this preparation's
-        :attr:`input`, which populates irrelevant and dependent source variables.
-        """
-        source_variable_ids = {
-            variable.id for variable in self._source_instance.used_decision_variables
-        }
-        source_samples = Samples({})
-        for sample_id in sorted(sample_set.sample_ids()):
-            prepared_state = sample_set.get(sample_id).state
-            entries: list[tuple[int, float]] = []
-            for variable_id in source_variable_ids:
-                value = prepared_state.get(variable_id)
-                if value is None:
-                    raise RuntimeError(
-                        "OpenJij preparation did not reconstruct source variable "
-                        f"ID {variable_id}"
-                    )
-                entries.append((variable_id, value))
-            source_samples.append([sample_id], State(entries=entries))
-        return self._source_instance.evaluate_samples(source_samples)
-
-
-def _create_preparation(
-    *,
-    input: Instance,
-    source_instance: Instance,
-    report: OpenJijPreparationReport,
-) -> OpenJijPreparation:
-    """Project one successful private pipeline result to the public value."""
-    if not report.is_successful:
-        raise ValueError("OpenJijPreparation requires a successful report")
-    preparation = object.__new__(OpenJijPreparation)
-    object.__setattr__(preparation, "_input", input)
-    object.__setattr__(preparation, "_source_instance", source_instance)
-    object.__setattr__(preparation, "report", report)
-    return preparation
-
-
-class OpenJijPreparationError(ValueError):
+class OpenJijPreparationError(PreparationError[OpenJijPreparationReport]):
     """Raised when explicit OpenJij preparation cannot produce an input."""
 
     report: OpenJijPreparationReport
@@ -297,10 +205,10 @@ class OpenJijPreparationError(ValueError):
             )
         elif report.preparation_failures:
             details = "\n".join(
-                f"- {failure.operation}/{failure.reason}: {failure.description}"
+                f"- {failure.name}/{failure.reason}: {failure.description}"
                 for failure in report.preparation_failures
             )
             message = f"OpenJij preparation failed:\n{details}"
         else:
             message = "OpenJij preparation did not produce an applicable input"
-        super().__init__(message)
+        ValueError.__init__(self, message)

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation_phases.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation_phases.py
@@ -11,13 +11,9 @@ from ommx import (
     LogEncodingError,
     SpecialConstraintKind,
 )
-from ommx.adapter import ConstraintRef
+from ommx.adapter import ConstraintRef, PreparationFailure, PreparationTransform
 
-from ._preparation import (
-    OpenJijPreparationConfig,
-    OpenJijPreparationFailure,
-    OpenJijPreparationStep,
-)
+from ._preparation import OpenJijPreparationPolicy
 from ._preparation_checks import active_constraint_refs
 from ._preparation_stages import (
     _AdapterInputCandidate,
@@ -40,15 +36,15 @@ MAX_LOG_ENCODING_BITS = 53
 
 
 def _materialization_failure(
-    operation: str,
+    name: str,
     error: Exception,
     *,
     variable_ids: frozenset[int] = frozenset(),
     constraint_refs: frozenset[ConstraintRef] = frozenset(),
-) -> OpenJijPreparationFailure:
-    phase = operation.replace("_", " ")
-    return OpenJijPreparationFailure(
-        operation=operation,
+) -> PreparationFailure:
+    phase = name.replace("_", " ")
+    return PreparationFailure(
+        name=name,
         reason="openjij.preparation.materialization",
         description=f"The {phase} phase could not be materialized: {error}",
         variable_ids=variable_ids,
@@ -62,8 +58,8 @@ def _log_encoding_unavailable(
     error: LogEncodingError,
     fallback_variable_ids: frozenset[int],
     *,
-    operation: str,
-) -> OpenJijPreparationFailure:
+    name: str,
+) -> PreparationFailure:
     kind = getattr(error, "kind", "unavailable")
     reason = {
         "non_finite_bound": "openjij.log_encoding.bound_finite",
@@ -76,8 +72,8 @@ def _log_encoding_unavailable(
         if isinstance(variable_id, int)
         else fallback_variable_ids
     )
-    return OpenJijPreparationFailure(
-        operation=operation,
+    return PreparationFailure(
+        name=name,
         reason=reason,
         description=f"Exact Integer-to-Binary log encoding is unavailable: {error}",
         variable_ids=variable_ids,
@@ -95,6 +91,8 @@ def _log_encoding_unavailable(
 
 def lower_special_constraints(
     state: _SourceMember,
+    *,
+    allowed_special_constraint_lowerings: frozenset[SpecialConstraintKind],
 ) -> _PhaseOutcome[_RegularSource]:
     working = state.take_instance()
     special_refs = {
@@ -111,8 +109,56 @@ def lower_special_constraints(
             for constraint_id in working.sos1_constraints
         ),
     }
+    special_transform_details = {
+        SpecialConstraintKind.Indicator: (
+            "indicator_lowering",
+            "Indicator",
+            "Lowered Indicator constraints exactly with validated Big-M bounds.",
+        ),
+        SpecialConstraintKind.OneHot: (
+            "one_hot_lowering",
+            "OneHot",
+            "Lowered OneHot constraints exactly to regular equalities.",
+        ),
+        SpecialConstraintKind.Sos1: (
+            "sos1_lowering",
+            "SOS1",
+            "Lowered SOS1 constraints exactly with validated Big-M bounds.",
+        ),
+    }
+    forbidden_kinds = tuple(
+        kind
+        for kind in (
+            SpecialConstraintKind.Indicator,
+            SpecialConstraintKind.OneHot,
+            SpecialConstraintKind.Sos1,
+        )
+        if special_refs[kind] and kind not in allowed_special_constraint_lowerings
+    )
+    if forbidden_kinds:
+        return _Blocked(
+            failures=tuple(
+                PreparationFailure(
+                    name=special_transform_details[kind][0],
+                    reason="openjij.special_constraint_lowering.policy",
+                    description=(
+                        f"{special_transform_details[kind][1]} lowering is disabled "
+                        "by the preparation policy."
+                    ),
+                    constraint_refs=special_refs[kind],
+                    observed="not allowed",
+                    expected=(
+                        f"allow {special_transform_details[kind][1]} lowering in "
+                        "allowed_special_constraint_lowerings"
+                    ),
+                )
+                for kind in forbidden_kinds
+            )
+        )
+
+    active_kinds = {kind for kind, refs in special_refs.items() if refs}
     try:
-        lowered_specials = working.lower_special_constraints(set(special_refs))
+        lowered_specials = working.lower_special_constraints(active_kinds)
     except (RuntimeError, ValueError) as error:
         return _Blocked(
             failures=(
@@ -124,21 +170,7 @@ def lower_special_constraints(
             )
         )
 
-    special_step_details = {
-        SpecialConstraintKind.Indicator: (
-            "indicator_lowering",
-            "Lowered Indicator constraints exactly with validated Big-M bounds.",
-        ),
-        SpecialConstraintKind.OneHot: (
-            "one_hot_lowering",
-            "Lowered OneHot constraints exactly to regular equalities.",
-        ),
-        SpecialConstraintKind.Sos1: (
-            "sos1_lowering",
-            "Lowered SOS1 constraints exactly with validated Big-M bounds.",
-        ),
-    }
-    steps = []
+    transforms = []
     for kind in (
         SpecialConstraintKind.Indicator,
         SpecialConstraintKind.OneHot,
@@ -146,15 +178,16 @@ def lower_special_constraints(
     ):
         if kind not in lowered_specials:
             continue
-        operation, description = special_step_details[kind]
-        steps.append(
-            OpenJijPreparationStep(
-                operation=operation,
+        name, _, description = special_transform_details[kind]
+        transforms.append(
+            PreparationTransform(
+                name=name,
                 description=description,
                 constraint_refs=special_refs[kind],
+                special_constraint_kinds=frozenset({kind}),
             )
         )
-    return _Applied(_RegularSource(working), tuple(steps))
+    return _Applied(_RegularSource(working), tuple(transforms))
 
 
 def encode_source_integers(
@@ -173,7 +206,7 @@ def encode_source_integers(
                 _log_encoding_unavailable(
                     error,
                     source_integer_ids,
-                    operation="integer_log_encoding",
+                    name="integer_log_encoding",
                 ),
             )
         )
@@ -191,8 +224,8 @@ def encode_source_integers(
     return _Applied(
         _SourceEncoded(working, source_integer_ids),
         (
-            OpenJijPreparationStep(
-                operation="integer_log_encoding",
+            PreparationTransform(
+                name="integer_log_encoding",
                 description=(
                     "Log-encoded source Integer variables after validating "
                     f"the {MAX_LOG_ENCODING_BITS}-bit encoding limit."
@@ -209,11 +242,11 @@ def normalize_sense(
     source_integer_ids = state.source_integer_ids
     working = state.take_instance()
     reversed_sense = working.as_minimization_problem()
-    steps = ()
+    transforms = ()
     if reversed_sense:
-        steps = (
-            OpenJijPreparationStep(
-                operation="sense_reversal",
+        transforms = (
+            PreparationTransform(
+                name="sense_reversal",
                 description=(
                     "Negated the objective for the Adapter minimization input; "
                     "sample evaluation retains the source maximization sense."
@@ -222,13 +255,13 @@ def normalize_sense(
         )
     return _Applied(
         _MinimizationSource(working, source_integer_ids),
-        steps,
+        transforms,
     )
 
 
 def prepare_inequalities(
     state: _MinimizationSource,
-    config: OpenJijPreparationConfig,
+    policy: OpenJijPreparationPolicy,
 ) -> _PhaseOutcome[_PenaltyReady]:
     working = state.take_instance()
     inequality_ids = frozenset(
@@ -237,23 +270,23 @@ def prepare_inequalities(
         if constraint.equality == Equality.LessThanOrEqualToZero
     )
     slack_outcomes = []
-    steps = []
+    transforms = []
 
     for constraint_id in sorted(inequality_ids):
         constraint_refs = frozenset({ConstraintRef("regular", constraint_id)})
         try:
             working.convert_inequality_to_equality_with_integer_slack(
                 constraint_id,
-                config.inequality_integer_slack_max_range,
+                policy.inequality_integer_slack_max_range,
             )
         except InfeasibleDetected as error:
             return _ProvenInfeasible(error)
         except ExactIntegerSlackError as exact_error:
-            if not config.allow_approximate_integer_slack:
+            if not policy.allow_approximate_integer_slack:
                 return _Blocked(
                     failures=(
-                        OpenJijPreparationFailure(
-                            operation="integer_slack",
+                        PreparationFailure(
+                            name="integer_slack",
                             reason=("openjij.slack.approximation_explicit_selection"),
                             description=(
                                 "Exact integer slack was unavailable "
@@ -266,12 +299,12 @@ def prepare_inequalities(
                             expected="allow_approximate_integer_slack=True",
                         ),
                     ),
-                    steps=tuple(steps),
+                    transforms=tuple(transforms),
                 )
             try:
                 residual_step = working.add_integer_slack_to_inequality(
                     constraint_id,
-                    config.inequality_integer_slack_max_range,
+                    policy.inequality_integer_slack_max_range,
                 )
             except InfeasibleDetected as error:
                 return _ProvenInfeasible(error)
@@ -284,14 +317,14 @@ def prepare_inequalities(
                             constraint_refs=constraint_refs,
                         ),
                     ),
-                    steps=tuple(steps),
+                    transforms=tuple(transforms),
                 )
 
             if residual_step is None:
                 slack_outcomes.append(_TrivialInequality(constraint_id))
-                steps.append(
-                    OpenJijPreparationStep(
-                        operation="trivial_inequality_removal",
+                transforms.append(
+                    PreparationTransform(
+                        name="trivial_inequality_removal",
                         description=(
                             "Removed an inequality proven satisfied by the variable "
                             "bounds."
@@ -303,9 +336,9 @@ def prepare_inequalities(
                 slack_outcomes.append(
                     _ApproximateIntegerSlack(constraint_id, residual_step)
                 )
-                steps.append(
-                    OpenJijPreparationStep(
-                        operation="approximate_integer_slack",
+                transforms.append(
+                    PreparationTransform(
+                        name="approximate_integer_slack",
                         description=(
                             "Exact integer slack was unavailable "
                             f"({exact_error}); used a discrete slack with residual "
@@ -323,7 +356,7 @@ def prepare_inequalities(
                         constraint_refs=constraint_refs,
                     ),
                 ),
-                steps=tuple(steps),
+                transforms=tuple(transforms),
             )
         else:
             if constraint_id in working.constraints:
@@ -336,9 +369,9 @@ def prepare_inequalities(
                 description = (
                     "Removed an inequality proven satisfied by the variable bounds."
                 )
-            steps.append(
-                OpenJijPreparationStep(
-                    operation=operation,
+            transforms.append(
+                PreparationTransform(
+                    name=operation,
                     description=description,
                     constraint_refs=constraint_refs,
                 )
@@ -346,15 +379,15 @@ def prepare_inequalities(
 
     return _Applied(
         _PenaltyReady(working, inequality_ids, tuple(slack_outcomes)),
-        tuple(steps),
+        tuple(transforms),
     )
 
 
 def _penalty_policy_failures(
     working: Instance,
     source_instance: Instance,
-    config: OpenJijPreparationConfig,
-) -> tuple[OpenJijPreparationFailure, ...]:
+    policy: OpenJijPreparationPolicy,
+) -> tuple[PreparationFailure, ...]:
     remaining_constraint_ids = frozenset(working.constraints)
     source_regular_ids = frozenset(source_instance.constraints)
     source_special_refs = frozenset(
@@ -363,20 +396,20 @@ def _penalty_policy_failures(
         if ref.family != "regular"
     )
     source_has_constraints = bool(active_constraint_refs(source_instance))
-    penalty_weights = config.penalty_weights
+    penalty_weights = policy.penalty_weights
     penalty_selected = (
-        config.uniform_penalty_weight is not None or penalty_weights is not None
+        policy.uniform_penalty_weight is not None or penalty_weights is not None
     )
     failures = []
 
     if not source_has_constraints and penalty_selected:
         failures.append(
-            OpenJijPreparationFailure(
-                operation="finite_penalty",
+            PreparationFailure(
+                name="finite_penalty",
                 reason="openjij.penalty.unused",
                 description="Penalty weights were supplied for an unconstrained model.",
                 observed="penalty weights supplied",
-                expected="no penalty configuration",
+                expected="no penalty selection in the preparation policy",
             )
         )
 
@@ -385,8 +418,8 @@ def _penalty_policy_failures(
         unexpected = configured_ids.difference(source_regular_ids)
         if unexpected:
             failures.append(
-                OpenJijPreparationFailure(
-                    operation="finite_penalty",
+                PreparationFailure(
+                    name="finite_penalty",
                     reason="openjij.penalty.weight_coverage",
                     description=(
                         "Per-constraint penalty weights contain unknown regular "
@@ -404,8 +437,8 @@ def _penalty_policy_failures(
         generated_ids = remaining_constraint_ids.difference(source_regular_ids)
         if generated_ids:
             failures.append(
-                OpenJijPreparationFailure(
-                    operation="finite_penalty",
+                PreparationFailure(
+                    name="finite_penalty",
                     reason="openjij.penalty.special_requires_uniform",
                     description=(
                         "Per-constraint weights cannot identify regular constraints "
@@ -422,8 +455,8 @@ def _penalty_policy_failures(
         missing = remaining_source_ids.difference(configured_ids)
         if missing:
             failures.append(
-                OpenJijPreparationFailure(
-                    operation="finite_penalty",
+                PreparationFailure(
+                    name="finite_penalty",
                     reason="openjij.penalty.weight_coverage",
                     description=(
                         "Per-constraint penalty weights do not cover every regular "
@@ -440,8 +473,8 @@ def _penalty_policy_failures(
 
     if remaining_constraint_ids and not penalty_selected:
         failures.append(
-            OpenJijPreparationFailure(
-                operation="finite_penalty",
+            PreparationFailure(
+                name="finite_penalty",
                 reason="openjij.penalty.explicit_selection",
                 description=(
                     "Constraints remaining after exact preparation require an "
@@ -469,10 +502,10 @@ def _penalty_policy_failures(
 def apply_penalties(
     state: _PenaltyReady,
     source_instance: Instance,
-    config: OpenJijPreparationConfig,
+    policy: OpenJijPreparationPolicy,
 ) -> _PhaseOutcome[_EncodingInput]:
     working = state.take_instance()
-    failures = _penalty_policy_failures(working, source_instance, config)
+    failures = _penalty_policy_failures(working, source_instance, policy)
     if failures:
         return _Blocked(failures=failures)
 
@@ -498,25 +531,25 @@ def apply_penalties(
     )
 
     try:
-        if config.penalty_weights is not None:
+        if policy.penalty_weights is not None:
             parametric = working.penalty_method()
             weights: dict[int, float] = {}
             for constraint_id in remaining_constraint_ids:
                 removed = parametric.removed_constraints[constraint_id]
                 parameter_id = int(removed.removed_reason_parameters["parameter_id"])
-                weights[parameter_id] = config.penalty_weights[constraint_id]
+                weights[parameter_id] = policy.penalty_weights[constraint_id]
             penalized = parametric.with_parameters(weights)
             penalty_description = "Applied positive per-constraint finite penalties."
         else:
-            assert config.uniform_penalty_weight is not None
+            assert policy.uniform_penalty_weight is not None
             parametric = working.uniform_penalty_method()
             parameter = parametric.parameters[0]
             penalized = parametric.with_parameters(
-                {parameter.id: config.uniform_penalty_weight}
+                {parameter.id: policy.uniform_penalty_weight}
             )
             penalty_description = (
                 "Applied finite uniform penalty weight "
-                f"{config.uniform_penalty_weight}."
+                f"{policy.uniform_penalty_weight}."
             )
     except (RuntimeError, ValueError) as error:
         return _Blocked(
@@ -532,8 +565,8 @@ def apply_penalties(
     return _Applied(
         _EncodingInput(penalized),
         (
-            OpenJijPreparationStep(
-                operation="finite_penalty",
+            PreparationTransform(
+                name="finite_penalty",
                 description=penalty_description,
                 constraint_refs=penalty_constraint_refs,
             ),
@@ -561,7 +594,7 @@ def encode_remaining_integers(
                 _log_encoding_unavailable(
                     error,
                     integer_ids,
-                    operation="integer_slack_log_encoding",
+                    name="integer_slack_log_encoding",
                 ),
             )
         )
@@ -579,8 +612,8 @@ def encode_remaining_integers(
     return _Applied(
         _AdapterInputCandidate(working),
         (
-            OpenJijPreparationStep(
-                operation="integer_slack_log_encoding",
+            PreparationTransform(
+                name="integer_slack_log_encoding",
                 description=(
                     "Log-encoded Integer variables introduced during preparation."
                 ),

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation_pipeline.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation_pipeline.py
@@ -5,17 +5,19 @@ from __future__ import annotations
 import copy
 from collections.abc import Callable
 
-from ommx import Instance, Kind
-from ommx.adapter import AdapterApplicabilityReport
+from ommx import Instance, Kind, SpecialConstraintKind
+from ommx.adapter import (
+    AdapterApplicabilityReport,
+    Preparation,
+    PreparationPolicy,
+    PreparationTransform,
+)
 
 from ._preparation import (
-    OpenJijPreparation,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
     OpenJijPreparationError,
     OpenJijPreparationReport,
     OpenJijPreparationSourceCheck,
-    OpenJijPreparationStep,
-    _create_preparation,
 )
 from ._preparation_checks import check_preparation_source
 from ._preparation_phases import (
@@ -43,59 +45,70 @@ def check_preparation(
     ommx_instance: Instance,
     *,
     check_input_applicability: Callable[[Instance], AdapterApplicabilityReport],
-    config: OpenJijPreparationConfig | None = None,
+    candidate_special_constraint_lowerings: tuple[SpecialConstraintKind, ...],
+    policy: PreparationPolicy | None = None,
 ) -> OpenJijPreparationReport:
     """Run explicit preparation on an isolated copy and return its report."""
-    normalized_config = _normalize_preparation_config(config)
+    normalized_policy = _normalize_preparation_policy(policy)
     attempt = _run_preparation(
         ommx_instance,
         check_input_applicability=check_input_applicability,
-        config=normalized_config,
+        candidate_special_constraint_lowerings=candidate_special_constraint_lowerings,
+        policy=normalized_policy,
     )
-    return _report_for_attempt(normalized_config, attempt)
+    return _report_for_attempt(normalized_policy, attempt)
 
 
 def prepare(
     ommx_instance: Instance,
     *,
     check_input_applicability: Callable[[Instance], AdapterApplicabilityReport],
-    config: OpenJijPreparationConfig | None = None,
-) -> OpenJijPreparation:
+    candidate_special_constraint_lowerings: tuple[SpecialConstraintKind, ...],
+    policy: PreparationPolicy | None = None,
+) -> Preparation[OpenJijPreparationReport]:
     """Produce a separate Adapter input and an auditable preparation report."""
-    normalized_config = _normalize_preparation_config(config)
+    normalized_policy = _normalize_preparation_policy(policy)
     attempt = _run_preparation(
         ommx_instance,
         check_input_applicability=check_input_applicability,
-        config=normalized_config,
+        candidate_special_constraint_lowerings=candidate_special_constraint_lowerings,
+        policy=normalized_policy,
     )
-    report = _report_for_attempt(normalized_config, attempt)
+    report = _report_for_attempt(normalized_policy, attempt)
     if not isinstance(attempt, _PreparedInput):
         raise OpenJijPreparationError(report)
-    return _create_preparation(
+    return Preparation._create(
+        source=attempt.source_instance,
         input=attempt.take_input(),
-        source_instance=attempt.source_instance,
         report=report,
+        preserves_optimality=False,
     )
 
 
-def _normalize_preparation_config(
-    config: OpenJijPreparationConfig | None,
-) -> OpenJijPreparationConfig:
-    if config is None:
-        return OpenJijPreparationConfig()
-    if not isinstance(config, OpenJijPreparationConfig):
-        raise TypeError("config must be an OpenJijPreparationConfig")
-    return config
+def _normalize_preparation_policy(
+    policy: PreparationPolicy | None,
+) -> OpenJijPreparationPolicy:
+    if policy is None:
+        return OpenJijPreparationPolicy()
+    if isinstance(policy, OpenJijPreparationPolicy):
+        return policy
+    if isinstance(policy, PreparationPolicy):
+        return OpenJijPreparationPolicy(
+            allowed_special_constraint_lowerings=(
+                policy.allowed_special_constraint_lowerings
+            )
+        )
+    raise TypeError("policy must be a PreparationPolicy")
 
 
 def _phase_rejected(
     source_check: OpenJijPreparationSourceCheck,
-    completed_steps: tuple[OpenJijPreparationStep, ...],
+    completed_transforms: tuple[PreparationTransform, ...],
     outcome: _Blocked,
 ) -> _PhaseRejected:
     return _PhaseRejected(
         source_check=source_check,
-        steps=completed_steps + outcome.steps,
+        transforms=completed_transforms + outcome.transforms,
         failures=outcome.failures,
     )
 
@@ -104,7 +117,8 @@ def _run_preparation(
     ommx_instance: Instance,
     *,
     check_input_applicability: Callable[[Instance], AdapterApplicabilityReport],
-    config: OpenJijPreparationConfig,
+    candidate_special_constraint_lowerings: tuple[SpecialConstraintKind, ...],
+    policy: OpenJijPreparationPolicy,
 ) -> _PreparationAttempt:
     source_check = check_preparation_source(ommx_instance)
     if not source_check.conditions_hold:
@@ -112,15 +126,35 @@ def _run_preparation(
 
     source_instance = copy.deepcopy(ommx_instance)
     working = copy.deepcopy(ommx_instance)
-    steps: tuple[OpenJijPreparationStep, ...] = ()
+    transforms: tuple[PreparationTransform, ...] = ()
 
-    lowering = lower_special_constraints(_SourceMember(working, source_check))
+    direct_applicability = check_input_applicability(working)
+    if direct_applicability.is_applicable:
+        return _PreparedInput(
+            source_check=source_check,
+            transforms=(),
+            checked_input=_CheckedAdapterInput(working, direct_applicability),
+            source_instance=source_instance,
+        )
+
+    declared_special_constraint_lowerings = frozenset(
+        candidate_special_constraint_lowerings
+    )
+    allowed_special_constraint_lowerings = declared_special_constraint_lowerings
+    if policy.allowed_special_constraint_lowerings is not None:
+        allowed_special_constraint_lowerings &= (
+            policy.allowed_special_constraint_lowerings
+        )
+    lowering = lower_special_constraints(
+        _SourceMember(working, source_check),
+        allowed_special_constraint_lowerings=allowed_special_constraint_lowerings,
+    )
     if isinstance(lowering, _Blocked):
-        return _phase_rejected(source_check, steps, lowering)
+        return _phase_rejected(source_check, transforms, lowering)
     if isinstance(lowering, _ProvenInfeasible):
         return lowering
     regular_source = lowering.value
-    steps += lowering.steps
+    transforms += lowering.transforms
 
     source_integer_ids = frozenset(
         variable.id
@@ -129,80 +163,80 @@ def _run_preparation(
     )
     source_encoding = encode_source_integers(regular_source, source_integer_ids)
     if isinstance(source_encoding, _Blocked):
-        return _phase_rejected(source_check, steps, source_encoding)
+        return _phase_rejected(source_check, transforms, source_encoding)
     if isinstance(source_encoding, _ProvenInfeasible):
         return source_encoding
     source_encoded = source_encoding.value
-    steps += source_encoding.steps
+    transforms += source_encoding.transforms
 
     normalization = normalize_sense(source_encoded)
     normalized_source = normalization.value
-    steps += normalization.steps
+    transforms += normalization.transforms
 
-    slack = prepare_inequalities(normalized_source, config)
+    slack = prepare_inequalities(normalized_source, policy)
     if isinstance(slack, _Blocked):
-        return _phase_rejected(source_check, steps, slack)
+        return _phase_rejected(source_check, transforms, slack)
     if isinstance(slack, _ProvenInfeasible):
         return slack
     penalty_ready = slack.value
-    steps += slack.steps
+    transforms += slack.transforms
 
-    penalty = apply_penalties(penalty_ready, source_instance, config)
+    penalty = apply_penalties(penalty_ready, source_instance, policy)
     if isinstance(penalty, _Blocked):
-        return _phase_rejected(source_check, steps, penalty)
+        return _phase_rejected(source_check, transforms, penalty)
     if isinstance(penalty, _ProvenInfeasible):
         return penalty
     encoding_input = penalty.value
-    steps += penalty.steps
+    transforms += penalty.transforms
 
     encoding = encode_remaining_integers(encoding_input)
     if isinstance(encoding, _Blocked):
-        return _phase_rejected(source_check, steps, encoding)
+        return _phase_rejected(source_check, transforms, encoding)
     if isinstance(encoding, _ProvenInfeasible):
         return encoding
     candidate = encoding.value
-    steps += encoding.steps
+    transforms += encoding.transforms
 
     checked_input = _CheckedAdapterInput.check(candidate, check_input_applicability)
     if not checked_input.applicability.is_applicable:
-        return _InputRejected(source_check, steps, checked_input)
+        return _InputRejected(source_check, transforms, checked_input)
     return _PreparedInput(
         source_check=source_check,
-        steps=steps,
+        transforms=transforms,
         checked_input=checked_input,
         source_instance=source_instance,
     )
 
 
 def _report_for_attempt(
-    config: OpenJijPreparationConfig,
+    policy: OpenJijPreparationPolicy,
     attempt: _PreparationAttempt,
 ) -> OpenJijPreparationReport:
     if isinstance(attempt, _ProvenInfeasible):
         raise attempt.error
     if isinstance(attempt, _SourceRejected):
         return OpenJijPreparationReport(
-            config=config,
+            policy=policy,
             source_check=attempt.source_check,
-            steps=(),
+            transforms=(),
         )
     if isinstance(attempt, _PhaseRejected):
         return OpenJijPreparationReport(
-            config=config,
+            policy=policy,
             source_check=attempt.source_check,
-            steps=attempt.steps,
+            transforms=attempt.transforms,
             preparation_failures=attempt.failures,
         )
     if isinstance(attempt, _InputRejected):
         return OpenJijPreparationReport(
-            config=config,
+            policy=policy,
             source_check=attempt.source_check,
-            steps=attempt.steps,
+            transforms=attempt.transforms,
             input_applicability=attempt.input_applicability,
         )
     return OpenJijPreparationReport(
-        config=config,
+        policy=policy,
         source_check=attempt.source_check,
-        steps=attempt.steps,
+        transforms=attempt.transforms,
         input_applicability=attempt.input_applicability,
     )

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation_stages.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/_preparation_stages.py
@@ -8,12 +8,14 @@ from math import isfinite
 from typing import Generic, TypeAlias, TypeVar
 
 from ommx import Equality, InfeasibleDetected, Instance, Kind, Sense
-from ommx.adapter import AdapterApplicabilityReport
+from ommx.adapter import (
+    AdapterApplicabilityReport,
+    PreparationFailure,
+    PreparationTransform,
+)
 
 from ._preparation import (
-    OpenJijPreparationFailure,
     OpenJijPreparationSourceCheck,
-    OpenJijPreparationStep,
 )
 
 
@@ -280,13 +282,13 @@ _T = TypeVar("_T")
 @dataclass(frozen=True, slots=True)
 class _Applied(Generic[_T]):
     value: _T
-    steps: tuple[OpenJijPreparationStep, ...] = ()
+    transforms: tuple[PreparationTransform, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
 class _Blocked:
-    failures: tuple[OpenJijPreparationFailure, ...]
-    steps: tuple[OpenJijPreparationStep, ...] = ()
+    failures: tuple[PreparationFailure, ...]
+    transforms: tuple[PreparationTransform, ...] = ()
 
     def __post_init__(self) -> None:
         _require(bool(self.failures), "blocked phase requires at least one failure")
@@ -314,8 +316,8 @@ class _SourceRejected:
 @dataclass(frozen=True, slots=True)
 class _PhaseRejected:
     source_check: OpenJijPreparationSourceCheck
-    steps: tuple[OpenJijPreparationStep, ...]
-    failures: tuple[OpenJijPreparationFailure, ...]
+    transforms: tuple[PreparationTransform, ...]
+    failures: tuple[PreparationFailure, ...]
 
     def __post_init__(self) -> None:
         _require(
@@ -328,7 +330,7 @@ class _PhaseRejected:
 @dataclass(frozen=True, slots=True)
 class _InputRejected:
     source_check: OpenJijPreparationSourceCheck
-    steps: tuple[OpenJijPreparationStep, ...]
+    transforms: tuple[PreparationTransform, ...]
     checked_input: _CheckedAdapterInput
 
     @property
@@ -349,7 +351,7 @@ class _InputRejected:
 @dataclass(frozen=True, slots=True)
 class _PreparedInput:
     source_check: OpenJijPreparationSourceCheck
-    steps: tuple[OpenJijPreparationStep, ...]
+    transforms: tuple[PreparationTransform, ...]
     checked_input: _CheckedAdapterInput
     source_instance: Instance = field(repr=False)
 

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/adapter.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/adapter.py
@@ -19,20 +19,19 @@ from ommx import (
     Samples,
     SampleSet,
     Solution,
+    SpecialConstraintKind,
 )
 from ommx.adapter import (
     AdapterPreconditionViolation,
     DiagnosticsSink,
+    Preparation,
+    PreparationPolicy,
     SamplerAdapter,
 )
 from opentelemetry import trace
 
 from ._decode import _decode_for_instance, decode_to_samples
-from ._preparation import (
-    OpenJijPreparation,
-    OpenJijPreparationConfig,
-    OpenJijPreparationReport,
-)
+from ._preparation import OpenJijPreparationReport
 from ._preparation_pipeline import (
     check_preparation as _check_preparation,
     prepare as _prepare,
@@ -52,7 +51,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
 
     Integer encoding, sense reversal, slack introduction, and finite constraint
     penalties are explicit preparation operations, not part of the declared
-    input class. Pass :attr:`OpenJijPreparation.input` back to this Adapter
+    input class. Pass :attr:`Preparation.input` back to this Adapter
     as a separate :class:`ommx.Instance` value.
     """
 
@@ -65,6 +64,13 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
                 allowed_senses={Sense.Minimize},
             )
         ]
+    )
+    PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS: ClassVar[
+        tuple[SpecialConstraintKind, ...]
+    ] = (
+        SpecialConstraintKind.Indicator,
+        SpecialConstraintKind.OneHot,
+        SpecialConstraintKind.Sos1,
     )
 
     MAX_OPENJIJ_VARIABLE_ID: ClassVar[int] = 2**63 - 1
@@ -202,9 +208,9 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     @classmethod
     def check_preparation(
         cls,
-        ommx_instance: Instance,
+        source: Instance,
         *,
-        config: OpenJijPreparationConfig | None = None,
+        policy: PreparationPolicy | None = None,
     ) -> OpenJijPreparationReport:
         """Dry-run the complete explicit preparation without mutating the input.
 
@@ -215,34 +221,40 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
         ``ommx.v2.Feature``. A model proven infeasible while preparing integer
         slack raises :class:`~ommx.InfeasibleDetected`. Approximate integer
         slack is disabled unless the supplied
-        :class:`OpenJijPreparationConfig` enables it.
+        :class:`OpenJijPreparationPolicy` enables it.
         """
         return _check_preparation(
-            ommx_instance,
+            source,
             check_input_applicability=cls.check_applicability,
-            config=config,
+            candidate_special_constraint_lowerings=(
+                cls._validated_preparation_lowering_candidates()
+            ),
+            policy=policy,
         )
 
     @classmethod
     def prepare(
         cls,
-        ommx_instance: Instance,
+        source: Instance,
         *,
-        config: OpenJijPreparationConfig | None = None,
-    ) -> OpenJijPreparation:
+        policy: PreparationPolicy | None = None,
+    ) -> Preparation[OpenJijPreparationReport]:
         """Produce a separate Adapter input and an auditable preparation report.
 
         Raises :class:`~ommx.InfeasibleDetected` when variable bounds
         prove an inequality infeasible. Other preparation failures raise
         :class:`OpenJijPreparationError`. Approximate integer slack is used only
-        when the supplied :class:`OpenJijPreparationConfig` enables it.
+        when the supplied :class:`OpenJijPreparationPolicy` enables it.
         """
         with _tracer.start_as_current_span("prepare") as span:
             span.set_attribute("adapter", f"{cls.__module__}.{cls.__qualname__}")
             return _prepare(
-                ommx_instance,
+                source,
                 check_input_applicability=cls.check_applicability,
-                config=config,
+                candidate_special_constraint_lowerings=(
+                    cls._validated_preparation_lowering_candidates()
+                ),
+                policy=policy,
             )
 
     @classmethod

--- a/python/ommx-openjij-adapter/tests/test_applicability.py
+++ b/python/ommx-openjij-adapter/tests/test_applicability.py
@@ -24,15 +24,15 @@ from ommx.adapter import (
     AdapterNotApplicableError,
     AdapterPreconditionViolation,
     ConstraintRef,
+    Preparation,
+    PreparationFailure,
+    PreparationTransform,
 )
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparation,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
     OpenJijPreparationError,
-    OpenJijPreparationFailure,
     OpenJijPreparationReport,
-    OpenJijPreparationStep,
 )
 
 
@@ -73,10 +73,10 @@ def _assert_direct_rejection_does_not_mutate(
 
 def _check_preparation_without_mutation(
     instance: Instance,
-    config: OpenJijPreparationConfig | None = None,
+    policy: OpenJijPreparationPolicy | None = None,
 ) -> OpenJijPreparationReport:
     before = instance.to_v2_bytes()
-    report = OMMXOpenJijSAAdapter.check_preparation(instance, config=config)
+    report = OMMXOpenJijSAAdapter.check_preparation(instance, policy=policy)
     assert instance.to_v2_bytes() == before
     return report
 
@@ -85,47 +85,47 @@ def _violation_text(violation: AdapterPreconditionViolation) -> str:
     return f"{violation.condition} {violation.description}".lower()
 
 
-def _failure_text(failure: OpenJijPreparationFailure) -> str:
+def _failure_text(failure: PreparationFailure) -> str:
     return f"{failure.reason} {failure.description}".lower()
 
 
-def test_preparation_config_owns_intrinsic_invariants() -> None:
+def test_preparation_policy_owns_intrinsic_invariants() -> None:
     with pytest.raises(ValueError, match="mutually exclusive"):
-        OpenJijPreparationConfig(
+        OpenJijPreparationPolicy(
             uniform_penalty_weight=2.0,
             penalty_weights={},
         )
 
     for weight in (0.0, -1.0, float("nan"), float("inf")):
         with pytest.raises(ValueError, match="finite positive"):
-            OpenJijPreparationConfig(uniform_penalty_weight=weight)
+            OpenJijPreparationPolicy(uniform_penalty_weight=weight)
         with pytest.raises(ValueError, match="finite positive"):
-            OpenJijPreparationConfig(penalty_weights={7: weight})
+            OpenJijPreparationPolicy(penalty_weights={7: weight})
 
     with pytest.raises(TypeError, match="must be a bool"):
-        OpenJijPreparationConfig(allow_approximate_integer_slack=cast(bool, 1))
+        OpenJijPreparationPolicy(allow_approximate_integer_slack=cast(bool, 1))
 
     for constraint_id in (cast(int, True), -1, 2**64, cast(int, "7")):
         with pytest.raises(ValueError, match="constraint IDs"):
-            OpenJijPreparationConfig(penalty_weights={constraint_id: 2.0})
+            OpenJijPreparationPolicy(penalty_weights={constraint_id: 2.0})
 
 
-def test_preparation_config_snapshots_per_constraint_weights() -> None:
+def test_preparation_policy_snapshots_per_constraint_weights() -> None:
     weights = {7: 2.0}
-    config = OpenJijPreparationConfig(penalty_weights=weights)
+    policy = OpenJijPreparationPolicy(penalty_weights=weights)
 
     weights[7] = 3.0
 
-    assert config.penalty_weights == {7: 2.0}
+    assert policy.penalty_weights == {7: 2.0}
     with pytest.raises(TypeError):
-        cast(dict[int, float], config.penalty_weights)[7] = 4.0
-    assert config.penalty_weights is not None
+        cast(dict[int, float], policy.penalty_weights)[7] = 4.0
+    assert policy.penalty_weights is not None
     with pytest.raises(AttributeError, match="immutable"):
-        setattr(config.penalty_weights, "_values", {})
+        setattr(policy.penalty_weights, "_values", {})
     with pytest.raises(AttributeError, match="immutable"):
-        delattr(config.penalty_weights, "_values")
-    assert copy.deepcopy(config) == config
-    assert asdict(config)["penalty_weights"] == {7: 2.0}
+        delattr(policy.penalty_weights, "_values")
+    assert copy.deepcopy(policy) == policy
+    assert asdict(policy)["penalty_weights"] == {7: 2.0}
 
 
 def test_preparation_report_rejects_impossible_outcome_combinations() -> None:
@@ -135,7 +135,7 @@ def test_preparation_report_rejects_impossible_outcome_combinations() -> None:
     with pytest.raises(ValueError, match="rejected preparation source"):
         replace(
             rejected,
-            steps=(OpenJijPreparationStep(operation="invalid", description="invalid"),),
+            transforms=(PreparationTransform(name="invalid", description="invalid"),),
         )
 
     prepared = _check_preparation_without_mutation(
@@ -147,8 +147,8 @@ def test_preparation_report_rejects_impossible_outcome_combinations() -> None:
         replace(
             prepared,
             preparation_failures=(
-                OpenJijPreparationFailure(
-                    operation="invalid",
+                PreparationFailure(
+                    name="invalid",
                     reason="invalid",
                     description="invalid",
                 ),
@@ -161,7 +161,7 @@ def test_preparation_report_has_four_terminal_states() -> None:
         _instance_with_variable(DecisionVariable.continuous(0))
     )
     assert not source_rejected.source_check.conditions_hold
-    assert source_rejected.steps == ()
+    assert source_rejected.transforms == ()
     assert source_rejected.preparation_failures == ()
     assert source_rejected.input_applicability is None
 
@@ -204,17 +204,18 @@ def test_penalty_policy_conditions_belong_to_the_penalty_phase() -> None:
         constraints={},
         sense=Sense.Minimize,
     )
-    unused_config = OpenJijPreparationConfig(uniform_penalty_weight=2.0)
+    unused_policy = OpenJijPreparationPolicy(uniform_penalty_weight=2.0)
 
-    unused_report = _check_preparation_without_mutation(
+    identity_report = _check_preparation_without_mutation(
         unconstrained,
-        unused_config,
+        unused_policy,
     )
 
-    assert unused_report.source_check.conditions_hold
-    [unused] = unused_report.preparation_failures
-    assert unused.reason == "openjij.penalty.unused"
-    assert unused_report.config is unused_config
+    assert identity_report.source_check.conditions_hold
+    assert identity_report.is_successful
+    assert identity_report.transforms == ()
+    assert identity_report.preparation_failures == ()
+    assert identity_report.policy is unused_policy
 
     constrained = Instance.from_components(
         decision_variables=[x],
@@ -222,11 +223,11 @@ def test_penalty_policy_conditions_belong_to_the_penalty_phase() -> None:
         constraints={7: x == 0},
         sense=Sense.Minimize,
     )
-    incomplete_config = OpenJijPreparationConfig(penalty_weights={})
+    incomplete_policy = OpenJijPreparationPolicy(penalty_weights={})
 
     incomplete_report = _check_preparation_without_mutation(
         constrained,
-        incomplete_config,
+        incomplete_policy,
     )
 
     assert incomplete_report.source_check.conditions_hold
@@ -409,13 +410,13 @@ def test_explicit_preparation_lowers_all_special_constraint_families() -> None:
         sense=Sense.Minimize,
     )
 
-    config = OpenJijPreparationConfig(uniform_penalty_weight=3.0)
-    report = _check_preparation_without_mutation(instance, config)
+    policy = OpenJijPreparationPolicy(uniform_penalty_weight=3.0)
+    report = _check_preparation_without_mutation(instance, policy)
     assert report.is_successful
-    assert report.config is config
-    prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
-    assert prepared.report.config is config
-    operations = {step.operation for step in prepared.report.steps}
+    assert report.policy is policy
+    prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
+    assert prepared.report.policy is policy
+    operations = {step.name for step in prepared.report.transforms}
     assert {
         "indicator_lowering",
         "one_hot_lowering",
@@ -443,10 +444,10 @@ def test_special_constraint_preparation_requires_uniform_penalty() -> None:
         sense=Sense.Minimize,
     )
 
-    config = OpenJijPreparationConfig(penalty_weights={})
-    report = _check_preparation_without_mutation(instance, config)
+    policy = OpenJijPreparationPolicy(penalty_weights={})
+    report = _check_preparation_without_mutation(instance, policy)
     assert not report.is_successful
-    assert report.config is config
+    assert report.policy is policy
     assert report.source_check.conditions_hold
     [failure] = report.preparation_failures
     assert failure.reason == "openjij.penalty.special_requires_uniform"
@@ -484,11 +485,11 @@ def test_integer_sos1_is_lowered_before_log_encoding() -> None:
         sense=Sense.Minimize,
     )
 
-    config = OpenJijPreparationConfig(uniform_penalty_weight=4.0)
-    report = _check_preparation_without_mutation(instance, config)
+    policy = OpenJijPreparationPolicy(uniform_penalty_weight=4.0)
+    report = _check_preparation_without_mutation(instance, policy)
     assert report.is_successful
-    prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
-    operations = [step.operation for step in prepared.report.steps]
+    prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
+    operations = [step.name for step in prepared.report.transforms]
     assert operations.index("sos1_lowering") < operations.index("integer_log_encoding")
     final = prepared.report.input_applicability
     assert final is not None and final.is_applicable
@@ -510,8 +511,8 @@ def test_source_integer_encoding_phase_reports_unbounded_integer() -> None:
     assert not report.is_successful
     assert report.source_check.source_membership.is_member
     [failure] = report.preparation_failures
-    assert isinstance(failure, OpenJijPreparationFailure)
-    assert failure.operation == "integer_log_encoding"
+    assert isinstance(failure, PreparationFailure)
+    assert failure.name == "integer_log_encoding"
     assert failure.reason == "openjij.log_encoding.bound_finite"
     assert failure.variable_ids == frozenset({0})
     assert failure.constraint_refs == frozenset()
@@ -545,7 +546,7 @@ def test_source_integer_encoding_phase_reports_more_than_53_bits() -> None:
     assert not report.is_successful
     assert report.source_check.source_membership.is_member
     [failure] = report.preparation_failures
-    assert failure.operation == "integer_log_encoding"
+    assert failure.name == "integer_log_encoding"
     assert failure.reason == "openjij.log_encoding.max_bits"
     assert failure.variable_ids == frozenset({0})
     assert failure.observed == 54
@@ -553,10 +554,10 @@ def test_source_integer_encoding_phase_reports_more_than_53_bits() -> None:
     assert "too large" in _failure_text(failure)
 
 
-def test_preparation_config_rejects_slack_range_outside_u64() -> None:
+def test_preparation_policy_rejects_slack_range_outside_u64() -> None:
     for slack_range in (0, 2**64, cast(int, True)):
         with pytest.raises(ValueError, match="integer in"):
-            OpenJijPreparationConfig(inequality_integer_slack_max_range=slack_range)
+            OpenJijPreparationPolicy(inequality_integer_slack_max_range=slack_range)
 
 
 def test_source_integer_encoding_phase_reports_inexact_f64_range() -> None:
@@ -570,7 +571,7 @@ def test_source_integer_encoding_phase_reports_inexact_f64_range() -> None:
     assert not report.is_successful
     assert report.source_check.source_membership.is_member
     [failure] = report.preparation_failures
-    assert failure.operation == "integer_log_encoding"
+    assert failure.name == "integer_log_encoding"
     assert failure.reason == "openjij.log_encoding.exact_integer_range"
     assert failure.variable_ids == frozenset({0})
     assert failure.observed == upper
@@ -591,14 +592,14 @@ def test_check_preparation_requires_an_explicit_penalty_for_constraints() -> Non
     assert not report.is_successful
     assert report.source_check.source_membership.is_member
     [failure] = report.preparation_failures
-    assert isinstance(failure, OpenJijPreparationFailure)
+    assert isinstance(failure, PreparationFailure)
     assert failure.variable_ids == frozenset()
     assert failure.constraint_refs == frozenset({ConstraintRef("regular", 7)})
     assert "penalty" in _failure_text(failure)
 
     accepted = _check_preparation_without_mutation(
         instance,
-        OpenJijPreparationConfig(uniform_penalty_weight=3.0),
+        OpenJijPreparationPolicy(uniform_penalty_weight=3.0),
     )
     assert accepted.is_successful
 
@@ -613,10 +614,10 @@ def test_per_constraint_penalty_preserves_u64_constraint_id() -> None:
         sense=Sense.Minimize,
     )
 
-    config = OpenJijPreparationConfig(penalty_weights={constraint_id: 2.0})
-    report = _check_preparation_without_mutation(instance, config)
+    policy = OpenJijPreparationPolicy(penalty_weights={constraint_id: 2.0})
+    report = _check_preparation_without_mutation(instance, policy)
     assert report.is_successful
-    prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
+    prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
     final = prepared.report.input_applicability
     assert final is not None and final.is_applicable
 
@@ -630,12 +631,12 @@ def test_check_preparation_reports_penalty_materialization_overflow() -> None:
         sense=Sense.Maximize,
     )
     weight = float.fromhex("0x1.fffffffffffffp+1023")
-    config = OpenJijPreparationConfig(uniform_penalty_weight=weight)
+    policy = OpenJijPreparationPolicy(uniform_penalty_weight=weight)
 
-    report = _check_preparation_without_mutation(instance, config)
+    report = _check_preparation_without_mutation(instance, policy)
     assert not report.is_successful
-    assert report.config is config
-    assert [step.operation for step in report.steps] == ["sense_reversal"]
+    assert report.policy is policy
+    assert [step.name for step in report.transforms] == ["sense_reversal"]
     [failure] = report.preparation_failures
     assert failure.reason == "openjij.preparation.materialization"
     assert failure.constraint_refs == frozenset({ConstraintRef("regular", 7)})
@@ -643,11 +644,11 @@ def test_check_preparation_reports_penalty_materialization_overflow() -> None:
     with pytest.raises(OpenJijPreparationError) as error:
         OMMXOpenJijSAAdapter.prepare(
             instance,
-            config=config,
+            policy=policy,
         )
     assert error.value.report.preparation_failures == (failure,)
-    assert error.value.report.steps == report.steps
-    assert error.value.report.config is config
+    assert error.value.report.transforms == report.transforms
+    assert error.value.report.policy is policy
 
 
 def test_preparation_surfaces_proven_infeasibility() -> None:
@@ -658,18 +659,18 @@ def test_preparation_surfaces_proven_infeasibility() -> None:
         constraints={7: x + 1 <= 0},
         sense=Sense.Minimize,
     )
-    config = OpenJijPreparationConfig(uniform_penalty_weight=2.0)
+    policy = OpenJijPreparationPolicy(uniform_penalty_weight=2.0)
     before = instance.to_v2_bytes()
 
     with pytest.raises(InfeasibleDetected):
         OMMXOpenJijSAAdapter.check_preparation(
             instance,
-            config=config,
+            policy=policy,
         )
     with pytest.raises(InfeasibleDetected):
         OMMXOpenJijSAAdapter.prepare(
             instance,
-            config=config,
+            policy=policy,
         )
     assert instance.to_v2_bytes() == before
 
@@ -685,21 +686,23 @@ def test_prepare_exact_maximization_and_integer_encoding() -> None:
     before = instance.to_v2_bytes()
 
     prepared = OMMXOpenJijSAAdapter.prepare(instance)
-    assert isinstance(prepared, OpenJijPreparation)
+    assert isinstance(prepared, Preparation)
     assert isinstance(prepared.report, OpenJijPreparationReport)
-    assert prepared.report.config == OpenJijPreparationConfig()
+    assert prepared.report.policy == OpenJijPreparationPolicy()
     assert prepared.report.source_check.conditions_hold
     final = prepared.report.input_applicability
     assert final is not None and final.is_applicable
     assert final.input_membership.matching_clauses == [(0, "openjij-binary-hubo")]
 
-    assert len(prepared.report.steps) >= 2
-    assert all(step.operation for step in prepared.report.steps)
+    assert len(prepared.report.transforms) >= 2
+    assert all(step.name for step in prepared.report.transforms)
     assert "approximate_integer_slack" not in {
-        step.operation for step in prepared.report.steps
+        step.name for step in prepared.report.transforms
     }
-    assert "finite_penalty" not in {step.operation for step in prepared.report.steps}
-    assert any(step.variable_ids == frozenset({5}) for step in prepared.report.steps)
+    assert "finite_penalty" not in {step.name for step in prepared.report.transforms}
+    assert any(
+        step.variable_ids == frozenset({5}) for step in prepared.report.transforms
+    )
     prepared_input = prepared.input
     assert prepared_input.sense == Sense.Minimize
     assert prepared_input.constraints == {}
@@ -721,19 +724,19 @@ def test_constrained_preparation_uses_exact_slack_by_default() -> None:
     )
     before = instance.to_v2_bytes()
 
-    config = OpenJijPreparationConfig(
+    policy = OpenJijPreparationPolicy(
         uniform_penalty_weight=4.0,
         inequality_integer_slack_max_range=32,
     )
-    prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
+    prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
     report = prepared.report
     assert report.is_successful
-    assert report.config is config
-    assert {step.operation for step in report.steps} >= {
+    assert report.policy is policy
+    assert {step.name for step in report.transforms} >= {
         "exact_integer_slack",
         "finite_penalty",
     }
-    assert "approximate_integer_slack" not in {step.operation for step in report.steps}
+    assert "approximate_integer_slack" not in {step.name for step in report.transforms}
     assert prepared.input.constraints == {}
     assert set(instance.constraints) == {7}
     assert instance.to_v2_bytes() == before
@@ -749,13 +752,13 @@ def test_approximate_integer_slack_requires_explicit_selection() -> None:
     )
     before = instance.to_v2_bytes()
 
-    config = OpenJijPreparationConfig(
+    policy = OpenJijPreparationPolicy(
         uniform_penalty_weight=4.0,
         inequality_integer_slack_max_range=1,
     )
-    report = _check_preparation_without_mutation(instance, config)
+    report = _check_preparation_without_mutation(instance, policy)
     assert not report.is_successful
-    assert report.config is config
+    assert report.policy is policy
     [failure] = report.preparation_failures
     assert failure.reason == "openjij.slack.approximation_explicit_selection"
     assert failure.constraint_refs == frozenset({ConstraintRef("regular", 7)})
@@ -764,7 +767,7 @@ def test_approximate_integer_slack_requires_explicit_selection() -> None:
     with pytest.raises(OpenJijPreparationError) as error:
         OMMXOpenJijSAAdapter.prepare(
             instance,
-            config=config,
+            policy=policy,
         )
     assert error.value.report == report
     assert instance.to_v2_bytes() == before
@@ -779,15 +782,15 @@ def test_approximate_integer_slack_can_be_selected_explicitly() -> None:
         sense=Sense.Minimize,
     )
 
-    config = OpenJijPreparationConfig(
+    policy = OpenJijPreparationPolicy(
         uniform_penalty_weight=4.0,
         inequality_integer_slack_max_range=1,
         allow_approximate_integer_slack=True,
     )
-    prepared = OMMXOpenJijSAAdapter.prepare(instance, config=config)
+    prepared = OMMXOpenJijSAAdapter.prepare(instance, policy=policy)
     assert prepared.report.is_successful
-    assert prepared.report.config is config
-    assert {step.operation for step in prepared.report.steps} >= {
+    assert prepared.report.policy is policy
+    assert {step.name for step in prepared.report.transforms} >= {
         "approximate_integer_slack",
         "finite_penalty",
     }
@@ -805,7 +808,7 @@ def test_approximate_slack_does_not_recover_exact_materialization_failure() -> N
 
     report = _check_preparation_without_mutation(
         instance,
-        OpenJijPreparationConfig(
+        OpenJijPreparationPolicy(
             uniform_penalty_weight=4.0,
             allow_approximate_integer_slack=True,
         ),
@@ -817,7 +820,7 @@ def test_approximate_slack_does_not_recover_exact_materialization_failure() -> N
     assert failure.constraint_refs == frozenset({ConstraintRef("regular", 7)})
     assert "exact integer slack" in failure.description.lower()
     assert "available decision variable id" in failure.description.lower()
-    assert "approximate_integer_slack" not in {step.operation for step in report.steps}
+    assert "approximate_integer_slack" not in {step.name for step in report.transforms}
 
 
 def test_preparation_rechecks_generated_variable_ids_for_openjij() -> None:
@@ -831,7 +834,7 @@ def test_preparation_rechecks_generated_variable_ids_for_openjij() -> None:
 
     report = _check_preparation_without_mutation(
         instance,
-        OpenJijPreparationConfig(uniform_penalty_weight=2.0),
+        OpenJijPreparationPolicy(uniform_penalty_weight=2.0),
     )
     assert not report.is_successful
     final = report.input_applicability
@@ -851,12 +854,12 @@ def test_preparation_reports_trivially_satisfied_inequality_as_exact() -> None:
     )
 
     prepared = OMMXOpenJijSAAdapter.prepare(instance)
-    steps = prepared.report.steps
+    transforms = prepared.report.transforms
     [removal] = [
-        step for step in steps if step.operation == "trivial_inequality_removal"
+        step for step in transforms if step.name == "trivial_inequality_removal"
     ]
     assert removal.constraint_refs == frozenset({ConstraintRef("regular", 7)})
-    assert not [step for step in steps if step.operation == "finite_penalty"]
+    assert not [step for step in transforms if step.name == "finite_penalty"]
     assert set(instance.constraints) == {7}
 
 
@@ -874,16 +877,16 @@ def test_penalty_coverage_uses_constraints_remaining_after_slack() -> None:
 
     prepared = OMMXOpenJijSAAdapter.prepare(
         instance,
-        config=OpenJijPreparationConfig(penalty_weights={8: 2.0}),
+        policy=OpenJijPreparationPolicy(penalty_weights={8: 2.0}),
     )
 
     [removal] = [
         step
-        for step in prepared.report.steps
-        if step.operation == "trivial_inequality_removal"
+        for step in prepared.report.transforms
+        if step.name == "trivial_inequality_removal"
     ]
     [penalty] = [
-        step for step in prepared.report.steps if step.operation == "finite_penalty"
+        step for step in prepared.report.transforms if step.name == "finite_penalty"
     ]
     assert removal.constraint_refs == frozenset({ConstraintRef("regular", 7)})
     assert penalty.constraint_refs == frozenset({ConstraintRef("regular", 8)})
@@ -900,11 +903,11 @@ def test_known_weight_for_trivially_removed_constraint_is_optional() -> None:
 
     prepared = OMMXOpenJijSAAdapter.prepare(
         instance,
-        config=OpenJijPreparationConfig(penalty_weights={}),
+        policy=OpenJijPreparationPolicy(penalty_weights={}),
     )
     assert prepared.report.is_successful
     assert not [
-        step for step in prepared.report.steps if step.operation == "finite_penalty"
+        step for step in prepared.report.transforms if step.name == "finite_penalty"
     ]
 
 
@@ -916,10 +919,10 @@ def test_unexpected_phase_exception_is_not_a_preparation_rejection(
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Sense.Minimize,
+        sense=Sense.Maximize,
     )
 
-    def broken_phase(_state: object) -> object:
+    def broken_phase(_state: object, **_kwargs: object) -> object:
         raise AssertionError("phase invariant sentinel")
 
     monkeypatch.setattr(

--- a/python/ommx-openjij-adapter/tests/test_experiment.py
+++ b/python/ommx-openjij-adapter/tests/test_experiment.py
@@ -3,7 +3,7 @@ from ommx.experiment import Experiment
 
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
 
@@ -18,7 +18,7 @@ def test_log_sample_records_the_exact_prepared_adapter_input() -> None:
     source_bytes = source.to_v2_bytes()
     preparation = OMMXOpenJijSAAdapter.prepare(
         source,
-        config=OpenJijPreparationConfig(uniform_penalty_weight=2.0),
+        policy=OpenJijPreparationPolicy(uniform_penalty_weight=2.0),
     )
     adapter_input = preparation.input
     input_bytes = adapter_input.to_v2_bytes()
@@ -43,7 +43,7 @@ def test_log_sample_records_the_exact_prepared_adapter_input() -> None:
         assert actual.sense == expected.sense
         assert len(actual.constraints) == len(expected.constraints)
 
-    source_samples = preparation.evaluate_source(prepared_samples)
+    source_samples = preparation.decode(prepared_samples)
     assert source_samples.sense == Sense.Maximize
     assert len(source_samples.constraints) == 1
     for sample_id in source_samples.sample_ids():

--- a/python/ommx-openjij-adapter/tests/test_openjij_special_constraint_lowering.py
+++ b/python/ommx-openjij-adapter/tests/test_openjij_special_constraint_lowering.py
@@ -3,10 +3,12 @@ from ommx import (
     Instance,
     OneHotConstraint,
     ProvenanceKind,
+    SpecialConstraintKind,
 )
+from ommx.adapter import ConstraintRef
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
 
@@ -22,7 +24,7 @@ def test_preparation_explicitly_lowers_special_constraints() -> None:
 
     preparation = OMMXOpenJijSAAdapter.prepare(
         instance,
-        config=OpenJijPreparationConfig(uniform_penalty_weight=2.0),
+        policy=OpenJijPreparationPolicy(uniform_penalty_weight=2.0),
     )
     adapter_input = preparation.input
 
@@ -32,3 +34,46 @@ def test_preparation_explicitly_lowers_special_constraints() -> None:
     assert len(constraints) == 1
     assert constraints[0].provenance[-1].kind == ProvenanceKind.OneHotConstraint
     assert constraints[0].provenance[-1].original_id == 10
+    [transform] = [
+        transform
+        for transform in preparation.report.transforms
+        if transform.name == "one_hot_lowering"
+    ]
+    assert transform.special_constraint_kinds == frozenset(
+        {SpecialConstraintKind.OneHot}
+    )
+
+
+def test_preparation_policy_can_forbid_active_special_constraint_lowering() -> None:
+    x = [DecisionVariable.binary(i) for i in range(2)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=sum(x),
+        constraints={},
+        one_hot_constraints={10: OneHotConstraint(variables=x)},
+        sense=Instance.MINIMIZE,
+    )
+    before = instance.to_v2_bytes()
+
+    report = OMMXOpenJijSAAdapter.check_preparation(
+        instance,
+        policy=OpenJijPreparationPolicy(
+            allowed_special_constraint_lowerings=frozenset(),
+            uniform_penalty_weight=2.0,
+        ),
+    )
+
+    assert report.transforms == ()
+    [failure] = report.preparation_failures
+    assert failure.name == "one_hot_lowering"
+    assert failure.reason == "openjij.special_constraint_lowering.policy"
+    assert failure.constraint_refs == frozenset({ConstraintRef("one_hot", 10)})
+    assert instance.to_v2_bytes() == before
+
+
+def test_adapter_declares_ordered_special_constraint_lowering_candidates() -> None:
+    assert OMMXOpenJijSAAdapter.PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS == (
+        SpecialConstraintKind.Indicator,
+        SpecialConstraintKind.OneHot,
+        SpecialConstraintKind.Sos1,
+    )

--- a/python/ommx-openjij-adapter/tests/test_preparation_stages.py
+++ b/python/ommx-openjij-adapter/tests/test_preparation_stages.py
@@ -22,7 +22,7 @@ from ommx_openjij_adapter._preparation_phases import (
     apply_penalties,
     encode_source_integers,
 )
-from ommx_openjij_adapter import OMMXOpenJijSAAdapter, OpenJijPreparationConfig
+from ommx_openjij_adapter import OMMXOpenJijSAAdapter, OpenJijPreparationPolicy
 
 
 def test_penalty_ready_accepts_an_approximate_slack_inequality() -> None:
@@ -170,7 +170,7 @@ def test_policy_rejection_still_consumes_the_penalty_ready_stage() -> None:
         slack_outcomes=(),
     )
 
-    outcome = apply_penalties(state, source_instance, OpenJijPreparationConfig())
+    outcome = apply_penalties(state, source_instance, OpenJijPreparationPolicy())
 
     assert isinstance(outcome, _Blocked)
     with pytest.raises(_StageInvariantError, match="already been consumed"):

--- a/python/ommx-openjij-adapter/tests/test_public_api.py
+++ b/python/ommx-openjij-adapter/tests/test_public_api.py
@@ -2,6 +2,13 @@ import inspect
 from typing import get_type_hints
 
 from ommx import DecisionVariable, Instance, Sense
+from ommx.adapter import (
+    Preparation,
+    PreparationError,
+    PreparationFailure,
+    PreparationPolicy,
+    PreparationTransform,
+)
 import ommx_openjij_adapter as package
 import pytest
 from ommx_openjij_adapter import _decode, _preparation, adapter
@@ -10,29 +17,35 @@ from ommx_openjij_adapter import _decode, _preparation, adapter
 def test_package_root_is_the_stable_public_facade() -> None:
     expected_exports = [
         "OMMXOpenJijSAAdapter",
-        "OpenJijPreparation",
-        "OpenJijPreparationConfig",
+        "OpenJijPreparationPolicy",
         "OpenJijPreparationError",
-        "OpenJijPreparationFailure",
         "OpenJijPreparationReport",
         "OpenJijPreparationSourceCheck",
-        "OpenJijPreparationStep",
         "decode_to_samples",
     ]
 
     assert package.__all__ == expected_exports
     assert issubclass(package.OMMXOpenJijSAAdapter, adapter.OMMXOpenJijSAAdapter)
-    assert package.OpenJijPreparation is _preparation.OpenJijPreparation
-    assert package.OpenJijPreparationConfig is _preparation.OpenJijPreparationConfig
+    assert package.OpenJijPreparationPolicy is _preparation.OpenJijPreparationPolicy
     assert package.OpenJijPreparationError is _preparation.OpenJijPreparationError
-    assert package.OpenJijPreparationFailure is _preparation.OpenJijPreparationFailure
     assert package.OpenJijPreparationReport is _preparation.OpenJijPreparationReport
     assert (
         package.OpenJijPreparationSourceCheck
         is _preparation.OpenJijPreparationSourceCheck
     )
-    assert package.OpenJijPreparationStep is _preparation.OpenJijPreparationStep
+    assert issubclass(package.OpenJijPreparationPolicy, PreparationPolicy)
+    assert issubclass(package.OpenJijPreparationError, PreparationError)
     assert package.decode_to_samples is _decode.decode_to_samples
+    for removed_name in (
+        "OpenJijPreparation",
+        "OpenJijPreparationConfig",
+        "OpenJijPreparationFailure",
+        "OpenJijPreparationStep",
+        "Preparation",
+        "PreparationFailure",
+        "PreparationTransform",
+    ):
+        assert not hasattr(package, removed_name)
     assert not hasattr(package, "response_to_samples")
     assert not hasattr(package, "sample_qubo_sa")
     assert not hasattr(_decode, "response_to_samples")
@@ -43,13 +56,13 @@ def test_package_root_is_the_stable_public_facade() -> None:
 def test_public_classes_support_standard_introspection() -> None:
     public_classes = [
         package.OMMXOpenJijSAAdapter,
-        package.OpenJijPreparation,
-        package.OpenJijPreparationConfig,
+        package.OpenJijPreparationPolicy,
         package.OpenJijPreparationError,
-        package.OpenJijPreparationFailure,
         package.OpenJijPreparationReport,
         package.OpenJijPreparationSourceCheck,
-        package.OpenJijPreparationStep,
+        Preparation,
+        PreparationFailure,
+        PreparationTransform,
     ]
 
     for class_ in public_classes:
@@ -57,18 +70,14 @@ def test_public_classes_support_standard_introspection() -> None:
         get_type_hints(class_)
 
     assert (
-        get_type_hints(package.OpenJijPreparation)["report"]
-        is package.OpenJijPreparationReport
-    )
-    assert (
-        get_type_hints(package.OpenJijPreparationReport)["config"]
-        is package.OpenJijPreparationConfig
+        get_type_hints(package.OpenJijPreparationReport)["policy"]
+        is package.OpenJijPreparationPolicy
     )
 
 
 def test_preparation_value_is_created_only_by_the_pipeline() -> None:
-    with pytest.raises(TypeError, match="created only by prepare"):
-        package.OpenJijPreparation()
+    with pytest.raises(TypeError, match="created only by .*prepare"):
+        Preparation()
 
 
 def test_adapter_identity_in_applicability_report_is_unchanged() -> None:

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -6,7 +6,7 @@ import pytest
 from ommx import DecisionVariable, Instance, Sos1Constraint
 from ommx_openjij_adapter import (
     OMMXOpenJijSAAdapter,
-    OpenJijPreparationConfig,
+    OpenJijPreparationPolicy,
 )
 
 
@@ -172,7 +172,7 @@ def _openjij_input(instance):
     else:
         preparation = OMMXOpenJijSAAdapter.prepare(
             instance,
-            config=OpenJijPreparationConfig(
+            policy=OpenJijPreparationPolicy(
                 uniform_penalty_weight=3.1 if instance.constraints else None,
             ),
         )
@@ -181,10 +181,10 @@ def _openjij_input(instance):
     return adapter_input, preparation, source
 
 
-def _evaluate_source_if_prepared(sample_set, preparation):
+def _decode_if_prepared(sample_set, preparation):
     if preparation is None:
         return sample_set
-    return preparation.evaluate_source(sample_set)
+    return preparation.decode(sample_set)
 
 
 def _expected_solution(instance, ans):
@@ -232,7 +232,7 @@ def test_sample(instance, ans):
     # that constraints are sufficiently penalized without overwhelming the objective.
     adapter_input, preparation, source = _openjij_input(instance)
     prepared_samples = OMMXOpenJijSAAdapter.sample(adapter_input, num_reads=1, seed=999)
-    sample_set = _evaluate_source_if_prepared(prepared_samples, preparation)
+    sample_set = _decode_if_prepared(prepared_samples, preparation)
     assert sample_set.extract_decision_variables("x", 0) == ans
     _assert_sample_set_uses_source_model(sample_set, instance, ans)
     assert instance.to_v2_bytes() == source
@@ -274,7 +274,7 @@ def test_sample_twice(instance, ans):
         prepared_samples = OMMXOpenJijSAAdapter.sample(
             adapter_input, num_reads=1, seed=999
         )
-        sample_set = _evaluate_source_if_prepared(prepared_samples, preparation)
+        sample_set = _decode_if_prepared(prepared_samples, preparation)
         assert sample_set.extract_decision_variables("x", 0) == ans
         _assert_sample_set_uses_source_model(sample_set, instance, ans)
         assert instance.to_v2_bytes() == source
@@ -366,7 +366,7 @@ def test_source_evaluation_populates_variable_removed_with_trivial_inequality(
     )
     assert input_samples.get(0).state.get(0) == expected_value
 
-    source_samples = preparation.evaluate_source(input_samples)
+    source_samples = preparation.decode(input_samples)
     source_solution = source_samples.get(0)
     assert source_solution.state.get(0) == expected_value
     assert source_solution.feasible
@@ -385,14 +385,14 @@ def test_sample_decodes_integer_sos1_against_source_model():
 
     preparation = OMMXOpenJijSAAdapter.prepare(
         instance,
-        config=OpenJijPreparationConfig(uniform_penalty_weight=4.0),
+        policy=OpenJijPreparationPolicy(uniform_penalty_weight=4.0),
     )
     prepared_samples = OMMXOpenJijSAAdapter.sample(
         preparation.input,
         num_reads=4,
         seed=999,
     )
-    sample_set = preparation.evaluate_source(prepared_samples)
+    sample_set = preparation.decode(prepared_samples)
     assert len(sample_set.constraints_df(kind="sos1")) == 1
     for sample_id in sample_set.sample_ids():
         solution = sample_set.get(sample_id)

--- a/python/ommx-tests/tests/test_instance_class.py
+++ b/python/ommx-tests/tests/test_instance_class.py
@@ -566,6 +566,7 @@ def test_solver_adapter_prepare_lowers_declared_kind_and_decodes_outputs() -> No
 
     preparation = Adapter.prepare(source)
 
+    assert isinstance(preparation.report, PreparationReport)
     assert source.to_v2_bytes() == before
     assert not preparation.report.source_applicability.is_applicable
     assert preparation.report.input_applicability is not None

--- a/python/ommx-tests/tests/test_instance_class.py
+++ b/python/ommx-tests/tests/test_instance_class.py
@@ -15,16 +15,26 @@ from ommx import (
     InstanceClassMembershipReport,
     InstanceClassMismatch,
     Kind,
+    NamedFunction,
     OneHotConstraint,
+    Samples,
     Sense,
+    Solution,
     Sos1Constraint,
     SpecialConstraintKind,
+    State,
 )
 from ommx.adapter import (
     AdapterApplicabilityReport,
     AdapterNotApplicableError,
     AdapterPreconditionViolation,
     ConstraintRef,
+    Preparation,
+    PreparationError,
+    PreparationFailure,
+    PreparationPolicy,
+    PreparationReport,
+    PreparationTransform,
     SolverAdapter,
 )
 
@@ -460,3 +470,245 @@ def test_precondition_hook_is_isolated_and_validated() -> None:
 
     with pytest.raises(TypeError, match="AdapterPreconditionViolation"):
         InvalidHook.check_applicability(instance)
+
+
+def binary_linear_equality_input_class() -> InstanceClass:
+    return InstanceClass(
+        [
+            clause(
+                "binary-linear-equality",
+                allowed_variable_kinds={Kind.Binary},
+                objective_degree_bound=DegreeBound.at_most(1),
+                regular_constraint_degree_bounds={
+                    Equality.EqualToZero: DegreeBound.at_most(1)
+                },
+            )
+        ]
+    )
+
+
+def one_hot_source() -> Instance:
+    x = [DecisionVariable.binary(1), DecisionVariable.binary(2)]
+    return Instance.from_components(
+        sense=Sense.Minimize,
+        objective=x[0] + x[1],
+        decision_variables=x,
+        constraints={},
+        one_hot_constraints={30: OneHotConstraint(variables=x)},
+    )
+
+
+def test_preparation_policy_snapshots_and_validates_lowering_restrictions() -> None:
+    mutable = {SpecialConstraintKind.OneHot}
+    policy = PreparationPolicy(
+        allowed_special_constraint_lowerings=cast(
+            frozenset[SpecialConstraintKind], mutable
+        )
+    )
+    mutable.clear()
+
+    assert policy.allowed_special_constraint_lowerings == frozenset(
+        {SpecialConstraintKind.OneHot}
+    )
+    with pytest.raises(TypeError, match="SpecialConstraintKind"):
+        PreparationPolicy(
+            allowed_special_constraint_lowerings=cast(
+                frozenset[SpecialConstraintKind], frozenset({"one_hot"})
+            )
+        )
+
+
+def test_preparation_value_and_receipts_validate_public_invariants() -> None:
+    with pytest.raises(TypeError, match="created only"):
+        Preparation()
+    with pytest.raises(ValueError, match="name must not be empty"):
+        PreparationTransform(name="", description="invalid")
+    with pytest.raises(ValueError, match="name must not be empty"):
+        PreparationFailure(name="", reason="invalid", description="invalid")
+
+
+def test_solver_adapter_prepare_prefers_identity_and_defensively_copies() -> None:
+    x = DecisionVariable.binary(1)
+    source = instance_with_objective(x, x)
+
+    class Adapter(SolverAdapter):
+        INPUT_CLASS = binary_linear_input_class()
+
+    preparation = Adapter.prepare(source)
+
+    assert isinstance(preparation, Preparation)
+    assert isinstance(preparation.report, PreparationReport)
+    assert preparation.report.is_successful
+    assert preparation.report.source_applicability.is_applicable
+    assert preparation.report.transforms == ()
+    assert preparation.source.to_v2_bytes() == source.to_v2_bytes()
+    assert preparation.input.to_v2_bytes() == source.to_v2_bytes()
+    assert preparation.source is not source
+    assert preparation.input is not source
+    assert preparation.input is not preparation.input
+
+    direct = source.evaluate({1: 1})
+    direct.optimality = Solution.OPTIMAL
+    decoded = preparation.decode(direct)
+    assert isinstance(decoded, Solution)
+    assert decoded is not direct
+    assert decoded.objective == direct.objective
+    assert decoded.optimality == Solution.OPTIMAL
+
+
+def test_solver_adapter_prepare_lowers_declared_kind_and_decodes_outputs() -> None:
+    source = one_hot_source()
+    before = source.to_v2_bytes()
+
+    class Adapter(SolverAdapter):
+        INPUT_CLASS = binary_linear_equality_input_class()
+        PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS = (SpecialConstraintKind.OneHot,)
+
+    preparation = Adapter.prepare(source)
+
+    assert source.to_v2_bytes() == before
+    assert not preparation.report.source_applicability.is_applicable
+    assert preparation.report.input_applicability is not None
+    assert preparation.report.input_applicability.is_applicable
+    [transform] = preparation.report.transforms
+    assert transform.name == "one_hot_lowering"
+    assert transform.special_constraint_kinds == frozenset(
+        {SpecialConstraintKind.OneHot}
+    )
+    assert transform.constraint_refs == frozenset({ConstraintRef("one_hot", 30)})
+
+    adapter_input = preparation.input
+    assert adapter_input.active_special_constraint_kinds == set()
+    assert adapter_input.one_hot_constraints == {}
+    input_solution = adapter_input.evaluate({1: 1, 2: 0})
+    input_solution.optimality = Solution.OPTIMAL
+    source_solution = preparation.decode(input_solution)
+    assert isinstance(source_solution, Solution)
+    assert source_solution.feasible
+    assert source_solution.optimality == Solution.OPTIMAL
+    assert len(source_solution.constraints_df(kind="one_hot")) == 1
+
+    samples = Samples({})
+    samples.append([5], State(entries=[(1, 0), (2, 1)]))
+    input_samples = adapter_input.evaluate_samples(samples)
+    source_samples = preparation.decode(input_samples)
+    assert source_samples.sample_ids() == {5}
+    assert source_samples.get(5).feasible
+    assert len(source_samples.constraints_df(kind="one_hot")) == 1
+
+    detached_input = preparation.input
+    [constraint_id] = detached_input.constraints
+    detached_input.relax_constraint(constraint_id, "test")
+    assert preparation.input.constraints
+
+    source.lower_special_constraints({SpecialConstraintKind.OneHot})
+    assert preparation.source.one_hot_constraints
+
+
+def test_preparation_decode_preserves_every_source_variable_coordinate() -> None:
+    x = [DecisionVariable.binary(1), DecisionVariable.binary(2)]
+    named_only = DecisionVariable.binary(3)
+    source = Instance.from_components(
+        sense=Sense.Minimize,
+        objective=x[0] + x[1],
+        decision_variables=[*x, named_only],
+        constraints={},
+        one_hot_constraints={30: OneHotConstraint(variables=x)},
+        named_functions=[NamedFunction(id=40, function=named_only, name="named_only")],
+    )
+
+    class Adapter(SolverAdapter):
+        INPUT_CLASS = binary_linear_equality_input_class()
+        PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS = (SpecialConstraintKind.OneHot,)
+
+    preparation = Adapter.prepare(source)
+    input_solution = preparation.input.evaluate({1: 1, 2: 0, 3: 1})
+    decoded_solution = preparation.decode(input_solution)
+
+    assert decoded_solution.state.get(3) == 1
+    assert decoded_solution.get_named_function_by_id(40).evaluated_value == 1
+
+    input_samples = preparation.input.evaluate_samples({5: {1: 0, 2: 1, 3: 1}})
+    decoded_samples = preparation.decode(input_samples)
+
+    assert decoded_samples.get(5).state.get(3) == 1
+    assert decoded_samples.extract_named_functions("named_only", 5) == {(): 1}
+
+
+def test_preparation_policy_only_restricts_adapter_candidates() -> None:
+    source = one_hot_source()
+    before = source.to_v2_bytes()
+
+    class Adapter(SolverAdapter):
+        INPUT_CLASS = binary_linear_equality_input_class()
+        PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS = (SpecialConstraintKind.OneHot,)
+
+    with pytest.raises(PreparationError) as error:
+        Adapter.prepare(
+            source,
+            policy=PreparationPolicy(allowed_special_constraint_lowerings=frozenset()),
+        )
+
+    report = error.value.report
+    assert report.transforms == ()
+    [failure] = report.preparation_failures
+    assert failure.name == "special_constraint_lowering"
+    assert (
+        failure.reason == "preparation.policy.special_constraint_lowering_not_allowed"
+    )
+    assert failure.constraint_refs == frozenset({ConstraintRef("one_hot", 30)})
+    assert report.input_applicability is None
+    assert source.to_v2_bytes() == before
+
+
+def test_preparation_rechecks_applicability_after_transform() -> None:
+    x = [DecisionVariable.binary(1), DecisionVariable.binary(2)]
+    source = Instance.from_components(
+        sense=Sense.Minimize,
+        objective=x[0] * x[1],
+        decision_variables=x,
+        constraints={},
+        one_hot_constraints={30: OneHotConstraint(variables=x)},
+    )
+    before = source.to_v2_bytes()
+
+    class Adapter(SolverAdapter):
+        INPUT_CLASS = binary_linear_equality_input_class()
+        PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS = (SpecialConstraintKind.OneHot,)
+
+    with pytest.raises(PreparationError) as error:
+        Adapter.prepare(source)
+
+    report = error.value.report
+    assert [transform.name for transform in report.transforms] == ["one_hot_lowering"]
+    assert report.input_applicability is not None
+    assert not report.input_applicability.is_applicable
+    assert source.to_v2_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "candidates, message",
+    [
+        (
+            (SpecialConstraintKind.OneHot, SpecialConstraintKind.OneHot),
+            "duplicate",
+        ),
+        (
+            (SpecialConstraintKind.Sos1, SpecialConstraintKind.Indicator),
+            "SDK order",
+        ),
+    ],
+)
+def test_preparation_rejects_invalid_adapter_candidate_declarations(
+    candidates: tuple[SpecialConstraintKind, ...],
+    message: str,
+) -> None:
+    x = DecisionVariable.binary(1)
+    source = instance_with_objective(x, x)
+
+    class Adapter(SolverAdapter):
+        INPUT_CLASS = binary_linear_input_class()
+        PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS = candidates
+
+    with pytest.raises(ValueError, match=message):
+        Adapter.prepare(source)

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -4,7 +4,16 @@ import copy
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Protocol, runtime_checkable
+from typing import (
+    Any,
+    ClassVar,
+    Generic,
+    Protocol,
+    TypeVar,
+    cast,
+    overload,
+    runtime_checkable,
+)
 
 from ommx._ommx_rust import DiagnosticCollector as DiagnosticCollector
 from ommx import (
@@ -12,8 +21,11 @@ from ommx import (
     Instance,
     InstanceClass,
     InstanceClassMembershipReport,
+    Samples,
     SampleSet,
     Solution,
+    SpecialConstraintKind,
+    State,
 )
 
 
@@ -124,6 +136,313 @@ class AdapterNotApplicableError(ValueError):
         super().__init__(str(report))
 
 
+PreparationDiagnosticValue = str | int | float | bool | None
+
+
+@dataclass(frozen=True, slots=True)
+class PreparationPolicy:
+    """Caller-owned restrictions on an Adapter's preparation candidates.
+
+    ``None`` leaves the Adapter's declared special-constraint lowering
+    candidates unrestricted. A concrete set can only remove candidates; an
+    empty set therefore forbids every automatic special-constraint lowering.
+    """
+
+    allowed_special_constraint_lowerings: frozenset[SpecialConstraintKind] | None = None
+
+    def __post_init__(self) -> None:
+        allowed = self.allowed_special_constraint_lowerings
+        if allowed is None:
+            return
+        try:
+            snapshot = frozenset(allowed)
+        except TypeError as error:
+            raise TypeError(
+                "allowed_special_constraint_lowerings must be an iterable of "
+                "SpecialConstraintKind values or None"
+            ) from error
+        if not all(isinstance(kind, SpecialConstraintKind) for kind in snapshot):
+            raise TypeError(
+                "allowed_special_constraint_lowerings must contain only "
+                "SpecialConstraintKind values"
+            )
+        object.__setattr__(self, "allowed_special_constraint_lowerings", snapshot)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparationTransform:
+    """Audit receipt for one applied SDK Transform.
+
+    This is a record of a Transform that was applied while producing an
+    Adapter input. It is not an executable Transform or a formal proof object.
+    In particular, it does not provide a public ``encode`` operation.
+    """
+
+    name: str
+    description: str
+    variable_ids: frozenset[int] = field(default_factory=frozenset)
+    constraint_refs: frozenset[ConstraintRef] = field(default_factory=frozenset)
+    special_constraint_kinds: frozenset[SpecialConstraintKind] = field(
+        default_factory=frozenset
+    )
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("preparation transform name must not be empty")
+        if not all(
+            isinstance(kind, SpecialConstraintKind)
+            for kind in self.special_constraint_kinds
+        ):
+            raise TypeError(
+                "special_constraint_kinds must contain only "
+                "SpecialConstraintKind values"
+            )
+        object.__setattr__(self, "variable_ids", frozenset(self.variable_ids))
+        object.__setattr__(self, "constraint_refs", frozenset(self.constraint_refs))
+        object.__setattr__(
+            self,
+            "special_constraint_kinds",
+            frozenset(self.special_constraint_kinds),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PreparationFailure:
+    """One structured failure discovered while preparing an Adapter input."""
+
+    name: str
+    reason: str
+    description: str
+    variable_ids: frozenset[int] = field(default_factory=frozenset)
+    constraint_refs: frozenset[ConstraintRef] = field(default_factory=frozenset)
+    observed: PreparationDiagnosticValue = None
+    expected: PreparationDiagnosticValue = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("preparation failure name must not be empty")
+        if not self.reason:
+            raise ValueError("preparation failure reason must not be empty")
+        object.__setattr__(self, "variable_ids", frozenset(self.variable_ids))
+        object.__setattr__(self, "constraint_refs", frozenset(self.constraint_refs))
+
+
+@dataclass(frozen=True, slots=True)
+class PreparationReport:
+    """Audit of one common SolverAdapter preparation attempt."""
+
+    policy: PreparationPolicy
+    source_applicability: AdapterApplicabilityReport
+    transforms: tuple[PreparationTransform, ...]
+    preparation_failures: tuple[PreparationFailure, ...] = ()
+    input_applicability: AdapterApplicabilityReport | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "transforms", tuple(self.transforms))
+        object.__setattr__(
+            self,
+            "preparation_failures",
+            tuple(self.preparation_failures),
+        )
+        if self.preparation_failures and self.input_applicability is not None:
+            raise ValueError(
+                "a preparation report cannot contain both preparation failures "
+                "and an input applicability result"
+            )
+
+    @property
+    def is_successful(self) -> bool:
+        return (
+            not self.preparation_failures
+            and self.input_applicability is not None
+            and self.input_applicability.is_applicable
+        )
+
+
+@runtime_checkable
+class PreparationReportProtocol(Protocol):
+    """Common read-only surface exposed by Adapter preparation reports."""
+
+    @property
+    def policy(self) -> PreparationPolicy: ...
+
+    @property
+    def transforms(self) -> tuple[PreparationTransform, ...]: ...
+
+    @property
+    def preparation_failures(self) -> tuple[PreparationFailure, ...]: ...
+
+    @property
+    def input_applicability(self) -> AdapterApplicabilityReport | None: ...
+
+    @property
+    def is_successful(self) -> bool: ...
+
+
+PreparationReportT = TypeVar("PreparationReportT", bound=PreparationReportProtocol)
+PreparationReportT_co = TypeVar(
+    "PreparationReportT_co", bound=PreparationReportProtocol, covariant=True
+)
+
+
+class PreparationError(ValueError, Generic[PreparationReportT]):
+    """Raised when preparation cannot produce an applicable Adapter input."""
+
+    report: PreparationReportT
+
+    def __init__(self, report: PreparationReportT):
+        self.report = report
+        preparation_failures = getattr(report, "preparation_failures", ())
+        input_applicability = getattr(report, "input_applicability", None)
+        if preparation_failures:
+            details = "\n".join(
+                f"- {failure.name}/{failure.reason}: {failure.description}"
+                for failure in preparation_failures
+            )
+            message = f"Adapter input preparation failed:\n{details}"
+        elif input_applicability is not None:
+            message = (
+                "Preparation did not produce an applicable Adapter input:\n"
+                f"{input_applicability}"
+            )
+        else:
+            message = "Preparation did not produce an Adapter input"
+        super().__init__(message)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class Preparation(Generic[PreparationReportT_co]):
+    """An auditable source-to-Adapter-input relation with output decoding.
+
+    Values are created by :meth:`SolverAdapter.prepare` or an Adapter-specific
+    preparation pipeline. ``source`` and ``input`` are isolated snapshots.
+    Direct Adapter outputs still belong to ``input``; :meth:`decode` returns a
+    separately evaluated source-side output.
+    """
+
+    _source: Instance = field(repr=False)
+    _input: Instance = field(repr=False)
+    policy: PreparationPolicy
+    _report: PreparationReportT_co = field(repr=False)
+    _input_applicability: AdapterApplicabilityReport = field(repr=False)
+    _preserves_optimality: bool = field(repr=False)
+    _is_identity: bool = field(repr=False)
+
+    def __init__(self) -> None:
+        raise TypeError("Preparation is created only by SolverAdapter.prepare()")
+
+    @classmethod
+    def _create(
+        cls,
+        *,
+        source: Instance,
+        input: Instance,
+        report: PreparationReportT,
+        preserves_optimality: bool = False,
+    ) -> Preparation[PreparationReportT]:
+        """Create a value after an Adapter has checked the concrete input."""
+        if not isinstance(preserves_optimality, bool):
+            raise TypeError("preserves_optimality must be a bool")
+        if not isinstance(report, PreparationReportProtocol):
+            raise TypeError("report must implement PreparationReportProtocol")
+        if not isinstance(report.policy, PreparationPolicy):
+            raise TypeError("Preparation report policy must be a PreparationPolicy")
+        if report.is_successful is not True:
+            raise ValueError("Preparation requires a successful report")
+        input_applicability = report.input_applicability
+        if input_applicability is None or not input_applicability.is_applicable:
+            raise ValueError("Preparation requires an applicable Adapter input")
+
+        source_snapshot = copy.deepcopy(source)
+        input_snapshot = copy.deepcopy(input)
+        preparation = object.__new__(cls)
+        object.__setattr__(preparation, "_source", source_snapshot)
+        object.__setattr__(preparation, "_input", input_snapshot)
+        object.__setattr__(preparation, "policy", report.policy)
+        object.__setattr__(preparation, "_report", report)
+        object.__setattr__(
+            preparation,
+            "_input_applicability",
+            input_applicability,
+        )
+        object.__setattr__(
+            preparation,
+            "_preserves_optimality",
+            preserves_optimality,
+        )
+        object.__setattr__(
+            preparation,
+            "_is_identity",
+            source_snapshot.to_v2_bytes() == input_snapshot.to_v2_bytes(),
+        )
+        return cast(Preparation[PreparationReportT], preparation)
+
+    @property
+    def report(self) -> PreparationReportT_co:
+        """Return the Adapter-specific audit report for this preparation."""
+        return self._report
+
+    @property
+    def source(self) -> Instance:
+        """Return an isolated copy of the exact caller-supplied source."""
+        return copy.deepcopy(self._source)
+
+    @property
+    def input(self) -> Instance:
+        """Return an isolated copy of the applicable Adapter input."""
+        return copy.deepcopy(self._input)
+
+    @overload
+    def decode(self, output: Solution) -> Solution: ...
+
+    @overload
+    def decode(self, output: SampleSet) -> SampleSet: ...
+
+    def decode(self, output: Solution | SampleSet) -> Solution | SampleSet:
+        """Decode an input-side output and reevaluate it against ``source``.
+
+        For non-identity preparation, auxiliary input variable IDs are removed
+        before source evaluation. Every sample is decoded independently before
+        source feasibility or best-sample selection is considered.
+        """
+        if not isinstance(output, (Solution, SampleSet)):
+            raise TypeError("output must be a Solution or SampleSet")
+        if self._is_identity:
+            return copy.deepcopy(output)
+
+        source_variable_ids = {
+            variable.id for variable in self._source.decision_variables
+        }
+        if isinstance(output, Solution):
+            state = self._decode_state(output.state, source_variable_ids)
+            decoded = self._source.evaluate(state)
+            if self._preserves_optimality:
+                decoded.optimality = output.optimality
+            return decoded
+
+        source_samples = Samples({})
+        for sample_id in sorted(output.sample_ids()):
+            state = self._decode_state(
+                output.get(sample_id).state,
+                source_variable_ids,
+            )
+            source_samples.append([sample_id], state)
+        return self._source.evaluate_samples(source_samples)
+
+    @staticmethod
+    def _decode_state(state: State, source_variable_ids: set[int]) -> State:
+        entries: list[tuple[int, float]] = []
+        for variable_id in source_variable_ids:
+            value = state.get(variable_id)
+            if value is None:
+                raise RuntimeError(
+                    "Preparation decode could not reconstruct source variable "
+                    f"ID {variable_id}"
+                )
+            entries.append((variable_id, value))
+        return State(entries=entries)
+
+
 class SolverAdapter(ABC):
     """
     An abstract interface for OMMX Solver Adapters, defining how solvers should be used with OMMX.
@@ -136,11 +455,232 @@ class SolverAdapter(ABC):
     ``_check_preconditions`` hook.
 
     ``INPUT_CLASS`` describes only which exact inputs an adapter accepts; it does
-    not prescribe how the subclass processes them. The base class never lowers
-    or otherwise mutates the input instance.
+    not prescribe how the subclass processes them. Direct constructors,
+    :meth:`solve`, and :meth:`sample` never prepare their input. The separate
+    :meth:`prepare` workflow may lower only the canonical special-constraint
+    families declared by the Adapter and permitted by the caller's policy.
     """
 
     INPUT_CLASS: ClassVar[InstanceClass | None] = None
+    PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS: ClassVar[
+        tuple[SpecialConstraintKind, ...]
+    ] = ()
+
+    @classmethod
+    def prepare(
+        cls,
+        source: Instance,
+        *,
+        policy: PreparationPolicy | None = None,
+    ) -> Preparation[PreparationReportProtocol]:
+        """Prepare an isolated ``source`` for this Adapter.
+
+        Identity is preferred whenever ``source`` is already applicable. For a
+        non-applicable source, this base implementation lowers the active
+        special-constraint kinds in the Adapter's declared candidate tuple,
+        intersected with the caller's policy. The concrete produced input is
+        always checked again before a :class:`Preparation` is returned.
+
+        This method does not call :meth:`solve` and never mutates ``source``.
+        Adapter packages may override it for a target-specific pipeline while
+        retaining identity preference, caller isolation, policy restriction,
+        and final-applicability checking.
+        """
+        if not isinstance(source, Instance):
+            raise TypeError("source must be an Instance")
+        normalized_policy = PreparationPolicy() if policy is None else policy
+        if not isinstance(normalized_policy, PreparationPolicy):
+            raise TypeError("policy must be a PreparationPolicy")
+
+        declared_candidates = cls._validated_preparation_lowering_candidates()
+        source_applicability = cls.check_applicability(source)
+        if source_applicability.is_applicable:
+            report = PreparationReport(
+                policy=normalized_policy,
+                source_applicability=source_applicability,
+                transforms=(),
+                input_applicability=source_applicability,
+            )
+            return Preparation._create(
+                source=source,
+                input=source,
+                report=report,
+                preserves_optimality=True,
+            )
+
+        working = copy.deepcopy(source)
+        active_kinds = working.active_special_constraint_kinds
+        allowed_kinds = normalized_policy.allowed_special_constraint_lowerings
+        selected_candidates = tuple(
+            kind
+            for kind in declared_candidates
+            if kind in active_kinds and (allowed_kinds is None or kind in allowed_kinds)
+        )
+        selected_set = set(selected_candidates)
+        blocked_by_policy = tuple(
+            kind
+            for kind in declared_candidates
+            if kind in active_kinds
+            and allowed_kinds is not None
+            and kind not in allowed_kinds
+        )
+        if blocked_by_policy:
+            kind_names = {
+                SpecialConstraintKind.Indicator: "Indicator",
+                SpecialConstraintKind.OneHot: "OneHot",
+                SpecialConstraintKind.Sos1: "Sos1",
+            }
+            blocked_refs = frozenset(
+                ref
+                for kind in blocked_by_policy
+                for ref in cls._special_constraint_refs(working, kind)
+            )
+            failure = PreparationFailure(
+                name="special_constraint_lowering",
+                reason="preparation.policy.special_constraint_lowering_not_allowed",
+                description=(
+                    "The caller policy forbids an active special-constraint "
+                    "lowering declared by this Adapter."
+                ),
+                constraint_refs=blocked_refs,
+                observed=", ".join(kind_names[kind] for kind in blocked_by_policy),
+                expected="included in allowed_special_constraint_lowerings",
+            )
+            report = PreparationReport(
+                policy=normalized_policy,
+                source_applicability=source_applicability,
+                transforms=(),
+                preparation_failures=(failure,),
+            )
+            raise PreparationError(report)
+        selected_refs = frozenset(
+            ref
+            for kind in selected_candidates
+            for ref in cls._special_constraint_refs(working, kind)
+        )
+
+        try:
+            lowered = working.lower_special_constraints(selected_set)
+        except (RuntimeError, ValueError) as error:
+            failure = PreparationFailure(
+                name="special_constraint_lowering",
+                reason="materialization",
+                description=str(error),
+                constraint_refs=selected_refs,
+                observed=str(error),
+                expected="all selected special constraints are exactly lowerable",
+            )
+            report = PreparationReport(
+                policy=normalized_policy,
+                source_applicability=source_applicability,
+                transforms=(),
+                preparation_failures=(failure,),
+            )
+            raise PreparationError(report) from error
+
+        transforms = tuple(
+            cls._special_constraint_transform(kind, selected_refs)
+            for kind in selected_candidates
+            if kind in lowered
+        )
+        input_applicability = cls.check_applicability(working)
+        report = PreparationReport(
+            policy=normalized_policy,
+            source_applicability=source_applicability,
+            transforms=transforms,
+            input_applicability=input_applicability,
+        )
+        if not report.is_successful:
+            raise PreparationError(report)
+        return Preparation._create(
+            source=source,
+            input=working,
+            report=report,
+            preserves_optimality=True,
+        )
+
+    @classmethod
+    def _validated_preparation_lowering_candidates(
+        cls,
+    ) -> tuple[SpecialConstraintKind, ...]:
+        candidates = cls.PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS
+        if not isinstance(candidates, tuple):
+            raise TypeError("PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS must be a tuple")
+        if not all(isinstance(kind, SpecialConstraintKind) for kind in candidates):
+            raise TypeError(
+                "PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS must contain only "
+                "SpecialConstraintKind values"
+            )
+        if len(set(candidates)) != len(candidates):
+            raise ValueError(
+                "PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS must not contain "
+                "duplicate kinds"
+            )
+        sdk_order = (
+            SpecialConstraintKind.Indicator,
+            SpecialConstraintKind.OneHot,
+            SpecialConstraintKind.Sos1,
+        )
+        declared_in_sdk_order = tuple(kind for kind in sdk_order if kind in candidates)
+        if candidates != declared_in_sdk_order:
+            raise ValueError(
+                "PREPARATION_SPECIAL_CONSTRAINT_LOWERINGS must follow SDK order: "
+                "Indicator, OneHot, Sos1"
+            )
+        return candidates
+
+    @staticmethod
+    def _special_constraint_refs(
+        instance: Instance,
+        kind: SpecialConstraintKind,
+    ) -> frozenset[ConstraintRef]:
+        if kind == SpecialConstraintKind.Indicator:
+            return frozenset(
+                ConstraintRef("indicator", constraint_id)
+                for constraint_id in instance.indicator_constraints
+            )
+        if kind == SpecialConstraintKind.OneHot:
+            return frozenset(
+                ConstraintRef("one_hot", constraint_id)
+                for constraint_id in instance.one_hot_constraints
+            )
+        return frozenset(
+            ConstraintRef("sos1", constraint_id)
+            for constraint_id in instance.sos1_constraints
+        )
+
+    @classmethod
+    def _special_constraint_transform(
+        cls,
+        kind: SpecialConstraintKind,
+        selected_refs: frozenset[ConstraintRef],
+    ) -> PreparationTransform:
+        details = {
+            SpecialConstraintKind.Indicator: (
+                "indicator_lowering",
+                "Lowered Indicator constraints exactly with validated Big-M bounds.",
+                "indicator",
+            ),
+            SpecialConstraintKind.OneHot: (
+                "one_hot_lowering",
+                "Lowered OneHot constraints exactly to regular equalities.",
+                "one_hot",
+            ),
+            SpecialConstraintKind.Sos1: (
+                "sos1_lowering",
+                "Lowered SOS1 constraints exactly with validated Big-M bounds.",
+                "sos1",
+            ),
+        }
+        name, description, family = details[kind]
+        return PreparationTransform(
+            name=name,
+            description=description,
+            constraint_refs=frozenset(
+                ref for ref in selected_refs if ref.family == family
+            ),
+            special_constraint_kinds=frozenset({kind}),
+        )
 
     @classmethod
     def check_applicability(cls, ommx_instance: Instance) -> AdapterApplicabilityReport:


### PR DESCRIPTION
## Summary

- add a common explicit Preparation and PreparationPolicy workflow to SolverAdapter while keeping direct solver APIs preparation-free
- migrate OpenJij existing preparation pipeline to the shared types and the Transform, policy, and decode vocabulary
- declare exact special-constraint lowering candidates for HiGHS so prepare automatically lowers Indicator, OneHot, and SOS1 inputs before final applicability validation
- document applicability, policy restriction, transformation receipts, and source-side decoding in the English and Japanese docs

## Scope

This implements the first canonical special-constraint lowering slice from #1111. It does not introduce general path search or special-constraint promotion and recovery.