### PR TITLE
Add adapter preparation recommendations

### DIFF
--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -19,7 +19,9 @@ adapter calls remain strict and do not transform their input automatically.
 Start with the policy recommended by the adapter, edit any public policy fields
 needed by the application, and then prepare the instance for that adapter's
 `INPUT_CLASS`. For example, HiGHS recommends lowering active Indicator, OneHot,
-and SOS1 constraints into regular constraints:
+and SOS1 constraints into regular constraints. Python-MIP makes the same
+recommendation. PySCIPOpt accepts Indicator and SOS1 constraints directly, so
+it recommends lowering only OneHot constraints:
 
 ```python
 from ommx_highs_adapter import OMMXHighsAdapter

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,7 +8,7 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
-### 🆕 User-controlled `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147))
+### 🆕 User-controlled `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147), [#1152](https://github.com/Jij-Inc/ommx/pull/1152))
 
 In Python SDK v2, solver adapters selected and performed the model conversions
 needed by their solvers. Python SDK v3 makes this an explicit, caller-owned step.
@@ -16,31 +16,30 @@ needed by their solvers. Python SDK v3 makes this an explicit, caller-owned step
 place until it belongs to a requested {class}`~ommx.InstanceClass`; direct
 adapter calls remain strict and do not transform their input automatically.
 
-When an adapter supplies a recommended {class}`~ommx.PreparationPolicy` for its
-`INPUT_CLASS`, use that recommendation as a starting point, change any public
-policy fields needed by the application, and then pass the `INPUT_CLASS` and
-the policy separately to {meth}`~ommx.Instance.prepare`. A policy can also be
-constructed directly:
+Start with the policy recommended by the adapter, edit any public policy fields
+needed by the application, and then prepare the instance for that adapter's
+`INPUT_CLASS`. For example, HiGHS recommends lowering active Indicator, OneHot,
+and SOS1 constraints into regular constraints:
 
 ```python
-from ommx import (
-    IntegerEncodingPreparation,
-    PreparationPolicy,
-    SensePreparation,
-)
+from ommx_highs_adapter import OMMXHighsAdapter
 
-# `target_class` may be an adapter's INPUT_CLASS.
-policy = PreparationPolicy(
-    sense=SensePreparation.as_minimization_problem(),
-)
-# A policy returned by an adapter can be edited in the same way.
-policy.integer_encoding = (
-    IntegerEncodingPreparation.log_encode_all_used_integers()
-)
+input_class = OMMXHighsAdapter.INPUT_CLASS
+assert input_class is not None
+policy = OMMXHighsAdapter.recommended_preparation_policy()
+# Change public policy fields here when the application needs different choices.
 
-instance.prepare(target_class, policy)
-assert target_class.contains(instance)
+instance.prepare(input_class, policy)
+OMMXHighsAdapter.require_applicable(instance)
+solution = OMMXHighsAdapter.solve(instance)
 ```
+
+{meth}`~ommx.adapter.SolverAdapter.recommended_preparation_policy` returns a
+fresh, editable policy on every call. The base recommendation enables no
+changes; each adapter may override it with choices suitable for its direct
+input class. A recommendation does not inspect or mutate an instance, execute
+preparation, or guarantee applicability. Applications may also construct a
+{class}`~ommx.PreparationPolicy` directly.
 
 Policy fields let the caller allow special-constraint lowering, minimization
 sense normalization, Integer slack, used-Integer encoding, and fixed-weight
@@ -53,8 +52,8 @@ reached. If the allowed changes are exhausted first,
 {class}`~ommx.InstanceClassMembershipReport` as `error.report`. Errors from an
 individual model change keep their existing Python exception types. Preparation
 does not roll the instance back: changes completed before a later error remain.
-Successful preparation guarantees target membership only. When the target is an
-adapter's `INPUT_CLASS`, the adapter's normal applicability check still applies.
+Successful preparation guarantees target membership only. The adapter's normal
+applicability check still applies, as shown above.
 
 ### 🛠 Model and sample errors follow caller ownership ([#1104](https://github.com/Jij-Inc/ommx/pull/1104), [#1105](https://github.com/Jij-Inc/ommx/pull/1105), [#1107](https://github.com/Jij-Inc/ommx/pull/1107))
 

--- a/docs/en/tutorial/implement_adapter.md
+++ b/docs/en/tutorial/implement_adapter.md
@@ -286,6 +286,10 @@ class SolverAdapter(ABC):
     INPUT_CLASS: InstanceClass | None = None
 
     @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        return PreparationPolicy()
+
+    @classmethod
     @abstractmethod
     def solve(
         cls,
@@ -312,36 +316,73 @@ This abstract base class assumes the following two use cases:
 
 The `solve` class method may define additional adapter-specific keyword options in concrete adapters. The reserved `diagnostics` keyword is owned by `Run.log_solve`. When `Run.log_solve(..., store_diagnostics=True)` is used, adapters may record adapter-defined diagnostic reports into that sink; `None` means diagnostics are disabled.
 
-#### Input Class and Explicit Constraint Lowering
+#### Input Class and Recommended Preparation
 
 An adapter declares the structural set of exact `Instance` values it can receive with `INPUT_CLASS`. `check_applicability()` evaluates membership first and then adapter-owned preconditions without mutating the caller's instance; `require_applicable()` raises with the same structured report when either condition fails.
 
-`SolverAdapter` does not prescribe how a concrete adapter processes an accepted input and does not mutate the instance in a base constructor. A concrete adapter may explicitly call {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` as an implementation detail. Its `kinds_to_lower` argument uses these special-constraint family selectors:
+Direct adapter APIs are strict: they do not transform an input to make it applicable. Instead, an adapter may override `recommended_preparation_policy()` to return a fresh, caller-editable {class}`~ommx.PreparationPolicy` for its `INPUT_CLASS`. The recommendation does not inspect or mutate an instance, run preparation, or guarantee applicability. `INPUT_CLASS` and the policy remain independent inputs to {meth}`~ommx.Instance.prepare`.
+
+A recommendation can enable special-constraint lowering with these family selectors:
 
 - `SpecialConstraintKind.Indicator`: Indicator constraints (`binvar = 1 → f(x) <= 0`)
 - `SpecialConstraintKind.OneHot`: Exactly one of a set of binary variables is 1
 - `SpecialConstraintKind.Sos1`: At most one of a set of variables is non-zero
 
-Use {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` to inspect the currently active families. `lower_special_constraints` converts each selected active family into regular constraints (Big-M for indicator / SOS1, linear equality for one-hot), mutates the instance in place, and logs each lowering at `INFO` level. Neither this property nor lowering establishes `INPUT_CLASS` membership or adapter applicability.
+Use {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` to inspect the currently active families. The selected Preparation phase delegates to {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>`, which converts each selected active family into regular constraints (Big-M for indicator / SOS1, linear equality for one-hot). The owner operation still defines its validation and mathematical meaning.
 
 ```{important}
-`INPUT_CLASS` describes the exact value received by the adapter, regardless of its internal implementation. If a caller explicitly lowers an instance before choosing an adapter, the result is a different input value and must be checked again with `check_applicability()` or `require_applicable()`.
+`INPUT_CLASS` describes the exact value received by the adapter. Preparation is owned by the caller and changes that value in place. Successful preparation guarantees `INPUT_CLASS` membership only; the adapter must still run its normal applicability check for adapter-owned preconditions.
 ```
 
 Using the functions prepared so far, you can implement it as follows:
 
 ```{code-cell} ipython3
 from ommx.adapter import DiagnosticsSink, SolverAdapter
-from ommx import SpecialConstraintKind
+from ommx import (
+    DegreeBound,
+    Equality,
+    InstanceClass,
+    InstanceClassClause,
+    Kind,
+    PreparationPolicy,
+    Sense,
+    SpecialConstraintKind,
+    SpecialConstraintPreparation,
+)
 
 class OMMXPySCIPOptAdapter(SolverAdapter):
+    INPUT_CLASS = InstanceClass(
+        [
+            InstanceClassClause(
+                label="tutorial-quadratic-mip",
+                allowed_variable_kinds={Kind.Binary, Kind.Integer, Kind.Continuous},
+                objective_degree_bound=DegreeBound.at_most(2),
+                regular_constraint_degree_bounds={
+                    Equality.EqualToZero: DegreeBound.at_most(2),
+                    Equality.LessThanOrEqualToZero: DegreeBound.at_most(2),
+                },
+                allowed_senses={Sense.Minimize, Sense.Maximize},
+            )
+        ]
+    )
+
+    @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        return PreparationPolicy(
+            special_constraints=SpecialConstraintPreparation.lower_special_constraints(
+                kinds={
+                    SpecialConstraintKind.Indicator,
+                    SpecialConstraintKind.OneHot,
+                    SpecialConstraintKind.Sos1,
+                }
+            )
+        )
+
     def __init__(
         self,
         ommx_instance: Instance,
     ):
-        # This adapter handles Indicator and SOS1 directly, and explicitly
-        # lowers OneHot constraints.
-        ommx_instance.lower_special_constraints({SpecialConstraintKind.OneHot})
+        self.require_applicable(ommx_instance)
         self.instance = ommx_instance
         self.model = pyscipopt.Model()
         self.model.hideOutput()
@@ -393,6 +434,18 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             solution.optimality = Solution.OPTIMAL
 
         return solution
+```
+
+The caller decides whether to use and modify the recommendation before invoking the strict adapter API:
+
+```python
+input_class = OMMXPySCIPOptAdapter.INPUT_CLASS
+assert input_class is not None
+policy = OMMXPySCIPOptAdapter.recommended_preparation_policy()
+# Edit public policy fields here when the application needs different choices.
+instance.prepare(input_class, policy)
+OMMXPySCIPOptAdapter.require_applicable(instance)
+solution = OMMXPySCIPOptAdapter.solve(instance)
 ```
 
 This completes the Solver Adapter 🎉
@@ -606,7 +659,7 @@ sample_set.summary
 In this tutorial, we learned how to implement an OMMX Adapter by connecting to PySCIPOpt as a Solver Adapter and OpenJij as a Sampler Adapter. Here are the key points when implementing an OMMX Adapter:
 
 1. Implement an OMMX Adapter by inheriting the abstract base class `SolverAdapter` or `SamplerAdapter`.
-2. Declare the structural input condition with `INPUT_CLASS`, then use `check_applicability()` or `require_applicable()` to evaluate membership and adapter-owned preconditions. If lowering is needed, make it an explicit concrete-adapter or caller operation; the base Adapter contract never mutates the input.
+2. Declare the strict structural input condition with `INPUT_CLASS`. If useful, return a fresh caller-editable policy from `recommended_preparation_policy()`; the caller applies it with `Instance.prepare()` before the adapter performs its normal applicability check.
 3. The main steps of the implementation are as follows:
    - Convert `ommx.Instance` into a format that the backend solver can understand.
    - Run the backend solver to obtain a solution.

--- a/docs/en/tutorial/implement_adapter.md
+++ b/docs/en/tutorial/implement_adapter.md
@@ -361,6 +361,11 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                     Equality.EqualToZero: DegreeBound.at_most(2),
                     Equality.LessThanOrEqualToZero: DegreeBound.at_most(2),
                 },
+                indicator_constraint_degree_bounds={
+                    Equality.EqualToZero: DegreeBound.at_most(1),
+                    Equality.LessThanOrEqualToZero: DegreeBound.at_most(1),
+                },
+                allows_sos1=True,
                 allowed_senses={Sense.Minimize, Sense.Maximize},
             )
         ]
@@ -370,11 +375,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
     def recommended_preparation_policy(cls) -> PreparationPolicy:
         return PreparationPolicy(
             special_constraints=SpecialConstraintPreparation.lower_special_constraints(
-                kinds={
-                    SpecialConstraintKind.Indicator,
-                    SpecialConstraintKind.OneHot,
-                    SpecialConstraintKind.Sos1,
-                }
+                kinds={SpecialConstraintKind.OneHot}
             )
         )
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -19,7 +19,9 @@ in-placeで変更します。Adapterを直接呼び出した場合は引き続�
 
 まずAdapterが推奨するPolicyを取得し、applicationに応じてpublic fieldを編集してから、
 そのAdapterの `INPUT_CLASS` 向けにinstanceをprepareします。例えばHiGHSは、activeな
-Indicator、OneHot、SOS1制約を通常制約へloweringすることを推奨します。
+Indicator、OneHot、SOS1制約を通常制約へloweringすることを推奨します。Python-MIPも
+同じPolicyを推奨します。PySCIPOptはIndicatorとSOS1制約を直接扱えるため、OneHot制約
+だけをloweringすることを推奨します。
 
 ```python
 from ommx_highs_adapter import OMMXHighsAdapter

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,7 +8,7 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
-### 🆕 ユーザーが制御する `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147))
+### 🆕 ユーザーが制御する `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147)、[#1152](https://github.com/Jij-Inc/ommx/pull/1152))
 
 Python SDK v2では、solver adapterがsolverに必要なモデル変換を選び、実行していました。
 Python SDK v3では、この操作をユーザーが明示的に制御します。
@@ -17,30 +17,28 @@ Python SDK v3では、この操作をユーザーが明示的に制御します�
 in-placeで変更します。Adapterを直接呼び出した場合は引き続き入力を厳密に検査し、
 暗黙の変換は行いません。
 
-Adapterが `INPUT_CLASS` 向けの推奨 {class}`~ommx.PreparationPolicy` を提供する場合は、
-それを出発点にします。必要に応じてユーザーがpublic fieldを書き換え、`INPUT_CLASS` と
-policyを別々に {meth}`~ommx.Instance.prepare` へ渡します。Policyを直接構築することも
-できます。
+まずAdapterが推奨するPolicyを取得し、applicationに応じてpublic fieldを編集してから、
+そのAdapterの `INPUT_CLASS` 向けにinstanceをprepareします。例えばHiGHSは、activeな
+Indicator、OneHot、SOS1制約を通常制約へloweringすることを推奨します。
 
 ```python
-from ommx import (
-    IntegerEncodingPreparation,
-    PreparationPolicy,
-    SensePreparation,
-)
+from ommx_highs_adapter import OMMXHighsAdapter
 
-# `target_class` にはAdapterのINPUT_CLASSも指定できます。
-policy = PreparationPolicy(
-    sense=SensePreparation.as_minimization_problem(),
-)
-# Adapterが返したpolicyも同じ方法で編集できます。
-policy.integer_encoding = (
-    IntegerEncodingPreparation.log_encode_all_used_integers()
-)
+input_class = OMMXHighsAdapter.INPUT_CLASS
+assert input_class is not None
+policy = OMMXHighsAdapter.recommended_preparation_policy()
+# Applicationに異なる選択が必要なら、ここでpublic fieldを編集します。
 
-instance.prepare(target_class, policy)
-assert target_class.contains(instance)
+instance.prepare(input_class, policy)
+OMMXHighsAdapter.require_applicable(instance)
+solution = OMMXHighsAdapter.solve(instance)
 ```
+
+{meth}`~ommx.adapter.SolverAdapter.recommended_preparation_policy` は、呼び出すたびに
+新しい編集可能なPolicyを返します。基底classの推奨では変換を何も有効にせず、各Adapterは
+直接受け取れるinput classに適した選択でoverrideできます。推奨Policyはinstanceを参照・
+変更せず、Preparationを実行せず、Adapter applicabilityも保証しません。
+{class}`~ommx.PreparationPolicy` をapplication側で直接構築することもできます。
 
 Policyでは、特殊制約の通常制約化、最小化へのsense統一、Integer slack、使用中の
 Integer変数のencoding、固定weight penaltyを許可できます。OMMXは有効な変換を
@@ -52,8 +50,8 @@ Integer変数のencoding、固定weight penaltyを許可できます。OMMXは�
 {class}`~ommx.InstanceClassMembershipReport` を取得できます。個々の変換で発生する
 errorは既存のPython exception typeを保ちます。Preparationはinstanceをrollback
 しないため、後のerrorより前に完了した変更は残ります。成功時に保証されるのはtarget
-membershipだけです。targetがAdapterの `INPUT_CLASS` である場合も、Adapterが行う通常の
-applicability checkは引き続き必要です。
+membershipだけです。上の例のとおり、Adapterが行う通常のapplicability checkは
+引き続き必要です。
 
 ### 🛠 Model / sample error を呼び出し側の回復方法に応じて通知 ([#1104](https://github.com/Jij-Inc/ommx/pull/1104)、[#1105](https://github.com/Jij-Inc/ommx/pull/1105)、[#1107](https://github.com/Jij-Inc/ommx/pull/1107))
 

--- a/docs/ja/tutorial/implement_adapter.md
+++ b/docs/ja/tutorial/implement_adapter.md
@@ -282,6 +282,10 @@ class SolverAdapter(ABC):
     INPUT_CLASS: InstanceClass | None = None
 
     @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        return PreparationPolicy()
+
+    @classmethod
     @abstractmethod
     def solve(
         cls,
@@ -308,36 +312,73 @@ class SolverAdapter(ABC):
 
 具体的な adapter の `solve` クラスメソッドは、adapter 固有の keyword option を追加で定義できます。予約済みの `diagnostics` keyword は `Run.log_solve` が管理します。`Run.log_solve(..., store_diagnostics=True)` を使う場合、adapter はその sink に adapter 定義の diagnostic report を記録できます。`None` の場合、diagnostics は無効です。
 
-#### 入力 class と明示的な特殊制約 lowering
+#### 入力 class と推奨 Preparation
 
 Adapter は、受け取れる具体的な `Instance` 値の構造的な集合を `INPUT_CLASS` で宣言します。`check_applicability()` は membership、続いて Adapter 固有の precondition を呼び出し元の instance を変更せずに評価します。いずれかを満たさない場合に同じ構造化 report で例外を送出するには `require_applicable()` を使います。
 
-`SolverAdapter` は、受理した入力を具体的な Adapter がどのように処理するかを規定せず、基底 class の constructor で instance を変更しません。具体的な Adapter は、実装上必要であれば {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` を明示的に呼び出せます。`kinds_to_lower` 引数では、以下の特殊制約 family selector を使います：
+Adapter の直接 API は厳格であり、入力を適用可能にするための変換を内部では行いません。代わりに、Adapter は `recommended_preparation_policy()` を override して、その `INPUT_CLASS` 向けの新しい編集可能な {class}`~ommx.PreparationPolicy` を返せます。推奨 Policy は instance を参照・変更せず、Preparation を実行せず、Adapter applicability も保証しません。`INPUT_CLASS` と Policy は {meth}`~ommx.Instance.prepare` に別々の引数として渡します。
+
+推奨 Policy から特殊制約 lowering を有効にする場合は、以下の family selector を使います：
 
 - `SpecialConstraintKind.Indicator`: インジケーター制約 (`binvar = 1 → f(x) <= 0`)
 - `SpecialConstraintKind.OneHot`: バイナリ変数集合のうち丁度1つが1
 - `SpecialConstraintKind.Sos1`: 変数集合のうち高々1つが非ゼロ
 
-`Instance` が現在保持する family は {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` で確認できます。`lower_special_constraints` は選択した active な family を通常制約へ変換し（indicator/SOS1 は Big-M、one-hot は線形等式）、instance を in-place に変更して、各 lowering を `INFO` level で記録します。この property も lowering も、`INPUT_CLASS` の membership や Adapter applicability を保証しません。
+`Instance` が現在保持する family は {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` で確認できます。選択された Preparation phase は {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` に委譲し、active な family を通常制約へ変換します（indicator/SOS1 は Big-M、one-hot は線形等式）。Validation と数学的な意味は引き続き owner operation が定義します。
 
 ```{important}
-`INPUT_CLASS` は Adapter の内部実装にかかわらず、Adapter が受け取る時点の入力値そのものを記述します。呼び出し側が Adapter を選ぶ前に instance を明示的に lowering した場合、結果は別の入力値なので、`check_applicability()` または `require_applicable()` で再評価する必要があります。
+`INPUT_CLASS` は Adapter が受け取る時点の入力値そのものを記述します。Preparation は呼び出し側が所有し、その値を in-place に変更します。Preparation の成功が保証するのは `INPUT_CLASS` membership だけなので、Adapter は通常どおり Adapter 固有の precondition を含む applicability check を行う必要があります。
 ```
 
 ここまでで用意した関数を使って次のように実装することができます：
 
 ```{code-cell} ipython3
 from ommx.adapter import DiagnosticsSink, SolverAdapter
-from ommx import SpecialConstraintKind
+from ommx import (
+    DegreeBound,
+    Equality,
+    InstanceClass,
+    InstanceClassClause,
+    Kind,
+    PreparationPolicy,
+    Sense,
+    SpecialConstraintKind,
+    SpecialConstraintPreparation,
+)
 
 class OMMXPySCIPOptAdapter(SolverAdapter):
+    INPUT_CLASS = InstanceClass(
+        [
+            InstanceClassClause(
+                label="tutorial-quadratic-mip",
+                allowed_variable_kinds={Kind.Binary, Kind.Integer, Kind.Continuous},
+                objective_degree_bound=DegreeBound.at_most(2),
+                regular_constraint_degree_bounds={
+                    Equality.EqualToZero: DegreeBound.at_most(2),
+                    Equality.LessThanOrEqualToZero: DegreeBound.at_most(2),
+                },
+                allowed_senses={Sense.Minimize, Sense.Maximize},
+            )
+        ]
+    )
+
+    @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        return PreparationPolicy(
+            special_constraints=SpecialConstraintPreparation.lower_special_constraints(
+                kinds={
+                    SpecialConstraintKind.Indicator,
+                    SpecialConstraintKind.OneHot,
+                    SpecialConstraintKind.Sos1,
+                }
+            )
+        )
+
     def __init__(
         self,
         ommx_instance: Instance,
     ):
-        # この Adapter は Indicator と SOS1 を直接処理し、OneHot を
-        # 明示的に lowering する
-        ommx_instance.lower_special_constraints({SpecialConstraintKind.OneHot})
+        self.require_applicable(ommx_instance)
         self.instance = ommx_instance
         self.model = pyscipopt.Model()
         self.model.hideOutput()
@@ -389,6 +430,18 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             solution.optimality = Solution.OPTIMAL
 
         return solution
+```
+
+呼び出し側は、厳格な Adapter API を呼ぶ前に推奨 Policy を使うかどうかを決め、必要に応じて編集します：
+
+```python
+input_class = OMMXPySCIPOptAdapter.INPUT_CLASS
+assert input_class is not None
+policy = OMMXPySCIPOptAdapter.recommended_preparation_policy()
+# Application に異なる選択が必要なら、ここで public field を編集します。
+instance.prepare(input_class, policy)
+OMMXPySCIPOptAdapter.require_applicable(instance)
+solution = OMMXPySCIPOptAdapter.solve(instance)
 ```
 
 これでSolver Adapter完成です 🎉
@@ -600,7 +653,7 @@ sample_set.summary
 このチュートリアルでは、PySCIPOptと接続するSolver Adapterの実装とOpenJijと接続するSampler Adapterの実装を通して、OMMX Adapterの実装方法について学びました。以下がOMMX Adapterを実装する際の重要なポイントです：
 
 1. OMMX Adapterは `SolverAdapter` または `SamplerAdapter` の抽象基底クラスを継承することで実装します
-2. `INPUT_CLASS` で構造的な入力条件を宣言し、`check_applicability()` または `require_applicable()` で membership と Adapter 固有の precondition を評価します。lowering が必要な場合は具体的な Adapter または呼び出し側の明示的な操作とし、基底 Adapter の契約では入力を変更しません
+2. `INPUT_CLASS` で厳格な構造的入力条件を宣言します。有用な場合は、`recommended_preparation_policy()` から新しい編集可能な Policy を返します。呼び出し側が `Instance.prepare()` で適用した後、Adapter は通常の applicability check を行います
 3. 実装の主なステップは以下の通りです：
    - `ommx.Instance` をバックエンドソルバーが理解できる形式に変換する
    - バックエンドソルバーを実行して解を取得する

--- a/docs/ja/tutorial/implement_adapter.md
+++ b/docs/ja/tutorial/implement_adapter.md
@@ -357,6 +357,11 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                     Equality.EqualToZero: DegreeBound.at_most(2),
                     Equality.LessThanOrEqualToZero: DegreeBound.at_most(2),
                 },
+                indicator_constraint_degree_bounds={
+                    Equality.EqualToZero: DegreeBound.at_most(1),
+                    Equality.LessThanOrEqualToZero: DegreeBound.at_most(1),
+                },
+                allows_sos1=True,
                 allowed_senses={Sense.Minimize, Sense.Maximize},
             )
         ]
@@ -366,11 +371,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
     def recommended_preparation_policy(cls) -> PreparationPolicy:
         return PreparationPolicy(
             special_constraints=SpecialConstraintPreparation.lower_special_constraints(
-                kinds={
-                    SpecialConstraintKind.Indicator,
-                    SpecialConstraintKind.OneHot,
-                    SpecialConstraintKind.Sos1,
-                }
+                kinds={SpecialConstraintKind.OneHot}
             )
         )
 

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -19,8 +19,11 @@ from ommx import (
     InstanceClass,
     InstanceClassClause,
     Kind,
+    PreparationPolicy,
     Sense,
     Solution,
+    SpecialConstraintKind,
+    SpecialConstraintPreparation,
     State,
 )
 from ommx.adapter import (
@@ -585,6 +588,26 @@ class OMMXHighsAdapter(SolverAdapter):
             )
         ]
     )
+
+    @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        """Recommend lowering special constraints before using HiGHS.
+
+        HiGHS accepts both optimization senses, Binary, Integer, and Continuous
+        variables, and linear regular constraints directly. Its recommendation
+        therefore enables only lowering for the special-constraint families
+        currently understood by OMMX. The returned policy is fresh and may be
+        edited by the caller before :meth:`Instance.prepare` is invoked.
+        """
+        return PreparationPolicy(
+            special_constraints=SpecialConstraintPreparation.lower_special_constraints(
+                kinds={
+                    SpecialConstraintKind.Indicator,
+                    SpecialConstraintKind.OneHot,
+                    SpecialConstraintKind.Sos1,
+                }
+            )
+        )
 
     def __init__(self, ommx_instance: Instance, *, verbose: bool = False):
         """

--- a/python/ommx-highs-adapter/tests/test_error.py
+++ b/python/ommx-highs-adapter/tests/test_error.py
@@ -177,6 +177,40 @@ def test_rejects_special_constraints_without_mutating_input():
     assert instance.to_v2_bytes() == before
 
 
+def test_recommended_preparation_reaches_the_highs_input_class():
+    x = DecisionVariable.binary(0)
+    y = DecisionVariable.continuous(1, lower=0, upper=2)
+    instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x + y,
+        constraints={},
+        sense=Sense.Minimize,
+        indicator_constraints={
+            10: IndicatorConstraint(
+                indicator_variable=x,
+                function=y - 1,
+                equality=Equality.LessThanOrEqualToZero,
+            )
+        },
+        one_hot_constraints={20: OneHotConstraint(variables=[x])},
+        sos1_constraints={30: Sos1Constraint(variables=[y])},
+    )
+    input_class = OMMXHighsAdapter.INPUT_CLASS
+    assert input_class is not None
+    assert not input_class.contains(instance)
+
+    policy = OMMXHighsAdapter.recommended_preparation_policy()
+    assert policy.special_constraints is not None
+    assert policy.sense is None
+    assert policy.integer_slack is None
+    assert policy.integer_encoding is None
+    assert policy.fixed_penalty is None
+
+    assert instance.prepare(input_class, policy) is None
+    assert input_class.contains(instance)
+    assert OMMXHighsAdapter.check_applicability(instance).is_applicable
+
+
 def test_error_infeasible_constant_equality_constraint():
     ommx_instance = Instance.from_components(
         decision_variables=[],

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -25,8 +25,11 @@ from ommx import (
     InstanceClass,
     InstanceClassClause,
     Kind,
+    PreparationPolicy,
     Sense,
     Solution,
+    SpecialConstraintKind,
+    SpecialConstraintPreparation,
     State,
     ToState,
 )
@@ -517,6 +520,21 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             )
         ]
     )
+
+    @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        """Recommend lowering OneHot constraints before using PySCIPOpt.
+
+        PySCIPOpt accepts Indicator and SOS1 constraints directly, so this
+        recommendation preserves those families and lowers only OneHot
+        constraints. The returned policy is fresh and may be edited by the
+        caller before :meth:`Instance.prepare` is invoked.
+        """
+        return PreparationPolicy(
+            special_constraints=SpecialConstraintPreparation.lower_special_constraints(
+                kinds={SpecialConstraintKind.OneHot}
+            )
+        )
 
     def __init__(
         self,

--- a/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
@@ -11,7 +11,7 @@ from ommx import (
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
 
 
-def test_adapter_accepts_an_explicitly_prepared_input() -> None:
+def test_recommended_preparation_lowers_only_one_hot() -> None:
     indicator = DecisionVariable.binary(0)
     x = [DecisionVariable.binary(i) for i in range(1, 3)]
     value = DecisionVariable.continuous(3, lower=0, upper=2)
@@ -26,7 +26,12 @@ def test_adapter_accepts_an_explicitly_prepared_input() -> None:
     )
 
     prepared = copy.copy(instance)
-    prepared.lower_special_constraints({SpecialConstraintKind.OneHot})
+    input_class = OMMXPySCIPOptAdapter.INPUT_CLASS
+    assert input_class is not None
+    prepared.prepare(
+        input_class,
+        OMMXPySCIPOptAdapter.recommended_preparation_policy(),
+    )
 
     assert set(instance.one_hot_constraints) == {10}
     assert prepared.active_special_constraint_kinds == {
@@ -46,6 +51,7 @@ def test_adapter_accepts_an_explicitly_prepared_input() -> None:
     assert len(lowered) == 1
     assert lowered[0].provenance[-1].original_id == 10
 
+    assert input_class.contains(prepared)
     report = OMMXPySCIPOptAdapter.check_applicability(prepared)
     assert report.is_applicable
     adapter = OMMXPySCIPOptAdapter(prepared)

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
@@ -22,8 +22,11 @@ from ommx import (
     InstanceClass,
     InstanceClassClause,
     Kind,
+    PreparationPolicy,
     Sense,
     Solution,
+    SpecialConstraintKind,
+    SpecialConstraintPreparation,
     State,
 )
 
@@ -49,6 +52,25 @@ class OMMXPythonMIPAdapter(SolverAdapter):
             )
         ]
     )
+
+    @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        """Recommend lowering special constraints before using Python-MIP.
+
+        Python-MIP currently accepts only regular constraints through this
+        adapter. The recommendation therefore lowers the special-constraint
+        families currently understood by OMMX. The returned policy is fresh and
+        may be edited by the caller before :meth:`Instance.prepare` is invoked.
+        """
+        return PreparationPolicy(
+            special_constraints=SpecialConstraintPreparation.lower_special_constraints(
+                kinds={
+                    SpecialConstraintKind.Indicator,
+                    SpecialConstraintKind.OneHot,
+                    SpecialConstraintKind.Sos1,
+                }
+            )
+        )
 
     def __init__(
         self,

--- a/python/ommx-python-mip-adapter/tests/test_adapter.py
+++ b/python/ommx-python-mip-adapter/tests/test_adapter.py
@@ -171,3 +171,37 @@ def test_rejects_special_constraints_without_mutating_input() -> None:
     assert InstanceClassMismatch.OneHotConstraintsNotAllowed in mismatch_types
     assert InstanceClassMismatch.Sos1ConstraintsNotAllowed in mismatch_types
     assert instance.to_v2_bytes() == before
+
+
+def test_recommended_preparation_reaches_the_python_mip_input_class() -> None:
+    x = DecisionVariable.binary(0)
+    y = DecisionVariable.continuous(1, lower=0, upper=2)
+    instance = Instance.from_components(
+        decision_variables=[x, y],
+        objective=x + y,
+        constraints={},
+        sense=Sense.Minimize,
+        indicator_constraints={
+            10: IndicatorConstraint(
+                indicator_variable=x,
+                function=y - 1,
+                equality=Equality.LessThanOrEqualToZero,
+            )
+        },
+        one_hot_constraints={20: OneHotConstraint(variables=[x])},
+        sos1_constraints={30: Sos1Constraint(variables=[y])},
+    )
+    input_class = OMMXPythonMIPAdapter.INPUT_CLASS
+    assert input_class is not None
+    assert not input_class.contains(instance)
+
+    policy = OMMXPythonMIPAdapter.recommended_preparation_policy()
+    assert policy.special_constraints is not None
+    assert policy.sense is None
+    assert policy.integer_slack is None
+    assert policy.integer_encoding is None
+    assert policy.fixed_penalty is None
+
+    assert instance.prepare(input_class, policy) is None
+    assert input_class.contains(instance)
+    assert OMMXPythonMIPAdapter.check_applicability(instance).is_applicable

--- a/python/ommx-tests/tests/test_instance_class.py
+++ b/python/ommx-tests/tests/test_instance_class.py
@@ -16,7 +16,9 @@ from ommx import (
     InstanceClassMismatch,
     Kind,
     OneHotConstraint,
+    PreparationPolicy,
     Sense,
+    SensePreparation,
     Sos1Constraint,
     SpecialConstraintKind,
 )
@@ -332,6 +334,18 @@ def test_membership_is_recomputed_after_explicit_lowering() -> None:
 
 def test_solver_adapter_has_no_implicit_input_transformation_hook() -> None:
     assert "__init__" not in SolverAdapter.__dict__
+
+
+def test_solver_adapter_returns_a_fresh_empty_preparation_recommendation() -> None:
+    first = SolverAdapter.recommended_preparation_policy()
+    second = SolverAdapter.recommended_preparation_policy()
+
+    assert first == PreparationPolicy()
+    assert second == PreparationPolicy()
+    assert first is not second
+
+    first.sense = SensePreparation.as_minimization_problem()
+    assert second.sense is None
 
 
 def test_solver_adapter_layers_preconditions_and_preserves_the_caller() -> None:

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -12,6 +12,7 @@ from ommx import (
     Instance,
     InstanceClass,
     InstanceClassMembershipReport,
+    PreparationPolicy,
     SampleSet,
     Solution,
 )
@@ -141,6 +142,21 @@ class SolverAdapter(ABC):
     """
 
     INPUT_CLASS: ClassVar[InstanceClass | None] = None
+
+    @classmethod
+    def recommended_preparation_policy(cls) -> PreparationPolicy:
+        """Return a fresh, caller-editable policy recommended by this adapter.
+
+        The recommendation and :attr:`INPUT_CLASS` are independent inputs to
+        :meth:`ommx.Instance.prepare`. This method does not inspect or mutate an
+        instance, execute preparation, or guarantee adapter applicability.
+        Concrete adapters may override it when they can recommend model changes
+        for reaching their input class.
+
+        The default recommendation enables no preparation phases. A new policy
+        is returned on every call so callers may edit it without sharing state.
+        """
+        return PreparationPolicy()
 
     @classmethod
     def check_applicability(cls, ommx_instance: Instance) -> AdapterApplicabilityReport:


### PR DESCRIPTION
## Summary

- add a fresh, caller-editable `SolverAdapter.recommended_preparation_policy()` default
- add capability-aware recommendations for HiGHS, Python-MIP, and PySCIPOpt
- document the caller-owned adapter preparation workflow and HiGHS example in the English and Japanese tutorial and release note

## Design boundary

Recommendations do not inspect or mutate an `Instance`, execute preparation, or guarantee applicability. `INPUT_CLASS` and the policy remain independent inputs. Direct adapter constructors and solve/sample methods remain strict.

HiGHS and Python-MIP recommend lowering Indicator, OneHot, and SOS1 constraints because their direct input classes accept only regular constraints. PySCIPOpt accepts Indicator and SOS1 constraints directly, so it recommends lowering only OneHot constraints. OpenJij migration remains a separate PR.

Part of #1111.
