### PR TITLE
Clarify Adapter preparation API responsibilities

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -6347,7 +6347,7 @@
         {
           "kind": "Class",
           "name": "FixedPenaltyPreparation",
-          "doc": "Selection for the fixed-weight penalty Preparation phase.\n\nExactly one fixed-weight owner operation is selected. Weight and\nconstraint-ID validation remains owned by that operation.",
+          "doc": "Selection of a fixed-weight penalty transformation for\n{meth}`~ommx.Instance.prepare`.",
           "bases": [],
           "methods": [
             {
@@ -6378,7 +6378,7 @@
             },
             {
               "name": "penalty_method_with_fixed_weights",
-              "doc": "Select the keyed fixed-weight penalty owner operation.\n\n``atol`` is used by the owner operation to accept a decision-rule weight\ndown to ``-atol`` and normalize a tolerated negative value to zero.",
+              "doc": "Select {meth}`~ommx.Instance.penalty_method_with_fixed_weights`.",
               "signatures": [
                 {
                   "parameters": [
@@ -6433,7 +6433,7 @@
             },
             {
               "name": "uniform_penalty_method_with_fixed_weight",
-              "doc": "Select the uniform fixed-weight penalty owner operation.\n\n``atol`` is used by the owner operation to accept a decision-rule weight\ndown to ``-atol`` and normalize a tolerated negative value to zero.",
+              "doc": "Select {meth}`~ommx.Instance.uniform_penalty_method_with_fixed_weight`.",
               "signatures": [
                 {
                   "parameters": [
@@ -10654,7 +10654,7 @@
             },
             {
               "name": "prepare",
-              "doc": "Prepare this instance in place for membership in ``input_class``.\n\n``policy`` selects existing :class:`Instance` owner operations. The\nmethod stops once ``input_class`` contains this instance and returns\n``None``. Success guarantees only that membership; Adapter-specific\napplicability remains a separate check.\n\nPreparation is not globally transactional. Changes committed by an\nearlier owner operation remain if a later operation raises an error.\nExisting Rust owner signals retain their Python exception mappings.\nWhen configured phases are exhausted without reaching ``input_class``,\n:class:`PreparationTargetNotReachedError` exposes the final membership\nreport through its ``report`` attribute.",
+              "doc": "Apply the caller's ``policy`` to this instance in place to reach\n``input_class`` membership.\n\nThe caller owns policy selection; the instance owns the transformations\nand their application. Success guarantees membership only, not Adapter\napplicability. This operation is not transactional, so an error may leave\nthe instance changed.\n{class}`~ommx.PreparationTargetNotReachedError` exposes the final membership\nreport when the selections do not reach ``input_class``.",
               "signatures": [
                 {
                   "parameters": [
@@ -12606,7 +12606,7 @@
         {
           "kind": "Class",
           "name": "IntegerEncodingPreparation",
-          "doc": "Selection for the used-Integer encoding Preparation phase.\n\nExactly one encoding owner operation is selected. Validation and mutation\nsemantics remain owned by that operation.",
+          "doc": "Selection of a used-Integer transformation for\n{meth}`~ommx.Instance.prepare`.",
           "bases": [],
           "methods": [
             {
@@ -12637,7 +12637,7 @@
             },
             {
               "name": "log_encode_all_used_integers",
-              "doc": "Select the underlying Rust ``log_encode_all_used_integers`` owner\noperation. On success, no used Integer decision variables remain.",
+              "doc": "Select {meth}`~ommx.Instance.log_encode_all_used_integers`.",
               "signatures": [
                 {
                   "parameters": [
@@ -12677,7 +12677,7 @@
         {
           "kind": "Class",
           "name": "IntegerSlackPreparation",
-          "doc": "Integer-slack Preparation for active regular inequalities.\n\nPreparation first attempts exact conversion to equality using\n``max_integer_range`` and ``atol``. ``slack_upper_bound=None`` requires the\nconstraint to become an equality or be removed as trivially satisfied, so\n:class:`ExactIntegerSlackError` is propagated. An integer value permits the\nconstraint to remain an inequality: only that signal selects the\ninequality-preserving owner operation with this upper bound. The latter is\nnot an approximation of the original feasible set. Every other owner error\nis propagated unchanged.",
+          "doc": "Selection of Integer-slack transformations for\n{meth}`~ommx.Instance.prepare`.",
           "bases": [],
           "methods": [
             {
@@ -12794,7 +12794,7 @@
             },
             {
               "name": "slack_upper_bound",
-              "doc": "Optional upper bound for inequality-preserving Integer slack.\n\n``None`` requires equality. An integer permits the inequality-preserving\nowner operation only after :class:`ExactIntegerSlackError`.",
+              "doc": "Optional upper bound for inequality-preserving Integer slack.\n\n``None`` selects only\n{meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`.\nAn integer also selects {meth}`~ommx.Instance.add_integer_slack_to_inequality`\nas a fallback when exact conversion is unavailable.",
               "type_": {
                 "display": "Optional[int]",
                 "link_target": null,
@@ -19289,7 +19289,7 @@
         {
           "kind": "Class",
           "name": "PreparationPolicy",
-          "doc": "Optional phases interpreted by :meth:`Instance.prepare`.\n\nEach property independently selects at most one well-formed phase. Fields\nmay be combined freely, although owner validation and target membership can\nstill make a combination fail for a particular :class:`Instance`.\n\n``Instance.prepare`` applies selected phases at most once in the canonical\nRust-owned order: special constraints, optimization sense, Integer slack,\nInteger encoding, then fixed penalty. All phases are disabled by default.\nFuture phases will also default to disabled.\n\nConstruct the table with keyword arguments or assign its public properties:\n\n```python\nfrom ommx import PreparationPolicy, SensePreparation\n\npolicy = PreparationPolicy()\npolicy.sense = SensePreparation.as_minimization_problem()\n```",
+          "doc": "Caller-owned selection of optional transformations for\n{meth}`~ommx.Instance.prepare`.\n\n{class}`~ommx.Instance` owns their application. All selections are disabled\nby default.",
           "bases": [],
           "methods": [
             {
@@ -23875,7 +23875,7 @@
         {
           "kind": "Class",
           "name": "SensePreparation",
-          "doc": "Selection for the optimization-sense Preparation phase.\n\nConstruct a value with an owner-operation factory. Validation and mutation\nsemantics remain owned by that :class:`Instance` operation.",
+          "doc": "Selection of an optimization-sense transformation for\n{meth}`~ommx.Instance.prepare`.",
           "bases": [],
           "methods": [
             {
@@ -23906,7 +23906,7 @@
             },
             {
               "name": "as_minimization_problem",
-              "doc": "Select :meth:`Instance.as_minimization_problem`.",
+              "doc": "Select {meth}`~ommx.Instance.as_minimization_problem`.",
               "signatures": [
                 {
                   "parameters": [],
@@ -25810,7 +25810,7 @@
         {
           "kind": "Class",
           "name": "SpecialConstraintPreparation",
-          "doc": "Selection for the special-constraint Preparation phase.\n\nConstruct a value with an owner-operation factory. Validation and mutation\nsemantics remain owned by that :class:`Instance` operation.",
+          "doc": "Selection of a special-constraint transformation for\n{meth}`~ommx.Instance.prepare`.",
           "bases": [],
           "methods": [
             {
@@ -25841,7 +25841,7 @@
             },
             {
               "name": "lower_special_constraints",
-              "doc": "Select :meth:`Instance.lower_special_constraints`.",
+              "doc": "Select {meth}`~ommx.Instance.lower_special_constraints`.",
               "signatures": [
                 {
                   "parameters": [

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -6347,7 +6347,7 @@
         {
           "kind": "Class",
           "name": "FixedPenaltyPreparation",
-          "doc": "Selection of a fixed-weight penalty transformation for\n{meth}`~ommx.Instance.prepare`.",
+          "doc": "",
           "bases": [],
           "methods": [
             {
@@ -6378,7 +6378,7 @@
             },
             {
               "name": "penalty_method_with_fixed_weights",
-              "doc": "Select {meth}`~ommx.Instance.penalty_method_with_fixed_weights`.",
+              "doc": "",
               "signatures": [
                 {
                   "parameters": [
@@ -6433,7 +6433,7 @@
             },
             {
               "name": "uniform_penalty_method_with_fixed_weight",
-              "doc": "Select {meth}`~ommx.Instance.uniform_penalty_method_with_fixed_weight`.",
+              "doc": "",
               "signatures": [
                 {
                   "parameters": [
@@ -10654,7 +10654,7 @@
             },
             {
               "name": "prepare",
-              "doc": "Apply the caller's ``policy`` to this instance in place to reach\n``input_class`` membership.\n\nThe caller owns policy selection; the instance owns the transformations\nand their application. Success guarantees membership only, not Adapter\napplicability. This operation is not transactional, so an error may leave\nthe instance changed.\n{class}`~ommx.PreparationTargetNotReachedError` exposes the final membership\nreport when the selections do not reach ``input_class``.",
+              "doc": "Apply the caller's ``policy`` to this instance in place to reach\n``input_class`` membership.\n\nSelected phases are applied at most once in this order, stopping as soon\nas membership is reached:\n\n1. ``special_constraints``:\n   {meth}`~ommx.Instance.lower_special_constraints`\n2. ``sense``: {meth}`~ommx.Instance.as_minimization_problem`\n3. ``integer_slack``:\n   {meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`,\n   followed by {meth}`~ommx.Instance.add_integer_slack_to_inequality` only\n   when exact conversion is unavailable and ``slack_upper_bound`` is set\n4. ``integer_encoding``: {meth}`~ommx.Instance.log_encode`\n5. ``fixed_penalty``\n\nSuccess guarantees membership only, not Adapter applicability. This\noperation is not transactional, so an error may leave the instance changed.\n{class}`~ommx.PreparationTargetNotReachedError` exposes the final membership\nreport when the selections do not reach ``input_class``.",
               "signatures": [
                 {
                   "parameters": [
@@ -12606,7 +12606,7 @@
         {
           "kind": "Class",
           "name": "IntegerEncodingPreparation",
-          "doc": "Selection of a used-Integer transformation for\n{meth}`~ommx.Instance.prepare`.",
+          "doc": "",
           "bases": [],
           "methods": [
             {
@@ -12637,7 +12637,7 @@
             },
             {
               "name": "log_encode_all_used_integers",
-              "doc": "Select {meth}`~ommx.Instance.log_encode_all_used_integers`.",
+              "doc": "",
               "signatures": [
                 {
                   "parameters": [
@@ -12677,7 +12677,7 @@
         {
           "kind": "Class",
           "name": "IntegerSlackPreparation",
-          "doc": "Selection of Integer-slack transformations for\n{meth}`~ommx.Instance.prepare`.",
+          "doc": "",
           "bases": [],
           "methods": [
             {
@@ -12772,7 +12772,7 @@
           "attributes": [
             {
               "name": "atol",
-              "doc": "Absolute tolerance used to normalize bounds to integers.",
+              "doc": "",
               "type_": {
                 "display": "float",
                 "link_target": null,
@@ -12783,7 +12783,7 @@
             },
             {
               "name": "max_integer_range",
-              "doc": "Maximum finite range accepted for exact Integer slack.",
+              "doc": "",
               "type_": {
                 "display": "int",
                 "link_target": null,
@@ -12794,7 +12794,7 @@
             },
             {
               "name": "slack_upper_bound",
-              "doc": "Optional upper bound for inequality-preserving Integer slack.\n\n``None`` selects only\n{meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`.\nAn integer also selects {meth}`~ommx.Instance.add_integer_slack_to_inequality`\nas a fallback when exact conversion is unavailable.",
+              "doc": "",
               "type_": {
                 "display": "Optional[int]",
                 "link_target": null,
@@ -19289,7 +19289,7 @@
         {
           "kind": "Class",
           "name": "PreparationPolicy",
-          "doc": "Caller-owned selection of optional transformations for\n{meth}`~ommx.Instance.prepare`.\n\n{class}`~ommx.Instance` owns their application. All selections are disabled\nby default.",
+          "doc": "",
           "bases": [],
           "methods": [
             {
@@ -23875,7 +23875,7 @@
         {
           "kind": "Class",
           "name": "SensePreparation",
-          "doc": "Selection of an optimization-sense transformation for\n{meth}`~ommx.Instance.prepare`.",
+          "doc": "",
           "bases": [],
           "methods": [
             {
@@ -23906,7 +23906,7 @@
             },
             {
               "name": "as_minimization_problem",
-              "doc": "Select {meth}`~ommx.Instance.as_minimization_problem`.",
+              "doc": "",
               "signatures": [
                 {
                   "parameters": [],
@@ -25810,7 +25810,7 @@
         {
           "kind": "Class",
           "name": "SpecialConstraintPreparation",
-          "doc": "Selection of a special-constraint transformation for\n{meth}`~ommx.Instance.prepare`.",
+          "doc": "",
           "bases": [],
           "methods": [
             {
@@ -25841,7 +25841,7 @@
             },
             {
               "name": "lower_special_constraints",
-              "doc": "Select {meth}`~ommx.Instance.lower_special_constraints`.",
+              "doc": "",
               "signatures": [
                 {
                   "parameters": [

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -2469,10 +2469,8 @@ class ExperimentRef:
 @typing.final
 class FixedPenaltyPreparation:
     r"""
-    Selection for the fixed-weight penalty Preparation phase.
-
-    Exactly one fixed-weight owner operation is selected. Weight and
-    constraint-ID validation remains owned by that operation.
+    Selection of a fixed-weight penalty transformation for
+    {meth}`~ommx.Instance.prepare`.
     """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
@@ -2482,20 +2480,14 @@ class FixedPenaltyPreparation:
         atol: typing.Optional[builtins.float] = None,
     ) -> FixedPenaltyPreparation:
         r"""
-        Select the keyed fixed-weight penalty owner operation.
-
-        ``atol`` is used by the owner operation to accept a decision-rule weight
-        down to ``-atol`` and normalize a tolerated negative value to zero.
+        Select {meth}`~ommx.Instance.penalty_method_with_fixed_weights`.
         """
     @staticmethod
     def uniform_penalty_method_with_fixed_weight(
         *, weight: builtins.float, atol: typing.Optional[builtins.float] = None
     ) -> FixedPenaltyPreparation:
         r"""
-        Select the uniform fixed-weight penalty owner operation.
-
-        ``atol`` is used by the owner operation to accept a decision-rule weight
-        down to ``-atol`` and normalize a tolerated negative value to zero.
+        Select {meth}`~ommx.Instance.uniform_penalty_method_with_fixed_weight`.
         """
 
 @typing.final
@@ -4761,19 +4753,15 @@ class Instance:
         """
     def prepare(self, input_class: InstanceClass, policy: PreparationPolicy) -> None:
         r"""
-        Prepare this instance in place for membership in ``input_class``.
+        Apply the caller's ``policy`` to this instance in place to reach
+        ``input_class`` membership.
 
-        ``policy`` selects existing :class:`Instance` owner operations. The
-        method stops once ``input_class`` contains this instance and returns
-        ``None``. Success guarantees only that membership; Adapter-specific
-        applicability remains a separate check.
-
-        Preparation is not globally transactional. Changes committed by an
-        earlier owner operation remain if a later operation raises an error.
-        Existing Rust owner signals retain their Python exception mappings.
-        When configured phases are exhausted without reaching ``input_class``,
-        :class:`PreparationTargetNotReachedError` exposes the final membership
-        report through its ``report`` attribute.
+        The caller owns policy selection; the instance owns the transformations
+        and their application. Success guarantees membership only, not Adapter
+        applicability. This operation is not transactional, so an error may leave
+        the instance changed.
+        {class}`~ommx.PreparationTargetNotReachedError` exposes the final membership
+        report when the selections do not reach ``input_class``.
         """
 
 @typing.final
@@ -5082,10 +5070,8 @@ class InstanceDescription:
 @typing.final
 class IntegerEncodingPreparation:
     r"""
-    Selection for the used-Integer encoding Preparation phase.
-
-    Exactly one encoding owner operation is selected. Validation and mutation
-    semantics remain owned by that operation.
+    Selection of a used-Integer transformation for
+    {meth}`~ommx.Instance.prepare`.
     """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
@@ -5093,23 +5079,14 @@ class IntegerEncodingPreparation:
         *, atol: typing.Optional[builtins.float] = None
     ) -> IntegerEncodingPreparation:
         r"""
-        Select the underlying Rust ``log_encode_all_used_integers`` owner
-        operation. On success, no used Integer decision variables remain.
+        Select {meth}`~ommx.Instance.log_encode_all_used_integers`.
         """
 
 @typing.final
 class IntegerSlackPreparation:
     r"""
-    Integer-slack Preparation for active regular inequalities.
-
-    Preparation first attempts exact conversion to equality using
-    ``max_integer_range`` and ``atol``. ``slack_upper_bound=None`` requires the
-    constraint to become an equality or be removed as trivially satisfied, so
-    :class:`ExactIntegerSlackError` is propagated. An integer value permits the
-    constraint to remain an inequality: only that signal selects the
-    inequality-preserving owner operation with this upper bound. The latter is
-    not an approximation of the original feasible set. Every other owner error
-    is propagated unchanged.
+    Selection of Integer-slack transformations for
+    {meth}`~ommx.Instance.prepare`.
     """
     @property
     def max_integer_range(self) -> builtins.int:
@@ -5126,8 +5103,10 @@ class IntegerSlackPreparation:
         r"""
         Optional upper bound for inequality-preserving Integer slack.
 
-        ``None`` requires equality. An integer permits the inequality-preserving
-        owner operation only after :class:`ExactIntegerSlackError`.
+        ``None`` selects only
+        {meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`.
+        An integer also selects {meth}`~ommx.Instance.add_integer_slack_to_inequality`
+        as a fallback when exact conversion is unavailable.
         """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     def __new__(
@@ -6200,25 +6179,11 @@ class Polynomial:
 @typing.final
 class PreparationPolicy:
     r"""
-    Optional phases interpreted by :meth:`Instance.prepare`.
+    Caller-owned selection of optional transformations for
+    {meth}`~ommx.Instance.prepare`.
 
-    Each property independently selects at most one well-formed phase. Fields
-    may be combined freely, although owner validation and target membership can
-    still make a combination fail for a particular :class:`Instance`.
-
-    ``Instance.prepare`` applies selected phases at most once in the canonical
-    Rust-owned order: special constraints, optimization sense, Integer slack,
-    Integer encoding, then fixed penalty. All phases are disabled by default.
-    Future phases will also default to disabled.
-
-    Construct the table with keyword arguments or assign its public properties:
-
-    ```python
-    from ommx import PreparationPolicy, SensePreparation
-
-    policy = PreparationPolicy()
-    policy.sense = SensePreparation.as_minimization_problem()
-    ```
+    {class}`~ommx.Instance` owns their application. All selections are disabled
+    by default.
     """
     @property
     def special_constraints(self) -> typing.Optional[SpecialConstraintPreparation]: ...
@@ -7593,16 +7558,14 @@ class SealedRun:
 @typing.final
 class SensePreparation:
     r"""
-    Selection for the optimization-sense Preparation phase.
-
-    Construct a value with an owner-operation factory. Validation and mutation
-    semantics remain owned by that :class:`Instance` operation.
+    Selection of an optimization-sense transformation for
+    {meth}`~ommx.Instance.prepare`.
     """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
     def as_minimization_problem() -> SensePreparation:
         r"""
-        Select :meth:`Instance.as_minimization_problem`.
+        Select {meth}`~ommx.Instance.as_minimization_problem`.
         """
 
 @typing.final
@@ -8137,10 +8100,8 @@ class Sos1Constraint:
 @typing.final
 class SpecialConstraintPreparation:
     r"""
-    Selection for the special-constraint Preparation phase.
-
-    Construct a value with an owner-operation factory. Validation and mutation
-    semantics remain owned by that :class:`Instance` operation.
+    Selection of a special-constraint transformation for
+    {meth}`~ommx.Instance.prepare`.
     """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
@@ -8148,7 +8109,7 @@ class SpecialConstraintPreparation:
         *, kinds: builtins.set[SpecialConstraintKind]
     ) -> SpecialConstraintPreparation:
         r"""
-        Select :meth:`Instance.lower_special_constraints`.
+        Select {meth}`~ommx.Instance.lower_special_constraints`.
         """
 
 @typing.final

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -2468,27 +2468,17 @@ class ExperimentRef:
 
 @typing.final
 class FixedPenaltyPreparation:
-    r"""
-    Selection of a fixed-weight penalty transformation for
-    {meth}`~ommx.Instance.prepare`.
-    """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
     def penalty_method_with_fixed_weights(
         *,
         weights: typing.Mapping[builtins.int, builtins.float],
         atol: typing.Optional[builtins.float] = None,
-    ) -> FixedPenaltyPreparation:
-        r"""
-        Select {meth}`~ommx.Instance.penalty_method_with_fixed_weights`.
-        """
+    ) -> FixedPenaltyPreparation: ...
     @staticmethod
     def uniform_penalty_method_with_fixed_weight(
         *, weight: builtins.float, atol: typing.Optional[builtins.float] = None
-    ) -> FixedPenaltyPreparation:
-        r"""
-        Select {meth}`~ommx.Instance.uniform_penalty_method_with_fixed_weight`.
-        """
+    ) -> FixedPenaltyPreparation: ...
 
 @typing.final
 class Function:
@@ -4756,10 +4746,21 @@ class Instance:
         Apply the caller's ``policy`` to this instance in place to reach
         ``input_class`` membership.
 
-        The caller owns policy selection; the instance owns the transformations
-        and their application. Success guarantees membership only, not Adapter
-        applicability. This operation is not transactional, so an error may leave
-        the instance changed.
+        Selected phases are applied at most once in this order, stopping as soon
+        as membership is reached:
+
+        1. ``special_constraints``:
+           {meth}`~ommx.Instance.lower_special_constraints`
+        2. ``sense``: {meth}`~ommx.Instance.as_minimization_problem`
+        3. ``integer_slack``:
+           {meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`,
+           followed by {meth}`~ommx.Instance.add_integer_slack_to_inequality` only
+           when exact conversion is unavailable and ``slack_upper_bound`` is set
+        4. ``integer_encoding``: {meth}`~ommx.Instance.log_encode`
+        5. ``fixed_penalty``
+
+        Success guarantees membership only, not Adapter applicability. This
+        operation is not transactional, so an error may leave the instance changed.
         {class}`~ommx.PreparationTargetNotReachedError` exposes the final membership
         report when the selections do not reach ``input_class``.
         """
@@ -5069,45 +5070,20 @@ class InstanceDescription:
 
 @typing.final
 class IntegerEncodingPreparation:
-    r"""
-    Selection of a used-Integer transformation for
-    {meth}`~ommx.Instance.prepare`.
-    """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
     def log_encode_all_used_integers(
         *, atol: typing.Optional[builtins.float] = None
-    ) -> IntegerEncodingPreparation:
-        r"""
-        Select {meth}`~ommx.Instance.log_encode_all_used_integers`.
-        """
+    ) -> IntegerEncodingPreparation: ...
 
 @typing.final
 class IntegerSlackPreparation:
-    r"""
-    Selection of Integer-slack transformations for
-    {meth}`~ommx.Instance.prepare`.
-    """
     @property
-    def max_integer_range(self) -> builtins.int:
-        r"""
-        Maximum finite range accepted for exact Integer slack.
-        """
+    def max_integer_range(self) -> builtins.int: ...
     @property
-    def atol(self) -> builtins.float:
-        r"""
-        Absolute tolerance used to normalize bounds to integers.
-        """
+    def atol(self) -> builtins.float: ...
     @property
-    def slack_upper_bound(self) -> typing.Optional[builtins.int]:
-        r"""
-        Optional upper bound for inequality-preserving Integer slack.
-
-        ``None`` selects only
-        {meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`.
-        An integer also selects {meth}`~ommx.Instance.add_integer_slack_to_inequality`
-        as a fallback when exact conversion is unavailable.
-        """
+    def slack_upper_bound(self) -> typing.Optional[builtins.int]: ...
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     def __new__(
         cls,
@@ -6178,13 +6154,6 @@ class Polynomial:
 
 @typing.final
 class PreparationPolicy:
-    r"""
-    Caller-owned selection of optional transformations for
-    {meth}`~ommx.Instance.prepare`.
-
-    {class}`~ommx.Instance` owns their application. All selections are disabled
-    by default.
-    """
     @property
     def special_constraints(self) -> typing.Optional[SpecialConstraintPreparation]: ...
     @special_constraints.setter
@@ -7557,16 +7526,9 @@ class SealedRun:
 
 @typing.final
 class SensePreparation:
-    r"""
-    Selection of an optimization-sense transformation for
-    {meth}`~ommx.Instance.prepare`.
-    """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
-    def as_minimization_problem() -> SensePreparation:
-        r"""
-        Select {meth}`~ommx.Instance.as_minimization_problem`.
-        """
+    def as_minimization_problem() -> SensePreparation: ...
 
 @typing.final
 class Solution:
@@ -8099,18 +8061,11 @@ class Sos1Constraint:
 
 @typing.final
 class SpecialConstraintPreparation:
-    r"""
-    Selection of a special-constraint transformation for
-    {meth}`~ommx.Instance.prepare`.
-    """
     def __eq__(self, other: builtins.object, /) -> builtins.bool: ...
     @staticmethod
     def lower_special_constraints(
         *, kinds: builtins.set[SpecialConstraintKind]
-    ) -> SpecialConstraintPreparation:
-        r"""
-        Select {meth}`~ommx.Instance.lower_special_constraints`.
-        """
+    ) -> SpecialConstraintPreparation: ...
 
 @typing.final
 class State:

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -131,42 +131,29 @@ class SolverAdapter(ABC):
 
     See the `implementation guide <https://jij-inc-ommx.readthedocs-hosted.com/en/latest/tutorial/implement_adapter.html>`_ for more details.
 
-    Subclasses declare ``INPUT_CLASS`` as the OMMX-defined structural class used
-    by the first applicability condition. ``check_applicability`` does not mutate
-    the input and combines class membership with the adapter's
-    ``_check_preconditions`` hook.
-
-    ``INPUT_CLASS`` describes only which exact inputs an adapter accepts; it does
-    not prescribe how the subclass processes them. The base class never lowers
-    or otherwise mutates the input instance.
+    Concrete subclasses own ``INPUT_CLASS`` and additional applicability
+    preconditions; callers own applying any recommended policy with
+    :meth:`ommx.Instance.prepare`.
     """
 
     INPUT_CLASS: ClassVar[InstanceClass]
+    """Required structural condition for an exact Adapter input.
+
+    Membership does not include adapter-owned preconditions.
+    """
 
     @classmethod
     def recommended_preparation_policy(cls) -> PreparationPolicy:
-        """Return a fresh, caller-editable policy recommended by this adapter.
+        """Return a fresh policy recommended for this Adapter's ``INPUT_CLASS``.
 
-        The recommendation and :attr:`INPUT_CLASS` are independent inputs to
-        :meth:`ommx.Instance.prepare`. This method does not inspect or mutate an
-        instance, execute preparation, or guarantee adapter applicability.
-        Concrete adapters may override it when they can recommend model changes
-        for reaching their input class.
-
-        The default recommendation enables no preparation phases. A new policy
-        is returned on every call so callers may edit it without sharing state.
+        The caller owns editing and applying it. This method neither prepares an
+        instance nor guarantees applicability. The default policy is empty.
         """
         return PreparationPolicy()
 
     @classmethod
     def check_applicability(cls, ommx_instance: Instance) -> AdapterApplicabilityReport:
-        """Inspect applicability without mutating or preparing ``ommx_instance``.
-
-        Adapter-specific preconditions run only after at least one complete
-        input-class clause contains the instance. The hook receives an isolated
-        copy so it cannot mutate the caller's instance. Any explicitly
-        transformed value is a different input and must be checked separately.
-        """
+        """Check ``INPUT_CLASS`` and adapter-owned preconditions without mutation."""
         input_class: InstanceClass | None = getattr(cls, "INPUT_CLASS", None)
         if input_class is None:
             raise TypeError(

--- a/python/ommx/src/preparation.rs
+++ b/python/ommx/src/preparation.rs
@@ -10,8 +10,6 @@ fn resolve_atol(value: Option<f64>) -> OmmxPyResult<ommx::ATol> {
     })
 }
 
-/// Selection of a special-constraint transformation for
-/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,7 +20,6 @@ pub struct SpecialConstraintPreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl SpecialConstraintPreparation {
-    /// Select {meth}`~ommx.Instance.lower_special_constraints`.
     #[staticmethod]
     #[pyo3(signature = (*, kinds))]
     pub fn lower_special_constraints(kinds: HashSet<SpecialConstraintKind>) -> Self {
@@ -46,8 +43,6 @@ impl From<ommx::SpecialConstraintPreparation> for SpecialConstraintPreparation {
     }
 }
 
-/// Selection of an optimization-sense transformation for
-/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,7 +53,6 @@ pub struct SensePreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl SensePreparation {
-    /// Select {meth}`~ommx.Instance.as_minimization_problem`.
     #[staticmethod]
     pub fn as_minimization_problem() -> Self {
         Self {
@@ -79,8 +73,6 @@ impl From<ommx::SensePreparation> for SensePreparation {
     }
 }
 
-/// Selection of Integer-slack transformations for
-/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,24 +99,16 @@ impl IntegerSlackPreparation {
         })
     }
 
-    /// Maximum finite range accepted for exact Integer slack.
     #[getter]
     pub fn max_integer_range(&self) -> u64 {
         self.inner.max_integer_range
     }
 
-    /// Absolute tolerance used to normalize bounds to integers.
     #[getter]
     pub fn atol(&self) -> f64 {
         self.inner.atol.into_inner()
     }
 
-    /// Optional upper bound for inequality-preserving Integer slack.
-    ///
-    /// ``None`` selects only
-    /// {meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`.
-    /// An integer also selects {meth}`~ommx.Instance.add_integer_slack_to_inequality`
-    /// as a fallback when exact conversion is unavailable.
     #[getter]
     pub fn slack_upper_bound(&self) -> Option<u64> {
         self.inner.slack_upper_bound
@@ -143,8 +127,6 @@ impl From<ommx::IntegerSlackPreparation> for IntegerSlackPreparation {
     }
 }
 
-/// Selection of a used-Integer transformation for
-/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -155,7 +137,6 @@ pub struct IntegerEncodingPreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl IntegerEncodingPreparation {
-    /// Select {meth}`~ommx.Instance.log_encode_all_used_integers`.
     #[staticmethod]
     #[pyo3(signature = (*, atol=None))]
     pub fn log_encode_all_used_integers(atol: Option<f64>) -> OmmxPyResult<Self> {
@@ -179,8 +160,6 @@ impl From<ommx::IntegerEncodingPreparation> for IntegerEncodingPreparation {
     }
 }
 
-/// Selection of a fixed-weight penalty transformation for
-/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq)]
@@ -191,7 +170,6 @@ pub struct FixedPenaltyPreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl FixedPenaltyPreparation {
-    /// Select {meth}`~ommx.Instance.penalty_method_with_fixed_weights`.
     #[staticmethod]
     #[pyo3(signature = (*, weights, atol=None))]
     pub fn penalty_method_with_fixed_weights(
@@ -209,7 +187,6 @@ impl FixedPenaltyPreparation {
         })
     }
 
-    /// Select {meth}`~ommx.Instance.uniform_penalty_method_with_fixed_weight`.
     #[staticmethod]
     #[pyo3(signature = (*, weight, atol=None))]
     pub fn uniform_penalty_method_with_fixed_weight(
@@ -237,11 +214,6 @@ impl From<ommx::FixedPenaltyPreparation> for FixedPenaltyPreparation {
     }
 }
 
-/// Caller-owned selection of optional transformations for
-/// {meth}`~ommx.Instance.prepare`.
-///
-/// {class}`~ommx.Instance` owns their application. All selections are disabled
-/// by default.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq)]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -327,10 +299,21 @@ impl Instance {
     /// Apply the caller's ``policy`` to this instance in place to reach
     /// ``input_class`` membership.
     ///
-    /// The caller owns policy selection; the instance owns the transformations
-    /// and their application. Success guarantees membership only, not Adapter
-    /// applicability. This operation is not transactional, so an error may leave
-    /// the instance changed.
+    /// Selected phases are applied at most once in this order, stopping as soon
+    /// as membership is reached:
+    ///
+    /// 1. ``special_constraints``:
+    ///    {meth}`~ommx.Instance.lower_special_constraints`
+    /// 2. ``sense``: {meth}`~ommx.Instance.as_minimization_problem`
+    /// 3. ``integer_slack``:
+    ///    {meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`,
+    ///    followed by {meth}`~ommx.Instance.add_integer_slack_to_inequality` only
+    ///    when exact conversion is unavailable and ``slack_upper_bound`` is set
+    /// 4. ``integer_encoding``: {meth}`~ommx.Instance.log_encode`
+    /// 5. ``fixed_penalty``
+    ///
+    /// Success guarantees membership only, not Adapter applicability. This
+    /// operation is not transactional, so an error may leave the instance changed.
     /// {class}`~ommx.PreparationTargetNotReachedError` exposes the final membership
     /// report when the selections do not reach ``input_class``.
     pub fn prepare(

--- a/python/ommx/src/preparation.rs
+++ b/python/ommx/src/preparation.rs
@@ -10,10 +10,8 @@ fn resolve_atol(value: Option<f64>) -> OmmxPyResult<ommx::ATol> {
     })
 }
 
-/// Selection for the special-constraint Preparation phase.
-///
-/// Construct a value with an owner-operation factory. Validation and mutation
-/// semantics remain owned by that :class:`Instance` operation.
+/// Selection of a special-constraint transformation for
+/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -24,7 +22,7 @@ pub struct SpecialConstraintPreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl SpecialConstraintPreparation {
-    /// Select :meth:`Instance.lower_special_constraints`.
+    /// Select {meth}`~ommx.Instance.lower_special_constraints`.
     #[staticmethod]
     #[pyo3(signature = (*, kinds))]
     pub fn lower_special_constraints(kinds: HashSet<SpecialConstraintKind>) -> Self {
@@ -48,10 +46,8 @@ impl From<ommx::SpecialConstraintPreparation> for SpecialConstraintPreparation {
     }
 }
 
-/// Selection for the optimization-sense Preparation phase.
-///
-/// Construct a value with an owner-operation factory. Validation and mutation
-/// semantics remain owned by that :class:`Instance` operation.
+/// Selection of an optimization-sense transformation for
+/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -62,7 +58,7 @@ pub struct SensePreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl SensePreparation {
-    /// Select :meth:`Instance.as_minimization_problem`.
+    /// Select {meth}`~ommx.Instance.as_minimization_problem`.
     #[staticmethod]
     pub fn as_minimization_problem() -> Self {
         Self {
@@ -83,16 +79,8 @@ impl From<ommx::SensePreparation> for SensePreparation {
     }
 }
 
-/// Integer-slack Preparation for active regular inequalities.
-///
-/// Preparation first attempts exact conversion to equality using
-/// ``max_integer_range`` and ``atol``. ``slack_upper_bound=None`` requires the
-/// constraint to become an equality or be removed as trivially satisfied, so
-/// :class:`ExactIntegerSlackError` is propagated. An integer value permits the
-/// constraint to remain an inequality: only that signal selects the
-/// inequality-preserving owner operation with this upper bound. The latter is
-/// not an approximation of the original feasible set. Every other owner error
-/// is propagated unchanged.
+/// Selection of Integer-slack transformations for
+/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,8 +121,10 @@ impl IntegerSlackPreparation {
 
     /// Optional upper bound for inequality-preserving Integer slack.
     ///
-    /// ``None`` requires equality. An integer permits the inequality-preserving
-    /// owner operation only after :class:`ExactIntegerSlackError`.
+    /// ``None`` selects only
+    /// {meth}`~ommx.Instance.convert_inequality_to_equality_with_integer_slack`.
+    /// An integer also selects {meth}`~ommx.Instance.add_integer_slack_to_inequality`
+    /// as a fallback when exact conversion is unavailable.
     #[getter]
     pub fn slack_upper_bound(&self) -> Option<u64> {
         self.inner.slack_upper_bound
@@ -153,10 +143,8 @@ impl From<ommx::IntegerSlackPreparation> for IntegerSlackPreparation {
     }
 }
 
-/// Selection for the used-Integer encoding Preparation phase.
-///
-/// Exactly one encoding owner operation is selected. Validation and mutation
-/// semantics remain owned by that operation.
+/// Selection of a used-Integer transformation for
+/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,8 +155,7 @@ pub struct IntegerEncodingPreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl IntegerEncodingPreparation {
-    /// Select the underlying Rust ``log_encode_all_used_integers`` owner
-    /// operation. On success, no used Integer decision variables remain.
+    /// Select {meth}`~ommx.Instance.log_encode_all_used_integers`.
     #[staticmethod]
     #[pyo3(signature = (*, atol=None))]
     pub fn log_encode_all_used_integers(atol: Option<f64>) -> OmmxPyResult<Self> {
@@ -192,10 +179,8 @@ impl From<ommx::IntegerEncodingPreparation> for IntegerEncodingPreparation {
     }
 }
 
-/// Selection for the fixed-weight penalty Preparation phase.
-///
-/// Exactly one fixed-weight owner operation is selected. Weight and
-/// constraint-ID validation remains owned by that operation.
+/// Selection of a fixed-weight penalty transformation for
+/// {meth}`~ommx.Instance.prepare`.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq, frozen)]
 #[derive(Debug, Clone, PartialEq)]
@@ -206,10 +191,7 @@ pub struct FixedPenaltyPreparation {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl FixedPenaltyPreparation {
-    /// Select the keyed fixed-weight penalty owner operation.
-    ///
-    /// ``atol`` is used by the owner operation to accept a decision-rule weight
-    /// down to ``-atol`` and normalize a tolerated negative value to zero.
+    /// Select {meth}`~ommx.Instance.penalty_method_with_fixed_weights`.
     #[staticmethod]
     #[pyo3(signature = (*, weights, atol=None))]
     pub fn penalty_method_with_fixed_weights(
@@ -227,10 +209,7 @@ impl FixedPenaltyPreparation {
         })
     }
 
-    /// Select the uniform fixed-weight penalty owner operation.
-    ///
-    /// ``atol`` is used by the owner operation to accept a decision-rule weight
-    /// down to ``-atol`` and normalize a tolerated negative value to zero.
+    /// Select {meth}`~ommx.Instance.uniform_penalty_method_with_fixed_weight`.
     #[staticmethod]
     #[pyo3(signature = (*, weight, atol=None))]
     pub fn uniform_penalty_method_with_fixed_weight(
@@ -258,25 +237,11 @@ impl From<ommx::FixedPenaltyPreparation> for FixedPenaltyPreparation {
     }
 }
 
-/// Optional phases interpreted by :meth:`Instance.prepare`.
+/// Caller-owned selection of optional transformations for
+/// {meth}`~ommx.Instance.prepare`.
 ///
-/// Each property independently selects at most one well-formed phase. Fields
-/// may be combined freely, although owner validation and target membership can
-/// still make a combination fail for a particular :class:`Instance`.
-///
-/// ``Instance.prepare`` applies selected phases at most once in the canonical
-/// Rust-owned order: special constraints, optimization sense, Integer slack,
-/// Integer encoding, then fixed penalty. All phases are disabled by default.
-/// Future phases will also default to disabled.
-///
-/// Construct the table with keyword arguments or assign its public properties:
-///
-/// ```python
-/// from ommx import PreparationPolicy, SensePreparation
-///
-/// policy = PreparationPolicy()
-/// policy.sense = SensePreparation.as_minimization_problem()
-/// ```
+/// {class}`~ommx.Instance` owns their application. All selections are disabled
+/// by default.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass(eq)]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -359,19 +324,15 @@ impl PreparationPolicy {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl Instance {
-    /// Prepare this instance in place for membership in ``input_class``.
+    /// Apply the caller's ``policy`` to this instance in place to reach
+    /// ``input_class`` membership.
     ///
-    /// ``policy`` selects existing :class:`Instance` owner operations. The
-    /// method stops once ``input_class`` contains this instance and returns
-    /// ``None``. Success guarantees only that membership; Adapter-specific
-    /// applicability remains a separate check.
-    ///
-    /// Preparation is not globally transactional. Changes committed by an
-    /// earlier owner operation remain if a later operation raises an error.
-    /// Existing Rust owner signals retain their Python exception mappings.
-    /// When configured phases are exhausted without reaching ``input_class``,
-    /// :class:`PreparationTargetNotReachedError` exposes the final membership
-    /// report through its ``report`` attribute.
+    /// The caller owns policy selection; the instance owns the transformations
+    /// and their application. Success guarantees membership only, not Adapter
+    /// applicability. This operation is not transactional, so an error may leave
+    /// the instance changed.
+    /// {class}`~ommx.PreparationTargetNotReachedError` exposes the final membership
+    /// report when the selections do not reach ``input_class``.
     pub fn prepare(
         &mut self,
         py: Python<'_>,


### PR DESCRIPTION
## Summary

- make Adapter ownership of `INPUT_CLASS` and adapter-specific preconditions explicit
- state caller ownership of editing and applying a recommended `PreparationPolicy`
- keep policy APIs limited to selecting transformations and link their behavior to the owning `Instance` APIs
- state that `Instance.prepare` owns in-place application and guarantees input-class membership only

## Scope

This PR updates API Reference sources and their generated artifacts only. It does not change behavior or extend tutorials or user guides.
