### PR TITLE
Log-encode all used Integer variables

### DIFF
--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -852,6 +852,9 @@ encoders use ATol-aware bound normalization, reject ranges that cannot be
 represented safely, operate transactionally over multiple variable IDs, and
 reject fixed variables before substitution. Unary encoding uses one binary
 variable per unit of range width and is guarded by an explicit `max_range`.
+[`Instance::log_encode_used_integers`](crate::Instance::log_encode_used_integers)
+selects the currently used Integer variables with finite bounds for one atomic
+bulk encoding; unbounded and unused Integer variables remain unchanged.
 
 [`Instance::into_partial_evaluated`](crate::Instance::into_partial_evaluated)
 is the consuming counterpart to
@@ -865,7 +868,8 @@ promote unverified hints into first-class one-hot or SOS1 constraints.
 
 Related PRs: [#1010](https://github.com/Jij-Inc/ommx/pull/1010),
 [#1034](https://github.com/Jij-Inc/ommx/pull/1034),
-[#1058](https://github.com/Jij-Inc/ommx/pull/1058).
+[#1058](https://github.com/Jij-Inc/ommx/pull/1058),
+[#1143](https://github.com/Jij-Inc/ommx/pull/1143).
 
 ## ⚙️ Formatting and property-test domains
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -852,9 +852,11 @@ encoders use ATol-aware bound normalization, reject ranges that cannot be
 represented safely, operate transactionally over multiple variable IDs, and
 reject fixed variables before substitution. Unary encoding uses one binary
 variable per unit of range width and is guarded by an explicit `max_range`.
-[`Instance::log_encode_used_integers`](crate::Instance::log_encode_used_integers)
-selects the currently used Integer variables with finite bounds for one atomic
-bulk encoding; unbounded and unused Integer variables remain unchanged.
+[`Instance::log_encode_all_used_integers`](crate::Instance::log_encode_all_used_integers)
+selects every currently used Integer variable for one atomic bulk encoding. On
+success no used Integer variable remains; if any target cannot be encoded, the
+operation returns the existing error and leaves the instance unchanged. Active
+SOS1 constraints must be lowered before encoding their Integer members.
 
 [`Instance::into_partial_evaluated`](crate::Instance::into_partial_evaluated)
 is the consuming counterpart to

--- a/rust/ommx/src/instance/log_encode.rs
+++ b/rust/ommx/src/instance/log_encode.rs
@@ -213,23 +213,27 @@ impl Instance {
         Ok(encodings)
     }
 
-    /// Log-encode every bounded Integer decision variable currently used by solver input.
+    /// Log-encode all Integer decision variables currently used by solver input.
     ///
-    /// The target IDs are derived from [`Self::decision_variable_usage`] before
-    /// mutation. Unbounded, fixed, dependent, and irrelevant Integer variables
-    /// are not encoded. The selected variables are encoded together through
-    /// [`Self::log_encode`], preserving its remaining exact-representation
-    /// requirements, return value, error surface, and all-or-nothing mutation
-    /// semantics.
-    pub fn log_encode_used_integers(
+    /// The complete target set is derived from
+    /// [`Self::decision_variable_usage`] before mutation. All targets are
+    /// encoded together through [`Self::log_encode`]. On success,
+    /// [`DecisionVariableUsage::used_integer`](crate::DecisionVariableUsage::used_integer)
+    /// is empty; irrelevant Integer variables are not encoded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error from [`Self::log_encode`] if any used Integer variable
+    /// cannot be encoded. In particular, used variables with non-finite bounds
+    /// retain [`LogEncodingUnavailable`], while an active SOS1 member retains
+    /// [`SubstitutionError`](crate::SubstitutionError). Lower active SOS1
+    /// constraints with [`Self::lower_special_constraints`] before calling this
+    /// method. Any error leaves the instance unchanged.
+    pub fn log_encode_all_used_integers(
         &mut self,
         atol: ATol,
     ) -> crate::Result<BTreeMap<VariableID, Linear>> {
-        let ids = self
-            .decision_variable_usage()
-            .used_integer()
-            .into_iter()
-            .filter_map(|(id, bound)| bound.is_finite().then_some(id));
+        let ids = self.decision_variable_usage().used_integer().into_keys();
         self.log_encode(ids, atol)
     }
 
@@ -1097,11 +1101,10 @@ mod tests {
     }
 
     #[test]
-    fn log_encode_used_integers_targets_the_current_used_set() {
+    fn log_encode_all_used_integers_satisfies_its_postcondition() {
         let used0 = VariableID::from(0);
         let used1 = VariableID::from(1);
-        let unbounded = VariableID::from(2);
-        let irrelevant = VariableID::from(3);
+        let irrelevant = VariableID::from(2);
         let bounded_integer = || {
             DecisionVariable::new(
                 Kind::Integer,
@@ -1111,34 +1114,32 @@ mod tests {
             .unwrap()
         };
         let objective = (crate::linear!(0) + crate::linear!(1)).unwrap();
-        let objective = (objective + crate::linear!(2)).unwrap();
         let mut instance = Instance::builder()
             .sense(Sense::Minimize)
             .objective(Function::from(objective))
             .decision_variables(BTreeMap::from([
                 (used0, bounded_integer()),
                 (used1, bounded_integer()),
-                (unbounded, DecisionVariable::integer()),
                 (irrelevant, bounded_integer()),
             ]))
             .constraints(BTreeMap::new())
             .build()
             .unwrap();
+        let used_before = instance
+            .decision_variable_usage()
+            .used_integer()
+            .into_keys()
+            .collect::<BTreeSet<_>>();
 
-        let encodings = instance.log_encode_used_integers(ATol::default()).unwrap();
+        let encodings = instance
+            .log_encode_all_used_integers(ATol::default())
+            .unwrap();
 
         assert_eq!(
             encodings.keys().copied().collect::<BTreeSet<_>>(),
-            BTreeSet::from([used0, used1])
+            used_before
         );
-        assert_eq!(
-            instance
-                .decision_variable_usage()
-                .used_integer()
-                .into_keys()
-                .collect::<BTreeSet<_>>(),
-            BTreeSet::from([unbounded])
-        );
+        assert!(instance.decision_variable_usage().used_integer().is_empty());
         assert_eq!(
             instance.decision_variable_role(used0),
             Some(DecisionVariableRole::Dependent)
@@ -1148,28 +1149,18 @@ mod tests {
             Some(DecisionVariableRole::Dependent)
         );
         assert_eq!(
-            instance.decision_variable_role(unbounded),
-            Some(DecisionVariableRole::Used)
-        );
-        assert_eq!(
             instance.decision_variable_role(irrelevant),
             Some(DecisionVariableRole::Irrelevant)
         );
     }
 
     #[test]
-    fn log_encode_used_integers_is_atomic_when_one_bounded_target_is_unavailable() {
+    fn log_encode_all_used_integers_is_atomic_when_one_target_is_unbounded() {
         let bounded = VariableID::from(0);
-        let unavailable = VariableID::from(1);
+        let unbounded = VariableID::from(1);
         let bounded_integer = DecisionVariable::new(
             Kind::Integer,
             Bound::new(0.0, 3.0).unwrap(),
-            ATol::default(),
-        )
-        .unwrap();
-        let unavailable_integer = DecisionVariable::new(
-            Kind::Integer,
-            Bound::new(0.0, 2.0_f64.powi(Instance::MAX_LOG_ENCODING_BITS as i32)).unwrap(),
             ATol::default(),
         )
         .unwrap();
@@ -1180,7 +1171,7 @@ mod tests {
             ))
             .decision_variables(BTreeMap::from([
                 (bounded, bounded_integer),
-                (unavailable, unavailable_integer),
+                (unbounded, DecisionVariable::integer()),
             ]))
             .constraints(BTreeMap::new())
             .build()
@@ -1188,12 +1179,63 @@ mod tests {
         let before = instance.clone();
 
         let err = instance
-            .log_encode_used_integers(ATol::default())
+            .log_encode_all_used_integers(ATol::default())
             .unwrap_err();
 
         assert!(matches!(
             err.downcast_ref::<LogEncodingUnavailable>(),
-            Some(LogEncodingUnavailable::RangeTooLarge { id, .. }) if *id == unavailable
+            Some(LogEncodingUnavailable::NonFiniteBound { id, .. }) if *id == unbounded
+        ));
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn log_encode_all_used_integers_requires_sos1_to_be_lowered() {
+        let ordinary = VariableID::from(0);
+        let sos1_member = VariableID::from(1);
+        let sos1_id = Sos1ConstraintID::from(0);
+        let bounded_integer = || {
+            DecisionVariable::new(
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
+            )
+            .unwrap()
+        };
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(crate::linear!(0)))
+            .decision_variables(BTreeMap::from([
+                (ordinary, bounded_integer()),
+                (sos1_member, bounded_integer()),
+            ]))
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(
+                sos1_id,
+                Sos1Constraint::new(BTreeSet::from([sos1_member])).unwrap(),
+            )]))
+            .build()
+            .unwrap();
+        assert_eq!(
+            instance
+                .decision_variable_usage()
+                .used_integer()
+                .into_keys()
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([ordinary, sos1_member])
+        );
+        let before = instance.clone();
+
+        let err = instance
+            .log_encode_all_used_integers(ATol::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            err.downcast_ref::<crate::SubstitutionError>(),
+            Some(crate::SubstitutionError::Sos1VariableSubstitution {
+                variable,
+                constraint_id,
+            }) if *variable == sos1_member && *constraint_id == sos1_id
         ));
         assert_eq!(instance, before);
     }

--- a/rust/ommx/src/instance/log_encode.rs
+++ b/rust/ommx/src/instance/log_encode.rs
@@ -213,6 +213,26 @@ impl Instance {
         Ok(encodings)
     }
 
+    /// Log-encode every bounded Integer decision variable currently used by solver input.
+    ///
+    /// The target IDs are derived from [`Self::decision_variable_usage`] before
+    /// mutation. Unbounded, fixed, dependent, and irrelevant Integer variables
+    /// are not encoded. The selected variables are encoded together through
+    /// [`Self::log_encode`], preserving its remaining exact-representation
+    /// requirements, return value, error surface, and all-or-nothing mutation
+    /// semantics.
+    pub fn log_encode_used_integers(
+        &mut self,
+        atol: ATol,
+    ) -> crate::Result<BTreeMap<VariableID, Linear>> {
+        let ids = self
+            .decision_variable_usage()
+            .used_integer()
+            .into_iter()
+            .filter_map(|(id, bound)| bound.is_finite().then_some(id));
+        self.log_encode(ids, atol)
+    }
+
     fn plan_log_encodings(
         &self,
         encoding_specs: Vec<(VariableID, Vec<Coefficient>, f64)>,
@@ -285,8 +305,8 @@ impl Instance {
 mod tests {
     use super::*;
     use crate::{
-        coeff, v1::State, Bound, DecisionVariable, Equality, Evaluate, Function,
-        IndicatorConstraint, IndicatorConstraintID, Instance, Kind, LinearMonomial,
+        coeff, v1::State, Bound, DecisionVariable, DecisionVariableRole, Equality, Evaluate,
+        Function, IndicatorConstraint, IndicatorConstraintID, Instance, Kind, LinearMonomial,
         OneHotConstraint, OneHotConstraintID, Sense, Solution, Sos1Constraint, Sos1ConstraintID,
     };
     use approx::relative_eq;
@@ -1074,6 +1094,108 @@ mod tests {
         assert!(instance.decision_variable_dependency.get(&id0).is_none());
         assert!(instance.decision_variable_dependency.get(&id1).is_none());
         assert_eq!(aux_variable_count(&instance, "ommx.log_encode"), 0);
+    }
+
+    #[test]
+    fn log_encode_used_integers_targets_the_current_used_set() {
+        let used0 = VariableID::from(0);
+        let used1 = VariableID::from(1);
+        let unbounded = VariableID::from(2);
+        let irrelevant = VariableID::from(3);
+        let bounded_integer = || {
+            DecisionVariable::new(
+                Kind::Integer,
+                Bound::new(0.0, 3.0).unwrap(),
+                ATol::default(),
+            )
+            .unwrap()
+        };
+        let objective = (crate::linear!(0) + crate::linear!(1)).unwrap();
+        let objective = (objective + crate::linear!(2)).unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(objective))
+            .decision_variables(BTreeMap::from([
+                (used0, bounded_integer()),
+                (used1, bounded_integer()),
+                (unbounded, DecisionVariable::integer()),
+                (irrelevant, bounded_integer()),
+            ]))
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap();
+
+        let encodings = instance.log_encode_used_integers(ATol::default()).unwrap();
+
+        assert_eq!(
+            encodings.keys().copied().collect::<BTreeSet<_>>(),
+            BTreeSet::from([used0, used1])
+        );
+        assert_eq!(
+            instance
+                .decision_variable_usage()
+                .used_integer()
+                .into_keys()
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([unbounded])
+        );
+        assert_eq!(
+            instance.decision_variable_role(used0),
+            Some(DecisionVariableRole::Dependent)
+        );
+        assert_eq!(
+            instance.decision_variable_role(used1),
+            Some(DecisionVariableRole::Dependent)
+        );
+        assert_eq!(
+            instance.decision_variable_role(unbounded),
+            Some(DecisionVariableRole::Used)
+        );
+        assert_eq!(
+            instance.decision_variable_role(irrelevant),
+            Some(DecisionVariableRole::Irrelevant)
+        );
+    }
+
+    #[test]
+    fn log_encode_used_integers_is_atomic_when_one_bounded_target_is_unavailable() {
+        let bounded = VariableID::from(0);
+        let unavailable = VariableID::from(1);
+        let bounded_integer = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(0.0, 3.0).unwrap(),
+            ATol::default(),
+        )
+        .unwrap();
+        let unavailable_integer = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(0.0, 2.0_f64.powi(Instance::MAX_LOG_ENCODING_BITS as i32)).unwrap(),
+            ATol::default(),
+        )
+        .unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::from(
+                (crate::linear!(0) + crate::linear!(1)).unwrap(),
+            ))
+            .decision_variables(BTreeMap::from([
+                (bounded, bounded_integer),
+                (unavailable, unavailable_integer),
+            ]))
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap();
+        let before = instance.clone();
+
+        let err = instance
+            .log_encode_used_integers(ATol::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            err.downcast_ref::<LogEncodingUnavailable>(),
+            Some(LogEncodingUnavailable::RangeTooLarge { id, .. }) if *id == unavailable
+        ));
+        assert_eq!(instance, before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `Instance::log_encode_all_used_integers(atol)` as a Rust SDK owner operation
- select the complete set of Integer variables currently used by solver input and delegate it to the existing atomic bulk `log_encode` operation
- guarantee that a successful call leaves no used Integer variables
- return the existing encoding or substitution error without mutating the `Instance` when any target cannot be encoded
- cover the success postcondition, unbounded-target failure, and active-SOS1 failure with contract-focused tests
- document the public API and its all-or-nothing contract in the Rust SDK 3.0 transformation release notes

## Context

This is the first standalone Rust owner-API prerequisite identified by the reset design for #1111. It keeps mathematical target selection inside `Instance` while leaving Preparation, fixed-weight penalties, Python/PyO3, adapters, generated artifacts, Sphinx documentation, and Lean out of scope.

Used Integer variables are not silently skipped. A non-finite bound retains `LogEncodingUnavailable`; an Integer member of an active SOS1 constraint retains `SubstitutionError` and requires that SOS1 family to be lowered before retrying. Either failure leaves the whole `Instance` unchanged.

Part of #1111.
