### PR TITLE
Require concrete adapter input classes

### DIFF
--- a/docs/en/migration/python_sdk_v2_to_v3.md
+++ b/docs/en/migration/python_sdk_v2_to_v3.md
@@ -429,7 +429,6 @@ from ommx import FixedPenaltyPreparation, IntegerSlackPreparation
 from ommx_openjij_adapter import OMMXOpenJijSAAdapter
 
 input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-assert input_class is not None
 policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
 policy.integer_slack = IntegerSlackPreparation(
     max_integer_range=32,

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,6 +8,16 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
+### Adapter input classes are required ([#1160](https://github.com/Jij-Inc/ommx/pull/1160))
+
+Concrete `SolverAdapter` and `SamplerAdapter` implementations must declare
+`INPUT_CLASS` as a non-optional `ClassVar[InstanceClass]`; `None` is not a valid
+declaration. In-repository adapters now expose `InstanceClass` directly, so
+callers can pass `Adapter.INPUT_CLASS` to {meth}`~ommx.Instance.prepare` without
+an `is not None` guard. A missing declaration still produces a clear `TypeError`
+when applicability is checked. See the [Adapter implementation tutorial](../tutorial/implement_adapter.md)
+for the complete contract.
+
 ## 3.0.0 Beta 3
 
 [![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b3-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b3)

--- a/docs/en/tutorial/implement_adapter.md
+++ b/docs/en/tutorial/implement_adapter.md
@@ -281,9 +281,11 @@ def decode_to_state(model: pyscipopt.Model, instance: Instance) -> State:
 Finally, create a class that inherits `ommx.adapter.SolverAdapter` to standardize the API for each adapter. This is an abstract base class with `@abstractmethod` as follows:
 
 ```python
+from typing import ClassVar
+
 class SolverAdapter(ABC):
     # OMMX-defined structural condition for adapter applicability.
-    INPUT_CLASS: InstanceClass | None = None
+    INPUT_CLASS: ClassVar[InstanceClass]
 
     @classmethod
     def recommended_preparation_policy(cls) -> PreparationPolicy:
@@ -441,7 +443,6 @@ The caller decides whether to use and modify the recommendation before invoking 
 
 ```python
 input_class = OMMXPySCIPOptAdapter.INPUT_CLASS
-assert input_class is not None
 policy = OMMXPySCIPOptAdapter.recommended_preparation_policy()
 # Edit public policy fields here when the application needs different choices.
 instance.prepare(input_class, policy)
@@ -569,10 +570,22 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     Sampling QUBO with Simulated Annealing (SA) by `openjij.SASampler`
     """
 
+    INPUT_CLASS = InstanceClass(
+        [
+            InstanceClassClause(
+                label="tutorial-binary-qubo",
+                allowed_variable_kinds={Kind.Binary},
+                objective_degree_bound=DegreeBound.at_most(2),
+                allowed_senses={Sense.Minimize},
+            )
+        ]
+    )
+
     # Retain the Instance because it is required to convert to SampleSet
     ommx_instance: Instance
     
     def __init__(self, ommx_instance: Instance):
+        self.require_applicable(ommx_instance)
         self.ommx_instance = ommx_instance
 
     # Perform sampling
@@ -580,7 +593,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
         sampler = oj.SASampler()
         # Convert to QUBO dictionary format
         # If the Instance is not in QUBO format, an error will be raised here
-        qubo, _offset = self.ommx_instance.to_qubo()
+        qubo, _offset = self.ommx_instance.as_qubo_format()
         return sampler.sample_qubo(qubo)
 
     # Common method for performing sampling
@@ -599,7 +612,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     # In this adapter, `SamplerInput` uses a QUBO dictionary
     @property
     def sampler_input(self) -> dict[tuple[int, int], float]:
-        qubo, _offset = self.ommx_instance.to_qubo()
+        qubo, _offset = self.ommx_instance.as_qubo_format()
         return qubo
    
     # Convert OpenJij Response to a SampleSet
@@ -632,12 +645,11 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
 
 ### Sampling using our Adapter
 
-Let's sample from the following optimization problem using our Adapter:
+Let's sample from the following QUBO using our Adapter:
 
 $$
 \begin{aligned}
-\max & \quad x_0 + x_1 \\
-\text{s.t.} & \quad x_0 \cdot x_1 = 1 \\
+\min & \quad -x_0 - x_1 + 2 x_0 x_1 \\
 & \quad x_0, x_1 \in \{0, 1\}
 \end{aligned}
 $$
@@ -646,9 +658,9 @@ $$
 x = [DecisionVariable.binary(id, name="x", subscripts=[id]) for id in range(2)]
 instance = Instance.from_components(
     decision_variables=x,
-    objective=x[0] + x[1],
-    constraints={0: x[0] * x[1] == 1},
-    sense=Instance.MAXIMIZE,
+    objective=-x[0] - x[1] + 2 * x[0] * x[1],
+    constraints={},
+    sense=Instance.MINIMIZE,
 )
 
 sample_set = OMMXOpenJijSAAdapter.sample(instance)

--- a/docs/en/tutorial/tsp_sampling_with_openjij_adapter.ipynb
+++ b/docs/en/tutorial/tsp_sampling_with_openjij_adapter.ipynb
@@ -234,7 +234,6 @@
     "from ommx_openjij_adapter import OMMXOpenJijSAAdapter\n",
     "\n",
     "input_class = OMMXOpenJijSAAdapter.INPUT_CLASS\n",
-    "assert input_class is not None\n",
     "\n",
     "# Start from the model conversions recommended for OpenJij.\n",
     "policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()\n",

--- a/docs/ja/migration/python_sdk_v2_to_v3.md
+++ b/docs/ja/migration/python_sdk_v2_to_v3.md
@@ -262,7 +262,6 @@ from ommx import FixedPenaltyPreparation, IntegerSlackPreparation
 from ommx_openjij_adapter import OMMXOpenJijSAAdapter
 
 input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-assert input_class is not None
 policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
 policy.integer_slack = IntegerSlackPreparation(
     max_integer_range=32,

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,6 +8,16 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
+### Adapter の input class 宣言を必須化 ([#1160](https://github.com/Jij-Inc/ommx/pull/1160))
+
+具体的な `SolverAdapter` / `SamplerAdapter` 実装では、`INPUT_CLASS` を
+非 Optional の `ClassVar[InstanceClass]` として宣言する必要があり、`None` は
+有効な宣言ではありません。リポジトリ内の Adapter も `InstanceClass` を直接公開するため、
+呼び出し側は `is not None` の確認なしで `Adapter.INPUT_CLASS` を
+{meth}`~ommx.Instance.prepare` に渡せます。宣言がない場合は、applicability の確認時に
+引き続き明確な `TypeError` を送出します。契約の全体像は
+[Adapter 実装チュートリアル](../tutorial/implement_adapter.md)を参照してください。
+
 ## 3.0.0 Beta 3
 
 [![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b3-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b3)

--- a/docs/ja/tutorial/implement_adapter.md
+++ b/docs/ja/tutorial/implement_adapter.md
@@ -277,9 +277,11 @@ def decode_to_state(model: pyscipopt.Model, instance: Instance) -> State:
 最後に、Adapter毎のAPIを揃えるために `ommx.adapter.SolverAdapter` を継承したクラスを作成します。これは `@abstractmethod` を含む次のような抽象基底クラスです：
 
 ```python
+from typing import ClassVar
+
 class SolverAdapter(ABC):
     # Adapter applicability の OMMX 定義の構造条件
-    INPUT_CLASS: InstanceClass | None = None
+    INPUT_CLASS: ClassVar[InstanceClass]
 
     @classmethod
     def recommended_preparation_policy(cls) -> PreparationPolicy:
@@ -437,7 +439,6 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
 ```python
 input_class = OMMXPySCIPOptAdapter.INPUT_CLASS
-assert input_class is not None
 policy = OMMXPySCIPOptAdapter.recommended_preparation_policy()
 # Application に異なる選択が必要なら、ここで public field を編集します。
 instance.prepare(input_class, policy)
@@ -563,10 +564,22 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     Sampling QUBO with Simulated Annealing (SA) by `openjij.SASampler`
     """
 
+    INPUT_CLASS = InstanceClass(
+        [
+            InstanceClassClause(
+                label="tutorial-binary-qubo",
+                allowed_variable_kinds={Kind.Binary},
+                objective_degree_bound=DegreeBound.at_most(2),
+                allowed_senses={Sense.Minimize},
+            )
+        ]
+    )
+
     # SampleSetに変換する必要があるので、Instanceを保持
     ommx_instance: Instance
     
     def __init__(self, ommx_instance: Instance):
+        self.require_applicable(ommx_instance)
         self.ommx_instance = ommx_instance
 
     # サンプリングを行う
@@ -574,7 +587,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
         sampler = oj.SASampler()
         # QUBOの辞書形式に変換
         # InstanceがQUBO形式でなければここでエラーになる
-        qubo, _offset = self.ommx_instance.to_qubo()
+        qubo, _offset = self.ommx_instance.as_qubo_format()
         return sampler.sample_qubo(qubo)
 
     # サンプリングを行う共通のメソッド
@@ -593,7 +606,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     # このAdapterでは `SamplerInput` は QUBO形式の辞書を使うことにする
     @property
     def sampler_input(self) -> dict[tuple[int, int], float]:
-        qubo, _offset = self.ommx_instance.to_qubo()
+        qubo, _offset = self.ommx_instance.as_qubo_format()
         return qubo
    
     # OpenJijのResponseをSampleSetに変換
@@ -626,12 +639,11 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
 
 ### Sampler Adapterを使って簡単なサンプリングを行う
 
-動作確認のため、これを使って次の最適化問題からサンプリングを行ってみましょう
+動作確認のため、これを使って次のQUBOからサンプリングを行ってみましょう
 
 $$
 \begin{aligned}
-\max & \quad x_0 + x_1 \\
-\text{s.t.} & \quad x_0 \cdot x_1 = 1 \\
+\min & \quad -x_0 - x_1 + 2 x_0 x_1 \\
 & \quad x_0, x_1 \in \{0, 1\}
 \end{aligned}
 $$
@@ -640,9 +652,9 @@ $$
 x = [DecisionVariable.binary(id, name="x", subscripts=[id]) for id in range(2)]
 instance = Instance.from_components(
     decision_variables=x,
-    objective=x[0] + x[1],
-    constraints={0: x[0] * x[1] == 1},
-    sense=Instance.MAXIMIZE,
+    objective=-x[0] - x[1] + 2 * x[0] * x[1],
+    constraints={},
+    sense=Instance.MINIMIZE,
 )
 
 sample_set = OMMXOpenJijSAAdapter.sample(instance)

--- a/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.ipynb
+++ b/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.ipynb
@@ -230,7 +230,6 @@
     "from ommx_openjij_adapter import OMMXOpenJijSAAdapter\n",
     "\n",
     "input_class = OMMXOpenJijSAAdapter.INPUT_CLASS\n",
-    "assert input_class is not None\n",
     "\n",
     "# OpenJij向けに推奨されるモデル変換から始めます。\n",
     "policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()\n",

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -577,7 +577,7 @@ class OMMXHighsAdapter(SolverAdapter):
 
     """
 
-    INPUT_CLASS: ClassVar[InstanceClass | None] = InstanceClass(
+    INPUT_CLASS: ClassVar[InstanceClass] = InstanceClass(
         [
             InstanceClassClause(
                 label="highs-linear-mip",

--- a/python/ommx-highs-adapter/tests/test_error.py
+++ b/python/ommx-highs-adapter/tests/test_error.py
@@ -20,7 +20,6 @@ from ommx_highs_adapter import OMMXHighsAdapter, OMMXHighsAdapterError
 
 def test_declares_linear_mip_input_class():
     input_class = OMMXHighsAdapter.INPUT_CLASS
-    assert input_class is not None
     [clause] = input_class.clauses
     assert clause.label == "highs-linear-mip"
     assert clause.allowed_variable_kinds == {
@@ -196,7 +195,6 @@ def test_recommended_preparation_reaches_the_highs_input_class():
         sos1_constraints={30: Sos1Constraint(variables=[y])},
     )
     input_class = OMMXHighsAdapter.INPUT_CLASS
-    assert input_class is not None
     assert not input_class.contains(instance)
 
     policy = OMMXHighsAdapter.recommended_preparation_policy()

--- a/python/ommx-openjij-adapter/README.md
+++ b/python/ommx-openjij-adapter/README.md
@@ -27,7 +27,6 @@ instance = Instance.from_components(
 )
 
 input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-assert input_class is not None
 policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
 policy.fixed_penalty = FixedPenaltyPreparation.uniform_penalty_method_with_fixed_weight(
     weight=2.0

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/adapter.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/adapter.py
@@ -54,7 +54,7 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     fixed penalty magnitudes, and apply the policy with :meth:`Instance.prepare`.
     """
 
-    INPUT_CLASS: ClassVar[InstanceClass | None] = InstanceClass(
+    INPUT_CLASS: ClassVar[InstanceClass] = InstanceClass(
         [
             InstanceClassClause(
                 label="openjij-binary-hubo",

--- a/python/ommx-openjij-adapter/tests/test_applicability.py
+++ b/python/ommx-openjij-adapter/tests/test_applicability.py
@@ -57,7 +57,6 @@ def _assert_direct_rejection_does_not_mutate(
 
 def test_declares_binary_polynomial_input_class() -> None:
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-    assert input_class is not None
 
     [clause] = input_class.clauses
     assert clause.label == "openjij-binary-hubo"
@@ -219,7 +218,6 @@ def test_recommended_policy_keeps_fixed_penalty_caller_owned() -> None:
         sense=Sense.Minimize,
     )
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-    assert input_class is not None
 
     policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
     assert policy.fixed_penalty is None
@@ -255,7 +253,6 @@ def test_recommended_preparation_reaches_the_openjij_input_class() -> None:
     )
     alias = instance
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-    assert input_class is not None
     assert not input_class.contains(instance)
 
     policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
@@ -278,7 +275,6 @@ def test_adapter_specific_preconditions_still_follow_preparation() -> None:
         sense=Sense.Maximize,
     )
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-    assert input_class is not None
 
     instance.prepare(
         input_class,

--- a/python/ommx-openjij-adapter/tests/test_experiment.py
+++ b/python/ommx-openjij-adapter/tests/test_experiment.py
@@ -13,7 +13,6 @@ def test_log_sample_records_the_exact_prepared_adapter_input() -> None:
         sense=Sense.Maximize,
     )
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-    assert input_class is not None
     policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
     policy.fixed_penalty = (
         FixedPenaltyPreparation.uniform_penalty_method_with_fixed_weight(weight=2.0)

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -164,7 +164,6 @@ def hubo_binary_inequality():
 def _openjij_input(instance):
     if not OMMXOpenJijSAAdapter.check_applicability(instance).is_applicable:
         input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-        assert input_class is not None
         policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
         policy.fixed_penalty = (
             FixedPenaltyPreparation.uniform_penalty_method_with_fixed_weight(weight=3.1)
@@ -339,7 +338,6 @@ def test_prepared_instance_evaluation_populates_variable_removed_with_trivial_in
         sense=Instance.MINIMIZE,
     )
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-    assert input_class is not None
     instance.prepare(
         input_class,
         OMMXOpenJijSAAdapter.recommended_preparation_policy(),
@@ -368,7 +366,6 @@ def test_prepared_instance_evaluation_restores_integer_sos1():
     )
 
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
-    assert input_class is not None
     policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
     policy.fixed_penalty = (
         FixedPenaltyPreparation.uniform_penalty_method_with_fixed_weight(weight=4.0)

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -503,7 +503,7 @@ def _dataframe(
 
 
 class OMMXPySCIPOptAdapter(SolverAdapter):
-    INPUT_CLASS: ClassVar[InstanceClass | None] = InstanceClass(
+    INPUT_CLASS: ClassVar[InstanceClass] = InstanceClass(
         [
             InstanceClassClause(
                 label="pyscipopt-quadratic-mip",

--- a/python/ommx-pyscipopt-adapter/tests/test_error.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_error.py
@@ -24,7 +24,6 @@ from ommx import (
 
 def test_declares_quadratic_mip_input_class():
     input_class = OMMXPySCIPOptAdapter.INPUT_CLASS
-    assert input_class is not None
     [clause] = input_class.clauses
     assert clause.label == "pyscipopt-quadratic-mip"
     assert clause.allowed_variable_kinds == {

--- a/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
@@ -27,7 +27,6 @@ def test_recommended_preparation_lowers_only_one_hot() -> None:
 
     prepared = copy.copy(instance)
     input_class = OMMXPySCIPOptAdapter.INPUT_CLASS
-    assert input_class is not None
     prepared.prepare(
         input_class,
         OMMXPySCIPOptAdapter.recommended_preparation_policy(),

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
@@ -41,7 +41,7 @@ _LINEAR_CONSTRAINT_DEGREE_BOUNDS = {
 
 
 class OMMXPythonMIPAdapter(SolverAdapter):
-    INPUT_CLASS: ClassVar[InstanceClass | None] = InstanceClass(
+    INPUT_CLASS: ClassVar[InstanceClass] = InstanceClass(
         [
             InstanceClassClause(
                 label="python-mip-linear-mip",

--- a/python/ommx-python-mip-adapter/tests/test_adapter.py
+++ b/python/ommx-python-mip-adapter/tests/test_adapter.py
@@ -18,7 +18,6 @@ from ommx_python_mip_adapter import OMMXPythonMIPAdapter
 
 def test_declares_linear_mip_input_class() -> None:
     input_class = OMMXPythonMIPAdapter.INPUT_CLASS
-    assert input_class is not None
     [clause] = input_class.clauses
 
     assert clause.label == "python-mip-linear-mip"
@@ -192,7 +191,6 @@ def test_recommended_preparation_reaches_the_python_mip_input_class() -> None:
         sos1_constraints={30: Sos1Constraint(variables=[y])},
     )
     input_class = OMMXPythonMIPAdapter.INPUT_CLASS
-    assert input_class is not None
     assert not input_class.contains(instance)
 
     policy = OMMXPythonMIPAdapter.recommended_preparation_policy()

--- a/python/ommx-tests/tests/test_instance_class.py
+++ b/python/ommx-tests/tests/test_instance_class.py
@@ -332,7 +332,8 @@ def test_membership_is_recomputed_after_explicit_lowering() -> None:
     assert prepared_input_class.contains(instance)
 
 
-def test_solver_adapter_has_no_implicit_input_transformation_hook() -> None:
+def test_solver_adapter_base_owns_no_input_class_or_transformation_hook() -> None:
+    assert "INPUT_CLASS" not in SolverAdapter.__dict__
     assert "__init__" not in SolverAdapter.__dict__
 
 
@@ -385,7 +386,7 @@ def test_solver_adapter_layers_preconditions_and_preserves_the_caller() -> None:
     assert exc_info.value.report.precondition_violations == (violation,)
 
 
-def test_membership_failure_skips_preconditions_and_missing_declaration_is_error() -> (
+def test_membership_failure_skips_preconditions_and_invalid_declarations_are_errors() -> (
     None
 ):
     y = DecisionVariable.continuous(1)
@@ -410,8 +411,12 @@ def test_membership_failure_skips_preconditions_and_missing_declaration_is_error
     class MissingDeclaration(SolverAdapter):
         pass
 
-    with pytest.raises(TypeError, match="must declare INPUT_CLASS"):
-        MissingDeclaration.check_applicability(outside_input_class)
+    class NoneDeclaration(SolverAdapter):
+        INPUT_CLASS = cast(InstanceClass, None)
+
+    for adapter in (MissingDeclaration, NoneDeclaration):
+        with pytest.raises(TypeError, match="must declare INPUT_CLASS"):
+            adapter.check_applicability(outside_input_class)
 
 
 def test_applicability_report_rejects_inconsistent_states() -> None:

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -141,7 +141,7 @@ class SolverAdapter(ABC):
     or otherwise mutates the input instance.
     """
 
-    INPUT_CLASS: ClassVar[InstanceClass | None] = None
+    INPUT_CLASS: ClassVar[InstanceClass]
 
     @classmethod
     def recommended_preparation_policy(cls) -> PreparationPolicy:
@@ -167,7 +167,7 @@ class SolverAdapter(ABC):
         copy so it cannot mutate the caller's instance. Any explicitly
         transformed value is a different input and must be checked separately.
         """
-        input_class = cls.INPUT_CLASS
+        input_class: InstanceClass | None = getattr(cls, "INPUT_CLASS", None)
         if input_class is None:
             raise TypeError(
                 f"{cls.__module__}.{cls.__qualname__} must declare INPUT_CLASS"


### PR DESCRIPTION
## Summary

- make `SolverAdapter.INPUT_CLASS` a required, non-optional `ClassVar[InstanceClass]`
- keep missing and explicitly invalid declarations behind the existing clear runtime error
- narrow all in-repository adapter declarations and remove redundant optional guards from consumers
- align the bilingual adapter tutorial with the strict input contract, including an applicable QUBO example and a format-only backend conversion
- document the adapter-author and caller contract in the bilingual Python SDK release notes

## Motivation

`None` represented only an undeclared base-class state, but exposing it in the public type made every concrete adapter appear optional and forced callers to narrow a state that valid adapters never produce. This keeps missing-declaration detection inside the base implementation while presenting the actual adapter-author and caller contract.