### PR TITLE
Make fixed penalty weights sense-aware

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -6378,7 +6378,7 @@
             },
             {
               "name": "penalty_method_with_fixed_weights",
-              "doc": "Select the keyed fixed-weight penalty owner operation.",
+              "doc": "Select the keyed fixed-weight penalty owner operation.\n\n``atol`` is used by the owner operation to accept a decision-rule weight\ndown to ``-atol`` and normalize a tolerated negative value to zero.",
               "signatures": [
                 {
                   "parameters": [
@@ -6401,6 +6401,24 @@
                         ]
                       },
                       "default": null
+                    },
+                    {
+                      "name": "atol",
+                      "type_": {
+                        "display": "Optional[float]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "float",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
                     }
                   ],
                   "return_type": {
@@ -6415,7 +6433,7 @@
             },
             {
               "name": "uniform_penalty_method_with_fixed_weight",
-              "doc": "Select the uniform fixed-weight penalty owner operation.",
+              "doc": "Select the uniform fixed-weight penalty owner operation.\n\n``atol`` is used by the owner operation to accept a decision-rule weight\ndown to ``-atol`` and normalize a tolerated negative value to zero.",
               "signatures": [
                 {
                   "parameters": [
@@ -6427,6 +6445,24 @@
                         "children": []
                       },
                       "default": null
+                    },
+                    {
+                      "name": "atol",
+                      "type_": {
+                        "display": "Optional[float]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "float",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
                     }
                   ],
                   "return_type": {

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,7 +8,7 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
-### 🆕 User-controlled `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147), [#1152](https://github.com/Jij-Inc/ommx/pull/1152))
+### 🆕 User-controlled `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147), [#1152](https://github.com/Jij-Inc/ommx/pull/1152), [#1154](https://github.com/Jij-Inc/ommx/pull/1154))
 
 In Python SDK v2, solver adapters selected and performed the model conversions
 needed by their solvers. Python SDK v3 makes this an explicit, caller-owned step.
@@ -47,6 +47,14 @@ Policy fields let the caller allow special-constraint lowering, minimization
 sense normalization, Integer slack, used-Integer encoding, and fixed-weight
 penalties. OMMX applies enabled changes in a fixed order and stops as soon as
 the target contains the instance.
+
+{class}`~ommx.FixedPenaltyPreparation` treats each weight as a nonnegative
+penalty magnitude. When that phase runs, OMMX adds `w * f(x) ** 2` to a
+minimization objective and subtracts it from a maximization objective. Its
+optional `atol` accepts decision-rule output in `[-atol, 0)` and normalizes it
+to zero. A non-finite value or one below `-atol` raises `ValueError` without
+committing the penalty phase. The application remains responsible for choosing
+a sufficiently large magnitude; OMMX neither selects nor caps it.
 
 {meth}`~ommx.Instance.prepare` returns `None` only after target membership is
 reached. If the allowed changes are exhausted first,

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,7 +8,7 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
-### 🆕 ユーザーが制御する `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147)、[#1152](https://github.com/Jij-Inc/ommx/pull/1152))
+### 🆕 ユーザーが制御する `Instance` preparation ([#1147](https://github.com/Jij-Inc/ommx/pull/1147)、[#1152](https://github.com/Jij-Inc/ommx/pull/1152)、[#1154](https://github.com/Jij-Inc/ommx/pull/1154))
 
 Python SDK v2では、solver adapterがsolverに必要なモデル変換を選び、実行していました。
 Python SDK v3では、この操作をユーザーが明示的に制御します。
@@ -45,6 +45,14 @@ solution = OMMXHighsAdapter.solve(instance)
 Policyでは、特殊制約の通常制約化、最小化へのsense統一、Integer slack、使用中の
 Integer変数のencoding、固定weight penaltyを許可できます。OMMXは有効な変換を
 定められた順序で適用し、instanceがtargetに含まれた時点で停止します。
+
+{class}`~ommx.FixedPenaltyPreparation` のweightは、非負のpenalty magnitudeとして
+扱われます。このphaseを適用すると、最小化では `w * f(x) ** 2` を目的関数へ加え、
+最大化では同じ項を引きます。任意指定の `atol` により、決定則の出力が
+`[-atol, 0)` に入る場合は受け入れて0へ正規化します。非有限値または `-atol` より
+小さい値では、penalty phaseをcommitせずに `ValueError` を送出します。用途に十分な
+大きさのweightを選ぶ責任はapplication側にあり、OMMXはweightの決定や上限設定を
+行いません。
 
 {meth}`~ommx.Instance.prepare` が `None` を返すのは、target membershipへ到達した
 場合だけです。許可した変換をすべて使っても到達できない場合は、

--- a/python/ommx-tests/tests/test_preparation.py
+++ b/python/ommx-tests/tests/test_preparation.py
@@ -117,3 +117,47 @@ def test_prepare_exposes_final_report_when_policy_is_exhausted() -> None:
 
     assert not target.contains(instance)
     assert error.value.report == target.check_membership(instance)
+
+
+@pytest.mark.parametrize("keyed", [False, True])
+def test_fixed_penalty_weight_tolerance_reaches_the_owner_boundary(keyed: bool) -> None:
+    target = unconstrained_class(
+        allowed_variable_kinds={Kind.Binary},
+        objective_degree=2,
+    )
+
+    def fixed_penalty(weight: float) -> FixedPenaltyPreparation:
+        if keyed:
+            return FixedPenaltyPreparation.penalty_method_with_fixed_weights(
+                weights={10: weight}, atol=0.1
+            )
+        return FixedPenaltyPreparation.uniform_penalty_method_with_fixed_weight(
+            weight=weight, atol=0.1
+        )
+
+    x = DecisionVariable.binary(0)
+    accepted = Instance.from_components(
+        sense=Sense.Minimize,
+        objective=x,
+        decision_variables=[x],
+        constraints={10: x == 1},
+    )
+    accepted.prepare(
+        target,
+        PreparationPolicy(fixed_penalty=fixed_penalty(-0.1)),
+    )
+    assert target.contains(accepted)
+
+    rejected = Instance.from_components(
+        sense=Sense.Minimize,
+        objective=x,
+        decision_variables=[x],
+        constraints={10: x == 1},
+    )
+    before = rejected.to_v2_bytes()
+    with pytest.raises(ValueError, match="Fixed penalty weight"):
+        rejected.prepare(
+            target,
+            PreparationPolicy(fixed_penalty=fixed_penalty(-0.100_001)),
+        )
+    assert rejected.to_v2_bytes() == before

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -2477,17 +2477,25 @@ class FixedPenaltyPreparation:
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
     def penalty_method_with_fixed_weights(
-        *, weights: typing.Mapping[builtins.int, builtins.float]
+        *,
+        weights: typing.Mapping[builtins.int, builtins.float],
+        atol: typing.Optional[builtins.float] = None,
     ) -> FixedPenaltyPreparation:
         r"""
         Select the keyed fixed-weight penalty owner operation.
+
+        ``atol`` is used by the owner operation to accept a decision-rule weight
+        down to ``-atol`` and normalize a tolerated negative value to zero.
         """
     @staticmethod
     def uniform_penalty_method_with_fixed_weight(
-        *, weight: builtins.float
+        *, weight: builtins.float, atol: typing.Optional[builtins.float] = None
     ) -> FixedPenaltyPreparation:
         r"""
         Select the uniform fixed-weight penalty owner operation.
+
+        ``atol`` is used by the owner operation to accept a decision-rule weight
+        down to ``-atol`` and normalize a tolerated negative value to zero.
         """
 
 @typing.final

--- a/python/ommx/src/error.rs
+++ b/python/ommx/src/error.rs
@@ -463,6 +463,7 @@ define_ommx_error_mappings!(
     ommx::artifact::ImageRefParseError => image_ref_parse_error_to_pyerr,
     ommx::ParameterIDCollision => value_error,
     ommx::AtolError => value_error,
+    ommx::InvalidPenaltyWeight => value_error,
     ommx::BoundError => value_error,
     ommx::SubstitutionError => value_error,
     ommx::CoefficientError => value_error,

--- a/python/ommx/src/preparation.rs
+++ b/python/ommx/src/preparation.rs
@@ -207,26 +207,42 @@ pub struct FixedPenaltyPreparation {
 #[pymethods]
 impl FixedPenaltyPreparation {
     /// Select the keyed fixed-weight penalty owner operation.
+    ///
+    /// ``atol`` is used by the owner operation to accept a decision-rule weight
+    /// down to ``-atol`` and normalize a tolerated negative value to zero.
     #[staticmethod]
-    #[pyo3(signature = (*, weights))]
-    pub fn penalty_method_with_fixed_weights(weights: BTreeMap<u64, f64>) -> Self {
-        Self {
+    #[pyo3(signature = (*, weights, atol=None))]
+    pub fn penalty_method_with_fixed_weights(
+        weights: BTreeMap<u64, f64>,
+        atol: Option<f64>,
+    ) -> OmmxPyResult<Self> {
+        Ok(Self {
             inner: ommx::FixedPenaltyPreparation::PenaltyMethodWithFixedWeights {
                 weights: weights
                     .into_iter()
                     .map(|(id, weight)| (ommx::ConstraintID::from(id), weight))
                     .collect(),
+                atol: resolve_atol(atol)?,
             },
-        }
+        })
     }
 
     /// Select the uniform fixed-weight penalty owner operation.
+    ///
+    /// ``atol`` is used by the owner operation to accept a decision-rule weight
+    /// down to ``-atol`` and normalize a tolerated negative value to zero.
     #[staticmethod]
-    #[pyo3(signature = (*, weight))]
-    pub fn uniform_penalty_method_with_fixed_weight(weight: f64) -> Self {
-        Self {
-            inner: ommx::FixedPenaltyPreparation::UniformPenaltyMethodWithFixedWeight { weight },
-        }
+    #[pyo3(signature = (*, weight, atol=None))]
+    pub fn uniform_penalty_method_with_fixed_weight(
+        weight: f64,
+        atol: Option<f64>,
+    ) -> OmmxPyResult<Self> {
+        Ok(Self {
+            inner: ommx::FixedPenaltyPreparation::UniformPenaltyMethodWithFixedWeight {
+                weight,
+                atol: resolve_atol(atol)?,
+            },
+        })
     }
 }
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -863,17 +863,25 @@ Fixed-weight penalty conversion now provides the in-place owner operations
 and
 [`Instance::uniform_penalty_method_with_fixed_weight`](crate::Instance::uniform_penalty_method_with_fixed_weight).
 The keyed form requires weights for exactly the active regular constraint IDs.
-Both operations add the fixed weighted squares directly to the objective,
-without creating parameter IDs or assignments, and commit only after all
-fallible arithmetic and constraint lifecycle changes succeed. Existing
-parameter assignments remain exactly unchanged. On success, every regular,
-indicator, one-hot, and SOS1 constraint is in its removed collection, so all
-four active collections are empty. Active regular constraints are moved to the
-removed collection and existing removed constraints of every family are
-preserved. Active special constraints are never penalty-converted by these
-operations: their presence returns an error without modifying the instance, so
-callers must lower them first. When no constraint of any family is active, both
-operations are exact identities.
+Both operations interpret each weight as a nonnegative penalty magnitude. For
+minimization they add $w f(x)^2$ to the objective; for maximization they
+subtract it. The caller-supplied `atol` admits a value in `[-atol, 0)` and
+normalizes it to zero. A non-finite value or one below `-atol` returns
+[`InvalidPenaltyWeight`](crate::InvalidPenaltyWeight) without modifying the
+instance. OMMX does not cap the magnitude or decide whether it is large enough
+for an application's penalty rule.
+
+The operations add the fixed weighted squares directly without creating
+parameter IDs or assignments, and commit only after all fallible arithmetic
+and constraint lifecycle changes succeed. Existing parameter assignments
+remain exactly unchanged. On success, every regular, indicator, one-hot, and
+SOS1 constraint is in its removed collection, so all four active collections
+are empty. Active regular constraints are moved to the removed collection and
+existing removed constraints of every family are preserved. Active special
+constraints are never penalty-converted by these operations: their presence
+returns an error without modifying the instance, so callers must lower them
+first. When no constraint of any family is active, both operations are exact
+identities.
 
 [`PreparationPolicy`](crate::PreparationPolicy) and
 [`Instance::prepare`](crate::Instance::prepare) provide the Rust Preparation
@@ -933,7 +941,8 @@ Related PRs: [#1010](https://github.com/Jij-Inc/ommx/pull/1010),
 [#1144](https://github.com/Jij-Inc/ommx/pull/1144),
 [#1145](https://github.com/Jij-Inc/ommx/pull/1145),
 [#1148](https://github.com/Jij-Inc/ommx/pull/1148),
-[#1149](https://github.com/Jij-Inc/ommx/pull/1149).
+[#1149](https://github.com/Jij-Inc/ommx/pull/1149),
+[#1154](https://github.com/Jij-Inc/ommx/pull/1154).
 
 ## ⚙️ Formatting and property-test domains
 

--- a/rust/ommx/doc/tutorial/error_handling.md
+++ b/rust/ommx/doc/tutorial/error_handling.md
@@ -26,8 +26,8 @@ returns the typed error directly):
 
 - [`InfeasibleDetected`](crate::InfeasibleDetected) — produced by [`Propagate`](crate::Propagate) when a constraint
   becomes infeasible after substitution.
-- [`CoefficientError`](crate::CoefficientError), [`BoundError`](crate::BoundError), [`AtolError`](crate::AtolError) — numeric-domain
-  validation failures.
+- [`CoefficientError`](crate::CoefficientError), [`BoundError`](crate::BoundError), [`AtolError`](crate::AtolError),
+  [`InvalidPenaltyWeight`](crate::InvalidPenaltyWeight) — numeric-domain validation failures.
 - [`DecisionVariableError`](crate::DecisionVariableError), [`SubstitutionError`](crate::SubstitutionError), [`SolutionError`](crate::SolutionError),
   [`SampleSetError`](crate::SampleSetError) — domain-specific structured errors consumed by
   in-crate tests and downstream code that wants to react programmatically.

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -19,6 +19,7 @@ mod parametric_builder;
 mod parse;
 mod pass;
 mod penalty;
+pub use penalty::InvalidPenaltyWeight;
 mod preparation;
 mod qubo;
 mod reduce_binary_power;

--- a/rust/ommx/src/instance/penalty.rs
+++ b/rust/ommx/src/instance/penalty.rs
@@ -1,7 +1,43 @@
 use super::*;
-use crate::{linear, Function, ParameterLabel, VariableID};
+use crate::{linear, ATol, Function, ParameterLabel, VariableID};
 use anyhow::Result;
 use std::collections::{BTreeMap, BTreeSet};
+
+/// Signal returned when a fixed penalty weight is outside its numeric domain.
+///
+/// A fixed penalty weight must be finite and no smaller than the negative
+/// absolute tolerance supplied to the owner operation. Callers can inspect the
+/// rejected [`Self::weight`] and [`Self::atol`], revise the weight decision rule
+/// or tolerance, and retry the unchanged [`Instance`].
+#[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+#[error(
+    "Fixed penalty weight must be finite and at least -atol: weight={weight}, atol={atol}",
+    atol = .atol.into_inner()
+)]
+pub struct InvalidPenaltyWeight {
+    weight: f64,
+    atol: ATol,
+}
+
+impl InvalidPenaltyWeight {
+    /// Return the rejected weight.
+    pub fn weight(&self) -> f64 {
+        self.weight
+    }
+
+    /// Return the absolute tolerance used to validate the weight.
+    pub fn atol(&self) -> ATol {
+        self.atol
+    }
+}
+
+fn normalize_fixed_penalty_weight(weight: f64, atol: ATol) -> Result<f64, InvalidPenaltyWeight> {
+    if !weight.is_finite() || weight < -atol {
+        return Err(InvalidPenaltyWeight { weight, atol });
+    }
+    Ok(if weight < 0.0 { 0.0 } else { weight })
+}
 
 impl Instance {
     #[cfg_attr(doc, katexit::katexit)]
@@ -115,9 +151,14 @@ impl Instance {
     /// Convert every active regular constraint to a penalty term with its fixed weight.
     ///
     /// The keys of `weights` must be exactly the active regular constraint IDs.
-    /// Constraint `id` with body $f_{id}(x)$ contributes
-    /// `weights[&id]` $\cdot f_{id}(x)^2$ directly to the objective. No
-    /// parameter ID or assignment is created, and the instance's recorded
+    /// Each weight is a penalty magnitude: it must be finite and at least
+    /// `-atol`. A weight in `[-atol, 0)` is normalized to zero. Constraint `id`
+    /// with body $f_{id}(x)$ contributes $+w_{id} f_{id}(x)^2$ to a minimization
+    /// objective and $-w_{id} f_{id}(x)^2$ to a maximization objective, where
+    /// $w_{id}$ is the normalized nonnegative magnitude. OMMX does not decide
+    /// whether a weight is large enough for an application's penalty rule.
+    ///
+    /// No parameter ID or assignment is created, and the instance's recorded
     /// parameter assignments remain exactly unchanged.
     ///
     /// On success, every regular, indicator, one-hot, and SOS1 constraint is in
@@ -135,12 +176,14 @@ impl Instance {
     /// # Errors
     ///
     /// Returns an error if an unsupported active special constraint is present,
-    /// if `weights` does not cover exactly the active regular constraints, or
-    /// if constructing or adding a penalty term fails. Any error leaves the
-    /// instance unchanged.
+    /// if `weights` does not cover exactly the active regular constraints, if a
+    /// weight is invalid, or if constructing or adding a penalty term fails.
+    /// Invalid weights retain [`InvalidPenaltyWeight`] in the error chain. Any
+    /// error leaves the instance unchanged.
     pub fn penalty_method_with_fixed_weights(
         &mut self,
         weights: &BTreeMap<ConstraintID, f64>,
+        atol: ATol,
     ) -> crate::Result<()> {
         let operation = "penalty_method_with_fixed_weights";
         self.ensure_penalty_method_supported(operation)?;
@@ -149,12 +192,18 @@ impl Instance {
             return Ok(());
         }
 
+        let normalized_weights = weights
+            .iter()
+            .map(|(&id, &weight)| Ok((id, normalize_fixed_penalty_weight(weight, atol)?)))
+            .collect::<Result<BTreeMap<_, _>, InvalidPenaltyWeight>>()?;
+
         let mut objective = self.objective.clone();
         for (&id, constraint) in self.constraint_collection.active() {
             let function = constraint.function();
             let mut penalty_term = function.clone();
             penalty_term.try_mul_assign_in_place(function)?;
-            penalty_term.try_mul_assign_in_place(&Function::try_from(weights[&id])?)?;
+            let weight = self.fixed_penalty_objective_coefficient(normalized_weights[&id]);
+            penalty_term.try_mul_assign_in_place(&Function::try_from(weight)?)?;
             objective.try_add_assign_in_place(penalty_term)?;
         }
         self.commit_fixed_penalty(objective, operation)
@@ -279,10 +328,15 @@ impl Instance {
     #[cfg_attr(doc, katexit::katexit)]
     /// Convert every active regular constraint to a penalty term with one fixed weight.
     ///
-    /// Each constraint body $f_i(x)$ contributes `weight` $\cdot f_i(x)^2$
-    /// directly to the objective. No parameter ID or assignment is created,
-    /// and the instance's recorded parameter assignments remain exactly
-    /// unchanged.
+    /// `weight` is a penalty magnitude: it must be finite and at least `-atol`.
+    /// A value in `[-atol, 0)` is normalized to zero. Each constraint body
+    /// $f_i(x)$ contributes $+w f_i(x)^2$ to a minimization objective and
+    /// $-w f_i(x)^2$ to a maximization objective, where $w$ is the normalized
+    /// nonnegative magnitude. OMMX does not decide whether the weight is large
+    /// enough for an application's penalty rule.
+    ///
+    /// No parameter ID or assignment is created, and the instance's recorded
+    /// parameter assignments remain exactly unchanged.
     ///
     /// On success, every regular, indicator, one-hot, and SOS1 constraint is in
     /// its removed collection; all four active collections are empty. Every
@@ -299,14 +353,22 @@ impl Instance {
     /// # Errors
     ///
     /// Returns an error if an unsupported active special constraint is present,
-    /// or if constructing or adding the penalty term fails. Any error leaves
-    /// the instance unchanged.
-    pub fn uniform_penalty_method_with_fixed_weight(&mut self, weight: f64) -> crate::Result<()> {
+    /// if `weight` is invalid, or if constructing or adding the penalty term
+    /// fails. Invalid weights retain [`InvalidPenaltyWeight`] in the error
+    /// chain. Any error leaves the instance unchanged.
+    pub fn uniform_penalty_method_with_fixed_weight(
+        &mut self,
+        weight: f64,
+        atol: ATol,
+    ) -> crate::Result<()> {
         let operation = "uniform_penalty_method_with_fixed_weight";
         self.ensure_penalty_method_supported(operation)?;
         if self.constraints().is_empty() {
             return Ok(());
         }
+
+        let weight = normalize_fixed_penalty_weight(weight, atol)?;
+        let weight = self.fixed_penalty_objective_coefficient(weight);
 
         let mut penalty_term = Function::zero();
         for constraint in self.constraint_collection.active().values() {
@@ -320,6 +382,13 @@ impl Instance {
         let mut objective = self.objective.clone();
         objective.try_add_assign_in_place(penalty_term)?;
         self.commit_fixed_penalty(objective, operation)
+    }
+
+    fn fixed_penalty_objective_coefficient(&self, weight: f64) -> f64 {
+        match self.sense() {
+            Sense::Minimize => weight,
+            Sense::Maximize => -weight,
+        }
     }
 
     fn ensure_penalty_method_supported(&self, operation: &str) -> crate::Result<()> {
@@ -784,7 +853,7 @@ mod tests {
         let mut instance = create_test_instance_with_constraints();
 
         instance
-            .uniform_penalty_method_with_fixed_weight(2.0)
+            .uniform_penalty_method_with_fixed_weight(2.0, ATol::default())
             .unwrap();
 
         assert_no_active_constraints(&instance);
@@ -806,7 +875,7 @@ mod tests {
         let mut zero_weight = create_test_instance_with_constraints();
         let objective = zero_weight.objective().clone();
         zero_weight
-            .uniform_penalty_method_with_fixed_weight(0.0)
+            .uniform_penalty_method_with_fixed_weight(0.0, ATol::default())
             .unwrap();
         assert_eq!(
             zero_weight
@@ -816,6 +885,129 @@ mod tests {
             objective.evaluate(&state, ATol::default()).unwrap()
         );
         assert_no_active_constraints(&zero_weight);
+    }
+
+    #[test]
+    fn fixed_penalty_direction_follows_instance_sense() {
+        let state = State::from_iter([(1, 2.0), (2, 1.0)]);
+
+        let mut uniform = create_test_instance_with_constraints();
+        uniform.sense = Sense::Maximize;
+        uniform
+            .uniform_penalty_method_with_fixed_weight(2.0, ATol::default())
+            .unwrap();
+        assert_eq!(
+            uniform
+                .objective()
+                .evaluate(&state, ATol::default())
+                .unwrap(),
+            -7.0
+        );
+
+        let mut keyed = create_test_instance_with_constraints();
+        keyed.sense = Sense::Maximize;
+        keyed
+            .penalty_method_with_fixed_weights(
+                &BTreeMap::from([(ConstraintID::from(1), 2.0), (ConstraintID::from(2), 3.0)]),
+                ATol::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            keyed.objective().evaluate(&state, ATol::default()).unwrap(),
+            -8.0
+        );
+    }
+
+    #[test]
+    fn fixed_penalty_normalizes_tolerated_negative_weights_to_zero() {
+        let atol = ATol::new(0.1).unwrap();
+        let state = State::from_iter([(1, 2.0), (2, 1.0)]);
+
+        let mut uniform = create_test_instance_with_constraints();
+        let uniform_objective = uniform.objective().clone();
+        uniform
+            .uniform_penalty_method_with_fixed_weight(-0.1, atol)
+            .unwrap();
+        assert_eq!(
+            uniform
+                .objective()
+                .evaluate(&state, ATol::default())
+                .unwrap(),
+            uniform_objective.evaluate(&state, ATol::default()).unwrap()
+        );
+        assert_no_active_constraints(&uniform);
+
+        let mut keyed = create_test_instance_with_constraints();
+        let keyed_objective = keyed.objective().clone();
+        keyed
+            .penalty_method_with_fixed_weights(
+                &BTreeMap::from([
+                    (ConstraintID::from(1), -0.1),
+                    (ConstraintID::from(2), -0.05),
+                ]),
+                atol,
+            )
+            .unwrap();
+        assert_eq!(
+            keyed.objective().evaluate(&state, ATol::default()).unwrap(),
+            keyed_objective.evaluate(&state, ATol::default()).unwrap()
+        );
+        assert_no_active_constraints(&keyed);
+    }
+
+    #[test]
+    fn fixed_penalty_rejects_weights_below_tolerance_atomically() {
+        let atol = ATol::new(0.1).unwrap();
+        let before = create_test_instance_with_constraints();
+
+        let mut uniform = before.clone();
+        let error = uniform
+            .uniform_penalty_method_with_fixed_weight(-0.100_001, atol)
+            .unwrap_err();
+        let signal = error.downcast_ref::<InvalidPenaltyWeight>().unwrap();
+        assert_eq!(signal.weight(), -0.100_001);
+        assert_eq!(signal.atol(), atol);
+        assert_eq!(uniform, before);
+
+        let mut keyed = before.clone();
+        let error = keyed
+            .penalty_method_with_fixed_weights(
+                &BTreeMap::from([
+                    (ConstraintID::from(1), 2.0),
+                    (ConstraintID::from(2), -0.100_001),
+                ]),
+                atol,
+            )
+            .unwrap_err();
+        assert!(error.is::<InvalidPenaltyWeight>());
+        assert_eq!(keyed, before);
+    }
+
+    #[test]
+    fn fixed_penalty_rejects_non_finite_weights_atomically() {
+        for weight in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let before = create_test_instance_with_constraints();
+
+            let mut uniform = before.clone();
+            let error = uniform
+                .uniform_penalty_method_with_fixed_weight(weight, ATol::default())
+                .unwrap_err();
+            assert!(error.is::<InvalidPenaltyWeight>());
+            assert_eq!(uniform, before);
+
+            let mut keyed = before.clone();
+            let error = keyed
+                .penalty_method_with_fixed_weights(
+                    &BTreeMap::from([
+                        (ConstraintID::from(1), 2.0),
+                        (ConstraintID::from(2), weight),
+                    ]),
+                    ATol::default(),
+                )
+                .unwrap_err();
+            assert!(error.is::<InvalidPenaltyWeight>());
+            assert_eq!(keyed, before);
+        }
     }
 
     #[test]
@@ -836,7 +1028,7 @@ mod tests {
         let weights = BTreeMap::from([(ConstraintID::from(1), 2.0), (ConstraintID::from(2), 3.0)]);
 
         instance
-            .penalty_method_with_fixed_weights(&weights)
+            .penalty_method_with_fixed_weights(&weights, ATol::default())
             .unwrap();
 
         assert_no_active_constraints(&instance);
@@ -877,12 +1069,12 @@ mod tests {
         let before = instance.clone();
 
         instance
-            .penalty_method_with_fixed_weights(&BTreeMap::new())
+            .penalty_method_with_fixed_weights(&BTreeMap::new(), ATol::default())
             .unwrap();
         assert_eq!(instance, before);
 
         instance
-            .uniform_penalty_method_with_fixed_weight(2.0)
+            .uniform_penalty_method_with_fixed_weight(2.0, ATol::default())
             .unwrap();
         assert_eq!(instance, before);
     }
@@ -902,7 +1094,7 @@ mod tests {
         for weights in cases {
             let mut instance = before.clone();
             let err = instance
-                .penalty_method_with_fixed_weights(&weights)
+                .penalty_method_with_fixed_weights(&weights, ATol::default())
                 .unwrap_err();
 
             assert!(err.to_string().contains("constraint IDs"));
@@ -922,13 +1114,13 @@ mod tests {
 
             let mut keyed = before.clone();
             keyed
-                .penalty_method_with_fixed_weights(&weights)
+                .penalty_method_with_fixed_weights(&weights, ATol::default())
                 .unwrap_err();
             assert_eq!(keyed, before);
 
             let mut uniform = before.clone();
             uniform
-                .uniform_penalty_method_with_fixed_weight(2.0)
+                .uniform_penalty_method_with_fixed_weight(2.0, ATol::default())
                 .unwrap_err();
             assert_eq!(uniform, before);
         }
@@ -987,7 +1179,9 @@ mod tests {
 
         let mut keyed = lowered.clone();
         let weights = keyed.constraints().keys().map(|id| (*id, 2.0)).collect();
-        keyed.penalty_method_with_fixed_weights(&weights).unwrap();
+        keyed
+            .penalty_method_with_fixed_weights(&weights, ATol::default())
+            .unwrap();
         assert_no_active_constraints(&keyed);
         assert_eq!(keyed.removed_constraints().len(), regular_constraint_count);
         assert_eq!(
@@ -1004,7 +1198,7 @@ mod tests {
 
         let mut uniform = lowered;
         uniform
-            .uniform_penalty_method_with_fixed_weight(2.0)
+            .uniform_penalty_method_with_fixed_weight(2.0, ATol::default())
             .unwrap();
         assert_no_active_constraints(&uniform);
         assert_eq!(
@@ -1035,17 +1229,17 @@ mod tests {
         let mut keyed = create_test_instance_with_constraints();
         keyed.parameters = parameters.clone();
         keyed
-            .penalty_method_with_fixed_weights(&BTreeMap::from([
-                (ConstraintID::from(1), 2.0),
-                (ConstraintID::from(2), 3.0),
-            ]))
+            .penalty_method_with_fixed_weights(
+                &BTreeMap::from([(ConstraintID::from(1), 2.0), (ConstraintID::from(2), 3.0)]),
+                ATol::default(),
+            )
             .unwrap();
         assert_eq!(keyed.parameters, parameters);
 
         let mut uniform = create_test_instance_with_constraints();
         uniform.parameters = parameters.clone();
         uniform
-            .uniform_penalty_method_with_fixed_weight(2.0)
+            .uniform_penalty_method_with_fixed_weight(2.0, ATol::default())
             .unwrap();
         assert_eq!(uniform.parameters, parameters);
     }
@@ -1075,7 +1269,7 @@ mod tests {
         let before = uniform.clone();
 
         let err = uniform
-            .uniform_penalty_method_with_fixed_weight(f64::MAX)
+            .uniform_penalty_method_with_fixed_weight(f64::MAX, ATol::default())
             .unwrap_err();
         assert!(matches!(
             err.downcast_ref::<crate::CoefficientError>(),
@@ -1086,7 +1280,10 @@ mod tests {
         let mut keyed = make_instance();
         let before = keyed.clone();
         let err = keyed
-            .penalty_method_with_fixed_weights(&BTreeMap::from([(ConstraintID::from(1), f64::MAX)]))
+            .penalty_method_with_fixed_weights(
+                &BTreeMap::from([(ConstraintID::from(1), f64::MAX)]),
+                ATol::default(),
+            )
             .unwrap_err();
         assert!(matches!(
             err.downcast_ref::<crate::CoefficientError>(),

--- a/rust/ommx/src/instance/preparation.rs
+++ b/rust/ommx/src/instance/preparation.rs
@@ -83,11 +83,15 @@ pub enum FixedPenaltyPreparation {
     PenaltyMethodWithFixedWeights {
         /// Constraint-ID-keyed weights passed unchanged to the owner operation.
         weights: BTreeMap<ConstraintID, f64>,
+        /// Absolute tolerance passed to the owner operation for weight validation.
+        atol: ATol,
     },
     /// Invoke [`Instance::uniform_penalty_method_with_fixed_weight`].
     UniformPenaltyMethodWithFixedWeight {
         /// Weight passed unchanged to the owner operation.
         weight: f64,
+        /// Absolute tolerance passed to the owner operation for weight validation.
+        atol: ATol,
     },
 }
 
@@ -125,7 +129,10 @@ pub enum FixedPenaltyPreparation {
 ///     slack_upper_bound: None,
 /// });
 /// policy.fixed_penalty = Some(
-///     FixedPenaltyPreparation::UniformPenaltyMethodWithFixedWeight { weight: 2.0 },
+///     FixedPenaltyPreparation::UniformPenaltyMethodWithFixedWeight {
+///         weight: 2.0,
+///         atol: ATol::default(),
+///     },
 /// );
 /// ```
 #[non_exhaustive]
@@ -234,11 +241,11 @@ impl PreparationStep for IntegerEncodingPreparation {
 impl PreparationStep for FixedPenaltyPreparation {
     fn apply(&self, instance: &mut Instance) -> crate::Result<()> {
         match self {
-            Self::PenaltyMethodWithFixedWeights { weights } => {
-                instance.penalty_method_with_fixed_weights(weights)?;
+            Self::PenaltyMethodWithFixedWeights { weights, atol } => {
+                instance.penalty_method_with_fixed_weights(weights, *atol)?;
             }
-            Self::UniformPenaltyMethodWithFixedWeight { weight } => {
-                instance.uniform_penalty_method_with_fixed_weight(*weight)?;
+            Self::UniformPenaltyMethodWithFixedWeight { weight, atol } => {
+                instance.uniform_penalty_method_with_fixed_weight(*weight, *atol)?;
             }
         }
         Ok(())
@@ -380,6 +387,7 @@ mod tests {
         let policy = PreparationPolicy {
             fixed_penalty: Some(FixedPenaltyPreparation::PenaltyMethodWithFixedWeights {
                 weights: BTreeMap::from([(ConstraintID::from(999), 1.0)]),
+                atol: ATol::default(),
             }),
             ..Default::default()
         };
@@ -514,6 +522,7 @@ mod tests {
             }),
             fixed_penalty: Some(FixedPenaltyPreparation::PenaltyMethodWithFixedWeights {
                 weights: BTreeMap::from([(ConstraintID::from(999), 1.0)]),
+                atol: ATol::default(),
             }),
             ..Default::default()
         };


### PR DESCRIPTION
## Summary

- interpret fixed penalty weights as nonnegative magnitudes and orient their objective contribution by the `Instance` sense
- accept decision-rule weights down to `-atol`, normalize tolerated negative values to zero, and expose invalid values as a typed owner signal
- carry the owner tolerance through Rust and Python Preparation, including `ValueError` mapping and regenerated Python API metadata
- document the fixed-weight contract in the Rust and English/Japanese Python release notes

## Contract

`penalty_method_with_fixed_weights` and `uniform_penalty_method_with_fixed_weight` add `+w f(x)^2` for minimization and `-w f(x)^2` for maximization after normalizing `-atol <= w < 0` to zero. Non-finite values and values below `-atol` fail without modifying the `Instance`.

OMMX does not cap fixed weights or decide whether a magnitude is sufficient for an application's penalty rule. Existing parameterized penalty operations are unchanged.
