### PR TITLE
Add a typed Preparation target-not-reached signal

### DIFF
--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -906,9 +906,15 @@ propagated unchanged, and numeric validation remains owner-defined.
 
 Preparation checks the target [`InstanceClass`](crate::InstanceClass) before
 and after each selected phase, stops as soon as membership holds, and
-guarantees only that membership on success. Preparation does not add a global
-transaction, so changes committed by earlier owner operations remain when a
-later operation fails.
+guarantees only that membership on success. When all configured phases complete
+without reaching the target, it returns the typed
+[`PreparationTargetNotReached`](crate::PreparationTargetNotReached) signal.
+The signal exposes the final
+[`InstanceClassMembershipReport`](crate::InstanceClassMembershipReport), so
+callers can add phases, revise the target class, or report the remaining
+mismatches. Errors from selected owner operations remain unchanged. Preparation
+does not add a global transaction, so changes committed by earlier owner
+operations remain when a later operation fails.
 
 [`Instance::into_partial_evaluated`](crate::Instance::into_partial_evaluated)
 is the consuming counterpart to
@@ -926,7 +932,8 @@ Related PRs: [#1010](https://github.com/Jij-Inc/ommx/pull/1010),
 [#1143](https://github.com/Jij-Inc/ommx/pull/1143),
 [#1144](https://github.com/Jij-Inc/ommx/pull/1144),
 [#1145](https://github.com/Jij-Inc/ommx/pull/1145),
-[#1148](https://github.com/Jij-Inc/ommx/pull/1148).
+[#1148](https://github.com/Jij-Inc/ommx/pull/1148),
+[#1149](https://github.com/Jij-Inc/ommx/pull/1149).
 
 ## ⚙️ Formatting and property-test domains
 

--- a/rust/ommx/doc/tutorial/error_handling.md
+++ b/rust/ommx/doc/tutorial/error_handling.md
@@ -66,6 +66,11 @@ returns the typed error directly):
   caller may explicitly choose another mathematical operation or postcondition.
   Contract, allocation, substitution, and arithmetic failures are not folded
   into these signals.
+- [`PreparationTargetNotReached`](crate::PreparationTargetNotReached) — reports
+  that all configured Preparation phases completed without establishing the
+  target [`InstanceClass`](crate::InstanceClass) membership. Callers can inspect
+  its typed membership report before adding phases, revising the target class,
+  or reporting the remaining mismatches.
 
 Evaluation does not define an umbrella error type. Caller-provided numeric
 validation reuses [`DecisionVariableError`](crate::DecisionVariableError), and

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -37,7 +37,7 @@ pub use builder::*;
 pub use parametric_builder::*;
 pub use preparation::{
     FixedPenaltyPreparation, IntegerEncodingPreparation, IntegerSlackPreparation,
-    PreparationPolicy, SensePreparation, SpecialConstraintPreparation,
+    PreparationPolicy, PreparationTargetNotReached, SensePreparation, SpecialConstraintPreparation,
 };
 pub use stats::*;
 

--- a/rust/ommx/src/instance/preparation.rs
+++ b/rust/ommx/src/instance/preparation.rs
@@ -1,5 +1,5 @@
 use super::{ExactIntegerSlackUnavailable, Instance, SpecialConstraintKinds};
-use crate::{ATol, ConstraintID, Equality, InstanceClass};
+use crate::{ATol, ConstraintID, Equality, InstanceClass, InstanceClassMembershipReport};
 use std::collections::BTreeMap;
 
 /// Preparation of active special constraints.
@@ -143,6 +143,26 @@ pub struct PreparationPolicy {
     pub fixed_penalty: Option<FixedPenaltyPreparation>,
 }
 
+/// Signal returned when configured Preparation phases are exhausted before the
+/// target [`InstanceClass`] contains the [`Instance`].
+///
+/// Callers can inspect [`Self::report`] to select additional Preparation
+/// phases, revise the target class, or report the remaining mismatches. The
+/// instance may retain changes committed by configured phases before this
+/// signal is returned.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("Preparation did not reach the target InstanceClass:\n{report}")]
+pub struct PreparationTargetNotReached {
+    report: InstanceClassMembershipReport,
+}
+
+impl PreparationTargetNotReached {
+    /// Return the final membership report for the prepared instance.
+    pub fn report(&self) -> &InstanceClassMembershipReport {
+        &self.report
+    }
+}
+
 trait PreparationStep {
     /// Apply one configured phase completely unless an owner operation fails.
     fn apply(&self, instance: &mut Instance) -> crate::Result<()>;
@@ -264,9 +284,10 @@ impl Instance {
     ///
     /// # Errors
     ///
-    /// Returns an error from a configured owner operation, or an ordinary
-    /// [`crate::Error`] with the final membership report when the configured
-    /// operations are exhausted without reaching `input_class`.
+    /// Returns an error from a configured owner operation, or
+    /// [`PreparationTargetNotReached`] with the final membership report when
+    /// the configured operations are exhausted without reaching
+    /// `input_class`.
     pub fn prepare(
         &mut self,
         input_class: &InstanceClass,
@@ -297,7 +318,7 @@ impl Instance {
         }
 
         let report = input_class.check_membership(self);
-        crate::bail!("Preparation did not reach the target InstanceClass:\n{report}")
+        crate::bail!(PreparationTargetNotReached { report })
     }
 }
 
@@ -568,10 +589,10 @@ mod tests {
     }
 
     #[test]
-    fn exhausted_policy_returns_error_outside_target() {
+    fn exhausted_policy_returns_the_final_membership_report() {
         let variable = VariableID::from(1);
         let mut instance = Instance::new(
-            Sense::Minimize,
+            Sense::Maximize,
             Function::from(linear!(variable)),
             BTreeMap::from([(variable, DecisionVariable::binary())]),
             BTreeMap::from([(
@@ -585,15 +606,22 @@ mod tests {
             [Kind::Binary],
             DegreeBound::at_most(1),
         );
-        let before = instance.clone();
-        let membership_report = target.check_membership(&instance).to_string();
+        let policy = PreparationPolicy {
+            sense: Some(SensePreparation::AsMinimizationProblem),
+            ..Default::default()
+        };
 
-        let error = instance
-            .prepare(&target, &PreparationPolicy::default())
-            .unwrap_err();
+        let error = instance.prepare(&target, &policy).unwrap_err();
+        let membership_report = target.check_membership(&instance);
 
         assert!(!target.contains(&instance));
-        assert_eq!(instance, before);
-        assert!(error.to_string().contains(&membership_report));
+        assert_eq!(instance.sense(), Sense::Minimize);
+        assert_eq!(
+            error
+                .downcast_ref::<PreparationTargetNotReached>()
+                .unwrap()
+                .report(),
+            &membership_report
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add `PreparationTargetNotReached` as the Rust-owned signal for exhausted Preparation policies
- retain the final `InstanceClassMembershipReport` as typed recovery data through `report()`
- return the signal only after all selected phases complete without establishing target membership
- document the recovery contract in the error tutorial and Rust 3.0 release notes, and verify that the report describes the final partially prepared `Instance`

## Design boundary

This signal represents only the terminal Preparation condition where the target class is not reached. Errors from selected `Instance` owner operations continue to propagate unchanged and are not wrapped in a Preparation-wide error.

The membership report remains owned by `InstanceClass`; the signal exposes it read-only so callers can add phases, revise the target class, or report the remaining mismatches. Preparation remains in-place and non-transactional.

This Rust-only change provides the typed owner signal required for a separate Python exception mapping.

Part of #1111.
