### PR TITLE
Correct integer slack preparation semantics

### DIFF
--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -341,7 +341,8 @@ Unknown, fixed, or non-Integer variables and auxiliary-allocation or
 substitution failures remain ordinary errors. Exact integer-slack callers can
 similarly downcast to
 [`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable) before
-selecting an explicitly approximate transformation.
+selecting a different operation that does not require the inequality to become
+an equality.
 
 **Moved / renamed error types:**
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -893,16 +893,16 @@ selected for the same penalty phase.
 
 Integer slack introduction is one optional phase. `None` disables the phase.
 [`IntegerSlackPreparation::AllowInequality`](crate::IntegerSlackPreparation::AllowInequality)
-adds Integer slack while allowing active regular constraints to remain
-inequalities; this owner operation preserves the feasible assignments of the
-original variables exactly. In contrast,
+first attempts exact conversion to equality. Only when that operation returns
+[`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable) does it
+add Integer slack while keeping the active regular constraint as an inequality;
+this alternative preserves the feasible assignments of the original variables
+exactly. In contrast,
 [`IntegerSlackPreparation::RequireEquality`](crate::IntegerSlackPreparation::RequireEquality)
-requires every active regular inequality to become an equality or be removed
-as trivially satisfied. If exact conversion cannot establish that postcondition,
-[`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable) is
-propagated without selecting an inequality-preserving alternative. Variant
-fields retain the corresponding owner arguments and their validation remains
-owner-defined.
+propagates that signal, requiring every active regular inequality to become an
+equality or be removed as trivially satisfied. Both variants propagate every
+other owner error unchanged. Variant fields retain the corresponding owner
+arguments and their validation remains owner-defined.
 
 Preparation checks the target [`InstanceClass`](crate::InstanceClass) before
 and after each selected phase, stops as soon as membership holds, and

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -887,22 +887,26 @@ operations. The non-exhaustive Policy is a freely composable table of optional
 it with `PreparationPolicy::default()` and assign public phase fields; every
 current or future phase is disabled by default. Each phase runs at most once in
 the special-constraint, sense, Integer-slack, Integer-encoding, fixed-penalty
-order owned by `Instance::prepare`, while its non-exhaustive enum keeps mutually
-exclusive owner-operation choices well formed. In particular, exact Integer
-slack may carry a typed approximate fallback, and keyed and uniform fixed
-penalties cannot both be selected for the same penalty phase.
+order owned by `Instance::prepare`. Phase-specific types keep their own choices
+well formed; for example, keyed and uniform fixed penalties cannot both be
+selected for the same penalty phase.
 
-The exact and approximate Integer slack owner arguments remain represented by
-[`ConvertInequalityToEqualityWithIntegerSlackArguments`](crate::ConvertInequalityToEqualityWithIntegerSlackArguments)
-and
-[`AddIntegerSlackToInequalityArguments`](crate::AddIntegerSlackToInequalityArguments)
-without changing their mathematical meanings or validation. Preparation checks
-the target [`InstanceClass`](crate::InstanceClass) before and after each
-selected phase, stops as soon as membership holds, and guarantees only that
-membership on success. An attached approximate Integer slack fallback is
-selected only for
-[`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable); other
-owner errors are propagated unchanged. Preparation does not add a global
+Integer slack introduction is one optional phase. `None` disables the phase.
+[`IntegerSlackPreparation::AllowInequality`](crate::IntegerSlackPreparation::AllowInequality)
+adds Integer slack while allowing active regular constraints to remain
+inequalities; this owner operation preserves the feasible assignments of the
+original variables exactly. In contrast,
+[`IntegerSlackPreparation::RequireEquality`](crate::IntegerSlackPreparation::RequireEquality)
+requires every active regular inequality to become an equality or be removed
+as trivially satisfied. If exact conversion cannot establish that postcondition,
+[`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable) is
+propagated without selecting an inequality-preserving alternative. Variant
+fields retain the corresponding owner arguments and their validation remains
+owner-defined.
+
+Preparation checks the target [`InstanceClass`](crate::InstanceClass) before
+and after each selected phase, stops as soon as membership holds, and
+guarantees only that membership on success. Preparation does not add a global
 transaction, so changes committed by earlier owner operations remain when a
 later operation fails.
 
@@ -921,7 +925,8 @@ Related PRs: [#1010](https://github.com/Jij-Inc/ommx/pull/1010),
 [#1058](https://github.com/Jij-Inc/ommx/pull/1058),
 [#1143](https://github.com/Jij-Inc/ommx/pull/1143),
 [#1144](https://github.com/Jij-Inc/ommx/pull/1144),
-[#1145](https://github.com/Jij-Inc/ommx/pull/1145).
+[#1145](https://github.com/Jij-Inc/ommx/pull/1145),
+[#1148](https://github.com/Jij-Inc/ommx/pull/1148).
 
 ## ⚙️ Formatting and property-test domains
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -892,17 +892,17 @@ well formed; for example, keyed and uniform fixed penalties cannot both be
 selected for the same penalty phase.
 
 Integer slack introduction is one optional phase. `None` disables the phase.
-[`IntegerSlackPreparation::AllowInequality`](crate::IntegerSlackPreparation::AllowInequality)
-first attempts exact conversion to equality. Only when that operation returns
-[`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable) does it
-add Integer slack while keeping the active regular constraint as an inequality;
-this alternative preserves the feasible assignments of the original variables
-exactly. In contrast,
-[`IntegerSlackPreparation::RequireEquality`](crate::IntegerSlackPreparation::RequireEquality)
-propagates that signal, requiring every active regular inequality to become an
-equality or be removed as trivially satisfied. Both variants propagate every
-other owner error unchanged. Variant fields retain the corresponding owner
-arguments and their validation remains owner-defined.
+[`IntegerSlackPreparation`](crate::IntegerSlackPreparation) is a single public
+argument struct shared by both supported postconditions. Preparation always
+first attempts exact conversion to equality using `max_integer_range` and
+`atol`. With `slack_upper_bound = None`, it propagates
+[`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable), requiring
+every active regular inequality to become an equality or be removed as
+trivially satisfied. `Some(value)` permits a constraint to remain an inequality:
+only that signal selects the inequality-preserving owner operation with
+`value`. This alternative preserves the feasible assignments of the original
+variables exactly and is not an approximation. Every other owner error is
+propagated unchanged, and numeric validation remains owner-defined.
 
 Preparation checks the target [`InstanceClass`](crate::InstanceClass) before
 and after each selected phase, stops as soon as membership holds, and

--- a/rust/ommx/doc/tutorial/error_handling.md
+++ b/rust/ommx/doc/tutorial/error_handling.md
@@ -63,9 +63,9 @@ returns the typed error directly):
 - [`LogEncodingUnavailable`](crate::LogEncodingUnavailable) and
   [`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable) — identify
   the narrow cases where an exact encoding operation is unavailable and a
-  caller may explicitly choose another mathematical operation. Contract,
-  allocation, substitution, and arithmetic failures are not folded into these
-  signals.
+  caller may explicitly choose another mathematical operation or postcondition.
+  Contract, allocation, substitution, and arithmetic failures are not folded
+  into these signals.
 
 Evaluation does not define an umbrella error type. Caller-provided numeric
 validation reuses [`DecisionVariableError`](crate::DecisionVariableError), and
@@ -90,12 +90,16 @@ match instance.propagate(&state, atol) {
 }
 ```
 
-For example, an Adapter preparation can select an approximate slack only for
-the exact-operation signal while continuing to propagate unrelated failures:
+For example, a caller that does not require the inequality to become an
+equality can explicitly select the inequality-preserving Integer slack
+operation after the exact-operation signal, while continuing to propagate
+unrelated failures:
 
 ```ignore
 match instance.convert_inequality_to_equality_with_integer_slack(id, 32, atol) {
     Err(e) if e.is::<ommx::ExactIntegerSlackUnavailable>() => {
+        // This operation keeps the relation as an inequality. It is not an
+        // approximate representation of the original feasible set.
         instance.add_integer_slack_to_inequality(id, 32)?;
     }
     Err(e) => return Err(e),
@@ -107,8 +111,8 @@ If exact integer-slack conversion cannot normalize the coefficients, the same
 error chain retains both the outer
 [`ExactIntegerSlackUnavailable`](crate::ExactIntegerSlackUnavailable) signal
 and its inner [`ContentFactorError`](crate::ContentFactorError). Callers can
-therefore choose an approximate transformation from the outer operation signal
-or change the coefficients based on the narrower cause.
+therefore choose an inequality-preserving transformation from the outer
+operation signal or change the coefficients based on the narrower cause.
 
 Protobuf wire decoding and the [`Parse`](crate::Parse) trait share the
 [`ParseError`](crate::ParseError) signal. Public byte decoders preserve wire

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -36,7 +36,6 @@ pub use arbitrary::{InstanceParameters, InstanceSpace};
 pub use builder::*;
 pub use parametric_builder::*;
 pub use preparation::{
-    AddIntegerSlackToInequalityArguments, ConvertInequalityToEqualityWithIntegerSlackArguments,
     FixedPenaltyPreparation, IntegerEncodingPreparation, IntegerSlackPreparation,
     PreparationPolicy, SensePreparation, SpecialConstraintPreparation,
 };

--- a/rust/ommx/src/instance/preparation.rs
+++ b/rust/ommx/src/instance/preparation.rs
@@ -1,31 +1,6 @@
-use super::{ExactIntegerSlackUnavailable, Instance, SpecialConstraintKinds};
+use super::{Instance, SpecialConstraintKinds};
 use crate::{ATol, ConstraintID, Equality, InstanceClass};
 use std::collections::BTreeMap;
-
-/// Arguments passed to
-/// [`Instance::convert_inequality_to_equality_with_integer_slack`] by
-/// [`Instance::prepare`].
-///
-/// Preparation supplies each active inequality's `constraint_id`; the remaining
-/// arguments retain the names and meanings defined by the owner operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ConvertInequalityToEqualityWithIntegerSlackArguments {
-    /// Maximum finite range accepted for an exact Integer slack variable.
-    pub max_integer_range: u64,
-    /// Absolute tolerance used to normalize bounds to integers.
-    pub atol: ATol,
-}
-
-/// Arguments passed to [`Instance::add_integer_slack_to_inequality`] by
-/// [`Instance::prepare`].
-///
-/// Preparation supplies each active inequality's `constraint_id`; the remaining
-/// argument retains the name and meaning defined by the owner operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AddIntegerSlackToInequalityArguments {
-    /// Upper bound passed to the approximate Integer slack operation.
-    pub slack_upper_bound: u64,
-}
 
 /// Preparation of active special constraints.
 ///
@@ -54,28 +29,33 @@ pub enum SensePreparation {
 /// Preparation that introduces Integer slack variables into active regular
 /// inequalities.
 ///
-/// Exactly one primary owner operation is selected. Exact conversion may carry
-/// an approximate fallback, but that fallback is invoked only for
-/// [`ExactIntegerSlackUnavailable`]. Every other owner error is propagated
-/// unchanged. Numeric and Instance-dependent validation remains owned by the
-/// selected [`Instance`] operations.
+/// Selecting this step permits Integer slack introduction. Its variant states
+/// whether active regular constraints may remain inequalities or must become
+/// equalities. Numeric and Instance-dependent validation remains owned by the
+/// corresponding [`Instance`] operations.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntegerSlackPreparation {
-    /// Invoke
-    /// [`Instance::convert_inequality_to_equality_with_integer_slack`] for
-    /// every active regular inequality.
-    ConvertInequalityToEqualityWithIntegerSlack {
-        /// Arguments passed to exact Integer slack conversion.
-        arguments: ConvertInequalityToEqualityWithIntegerSlackArguments,
-        /// Arguments passed to [`Instance::add_integer_slack_to_inequality`]
-        /// only when exact conversion returns
-        /// [`ExactIntegerSlackUnavailable`].
-        on_exact_integer_slack_unavailable: Option<AddIntegerSlackToInequalityArguments>,
+    /// Add Integer slack while allowing active regular constraints to remain
+    /// inequalities.
+    AllowInequality {
+        /// Upper bound passed to
+        /// [`Instance::add_integer_slack_to_inequality`].
+        slack_upper_bound: u64,
     },
-    /// Invoke [`Instance::add_integer_slack_to_inequality`] directly for every
-    /// active regular inequality.
-    AddIntegerSlackToInequality(AddIntegerSlackToInequalityArguments),
+    /// Add Integer slack and require every active regular inequality to become
+    /// an equality or be removed as trivially satisfied.
+    ///
+    /// [`crate::ExactIntegerSlackUnavailable`] is propagated when the owner
+    /// operation cannot establish this postcondition. Preparation does not
+    /// replace the requested postcondition with an inequality-preserving
+    /// operation.
+    RequireEquality {
+        /// Maximum finite range accepted for an exact Integer slack variable.
+        max_integer_range: u64,
+        /// Absolute tolerance used to normalize bounds to integers.
+        atol: ATol,
+    },
 }
 
 /// Preparation of currently used Integer decision variables.
@@ -133,26 +113,16 @@ pub enum FixedPenaltyPreparation {
 ///
 /// ```
 /// use ommx::{
-///     AddIntegerSlackToInequalityArguments, ATol,
-///     ConvertInequalityToEqualityWithIntegerSlackArguments, FixedPenaltyPreparation,
-///     IntegerSlackPreparation, PreparationPolicy, SensePreparation,
+///     ATol, FixedPenaltyPreparation, IntegerSlackPreparation, PreparationPolicy,
+///     SensePreparation,
 /// };
 ///
 /// let mut policy = PreparationPolicy::default();
 /// policy.sense = Some(SensePreparation::AsMinimizationProblem);
-/// policy.integer_slack = Some(
-///     IntegerSlackPreparation::ConvertInequalityToEqualityWithIntegerSlack {
-///         arguments: ConvertInequalityToEqualityWithIntegerSlackArguments {
-///             max_integer_range: 32,
-///             atol: ATol::default(),
-///         },
-///         on_exact_integer_slack_unavailable: Some(
-///             AddIntegerSlackToInequalityArguments {
-///                 slack_upper_bound: 32,
-///             },
-///         ),
-///     },
-/// );
+/// policy.integer_slack = Some(IntegerSlackPreparation::RequireEquality {
+///     max_integer_range: 32,
+///     atol: ATol::default(),
+/// });
 /// policy.fixed_penalty = Some(
 ///     FixedPenaltyPreparation::UniformPenaltyMethodWithFixedWeight { weight: 2.0 },
 /// );
@@ -164,7 +134,7 @@ pub struct PreparationPolicy {
     pub special_constraints: Option<SpecialConstraintPreparation>,
     /// Optional optimization-sense phase.
     pub sense: Option<SensePreparation>,
-    /// Optional Integer slack phase.
+    /// Optional Integer slack phase. `None` does not introduce Integer slack.
     pub integer_slack: Option<IntegerSlackPreparation>,
     /// Optional used-Integer encoding phase.
     pub integer_encoding: Option<IntegerEncodingPreparation>,
@@ -211,34 +181,18 @@ impl PreparationStep for IntegerSlackPreparation {
 
         for id in inequality_ids {
             match self {
-                Self::ConvertInequalityToEqualityWithIntegerSlack {
-                    arguments,
-                    on_exact_integer_slack_unavailable,
-                } => {
-                    match instance.convert_inequality_to_equality_with_integer_slack(
-                        id.into_inner(),
-                        arguments.max_integer_range,
-                        arguments.atol,
-                    ) {
-                        Ok(()) => {}
-                        Err(error) if error.is::<ExactIntegerSlackUnavailable>() => {
-                            let Some(arguments) = on_exact_integer_slack_unavailable else {
-                                return Err(error);
-                            };
-                            instance.add_integer_slack_to_inequality(
-                                id.into_inner(),
-                                arguments.slack_upper_bound,
-                            )?;
-                        }
-                        Err(error) => return Err(error),
-                    }
+                Self::AllowInequality { slack_upper_bound } => {
+                    instance
+                        .add_integer_slack_to_inequality(id.into_inner(), *slack_upper_bound)?;
                 }
-                Self::AddIntegerSlackToInequality(arguments) => {
-                    instance.add_integer_slack_to_inequality(
-                        id.into_inner(),
-                        arguments.slack_upper_bound,
-                    )?;
-                }
+                Self::RequireEquality {
+                    max_integer_range,
+                    atol,
+                } => instance.convert_inequality_to_equality_with_integer_slack(
+                    id.into_inner(),
+                    *max_integer_range,
+                    *atol,
+                )?,
             }
         }
         Ok(())
@@ -296,9 +250,11 @@ impl Instance {
     /// adapter-specific applicability remains outside this operation.
     ///
     /// Active regular inequalities are processed in ascending constraint-ID
-    /// order. Exact Integer slack conversion falls back to the configured
-    /// approximate operation only for [`ExactIntegerSlackUnavailable`]. All
-    /// other owner errors are propagated unchanged.
+    /// order. Integer slack Preparation either allows them to remain
+    /// inequalities or requires them to become equalities, according to the
+    /// selected [`IntegerSlackPreparation`] variant. Owner errors are
+    /// propagated unchanged; Preparation does not weaken the requested
+    /// postcondition by selecting another operation.
     ///
     /// Preparation has no global transaction. Each owner operation retains its
     /// own mutation and failure semantics, and changes committed by earlier
@@ -347,9 +303,9 @@ impl Instance {
 mod tests {
     use super::*;
     use crate::{
-        coeff, linear, quadratic, Bound, Constraint, DecisionVariable, DegreeBound, Function,
-        InfeasibleDetected, InstanceClassClause, Kind, OneHotConstraint, OneHotConstraintID, Sense,
-        SpecialConstraintKind, VariableID,
+        coeff, linear, quadratic, Bound, Constraint, DecisionVariable, DegreeBound,
+        ExactIntegerSlackUnavailable, Function, InfeasibleDetected, InstanceClassClause, Kind,
+        OneHotConstraint, OneHotConstraintID, Sense, SpecialConstraintKind, VariableID,
     };
     use std::collections::BTreeSet;
 
@@ -412,7 +368,32 @@ mod tests {
     }
 
     #[test]
-    fn exact_slack_signal_is_preserved_without_approximate_fallback() {
+    fn equality_requirement_propagates_exact_slack_unavailable_without_an_alternative() {
+        let mut instance = integer_inequality_instance();
+        let before = instance.clone();
+        let target = InstanceClassClause::new(
+            "integer equality",
+            BTreeSet::from([Kind::Integer]),
+            DegreeBound::at_most(1),
+            BTreeSet::from([Sense::Minimize]),
+        )
+        .with_regular_constraint(Equality::EqualToZero, DegreeBound::at_most(1))
+        .into();
+        let policy = PreparationPolicy {
+            integer_slack: Some(IntegerSlackPreparation::RequireEquality {
+                max_integer_range: 1,
+                atol: ATol::default(),
+            }),
+            ..Default::default()
+        };
+        let error = instance.prepare(&target, &policy).unwrap_err();
+
+        assert!(error.is::<ExactIntegerSlackUnavailable>());
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn equality_requirement_reaches_an_equality_target() {
         let mut instance = integer_inequality_instance();
         let target = InstanceClassClause::new(
             "integer equality",
@@ -423,57 +404,16 @@ mod tests {
         .with_regular_constraint(Equality::EqualToZero, DegreeBound::at_most(1))
         .into();
         let policy = PreparationPolicy {
-            integer_slack: Some(
-                IntegerSlackPreparation::ConvertInequalityToEqualityWithIntegerSlack {
-                    arguments: ConvertInequalityToEqualityWithIntegerSlackArguments {
-                        max_integer_range: 1,
-                        atol: ATol::default(),
-                    },
-                    on_exact_integer_slack_unavailable: None,
-                },
-            ),
-            ..Default::default()
-        };
-        let error = instance.prepare(&target, &policy).unwrap_err();
-
-        assert!(error.is::<ExactIntegerSlackUnavailable>());
-    }
-
-    #[test]
-    fn configured_approximate_slack_fallback_reaches_target_membership() {
-        let mut instance = integer_inequality_instance();
-        let target =
-            unconstrained_class("binary quadratic", [Kind::Binary], DegreeBound::at_most(2));
-        let policy = PreparationPolicy {
-            integer_slack: Some(
-                IntegerSlackPreparation::ConvertInequalityToEqualityWithIntegerSlack {
-                    arguments: ConvertInequalityToEqualityWithIntegerSlackArguments {
-                        max_integer_range: 1,
-                        atol: ATol::default(),
-                    },
-                    on_exact_integer_slack_unavailable: Some(
-                        AddIntegerSlackToInequalityArguments {
-                            slack_upper_bound: 2,
-                        },
-                    ),
-                },
-            ),
-            integer_encoding: Some(IntegerEncodingPreparation::LogEncodeAllUsedIntegers {
+            integer_slack: Some(IntegerSlackPreparation::RequireEquality {
+                max_integer_range: 32,
                 atol: ATol::default(),
             }),
-            fixed_penalty: Some(
-                FixedPenaltyPreparation::UniformPenaltyMethodWithFixedWeight { weight: 2.0 },
-            ),
             ..Default::default()
         };
 
         instance.prepare(&target, &policy).unwrap();
 
         assert!(target.contains(&instance));
-        assert!(instance
-            .decision_variables()
-            .keys()
-            .any(|id| instance.variable_labels().name(*id) == Some("ommx.slack")));
     }
 
     #[test]
@@ -517,11 +457,9 @@ mod tests {
         .with_regular_constraint(Equality::LessThanOrEqualToZero, DegreeBound::at_most(1))
         .into();
         let policy = PreparationPolicy {
-            integer_slack: Some(IntegerSlackPreparation::AddIntegerSlackToInequality(
-                AddIntegerSlackToInequalityArguments {
-                    slack_upper_bound: 2,
-                },
-            )),
+            integer_slack: Some(IntegerSlackPreparation::AllowInequality {
+                slack_upper_bound: 2,
+            }),
             fixed_penalty: Some(FixedPenaltyPreparation::PenaltyMethodWithFixedWeights {
                 weights: BTreeMap::from([(ConstraintID::from(999), 1.0)]),
             }),
@@ -575,19 +513,10 @@ mod tests {
                 kinds: BTreeSet::from([SpecialConstraintKind::OneHot]),
             }),
             sense: Some(SensePreparation::AsMinimizationProblem),
-            integer_slack: Some(
-                IntegerSlackPreparation::ConvertInequalityToEqualityWithIntegerSlack {
-                    arguments: ConvertInequalityToEqualityWithIntegerSlackArguments {
-                        max_integer_range: 32,
-                        atol: ATol::default(),
-                    },
-                    on_exact_integer_slack_unavailable: Some(
-                        AddIntegerSlackToInequalityArguments {
-                            slack_upper_bound: 2,
-                        },
-                    ),
-                },
-            ),
+            integer_slack: Some(IntegerSlackPreparation::RequireEquality {
+                max_integer_range: 32,
+                atol: ATol::default(),
+            }),
             ..Default::default()
         };
 

--- a/rust/ommx/src/instance/preparation.rs
+++ b/rust/ommx/src/instance/preparation.rs
@@ -1,4 +1,4 @@
-use super::{Instance, SpecialConstraintKinds};
+use super::{ExactIntegerSlackUnavailable, Instance, SpecialConstraintKinds};
 use crate::{ATol, ConstraintID, Equality, InstanceClass};
 use std::collections::BTreeMap;
 
@@ -31,14 +31,24 @@ pub enum SensePreparation {
 ///
 /// Selecting this step permits Integer slack introduction. Its variant states
 /// whether active regular constraints may remain inequalities or must become
-/// equalities. Numeric and Instance-dependent validation remains owned by the
+/// equalities. Both variants first attempt exact conversion to equality.
+/// Numeric and Instance-dependent validation remains owned by the
 /// corresponding [`Instance`] operations.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntegerSlackPreparation {
-    /// Add Integer slack while allowing active regular constraints to remain
-    /// inequalities.
+    /// Prefer equality conversion while allowing active regular constraints to
+    /// remain inequalities when exact conversion is unavailable.
+    ///
+    /// [`Instance::convert_inequality_to_equality_with_integer_slack`] is
+    /// attempted first. Only [`ExactIntegerSlackUnavailable`] selects
+    /// [`Instance::add_integer_slack_to_inequality`]; every other owner error
+    /// is propagated unchanged.
     AllowInequality {
+        /// Maximum finite range accepted for an exact Integer slack variable.
+        max_integer_range: u64,
+        /// Absolute tolerance used to normalize bounds to integers.
+        atol: ATol,
         /// Upper bound passed to
         /// [`Instance::add_integer_slack_to_inequality`].
         slack_upper_bound: u64,
@@ -181,9 +191,25 @@ impl PreparationStep for IntegerSlackPreparation {
 
         for id in inequality_ids {
             match self {
-                Self::AllowInequality { slack_upper_bound } => {
-                    instance
-                        .add_integer_slack_to_inequality(id.into_inner(), *slack_upper_bound)?;
+                Self::AllowInequality {
+                    max_integer_range,
+                    atol,
+                    slack_upper_bound,
+                } => {
+                    match instance.convert_inequality_to_equality_with_integer_slack(
+                        id.into_inner(),
+                        *max_integer_range,
+                        *atol,
+                    ) {
+                        Ok(()) => {}
+                        Err(error) if error.is::<ExactIntegerSlackUnavailable>() => {
+                            instance.add_integer_slack_to_inequality(
+                                id.into_inner(),
+                                *slack_upper_bound,
+                            )?;
+                        }
+                        Err(error) => return Err(error),
+                    }
                 }
                 Self::RequireEquality {
                     max_integer_range,
@@ -250,11 +276,12 @@ impl Instance {
     /// adapter-specific applicability remains outside this operation.
     ///
     /// Active regular inequalities are processed in ascending constraint-ID
-    /// order. Integer slack Preparation either allows them to remain
-    /// inequalities or requires them to become equalities, according to the
-    /// selected [`IntegerSlackPreparation`] variant. Owner errors are
-    /// propagated unchanged; Preparation does not weaken the requested
-    /// postcondition by selecting another operation.
+    /// order. Integer slack Preparation first attempts to convert them to
+    /// equalities. [`IntegerSlackPreparation::AllowInequality`] selects the
+    /// inequality-preserving owner operation only for
+    /// [`ExactIntegerSlackUnavailable`], while
+    /// [`IntegerSlackPreparation::RequireEquality`] propagates that signal.
+    /// Every other owner error is propagated unchanged.
     ///
     /// Preparation has no global transaction. Each owner operation retains its
     /// own mutation and failure semantics, and changes committed by earlier
@@ -417,6 +444,31 @@ mod tests {
     }
 
     #[test]
+    fn allowing_inequality_still_prefers_an_equality_when_available() {
+        let mut instance = integer_inequality_instance();
+        let target = InstanceClassClause::new(
+            "integer equality",
+            BTreeSet::from([Kind::Integer]),
+            DegreeBound::at_most(1),
+            BTreeSet::from([Sense::Minimize]),
+        )
+        .with_regular_constraint(Equality::EqualToZero, DegreeBound::at_most(1))
+        .into();
+        let policy = PreparationPolicy {
+            integer_slack: Some(IntegerSlackPreparation::AllowInequality {
+                max_integer_range: 32,
+                atol: ATol::default(),
+                slack_upper_bound: 2,
+            }),
+            ..Default::default()
+        };
+
+        instance.prepare(&target, &policy).unwrap();
+
+        assert!(target.contains(&instance));
+    }
+
+    #[test]
     fn integer_slack_phase_completes_before_membership_stops_later_phases() {
         let variable = VariableID::from(1);
         let first_id = ConstraintID::from(1);
@@ -458,6 +510,8 @@ mod tests {
         .into();
         let policy = PreparationPolicy {
             integer_slack: Some(IntegerSlackPreparation::AllowInequality {
+                max_integer_range: 1,
+                atol: ATol::default(),
                 slack_upper_bound: 2,
             }),
             fixed_penalty: Some(FixedPenaltyPreparation::PenaltyMethodWithFixedWeights {
@@ -476,7 +530,7 @@ mod tests {
     }
 
     #[test]
-    fn unrelated_owner_error_preserves_earlier_commits() {
+    fn allowing_inequality_propagates_unrelated_error_after_earlier_commits() {
         let converted_id = ConstraintID::from(1);
         let infeasible_id = ConstraintID::from(2);
         let variables = BTreeMap::from([
@@ -513,9 +567,10 @@ mod tests {
                 kinds: BTreeSet::from([SpecialConstraintKind::OneHot]),
             }),
             sense: Some(SensePreparation::AsMinimizationProblem),
-            integer_slack: Some(IntegerSlackPreparation::RequireEquality {
+            integer_slack: Some(IntegerSlackPreparation::AllowInequality {
                 max_integer_range: 32,
                 atol: ATol::default(),
+                slack_upper_bound: 2,
             }),
             ..Default::default()
         };

--- a/rust/ommx/src/instance/preparation.rs
+++ b/rust/ommx/src/instance/preparation.rs
@@ -29,43 +29,33 @@ pub enum SensePreparation {
 /// Preparation that introduces Integer slack variables into active regular
 /// inequalities.
 ///
-/// Selecting this step permits Integer slack introduction. Its variant states
-/// whether active regular constraints may remain inequalities or must become
-/// equalities. Both variants first attempt exact conversion to equality.
-/// Numeric and Instance-dependent validation remains owned by the
-/// corresponding [`Instance`] operations.
-#[non_exhaustive]
+/// For every active regular inequality, Preparation first invokes
+/// [`Instance::convert_inequality_to_equality_with_integer_slack`] using
+/// [`Self::max_integer_range`] and [`Self::atol`].
+///
+/// [`Self::slack_upper_bound`] selects the required postcondition. `None`
+/// requires the constraint to become an equality or be removed as trivially
+/// satisfied, so [`ExactIntegerSlackUnavailable`] is propagated. `Some(value)`
+/// permits the constraint to remain an inequality: only that signal selects
+/// [`Instance::add_integer_slack_to_inequality`] with `value`. The latter
+/// operation preserves the feasible assignments of the original variables
+/// exactly; it is not an approximation. Every other owner error is propagated
+/// unchanged.
+///
+/// Numeric and Instance-dependent validation remains owned by the corresponding
+/// [`Instance`] operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IntegerSlackPreparation {
-    /// Prefer equality conversion while allowing active regular constraints to
-    /// remain inequalities when exact conversion is unavailable.
+pub struct IntegerSlackPreparation {
+    /// Maximum finite range accepted for an exact Integer slack variable.
+    pub max_integer_range: u64,
+    /// Absolute tolerance used to normalize bounds to integers.
+    pub atol: ATol,
+    /// Optional upper bound for inequality-preserving Integer slack.
     ///
-    /// [`Instance::convert_inequality_to_equality_with_integer_slack`] is
-    /// attempted first. Only [`ExactIntegerSlackUnavailable`] selects
-    /// [`Instance::add_integer_slack_to_inequality`]; every other owner error
-    /// is propagated unchanged.
-    AllowInequality {
-        /// Maximum finite range accepted for an exact Integer slack variable.
-        max_integer_range: u64,
-        /// Absolute tolerance used to normalize bounds to integers.
-        atol: ATol,
-        /// Upper bound passed to
-        /// [`Instance::add_integer_slack_to_inequality`].
-        slack_upper_bound: u64,
-    },
-    /// Add Integer slack and require every active regular inequality to become
-    /// an equality or be removed as trivially satisfied.
-    ///
-    /// [`crate::ExactIntegerSlackUnavailable`] is propagated when the owner
-    /// operation cannot establish this postcondition. Preparation does not
-    /// replace the requested postcondition with an inequality-preserving
-    /// operation.
-    RequireEquality {
-        /// Maximum finite range accepted for an exact Integer slack variable.
-        max_integer_range: u64,
-        /// Absolute tolerance used to normalize bounds to integers.
-        atol: ATol,
-    },
+    /// `None` requires equality. `Some(value)` passes `value` unchanged to
+    /// [`Instance::add_integer_slack_to_inequality`] only when exact conversion
+    /// returns [`ExactIntegerSlackUnavailable`].
+    pub slack_upper_bound: Option<u64>,
 }
 
 /// Preparation of currently used Integer decision variables.
@@ -129,9 +119,10 @@ pub enum FixedPenaltyPreparation {
 ///
 /// let mut policy = PreparationPolicy::default();
 /// policy.sense = Some(SensePreparation::AsMinimizationProblem);
-/// policy.integer_slack = Some(IntegerSlackPreparation::RequireEquality {
+/// policy.integer_slack = Some(IntegerSlackPreparation {
 ///     max_integer_range: 32,
 ///     atol: ATol::default(),
+///     slack_upper_bound: None,
 /// });
 /// policy.fixed_penalty = Some(
 ///     FixedPenaltyPreparation::UniformPenaltyMethodWithFixedWeight { weight: 2.0 },
@@ -190,35 +181,19 @@ impl PreparationStep for IntegerSlackPreparation {
             .collect::<Vec<_>>();
 
         for id in inequality_ids {
-            match self {
-                Self::AllowInequality {
-                    max_integer_range,
-                    atol,
-                    slack_upper_bound,
-                } => {
-                    match instance.convert_inequality_to_equality_with_integer_slack(
-                        id.into_inner(),
-                        *max_integer_range,
-                        *atol,
-                    ) {
-                        Ok(()) => {}
-                        Err(error) if error.is::<ExactIntegerSlackUnavailable>() => {
-                            instance.add_integer_slack_to_inequality(
-                                id.into_inner(),
-                                *slack_upper_bound,
-                            )?;
-                        }
-                        Err(error) => return Err(error),
-                    }
+            match instance.convert_inequality_to_equality_with_integer_slack(
+                id.into_inner(),
+                self.max_integer_range,
+                self.atol,
+            ) {
+                Ok(()) => {}
+                Err(error) if error.is::<ExactIntegerSlackUnavailable>() => {
+                    let Some(slack_upper_bound) = self.slack_upper_bound else {
+                        return Err(error);
+                    };
+                    instance.add_integer_slack_to_inequality(id.into_inner(), slack_upper_bound)?;
                 }
-                Self::RequireEquality {
-                    max_integer_range,
-                    atol,
-                } => instance.convert_inequality_to_equality_with_integer_slack(
-                    id.into_inner(),
-                    *max_integer_range,
-                    *atol,
-                )?,
+                Err(error) => return Err(error),
             }
         }
         Ok(())
@@ -277,11 +252,11 @@ impl Instance {
     ///
     /// Active regular inequalities are processed in ascending constraint-ID
     /// order. Integer slack Preparation first attempts to convert them to
-    /// equalities. [`IntegerSlackPreparation::AllowInequality`] selects the
-    /// inequality-preserving owner operation only for
-    /// [`ExactIntegerSlackUnavailable`], while
-    /// [`IntegerSlackPreparation::RequireEquality`] propagates that signal.
-    /// Every other owner error is propagated unchanged.
+    /// equalities. [`IntegerSlackPreparation::slack_upper_bound`] set to `None`
+    /// requires equality and propagates [`ExactIntegerSlackUnavailable`].
+    /// `Some(value)` selects the inequality-preserving owner operation with
+    /// `value` only for that signal. Every other owner error is propagated
+    /// unchanged.
     ///
     /// Preparation has no global transaction. Each owner operation retains its
     /// own mutation and failure semantics, and changes committed by earlier
@@ -407,9 +382,10 @@ mod tests {
         .with_regular_constraint(Equality::EqualToZero, DegreeBound::at_most(1))
         .into();
         let policy = PreparationPolicy {
-            integer_slack: Some(IntegerSlackPreparation::RequireEquality {
+            integer_slack: Some(IntegerSlackPreparation {
                 max_integer_range: 1,
                 atol: ATol::default(),
+                slack_upper_bound: None,
             }),
             ..Default::default()
         };
@@ -431,9 +407,10 @@ mod tests {
         .with_regular_constraint(Equality::EqualToZero, DegreeBound::at_most(1))
         .into();
         let policy = PreparationPolicy {
-            integer_slack: Some(IntegerSlackPreparation::RequireEquality {
+            integer_slack: Some(IntegerSlackPreparation {
                 max_integer_range: 32,
                 atol: ATol::default(),
+                slack_upper_bound: None,
             }),
             ..Default::default()
         };
@@ -455,10 +432,10 @@ mod tests {
         .with_regular_constraint(Equality::EqualToZero, DegreeBound::at_most(1))
         .into();
         let policy = PreparationPolicy {
-            integer_slack: Some(IntegerSlackPreparation::AllowInequality {
+            integer_slack: Some(IntegerSlackPreparation {
                 max_integer_range: 32,
                 atol: ATol::default(),
-                slack_upper_bound: 2,
+                slack_upper_bound: Some(2),
             }),
             ..Default::default()
         };
@@ -509,10 +486,10 @@ mod tests {
         .with_regular_constraint(Equality::LessThanOrEqualToZero, DegreeBound::at_most(1))
         .into();
         let policy = PreparationPolicy {
-            integer_slack: Some(IntegerSlackPreparation::AllowInequality {
+            integer_slack: Some(IntegerSlackPreparation {
                 max_integer_range: 1,
                 atol: ATol::default(),
-                slack_upper_bound: 2,
+                slack_upper_bound: Some(2),
             }),
             fixed_penalty: Some(FixedPenaltyPreparation::PenaltyMethodWithFixedWeights {
                 weights: BTreeMap::from([(ConstraintID::from(999), 1.0)]),
@@ -567,10 +544,10 @@ mod tests {
                 kinds: BTreeSet::from([SpecialConstraintKind::OneHot]),
             }),
             sense: Some(SensePreparation::AsMinimizationProblem),
-            integer_slack: Some(IntegerSlackPreparation::AllowInequality {
+            integer_slack: Some(IntegerSlackPreparation {
                 max_integer_range: 32,
                 atol: ATol::default(),
-                slack_upper_bound: 2,
+                slack_upper_bound: Some(2),
             }),
             ..Default::default()
         };

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -9,9 +9,10 @@ use num::traits::Inv;
 /// Signal returned when exact integer-slack conversion is structurally valid
 /// but cannot construct an exact finite encoding.
 ///
-/// Callers may recover by selecting an explicitly approximate transformation.
-/// Missing constraints, unsupported variable kinds, and other contract or
-/// materialization failures are not classified as this signal.
+/// Callers may recover by changing the exact-conversion parameters or by
+/// selecting a different operation whose postcondition does not require an
+/// equality. Missing constraints, unsupported variable kinds, and other
+/// contract or materialization failures are not classified as this signal.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct ExactIntegerSlackUnavailable(ExactIntegerSlackFailure);
@@ -159,6 +160,13 @@ impl Instance {
 
     /// Convert an inequality $f(x) \leq 0$ to $f(x) + b s \leq 0$ with an integer
     /// slack variable $s \in [0, \text{slack\_upper\_bound}]$.
+    ///
+    /// This preserves the feasible assignments of the original decision
+    /// variables exactly: every original feasible assignment remains feasible
+    /// by choosing $s = 0$, while $b \geq 0$ and $s \geq 0$ ensure that every
+    /// augmented feasible assignment still satisfies $f(x) \leq 0$. The
+    /// relation remains an inequality; this operation is not an approximation
+    /// of the original feasible set.
     ///
     /// Returns the coefficient $b = -\mathrm{lower}(f(x)) / \text{slack\_upper\_bound}$.
     /// Returns `None` if the constraint was trivially satisfied and was moved to


### PR DESCRIPTION
## Summary

- Model Integer slack as one optional Preparation step with shared exact-conversion arguments and an optional inequality allowance.
- Attempt exact conversion to equality first. `slack_upper_bound = None` requires equality; `Some(value)` permits the inequality-preserving operation only for `ExactIntegerSlackUnavailable`.
- Remove the owner-method-shaped Preparation variants and redundant argument wrapper types.
- Clarify that `add_integer_slack_to_inequality` preserves the original feasible set exactly while keeping the relation as an inequality, and update the Rust migration, error-handling, and release documentation.

## Contract

`PreparationPolicy::integer_slack = None` disables Integer slack introduction. When the step is selected, exact equality conversion is the canonical first operation. `IntegerSlackPreparation::slack_upper_bound = None` requires every active regular inequality to become an equality or be removed as trivially satisfied; `Some(value)` permits an inequality-preserving alternative only when exact conversion is structurally unavailable. Unrelated owner errors are always propagated unchanged.
