### PR TITLE
Define adapter applicability solely by INPUT_CLASS

### DIFF
--- a/docs/en/migration/python_sdk_v2_to_v3.md
+++ b/docs/en/migration/python_sdk_v2_to_v3.md
@@ -444,9 +444,11 @@ samples = OMMXOpenJijSAAdapter.sample(source)
 `Instance.prepare()` returns only after target-class membership is reached and
 uses the existing exception types of the selected OMMX operations. It mutates
 the instance in place and does not globally roll back earlier operations after
-a later failure. `OMMXOpenJijSAAdapter.require_applicable(source)` can then
-check the remaining OpenJij-specific signed-ID and finite-coefficient
-preconditions.
+a later failure. That membership is the complete Adapter applicability
+condition; `OMMXOpenJijSAAdapter.require_applicable(source)` only reports or
+enforces it. When OpenJij solver input is built, the converter separately
+validates signed-ID limits and finite interaction coefficients. Those failures
+are conversion errors, not applicability failures.
 
 ```python
 # v2.5.1

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -16,6 +16,12 @@ adapter-owned precondition layer has been removed, including
 `AdapterPreconditionViolation`, `ConstraintRef`, `_check_preconditions()`, and
 the `preconditions_checked` and `precondition_violations` report fields.
 
+Both methods now return `InstanceClassMembershipReport` directly, and the
+`AdapterApplicabilityReport` wrapper has been removed. Replace
+`report.is_applicable` with `report.is_member` and `report.input_membership`
+with `report`. For `AdapterNotApplicableError`, `error.report` is the membership
+report itself and the Adapter identity is available as `error.adapter`.
+
 Adapter implementations must express every accepted-model condition in
 `INPUT_CLASS`. Converter-local representation checks and backend limits remain
 in the solver-input construction path; their failures are conversion or backend

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,6 +8,23 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
+### ⚠ Adapter applicability is defined only by `INPUT_CLASS` ([#1163](https://github.com/Jij-Inc/ommx/pull/1163))
+
+`SolverAdapter.check_applicability()` and `require_applicable()` now use
+`INPUT_CLASS` membership as the complete applicability condition. The secondary
+adapter-owned precondition layer has been removed, including
+`AdapterPreconditionViolation`, `ConstraintRef`, `_check_preconditions()`, and
+the `preconditions_checked` and `precondition_violations` report fields.
+
+Adapter implementations must express every accepted-model condition in
+`INPUT_CLASS`. Converter-local representation checks and backend limits remain
+in the solver-input construction path; their failures are conversion or backend
+errors rather than `AdapterNotApplicableError`. In particular, OpenJij signed-ID
+and finite-coefficient validation now occurs when sampler input is built. See
+[Adapter input classes](../user_guide/capability_model.md) and the
+[Adapter implementation tutorial](../tutorial/implement_adapter.md) for the
+responsibility boundary.
+
 ### Adapter input classes are required ([#1160](https://github.com/Jij-Inc/ommx/pull/1160))
 
 Concrete `SolverAdapter` and `SamplerAdapter` implementations must declare

--- a/docs/en/tutorial/implement_adapter.md
+++ b/docs/en/tutorial/implement_adapter.md
@@ -55,7 +55,7 @@ class OMMXPySCIPOptAdapterError(Exception):
     pass
 ```
 
-OMMX can store a wide range of optimization problems, so there may be cases where the backend solver does not support the problem. In such cases, throw an error.
+OMMX can store a wide range of optimization problems, so the adapter declares the exact set it accepts with `INPUT_CLASS`, as shown later. The converter helpers below may still validate the representation they consume and raise while building solver input. Such converter or backend failures are not additional applicability conditions: adapter applicability is defined only by `INPUT_CLASS` membership.
 
 ### Setting Decision Variables
 
@@ -73,7 +73,7 @@ def set_decision_variables(
     Add decision variables to the model and create a mapping from variable names to variables
     """
     # Create PySCIPOpt variables from OMMX decision variable information
-    for var in instance.decision_variables:
+    for var in instance.used_decision_variables:
         if var.kind == DecisionVariable.BINARY:
             model.addVar(name=str(var.id), vtype="B")
         elif var.kind == DecisionVariable.INTEGER:
@@ -267,7 +267,7 @@ def decode_to_state(model: pyscipopt.Model, instance: Instance) -> State:
         return State(
             entries={
                 var.id: sol[varname_map[str(var.id)]]
-                for var in instance.decision_variables
+                for var in instance.used_decision_variables
             }
         )
     except Exception:
@@ -284,7 +284,7 @@ Finally, create a class that inherits `ommx.adapter.SolverAdapter` to standardiz
 from typing import ClassVar
 
 class SolverAdapter(ABC):
-    # OMMX-defined structural condition for adapter applicability.
+    # Complete OMMX-defined condition for adapter applicability.
     INPUT_CLASS: ClassVar[InstanceClass]
 
     @classmethod
@@ -320,7 +320,9 @@ The `solve` class method may define additional adapter-specific keyword options 
 
 #### Input Class and Recommended Preparation
 
-An adapter declares the structural set of exact `Instance` values it can receive with `INPUT_CLASS`. `check_applicability()` evaluates membership first and then adapter-owned preconditions without mutating the caller's instance; `require_applicable()` raises with the same structured report when either condition fails.
+An adapter defines applicability entirely with `INPUT_CLASS`, the set of exact `Instance` values it accepts. `check_applicability()` reports membership without mutating the caller's instance, and `require_applicable()` raises with the same structured report only when membership fails.
+
+Applicability does not promise that every later conversion or backend operation succeeds. A converter may validate the narrower representation handled by a helper such as `as_linear()`, and a backend may reject a numeric value or implementation limit while solver input is being built. Report those as converter or backend errors; do not add them as a second source of adapter applicability semantics.
 
 Direct adapter APIs are strict: they do not transform an input to make it applicable. Instead, an adapter may override `recommended_preparation_policy()` to return a fresh, caller-editable {class}`~ommx.PreparationPolicy` for its `INPUT_CLASS`. The recommendation does not inspect or mutate an instance, run preparation, or guarantee applicability. `INPUT_CLASS` and the policy remain independent inputs to {meth}`~ommx.Instance.prepare`.
 
@@ -333,7 +335,7 @@ A recommendation can enable special-constraint lowering with these family select
 Use {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` to inspect the currently active families. The selected Preparation phase delegates to {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>`, which converts each selected active family into regular constraints (Big-M for indicator / SOS1, linear equality for one-hot). The owner operation still defines its validation and mathematical meaning.
 
 ```{important}
-`INPUT_CLASS` describes the exact value received by the adapter. Preparation is owned by the caller and changes that value in place. Successful preparation guarantees `INPUT_CLASS` membership only; the adapter must still run its normal applicability check for adapter-owned preconditions.
+`INPUT_CLASS` describes the exact value received by the adapter, and membership is the complete applicability condition. Preparation is owned by the caller and changes that value in place. Successful preparation guarantees membership. Building solver input can still fail during converter-local or backend validation, but that failure does not make the input "not applicable."
 ```
 
 Using the functions prepared so far, you can implement it as follows:
@@ -449,6 +451,8 @@ instance.prepare(input_class, policy)
 OMMXPySCIPOptAdapter.require_applicable(instance)
 solution = OMMXPySCIPOptAdapter.solve(instance)
 ```
+
+The explicit `require_applicable()` call above checks only `INPUT_CLASS` membership. `solve()` checks the same membership at its strict entry point, then may still raise a converter or backend error while constructing or solving the PySCIPOpt model.
 
 This completes the Solver Adapter 🎉
 
@@ -592,7 +596,8 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     def _sample(self) -> oj.Response:
         sampler = oj.SASampler()
         # Convert to QUBO dictionary format
-        # If the Instance is not in QUBO format, an error will be raised here
+        # QUBO conversion can fail here even after applicability was established.
+        # This is a converter error, not an applicability result.
         qubo, _offset = self.ommx_instance.as_qubo_format()
         return sampler.sample_qubo(qubo)
 
@@ -672,12 +677,12 @@ sample_set.summary
 In this tutorial, we learned how to implement an OMMX Adapter by connecting to PySCIPOpt as a Solver Adapter and OpenJij as a Sampler Adapter. Here are the key points when implementing an OMMX Adapter:
 
 1. Implement an OMMX Adapter by inheriting the abstract base class `SolverAdapter` or `SamplerAdapter`.
-2. Declare the strict structural input condition with `INPUT_CLASS`. If useful, return a fresh caller-editable policy from `recommended_preparation_policy()`; the caller applies it with `Instance.prepare()` before the adapter performs its normal applicability check.
+2. Define applicability with `INPUT_CLASS`. `check_applicability()` and `require_applicable()` report or enforce only membership. If useful, return a fresh caller-editable policy from `recommended_preparation_policy()`; the caller applies it with `Instance.prepare()` before calling the strict adapter API.
 3. The main steps of the implementation are as follows:
    - Convert `ommx.Instance` into a format that the backend solver can understand.
    - Run the backend solver to obtain a solution.
    - Convert the backend solver's output into `ommx.Solution` or `ommx.SampleSet`.
-4. Understand the characteristics and limitations of each backend solver and handle them appropriately.
+4. Keep converter-local and backend validation in the solver-input construction path, and report its failures as conversion or backend errors rather than applicability failures.
 5. Pay attention to managing IDs and mapping variables to bridge the backend solver and OMMX.
 
 If you want to connect your own backend solver to OMMX, refer to this tutorial for implementation. By implementing an OMMX Adapter following this tutorial, you can use optimization with various backend solvers through a common API.

--- a/docs/en/user_guide/capability_model.md
+++ b/docs/en/user_guide/capability_model.md
@@ -15,7 +15,7 @@ kernelspec:
 
 OMMX separates two concepts that were previously described together as adapter capabilities:
 
-- An {class}`~ommx.InstanceClass` describes a set of exact `Instance` values. An adapter declares its structural input condition with `INPUT_CLASS`, then evaluates adapter-owned preconditions to determine applicability.
+- An {class}`~ommx.InstanceClass` describes a set of exact `Instance` values. An adapter defines applicability by declaring that set as `INPUT_CLASS`.
 - {meth}`Instance.lower_special_constraints() <ommx.Instance.lower_special_constraints>` explicitly lowers selected special-constraint families on an instance. It does not declare an input class or establish adapter applicability.
 
 This page covers:
@@ -46,7 +46,9 @@ binary_linear_with_one_hot = InstanceClass(
 )
 ```
 
-Adapters declare this first applicability condition as `INPUT_CLASS`. Use `check_applicability()` for a structured result or `require_applicable()` to raise when membership or an adapter-owned precondition fails. Explicit preparation produces another input value, whose applicability must be checked again.
+Adapters declare their complete applicability condition as `INPUT_CLASS`. Use `check_applicability()` for a structured membership result or `require_applicable()` to raise when membership fails. Explicit preparation produces another input value, whose membership must be checked again.
+
+Applicability and solver-input construction are separate boundaries. Membership does not guarantee that every converter or backend operation succeeds. A converter may validate the representation consumed by a local helper, and a backend may reject a numeric value or implementation limit while solver input is built. Those failures are conversion or backend errors, not additional applicability conditions, and must not be reported as `AdapterNotApplicableError`.
 
 ## SpecialConstraintKind and active_special_constraint_kinds
 
@@ -91,7 +93,7 @@ assert instance.one_hot_constraints == {}
 assert len(instance.constraints) == 1
 ```
 
-The OneHot constraint has been removed and a regular equality $x_0 + x_1 + x_2 - 1 = 0$ has been added in its place. `lower_special_constraints` mutates the instance in place and returns only the selected families that were active and actually lowered. The method returns an empty set when no selected family was active. Recheck `INPUT_CLASS` membership or adapter applicability on this resulting value.
+The OneHot constraint has been removed and a regular equality $x_0 + x_1 + x_2 - 1 = 0$ has been added in its place. `lower_special_constraints` mutates the instance in place and returns only the selected families that were active and actually lowered. The method returns an empty set when no selected family was active. Recheck Adapter applicability, equivalently `INPUT_CLASS` membership, on this resulting value.
 
 ## Manual conversion APIs
 
@@ -200,8 +202,8 @@ for cid, c in instance2.constraints.items():
 | What you want to do | API |
 |---|---|
 | Describe a structural set of adapter inputs | {class}`~ommx.InstanceClass` |
-| Declare the first adapter applicability condition | `INPUT_CLASS` |
-| Check membership plus adapter-owned preconditions | `check_applicability()` / `require_applicable()` |
+| Define adapter applicability | `INPUT_CLASS` |
+| Report or enforce `INPUT_CLASS` membership | `check_applicability()` / `require_applicable()` |
 | Inspect active special-constraint families | {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` |
 | Explicitly lower selected special constraints | {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` |
 | Convert individually to regular constraints | `convert_*_to_constraint(s)` / `convert_all_*_to_constraints` |

--- a/docs/en/user_guide/special_constraints.md
+++ b/docs/en/user_guide/special_constraints.md
@@ -98,7 +98,7 @@ Explicitly lower OneHot before passing the instance to the PySCIPOpt Adapter. Th
 
 ```{code-cell} ipython3
 instance_oh.convert_all_one_hots_to_constraints()
-assert OMMXPySCIPOptAdapter.check_applicability(instance_oh).is_applicable
+assert OMMXPySCIPOptAdapter.check_applicability(instance_oh).is_member
 solution = OMMXPySCIPOptAdapter.solve(instance_oh)
 # Exactly one of the three is chosen, so x_1 with the largest value 10 is selected
 assert abs(solution.objective - 10.0) < 1e-6

--- a/docs/ja/migration/python_sdk_v2_to_v3.md
+++ b/docs/ja/migration/python_sdk_v2_to_v3.md
@@ -276,9 +276,11 @@ samples = OMMXOpenJijSAAdapter.sample(source)
 
 `Instance.prepare()` はtarget class membershipへ到達した場合だけreturnし、選択した
 OMMX operationの既存exception typeを使います。instanceをin-placeで変更し、後のerrorが
-起きても先に完了したoperationをglobalにrollbackしません。その後、
-`OMMXOpenJijSAAdapter.require_applicable(source)` で、signed IDとfinite coefficientという
-OpenJij固有の残りのpreconditionを検査できます。
+起きても先に完了したoperationをglobalにrollbackしません。このmembershipがAdapter
+applicabilityの完全な条件であり、`OMMXOpenJijSAAdapter.require_applicable(source)` が
+reportまたは強制するのもmembershipだけです。OpenJijのsolver inputを構築する際には、
+converterがsigned IDの上限とinteraction coefficientの有限性を別途検証します。これらの
+失敗はconversion errorであり、applicability failureではありません。
 
 ## 8. DataFrame accessor
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -16,6 +16,12 @@ Adapter が所有していた第2の precondition 層は廃止し、
 `AdapterPreconditionViolation`、`ConstraintRef`、`_check_preconditions()`、report の
 `preconditions_checked` と `precondition_violations` field を削除しました。
 
+両 method は `InstanceClassMembershipReport` を直接返すようになり、
+`AdapterApplicabilityReport` wrapper は削除されました。`report.is_applicable` は
+`report.is_member`、`report.input_membership` は `report` に置き換えてください。
+`AdapterNotApplicableError` では、`error.report` が membership report そのものであり、
+Adapter identity は `error.adapter` から取得できます。
+
 Adapter 実装は、受け入れる model の条件をすべて `INPUT_CLASS` で表現する必要があります。
 Converter 固有の表現検査や backend の上限検査は solver input の構築経路に残りますが、
 その失敗は `AdapterNotApplicableError` ではなく conversion または backend の error です。

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,6 +8,22 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
+### ⚠ Adapter applicability を `INPUT_CLASS` だけで定義 ([#1163](https://github.com/Jij-Inc/ommx/pull/1163))
+
+`SolverAdapter.check_applicability()` と `require_applicable()` は、完全な
+applicability 条件として `INPUT_CLASS` membership だけを使うようになりました。
+Adapter が所有していた第2の precondition 層は廃止し、
+`AdapterPreconditionViolation`、`ConstraintRef`、`_check_preconditions()`、report の
+`preconditions_checked` と `precondition_violations` field を削除しました。
+
+Adapter 実装は、受け入れる model の条件をすべて `INPUT_CLASS` で表現する必要があります。
+Converter 固有の表現検査や backend の上限検査は solver input の構築経路に残りますが、
+その失敗は `AdapterNotApplicableError` ではなく conversion または backend の error です。
+特に OpenJij の signed ID と finite coefficient の検査は sampler input の構築時に
+行われるようになりました。責務境界の詳細は
+[Adapter Input Class](../user_guide/capability_model.md) と
+[Adapter 実装チュートリアル](../tutorial/implement_adapter.md)を参照してください。
+
 ### Adapter の input class 宣言を必須化 ([#1160](https://github.com/Jij-Inc/ommx/pull/1160))
 
 具体的な `SolverAdapter` / `SamplerAdapter` 実装では、`INPUT_CLASS` を

--- a/docs/ja/tutorial/implement_adapter.md
+++ b/docs/ja/tutorial/implement_adapter.md
@@ -55,7 +55,7 @@ class OMMXPySCIPOptAdapterError(Exception):
     pass
 ```
 
-OMMXは広いクラスの最適化問題を保存できるようになっているので、バックエンドソルバーが対応していない問題が入力されるケースがあります。その場合はエラーを投げるようにしてください。
+OMMX は広いクラスの最適化問題を保存できるため、Adapter が受け入れる具体的な集合は、後述する `INPUT_CLASS` で宣言します。以下の converter helper は、自身が受け取る表現を検証し、solver input の構築中に error を返すことがあります。この converter または backend の失敗は追加の applicability 条件ではありません。Adapter applicability は `INPUT_CLASS` membership だけで定義されます。
 
 ### 決定変数を設定する
 
@@ -73,7 +73,7 @@ def set_decision_variables(
     モデルに決定変数を追加し、変数名のマッピングを作成して返す
     """
     # OMMXの決定変数の情報からPySCIPOptの変数を作成
-    for var in instance.decision_variables:
+    for var in instance.used_decision_variables:
         if var.kind == DecisionVariable.BINARY:
             model.addVar(name=str(var.id), vtype="B")
         elif var.kind == DecisionVariable.INTEGER:
@@ -263,7 +263,7 @@ def decode_to_state(model: pyscipopt.Model, instance: Instance) -> State:
         return State(
             entries={
                 var.id: sol[varname_map[str(var.id)]]
-                for var in instance.decision_variables
+                for var in instance.used_decision_variables
             }
         )
     except Exception:
@@ -280,7 +280,7 @@ def decode_to_state(model: pyscipopt.Model, instance: Instance) -> State:
 from typing import ClassVar
 
 class SolverAdapter(ABC):
-    # Adapter applicability の OMMX 定義の構造条件
+    # Adapter applicability を完全に定義する OMMX の条件
     INPUT_CLASS: ClassVar[InstanceClass]
 
     @classmethod
@@ -316,7 +316,9 @@ class SolverAdapter(ABC):
 
 #### 入力 class と推奨 Preparation
 
-Adapter は、受け取れる具体的な `Instance` 値の構造的な集合を `INPUT_CLASS` で宣言します。`check_applicability()` は membership、続いて Adapter 固有の precondition を呼び出し元の instance を変更せずに評価します。いずれかを満たさない場合に同じ構造化 report で例外を送出するには `require_applicable()` を使います。
+Adapter は、受け取れる具体的な `Instance` 値の集合 `INPUT_CLASS` だけで applicability を定義します。`check_applicability()` は呼び出し元の instance を変更せずに membership を report し、`require_applicable()` は membership が満たされない場合だけ同じ構造化 report で例外を送出します。
+
+Applicability は、その後の全ての変換や backend operation の成功を保証するものではありません。`as_linear()` のような helper が扱う、より狭い表現を converter が検証したり、solver input の構築中に backend が数値や実装上の上限を拒否したりすることがあります。これらは converter または backend の error として扱い、Adapter applicability の別の source of truth にしないでください。
 
 Adapter の直接 API は厳格であり、入力を適用可能にするための変換を内部では行いません。代わりに、Adapter は `recommended_preparation_policy()` を override して、その `INPUT_CLASS` 向けの新しい編集可能な {class}`~ommx.PreparationPolicy` を返せます。推奨 Policy は instance を参照・変更せず、Preparation を実行せず、Adapter applicability も保証しません。`INPUT_CLASS` と Policy は {meth}`~ommx.Instance.prepare` に別々の引数として渡します。
 
@@ -329,7 +331,7 @@ Adapter の直接 API は厳格であり、入力を適用可能にするため�
 `Instance` が現在保持する family は {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` で確認できます。選択された Preparation phase は {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` に委譲し、active な family を通常制約へ変換します（indicator/SOS1 は Big-M、one-hot は線形等式）。Validation と数学的な意味は引き続き owner operation が定義します。
 
 ```{important}
-`INPUT_CLASS` は Adapter が受け取る時点の入力値そのものを記述します。Preparation は呼び出し側が所有し、その値を in-place に変更します。Preparation の成功が保証するのは `INPUT_CLASS` membership だけなので、Adapter は通常どおり Adapter 固有の precondition を含む applicability check を行う必要があります。
+`INPUT_CLASS` は Adapter が受け取る時点の入力値そのものを記述し、その membership が applicability の完全な条件です。Preparation は呼び出し側が所有し、その値を in-place に変更します。Preparation の成功は membership を保証します。その後も solver input の構築時に converter 固有または backend 固有の validation が失敗することはありますが、その失敗によって入力が「not applicable」になるわけではありません。
 ```
 
 ここまでで用意した関数を使って次のように実装することができます：
@@ -445,6 +447,8 @@ instance.prepare(input_class, policy)
 OMMXPySCIPOptAdapter.require_applicable(instance)
 solution = OMMXPySCIPOptAdapter.solve(instance)
 ```
+
+上の明示的な `require_applicable()` は `INPUT_CLASS` membership だけを検査します。`solve()` も厳格な入口で同じ membership を検査し、その後の PySCIPOpt model の構築・求解時には converter または backend の error を返すことがあります。
 
 これでSolver Adapter完成です 🎉
 
@@ -586,7 +590,8 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
     def _sample(self) -> oj.Response:
         sampler = oj.SASampler()
         # QUBOの辞書形式に変換
-        # InstanceがQUBO形式でなければここでエラーになる
+        # Applicability の成立後でも、QUBO 変換はここで失敗し得る。
+        # これは converter error であり、applicability result ではない。
         qubo, _offset = self.ommx_instance.as_qubo_format()
         return sampler.sample_qubo(qubo)
 
@@ -666,13 +671,13 @@ sample_set.summary
 このチュートリアルでは、PySCIPOptと接続するSolver Adapterの実装とOpenJijと接続するSampler Adapterの実装を通して、OMMX Adapterの実装方法について学びました。以下がOMMX Adapterを実装する際の重要なポイントです：
 
 1. OMMX Adapterは `SolverAdapter` または `SamplerAdapter` の抽象基底クラスを継承することで実装します
-2. `INPUT_CLASS` で厳格な構造的入力条件を宣言します。有用な場合は、`recommended_preparation_policy()` から新しい編集可能な Policy を返します。呼び出し側が `Instance.prepare()` で適用した後、Adapter は通常の applicability check を行います
+2. `INPUT_CLASS` で applicability を定義します。`check_applicability()` と `require_applicable()` が report または強制するのは membership だけです。有用な場合は、`recommended_preparation_policy()` から新しい編集可能な Policy を返し、呼び出し側が厳格な Adapter API を呼ぶ前に `Instance.prepare()` で適用します
 3. 実装の主なステップは以下の通りです：
    - `ommx.Instance` をバックエンドソルバーが理解できる形式に変換する
    - バックエンドソルバーを実行して解を取得する
    - バックエンドソルバーの出力を `ommx.Solution` や `ommx.SampleSet` に変換する
-4. 各バックエンドソルバーの特性や制限を理解し、適切に処理する必要があります
-4. IDの管理や変数の対応付けなど、バックエンドソルバーとOMMXの橋渡しに注意を払う必要があります
+4. Converter 固有または backend 固有の validation は solver input の構築経路に置き、その失敗を applicability failure ではなく conversion または backend error として扱います
+5. IDの管理や変数の対応付けなど、バックエンドソルバーとOMMXの橋渡しに注意を払う必要があります
 
 独自のバックエンドソルバーをOMMXと接続したい場合は、このチュートリアルを参考に実装すると良いでしょう。このチュートリアルに従ってOMMX Adapterを実装することで、様々なバックエンドソルバーでの最適化を共通化されたAPIで利用できるようになります。
 

--- a/docs/ja/user_guide/capability_model.md
+++ b/docs/ja/user_guide/capability_model.md
@@ -15,7 +15,7 @@ kernelspec:
 
 OMMX では、従来 Adapter Capability として一緒に説明されていた次の2つの概念を分けて扱います。
 
-- {class}`~ommx.InstanceClass` は、具体的な `Instance` 値の集合です。Adapter は構造的な入力条件を `INPUT_CLASS` で宣言し、その後に Adapter 固有の precondition を評価して applicability を判定します。
+- {class}`~ommx.InstanceClass` は、具体的な `Instance` 値の集合です。Adapter は、その集合を `INPUT_CLASS` として宣言することで applicability を定義します。
 - {meth}`Instance.lower_special_constraints() <ommx.Instance.lower_special_constraints>` は、Instance 上で選択した特殊制約 family を明示的に lowering します。入力 class の宣言でも、Adapter applicability の証明でもありません。
 
 本ページでは以下を説明します。
@@ -46,7 +46,9 @@ binary_linear_with_one_hot = InstanceClass(
 )
 ```
 
-Adapter は applicability の最初の条件を `INPUT_CLASS` として宣言します。構造化された結果を得るには `check_applicability()`、membership または Adapter 固有の precondition が満たされない場合に例外を送出するには `require_applicable()` を使います。明示的な preparation で別の入力値を作った場合は、その値で applicability を再評価します。
+Adapter は applicability の完全な条件を `INPUT_CLASS` として宣言します。構造化された membership result を得るには `check_applicability()`、membership が満たされない場合に例外を送出するには `require_applicable()` を使います。明示的な preparation で別の入力値を作った場合は、その値で membership を再評価します。
+
+Applicability と solver input の構築は別の境界です。Membership は、その後の全ての converter または backend operation の成功を保証しません。Converter は local helper が受け取る表現を検証でき、backend は solver input の構築中に数値や実装上の上限を拒否できます。これらは conversion または backend の error であり、追加の applicability 条件ではありません。また、`AdapterNotApplicableError` として報告してはいけません。
 
 ## SpecialConstraintKind と active_special_constraint_kinds
 
@@ -91,7 +93,7 @@ assert instance.one_hot_constraints == {}
 assert len(instance.constraints) == 1
 ```
 
-One-hot 制約が除去され、その代わりに通常の等式制約 $x_0 + x_1 + x_2 - 1 = 0$ が1つ追加されたことが分かります。`lower_special_constraints` はインスタンスを in-place に変更し、選択され、active で、実際に lowering された family だけを返します。選択した family が active でなければ空集合を返します。得られた値に対して `INPUT_CLASS` の membership または Adapter applicability を再評価してください。
+One-hot 制約が除去され、その代わりに通常の等式制約 $x_0 + x_1 + x_2 - 1 = 0$ が1つ追加されたことが分かります。`lower_special_constraints` はインスタンスを in-place に変更し、選択され、active で、実際に lowering された family だけを返します。選択した family が active でなければ空集合を返します。得られた値に対して Adapter applicability、すなわち `INPUT_CLASS` membership を再評価してください。
 
 ## 手動変換 API
 
@@ -200,8 +202,8 @@ for cid, c in instance2.constraints.items():
 | やりたいこと | 使う API |
 |---|---|
 | Adapter 入力の構造的な集合を記述する | {class}`~ommx.InstanceClass` |
-| Adapter applicability の最初の条件を宣言する | `INPUT_CLASS` |
-| membership と Adapter 固有の precondition を検査する | `check_applicability()` / `require_applicable()` |
+| Adapter applicability を定義する | `INPUT_CLASS` |
+| `INPUT_CLASS` membership を report または強制する | `check_applicability()` / `require_applicable()` |
 | active な特殊制約 family を調べる | {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` |
 | 選択した特殊制約を明示的に lowering する | {meth}`Instance.lower_special_constraints <ommx.Instance.lower_special_constraints>` |
 | 個別に通常制約に変換する | `convert_*_to_constraint(s)` / `convert_all_*_to_constraints` |

--- a/docs/ja/user_guide/special_constraints.md
+++ b/docs/ja/user_guide/special_constraints.md
@@ -98,7 +98,7 @@ PySCIPOpt Adapter に渡す前に、OneHot を通常の等式制約 $x_0 + x_1 +
 
 ```{code-cell} ipython3
 instance_oh.convert_all_one_hots_to_constraints()
-assert OMMXPySCIPOptAdapter.check_applicability(instance_oh).is_applicable
+assert OMMXPySCIPOptAdapter.check_applicability(instance_oh).is_member
 solution = OMMXPySCIPOptAdapter.solve(instance_oh)
 # 3 つのうち丁度 1 つを選ぶので、最大値 10 をもつ x_1 が選ばれる
 assert abs(solution.objective - 10.0) < 1e-6

--- a/python/ommx-highs-adapter/tests/test_error.py
+++ b/python/ommx-highs-adapter/tests/test_error.py
@@ -51,8 +51,8 @@ def test_input_class_accepts_complete_linear_mip_boundary(sense):
     )
 
     report = OMMXHighsAdapter.check_applicability(instance)
-    assert report.is_applicable
-    assert report.input_membership.matching_clauses == [(0, "highs-linear-mip")]
+    assert report.is_member
+    assert report.matching_clauses == [(0, "highs-linear-mip")]
 
 
 def test_error_nonlinear_objective():
@@ -67,7 +67,7 @@ def test_error_nonlinear_objective():
 
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXHighsAdapter(ommx_instance)
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     assert isinstance(
         mismatches[0],
@@ -88,7 +88,7 @@ def test_error_nonlinear_constraint():
 
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXHighsAdapter(ommx_instance)
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     assert isinstance(
         mismatches[0],
@@ -116,7 +116,7 @@ def test_rejects_unsupported_variable_kinds(variable, kind):
 
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXHighsAdapter(instance)
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     mismatch = mismatches[0]
     assert isinstance(mismatch, InstanceClassMismatch.VariableKindNotAllowed)
@@ -136,8 +136,8 @@ def test_accepts_unused_unsupported_variable_kind_without_mutating_input():
     before = instance.to_v2_bytes()
 
     report = OMMXHighsAdapter.check_applicability(instance)
-    assert report.is_applicable
-    assert report.input_membership.matching_clauses == [(0, "highs-linear-mip")]
+    assert report.is_member
+    assert report.matching_clauses == [(0, "highs-linear-mip")]
     OMMXHighsAdapter(instance)
     assert instance.to_v2_bytes() == before
 
@@ -166,8 +166,7 @@ def test_rejects_special_constraints_without_mutating_input():
         OMMXHighsAdapter(instance)
 
     mismatch_types = {
-        type(mismatch)
-        for mismatch in e.value.report.input_membership.clause_reports[0].mismatches
+        type(mismatch) for mismatch in e.value.report.clause_reports[0].mismatches
     }
     assert InstanceClassMismatch.IndicatorConstraintsNotAllowed in mismatch_types
     assert InstanceClassMismatch.OneHotConstraintsNotAllowed in mismatch_types
@@ -205,7 +204,7 @@ def test_recommended_preparation_reaches_the_highs_input_class():
 
     assert instance.prepare(input_class, policy) is None
     assert input_class.contains(instance)
-    assert OMMXHighsAdapter.check_applicability(instance).is_applicable
+    assert OMMXHighsAdapter.check_applicability(instance).is_member
 
 
 def test_error_infeasible_constant_equality_constraint():

--- a/python/ommx-highs-adapter/tests/test_error.py
+++ b/python/ommx-highs-adapter/tests/test_error.py
@@ -53,7 +53,6 @@ def test_input_class_accepts_complete_linear_mip_boundary(sense):
     report = OMMXHighsAdapter.check_applicability(instance)
     assert report.is_applicable
     assert report.input_membership.matching_clauses == [(0, "highs-linear-mip")]
-    assert report.precondition_violations == ()
 
 
 def test_error_nonlinear_objective():

--- a/python/ommx-openjij-adapter/README.md
+++ b/python/ommx-openjij-adapter/README.md
@@ -40,30 +40,27 @@ sample_set = OMMXOpenJijSAAdapter.sample(
 print(sample_set.summary)
 ```
 
-The fixed penalty weight is a nonnegative magnitude in the caller-owned
-preparation policy, not an OpenJij backend sampler parameter. The owner
-operation accepts values down to `-atol` and normalizes tolerated negative
-values to zero. The adapter deliberately does not choose a magnitude: zero
+The fixed penalty weight is part of the preparation policy, not an OpenJij
+sampler parameter. The adapter deliberately does not choose a magnitude: zero
 adds no preference for feasibility, while a sufficiently large positive value
 is application-specific and still does not guarantee that every returned
 sample is feasible.
 
-## Input class and preparation recommendation
+## Accepted models and recommended preparation
 
-`OMMXOpenJijSAAdapter.INPUT_CLASS` describes the instances that the adapter
-accepts directly:
+This adapter directly accepts:
 
 - Binary decision variables
 - a polynomial objective of any degree (QUBO or Binary HUBO)
 - no active regular or special constraints
 - minimization
 
-`INPUT_CLASS` membership is the complete Adapter applicability condition.
-`check_applicability()` reports that membership, while `require_applicable()`
-and the constructor reject non-members without transforming the input. When
-solver input is built, the converter separately validates that used variable
-IDs fit a signed 64-bit integer and converted interaction coefficients are
-finite. Those failures are conversion errors, not applicability results.
+For the shared semantics of adapter input classes and preparation, see
+[Adapter Input Classes and Explicit Constraint Lowering](https://jij-inc-ommx.readthedocs-hosted.com/en/latest/user_guide/capability_model.html).
+
+When building OpenJij sampler input, used variable IDs must fit a signed 64-bit
+integer and converted interaction coefficients must be finite. Violations are
+reported as conversion errors.
 
 `recommended_preparation_policy()` returns a fresh editable
 `ommx.PreparationPolicy`. It recommends:
@@ -81,22 +78,12 @@ are usually the convenient choice when special-constraint lowering creates
 regular constraints with generated IDs. OMMX validates the weight domain; the
 caller remains responsible for selecting a sufficient magnitude.
 
-`Instance.prepare()` mutates the same `Instance` that is then passed to the
-adapter. Success guarantees membership in `INPUT_CLASS`, so no additional
-applicability check is needed. Preparation uses the shared OMMX owner operations
-and their existing exception types. It is not globally transactional, so changes
-completed before a later error remain. Solver-input conversion can still fail on
-OpenJij-specific representation or backend limits; that failure does not change
-the instance's applicability.
+Pass the same prepared `Instance` to the adapter. It remains the evaluation
+owner for the returned `SampleSet` and retains the data needed to restore
+source-variable values and evaluate removed constraints. If an application
+also needs the pre-transformation model, copy it before calling `prepare()`.
 
-The mutated instance remains the evaluation owner for the returned `SampleSet`.
-It retains the dependency and removed-constraint data needed for evaluation;
-there is no separate OpenJij preparation result or source-reconstruction API.
-If an application separately needs the pre-transformation model, it should
-copy that model before calling `prepare()`.
-
-The exact representability and bit-count limits of Integer log encoding belong
-to the OMMX encoding operation, not to the OpenJij input class or an
-`ommx.v2.Feature`. OMMX does not yet implement `Kind::Spin`; direct OpenJij Spin
-input is tracked separately in
+Integer log encoding follows the representability and bit-count limits of the
+OMMX encoding operation. OMMX does not yet implement `Kind::Spin`; direct
+OpenJij Spin input is tracked separately in
 [OMMX issue #1082](https://github.com/Jij-Inc/ommx/issues/1082).

--- a/python/ommx-openjij-adapter/README.md
+++ b/python/ommx-openjij-adapter/README.md
@@ -32,7 +32,6 @@ policy.fixed_penalty = FixedPenaltyPreparation.uniform_penalty_method_with_fixed
     weight=2.0
 )
 instance.prepare(input_class, policy)
-OMMXOpenJijSAAdapter.require_applicable(instance)
 
 sample_set = OMMXOpenJijSAAdapter.sample(
     instance,
@@ -59,10 +58,12 @@ accepts directly:
 - no active regular or special constraints
 - minimization
 
-`check_applicability()` and the constructor are strict and never transform an
-input. In addition to input-class membership, they check the OpenJij-specific
-requirements that used variable IDs fit a signed 64-bit integer and converted
-interaction coefficients are finite.
+`INPUT_CLASS` membership is the complete Adapter applicability condition.
+`check_applicability()` reports that membership, while `require_applicable()`
+and the constructor reject non-members without transforming the input. When
+solver input is built, the converter separately validates that used variable
+IDs fit a signed 64-bit integer and converted interaction coefficients are
+finite. Those failures are conversion errors, not applicability results.
 
 `recommended_preparation_policy()` returns a fresh editable
 `ommx.PreparationPolicy`. It recommends:
@@ -81,10 +82,12 @@ regular constraints with generated IDs. OMMX validates the weight domain; the
 caller remains responsible for selecting a sufficient magnitude.
 
 `Instance.prepare()` mutates the same `Instance` that is then passed to the
-adapter. Success guarantees membership in `INPUT_CLASS`; the adapter-specific
-preconditions must still be checked normally. Preparation uses the shared OMMX
-owner operations and their existing exception types. It is not globally
-transactional, so changes completed before a later error remain.
+adapter. Success guarantees membership in `INPUT_CLASS`, so no additional
+applicability check is needed. Preparation uses the shared OMMX owner operations
+and their existing exception types. It is not globally transactional, so changes
+completed before a later error remain. Solver-input conversion can still fail on
+OpenJij-specific representation or backend limits; that failure does not change
+the instance's applicability.
 
 The mutated instance remains the evaluation owner for the returned `SampleSet`.
 It retains the dependency and removed-constraint data needed for evaluation;

--- a/python/ommx-openjij-adapter/ommx_openjij_adapter/adapter.py
+++ b/python/ommx-openjij-adapter/ommx_openjij_adapter/adapter.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 import copy
 from math import isfinite
 from typing import ClassVar
@@ -15,7 +14,6 @@ from ommx import (
     Instance,
     InstanceClass,
     InstanceClassClause,
-    InstanceClassMembershipReport,
     Kind,
     PreparationPolicy,
     Sense,
@@ -26,11 +24,7 @@ from ommx import (
     SpecialConstraintKind,
     SpecialConstraintPreparation,
 )
-from ommx.adapter import (
-    AdapterPreconditionViolation,
-    DiagnosticsSink,
-    SamplerAdapter,
-)
+from ommx.adapter import DiagnosticsSink, SamplerAdapter
 from opentelemetry import trace
 
 from ._decode import _decode_for_instance, decode_to_samples
@@ -167,69 +161,6 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
         self._qubo = {}
 
     @classmethod
-    def _check_preconditions(
-        cls,
-        ommx_instance: Instance,
-        input_membership: InstanceClassMembershipReport,
-    ) -> Iterable[AdapterPreconditionViolation]:
-        _ = input_membership
-        out_of_range_ids = frozenset(
-            variable.id
-            for variable in ommx_instance.used_decision_variables
-            if variable.id > cls.MAX_OPENJIJ_VARIABLE_ID
-        )
-        if out_of_range_ids:
-            return (
-                AdapterPreconditionViolation(
-                    condition="openjij.variable_id.signed_64_bit",
-                    description=(
-                        "OpenJij/cimod variable labels must fit a signed 64-bit "
-                        f"integer: {sorted(out_of_range_ids)}."
-                    ),
-                    variable_ids=out_of_range_ids,
-                    actual=max(out_of_range_ids),
-                    limit=cls.MAX_OPENJIJ_VARIABLE_ID,
-                ),
-            )
-        try:
-            hubo, _ = ommx_instance.as_hubo_format()
-            if any(len(key) > 2 for key in hubo):
-                interactions = hubo
-            else:
-                interactions, _ = ommx_instance.as_qubo_format()
-        except Exception as error:
-            return (
-                AdapterPreconditionViolation(
-                    condition="openjij.interactions.format",
-                    description=f"OpenJij interaction conversion failed: {error}",
-                    actual=str(error),
-                    limit="valid Binary QUBO or HUBO interactions",
-                ),
-            )
-
-        nonfinite = {
-            key: coefficient
-            for key, coefficient in interactions.items()
-            if not isfinite(coefficient)
-        }
-        if not nonfinite:
-            return ()
-        return (
-            AdapterPreconditionViolation(
-                condition="openjij.interactions.coefficient_finite",
-                description=(
-                    "OpenJij does not reliably reject non-finite interaction "
-                    f"coefficients: {nonfinite}."
-                ),
-                variable_ids=frozenset(
-                    variable_id for key in nonfinite for variable_id in key
-                ),
-                actual=len(nonfinite),
-                limit="all interaction coefficients finite",
-            ),
-        )
-
-    @classmethod
     def sample(
         cls,
         ommx_instance: Instance,
@@ -364,13 +295,43 @@ class OMMXOpenJijSAAdapter(SamplerAdapter):
             return
 
         with _tracer.start_as_current_span("convert"):
-            hubo, _ = self._solver_instance.as_hubo_format()
-            if any(len(k) > 2 for k in hubo):
-                self._is_hubo = True
-                self._hubo = hubo
-            else:
-                self._is_hubo = False
-                qubo, _ = self._solver_instance.as_qubo_format()
-                self._qubo = qubo
+            out_of_range_ids = sorted(
+                variable.id
+                for variable in self._solver_instance.used_decision_variables
+                if variable.id > self.MAX_OPENJIJ_VARIABLE_ID
+            )
+            if out_of_range_ids:
+                raise ValueError(
+                    "OpenJij/cimod variable labels must fit a signed 64-bit "
+                    f"integer: {out_of_range_ids}."
+                )
 
+            try:
+                hubo, _ = self._solver_instance.as_hubo_format()
+                is_hubo = any(len(key) > 2 for key in hubo)
+                if is_hubo:
+                    interactions = hubo
+                    qubo = {}
+                else:
+                    qubo, _ = self._solver_instance.as_qubo_format()
+                    interactions = qubo
+            except Exception as error:
+                raise ValueError(
+                    f"OpenJij interaction conversion failed: {error}"
+                ) from error
+
+            nonfinite = {
+                key: coefficient
+                for key, coefficient in interactions.items()
+                if not isfinite(coefficient)
+            }
+            if nonfinite:
+                raise ValueError(
+                    "OpenJij does not reliably reject non-finite interaction "
+                    f"coefficients: {nonfinite}."
+                )
+
+            self._is_hubo = is_hubo
+            self._hubo = hubo if is_hubo else {}
+            self._qubo = qubo
             self._sampler_input_prepared = True

--- a/python/ommx-openjij-adapter/tests/test_applicability.py
+++ b/python/ommx-openjij-adapter/tests/test_applicability.py
@@ -39,17 +39,15 @@ def _assert_direct_rejection_does_not_mutate(
     before = instance.to_v2_bytes()
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
-    assert not report.is_applicable
-    assert not report.input_membership.is_member
+    assert not report.is_member
     assert instance.to_v2_bytes() == before
 
     with pytest.raises(AdapterNotApplicableError) as error:
         OMMXOpenJijSAAdapter(instance)
-    assert error.value.report.adapter == report.adapter
-    assert not error.value.report.is_applicable
+    assert error.value.report == report
     assert instance.to_v2_bytes() == before
 
-    [clause_report] = report.input_membership.clause_reports
+    [clause_report] = report.clause_reports
     return tuple(clause_report.mismatches)
 
 
@@ -78,8 +76,8 @@ def test_direct_accepts_arbitrary_degree_binary_minimization_without_mutation() 
     before = instance.to_v2_bytes()
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
-    assert report.is_applicable
-    assert report.input_membership.matching_clauses == [(0, "openjij-binary-hubo")]
+    assert report.is_member
+    assert report.matching_clauses == [(0, "openjij-binary-hubo")]
 
     adapter = OMMXOpenJijSAAdapter(instance)
     assert adapter.ommx_instance.to_v2_bytes() == before
@@ -97,8 +95,7 @@ def test_sampler_input_rejects_nonfinite_aggregated_interactions() -> None:
     )
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
-    assert report.input_membership.is_member
-    assert report.is_applicable
+    assert report.is_member
 
     adapter = OMMXOpenJijSAAdapter(instance)
     with pytest.raises(ValueError, match="non-finite interaction coefficients"):
@@ -110,15 +107,14 @@ def test_sampler_input_rejects_nonfinite_aggregated_interactions() -> None:
 
 def test_sampler_input_rejects_variable_id_outside_openjij_signed_range() -> None:
     accepted = _instance_with_variable(DecisionVariable.binary(2**63 - 1))
-    assert OMMXOpenJijSAAdapter.check_applicability(accepted).is_applicable
+    assert OMMXOpenJijSAAdapter.check_applicability(accepted).is_member
     _ = OMMXOpenJijSAAdapter(accepted).sampler_input
 
     variable_id = 2**63
     instance = _instance_with_variable(DecisionVariable.binary(variable_id))
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
-    assert report.input_membership.is_member
-    assert report.is_applicable
+    assert report.is_member
 
     adapter = OMMXOpenJijSAAdapter(instance)
     with pytest.raises(ValueError, match="signed 64-bit integer"):
@@ -266,7 +262,7 @@ def test_recommended_preparation_reaches_the_openjij_input_class() -> None:
     assert instance.prepare(input_class, policy) is None
     assert alias is instance
     assert input_class.contains(alias)
-    assert OMMXOpenJijSAAdapter.check_applicability(alias).is_applicable
+    assert OMMXOpenJijSAAdapter.check_applicability(alias).is_member
 
 
 def test_sampler_input_validation_still_follows_preparation() -> None:
@@ -286,7 +282,7 @@ def test_sampler_input_validation_still_follows_preparation() -> None:
     assert input_class.contains(instance)
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
-    assert report.is_applicable
+    assert report.is_member
 
     adapter = OMMXOpenJijSAAdapter(instance)
     with pytest.raises(ValueError, match="signed 64-bit integer"):

--- a/python/ommx-openjij-adapter/tests/test_applicability.py
+++ b/python/ommx-openjij-adapter/tests/test_applicability.py
@@ -16,7 +16,7 @@ from ommx import (
     Sense,
     Sos1Constraint,
 )
-from ommx.adapter import AdapterNotApplicableError, AdapterPreconditionViolation
+from ommx.adapter import AdapterNotApplicableError
 from ommx_openjij_adapter import OMMXOpenJijSAAdapter
 
 
@@ -41,8 +41,6 @@ def _assert_direct_rejection_does_not_mutate(
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
     assert not report.is_applicable
     assert not report.input_membership.is_member
-    assert not report.preconditions_checked
-    assert report.precondition_violations == ()
     assert instance.to_v2_bytes() == before
 
     with pytest.raises(AdapterNotApplicableError) as error:
@@ -82,15 +80,13 @@ def test_direct_accepts_arbitrary_degree_binary_minimization_without_mutation() 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
     assert report.is_applicable
     assert report.input_membership.matching_clauses == [(0, "openjij-binary-hubo")]
-    assert report.preconditions_checked
-    assert report.precondition_violations == ()
 
     adapter = OMMXOpenJijSAAdapter(instance)
     assert adapter.ommx_instance.to_v2_bytes() == before
     assert instance.to_v2_bytes() == before
 
 
-def test_direct_rejects_nonfinite_aggregated_interactions() -> None:
+def test_sampler_input_rejects_nonfinite_aggregated_interactions() -> None:
     x = DecisionVariable.binary(0)
     maximum = float.fromhex("0x1.fffffffffffffp+1023")
     instance = Instance.from_components(
@@ -102,14 +98,17 @@ def test_direct_rejects_nonfinite_aggregated_interactions() -> None:
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
     assert report.input_membership.is_member
-    assert report.preconditions_checked
-    assert not report.is_applicable
-    [violation] = report.precondition_violations
-    assert violation.condition == "openjij.interactions.coefficient_finite"
-    assert violation.variable_ids == frozenset({0})
+    assert report.is_applicable
+
+    adapter = OMMXOpenJijSAAdapter(instance)
+    with pytest.raises(ValueError, match="non-finite interaction coefficients"):
+        _ = adapter.sampler_input
+    assert not adapter._sampler_input_prepared
+    assert adapter._hubo == {}
+    assert adapter._qubo == {}
 
 
-def test_direct_rejects_variable_id_outside_openjij_signed_range() -> None:
+def test_sampler_input_rejects_variable_id_outside_openjij_signed_range() -> None:
     accepted = _instance_with_variable(DecisionVariable.binary(2**63 - 1))
     assert OMMXOpenJijSAAdapter.check_applicability(accepted).is_applicable
 
@@ -118,11 +117,14 @@ def test_direct_rejects_variable_id_outside_openjij_signed_range() -> None:
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
     assert report.input_membership.is_member
-    assert not report.is_applicable
-    [violation] = report.precondition_violations
-    assert violation.condition == "openjij.variable_id.signed_64_bit"
-    assert violation.variable_ids == frozenset({variable_id})
-    assert violation.limit == 2**63 - 1
+    assert report.is_applicable
+
+    adapter = OMMXOpenJijSAAdapter(instance)
+    with pytest.raises(ValueError, match="signed 64-bit integer"):
+        _ = adapter.sampler_input
+    assert not adapter._sampler_input_prepared
+    assert adapter._hubo == {}
+    assert adapter._qubo == {}
 
 
 @pytest.mark.parametrize(
@@ -266,7 +268,7 @@ def test_recommended_preparation_reaches_the_openjij_input_class() -> None:
     assert OMMXOpenJijSAAdapter.check_applicability(alias).is_applicable
 
 
-def test_adapter_specific_preconditions_still_follow_preparation() -> None:
+def test_sampler_input_validation_still_follows_preparation() -> None:
     x = DecisionVariable.binary(2**63)
     instance = Instance.from_components(
         decision_variables=[x],
@@ -283,7 +285,8 @@ def test_adapter_specific_preconditions_still_follow_preparation() -> None:
     assert input_class.contains(instance)
 
     report = OMMXOpenJijSAAdapter.check_applicability(instance)
-    assert not report.is_applicable
-    [violation] = report.precondition_violations
-    assert isinstance(violation, AdapterPreconditionViolation)
-    assert violation.condition == "openjij.variable_id.signed_64_bit"
+    assert report.is_applicable
+
+    adapter = OMMXOpenJijSAAdapter(instance)
+    with pytest.raises(ValueError, match="signed 64-bit integer"):
+        _ = adapter.sampler_input

--- a/python/ommx-openjij-adapter/tests/test_applicability.py
+++ b/python/ommx-openjij-adapter/tests/test_applicability.py
@@ -111,6 +111,7 @@ def test_sampler_input_rejects_nonfinite_aggregated_interactions() -> None:
 def test_sampler_input_rejects_variable_id_outside_openjij_signed_range() -> None:
     accepted = _instance_with_variable(DecisionVariable.binary(2**63 - 1))
     assert OMMXOpenJijSAAdapter.check_applicability(accepted).is_applicable
+    _ = OMMXOpenJijSAAdapter(accepted).sampler_input
 
     variable_id = 2**63
     instance = _instance_with_variable(DecisionVariable.binary(variable_id))

--- a/python/ommx-openjij-adapter/tests/test_public_api.py
+++ b/python/ommx-openjij-adapter/tests/test_public_api.py
@@ -1,4 +1,7 @@
+import pytest
+
 from ommx import DecisionVariable, Instance, Sense
+from ommx.adapter import AdapterNotApplicableError
 import ommx_openjij_adapter as package
 from ommx_openjij_adapter import _decode, adapter
 
@@ -13,8 +16,8 @@ def test_package_root_is_the_stable_public_facade() -> None:
     assert package.OMMXOpenJijSAAdapter.__module__ == "ommx_openjij_adapter"
 
 
-def test_adapter_identity_in_applicability_report_is_unchanged() -> None:
-    x = DecisionVariable.binary(0)
+def test_adapter_identity_in_applicability_error_uses_public_facade() -> None:
+    x = DecisionVariable.continuous(0)
     instance = Instance.from_components(
         decision_variables=[x],
         objective=x,
@@ -23,5 +26,8 @@ def test_adapter_identity_in_applicability_report_is_unchanged() -> None:
     )
 
     report = package.OMMXOpenJijSAAdapter.check_applicability(instance)
+    with pytest.raises(AdapterNotApplicableError) as error:
+        package.OMMXOpenJijSAAdapter(instance)
 
-    assert report.adapter == "ommx_openjij_adapter.OMMXOpenJijSAAdapter"
+    assert error.value.adapter == "ommx_openjij_adapter.OMMXOpenJijSAAdapter"
+    assert error.value.report == report

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -162,7 +162,7 @@ def hubo_binary_inequality():
 
 
 def _openjij_input(instance):
-    if not OMMXOpenJijSAAdapter.check_applicability(instance).is_applicable:
+    if not OMMXOpenJijSAAdapter.check_applicability(instance).is_member:
         input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
         policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()
         policy.fixed_penalty = (

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -821,11 +821,6 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
         # Check if objective is quadratic to add auxiliary variable
         degree = self.instance.objective.degree()
-        if degree > 2:
-            raise OMMXPySCIPOptAdapterError(
-                f"Objective function degree {degree} is not supported. "
-                "Only constant, linear, and quadratic objectives are supported."
-            )
         if degree == 2:
             # If objective function is quadratic, add the auxiliary variable for the linearized objective function,
             # because the setObjective method in PySCIPOpt does not support quadratic objective functions.

--- a/python/ommx-pyscipopt-adapter/tests/test_error.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_error.py
@@ -66,7 +66,6 @@ def test_input_class_accepts_complete_quadratic_mip_boundary(sense):
     report = OMMXPySCIPOptAdapter.check_applicability(instance)
     assert report.is_applicable
     assert report.input_membership.matching_clauses == [(0, "pyscipopt-quadratic-mip")]
-    assert report.precondition_violations == ()
     OMMXPySCIPOptAdapter(instance)
     assert instance.to_v2_bytes() == before
 

--- a/python/ommx-pyscipopt-adapter/tests/test_error.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_error.py
@@ -64,8 +64,8 @@ def test_input_class_accepts_complete_quadratic_mip_boundary(sense):
     before = instance.to_v2_bytes()
 
     report = OMMXPySCIPOptAdapter.check_applicability(instance)
-    assert report.is_applicable
-    assert report.input_membership.matching_clauses == [(0, "pyscipopt-quadratic-mip")]
+    assert report.is_member
+    assert report.matching_clauses == [(0, "pyscipopt-quadratic-mip")]
     OMMXPySCIPOptAdapter(instance)
     assert instance.to_v2_bytes() == before
 
@@ -80,7 +80,7 @@ def test_error_polynomial_objective():
     )
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPySCIPOptAdapter(ommx_instance)
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     mismatch = mismatches[0]
     assert isinstance(mismatch, InstanceClassMismatch.ObjectiveDegreeExceedsBound)
@@ -122,7 +122,7 @@ def test_error_nonlinear_constraint():
     )
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPySCIPOptAdapter(ommx_instance)
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     mismatch = mismatches[0]
     assert isinstance(
@@ -147,7 +147,7 @@ def test_rejects_quadratic_indicator_body_without_mutating_input():
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPySCIPOptAdapter(instance)
 
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     mismatch = mismatches[0]
     assert isinstance(mismatch, InstanceClassMismatch.IndicatorBodyDegreeExceedsBound)
@@ -176,7 +176,7 @@ def test_rejects_unsupported_variable_kinds(variable, kind):
 
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPySCIPOptAdapter(instance)
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     mismatch = mismatches[0]
     assert isinstance(mismatch, InstanceClassMismatch.VariableKindNotAllowed)
@@ -196,7 +196,7 @@ def test_accepts_unused_unsupported_variable_kind_without_mutating_input():
     before = instance.to_v2_bytes()
 
     report = OMMXPySCIPOptAdapter.check_applicability(instance)
-    assert report.is_applicable
+    assert report.is_member
     OMMXPySCIPOptAdapter(instance)
     assert instance.to_v2_bytes() == before
 
@@ -216,7 +216,7 @@ def test_rejects_one_hot_without_implicit_lowering():
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPySCIPOptAdapter(instance)
 
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     assert len(mismatches) == 1
     mismatch = mismatches[0]
     assert isinstance(mismatch, InstanceClassMismatch.OneHotConstraintsNotAllowed)

--- a/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
@@ -52,7 +52,7 @@ def test_recommended_preparation_lowers_only_one_hot() -> None:
 
     assert input_class.contains(prepared)
     report = OMMXPySCIPOptAdapter.check_applicability(prepared)
-    assert report.is_applicable
+    assert report.is_member
     adapter = OMMXPySCIPOptAdapter(prepared)
     assert adapter.instance is prepared
 

--- a/python/ommx-python-mip-adapter/tests/test_adapter.py
+++ b/python/ommx-python-mip-adapter/tests/test_adapter.py
@@ -53,8 +53,6 @@ def test_input_class_accepts_complete_linear_mip_boundary(sense: Sense) -> None:
 
     assert report.is_applicable
     assert report.input_membership.matching_clauses == [(0, "python-mip-linear-mip")]
-    assert report.preconditions_checked
-    assert report.precondition_violations == ()
 
 
 def test_error_nonlinear_objective():

--- a/python/ommx-python-mip-adapter/tests/test_adapter.py
+++ b/python/ommx-python-mip-adapter/tests/test_adapter.py
@@ -51,8 +51,8 @@ def test_input_class_accepts_complete_linear_mip_boundary(sense: Sense) -> None:
 
     report = OMMXPythonMIPAdapter.check_applicability(instance)
 
-    assert report.is_applicable
-    assert report.input_membership.matching_clauses == [(0, "python-mip-linear-mip")]
+    assert report.is_member
+    assert report.matching_clauses == [(0, "python-mip-linear-mip")]
 
 
 def test_error_nonlinear_objective():
@@ -68,7 +68,7 @@ def test_error_nonlinear_objective():
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPythonMIPAdapter(ommx_instance)
     assert isinstance(
-        e.value.report.input_membership.clause_reports[0].mismatches[0],
+        e.value.report.clause_reports[0].mismatches[0],
         InstanceClassMismatch.ObjectiveDegreeExceedsBound,
     )
 
@@ -87,7 +87,7 @@ def test_error_nonlinear_constraint():
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPythonMIPAdapter(ommx_instance)
     assert isinstance(
-        e.value.report.input_membership.clause_reports[0].mismatches[0],
+        e.value.report.clause_reports[0].mismatches[0],
         InstanceClassMismatch.RegularConstraintDegreeExceedsBound,
     )
 
@@ -115,7 +115,7 @@ def test_rejects_used_unsupported_variable_kinds(
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPythonMIPAdapter(instance)
 
-    mismatch = e.value.report.input_membership.clause_reports[0].mismatches[0]
+    mismatch = e.value.report.clause_reports[0].mismatches[0]
     assert isinstance(mismatch, InstanceClassMismatch.VariableKindNotAllowed)
     assert mismatch.kind == kind
     assert mismatch.variable_ids == {0}
@@ -134,7 +134,7 @@ def test_ignores_unused_unsupported_variable_kind() -> None:
     report = OMMXPythonMIPAdapter.check_applicability(instance)
     adapter = OMMXPythonMIPAdapter(instance)
 
-    assert report.is_applicable
+    assert report.is_member
     assert adapter.instance is instance
     assert [variable.name for variable in adapter.solver_input.vars] == ["0"]
 
@@ -162,7 +162,7 @@ def test_rejects_special_constraints_without_mutating_input() -> None:
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPythonMIPAdapter(instance)
 
-    mismatches = e.value.report.input_membership.clause_reports[0].mismatches
+    mismatches = e.value.report.clause_reports[0].mismatches
     mismatch_types = {type(mismatch) for mismatch in mismatches}
     assert InstanceClassMismatch.IndicatorConstraintsNotAllowed in mismatch_types
     assert InstanceClassMismatch.OneHotConstraintsNotAllowed in mismatch_types
@@ -200,4 +200,4 @@ def test_recommended_preparation_reaches_the_python_mip_input_class() -> None:
 
     assert instance.prepare(input_class, policy) is None
     assert input_class.contains(instance)
-    assert OMMXPythonMIPAdapter.check_applicability(instance).is_applicable
+    assert OMMXPythonMIPAdapter.check_applicability(instance).is_member

--- a/python/ommx-tests/tests/test_instance_class.py
+++ b/python/ommx-tests/tests/test_instance_class.py
@@ -12,6 +12,7 @@ from ommx import (
     Instance,
     InstanceClass,
     InstanceClassClause,
+    InstanceClassMembershipReport,
     InstanceClassMismatch,
     Kind,
     OneHotConstraint,
@@ -347,11 +348,10 @@ def test_solver_adapter_applicability_is_input_class_membership() -> None:
         INPUT_CLASS = binary_linear_input_class()
 
     report = Adapter.check_applicability(instance)
-    assert report.is_applicable
-    assert report.input_membership.is_member
-    assert report.adapter.endswith(".Adapter")
+    assert isinstance(report, InstanceClassMembershipReport)
+    assert report.is_member
     assert instance.to_v2_bytes() == before
-    assert Adapter.require_applicable(instance).is_applicable
+    assert Adapter.require_applicable(instance) == report
 
 
 def test_membership_failure_and_invalid_declarations_are_errors() -> None:
@@ -362,11 +362,11 @@ def test_membership_failure_and_invalid_declarations_are_errors() -> None:
         INPUT_CLASS = binary_linear_input_class()
 
     report = Adapter.check_applicability(outside_input_class)
-    assert not report.is_applicable
-    assert not report.input_membership.is_member
+    assert not report.is_member
     with pytest.raises(AdapterNotApplicableError) as exc_info:
         Adapter.require_applicable(outside_input_class)
-    assert exc_info.value.report.input_membership == report.input_membership
+    assert exc_info.value.report == report
+    assert exc_info.value.adapter.endswith(".Adapter")
 
     class MissingDeclaration(SolverAdapter):
         pass

--- a/python/ommx-tests/tests/test_instance_class.py
+++ b/python/ommx-tests/tests/test_instance_class.py
@@ -326,12 +326,6 @@ def test_membership_is_recomputed_after_explicit_lowering() -> None:
     assert prepared_input_class.contains(instance)
 
 
-def test_solver_adapter_base_owns_no_input_class_or_transformation_hook() -> None:
-    assert "INPUT_CLASS" not in SolverAdapter.__dict__
-    assert "__init__" not in SolverAdapter.__dict__
-    assert "_check_preconditions" not in SolverAdapter.__dict__
-
-
 def test_solver_adapter_returns_a_fresh_empty_preparation_recommendation() -> None:
     first = SolverAdapter.recommended_preparation_policy()
     second = SolverAdapter.recommended_preparation_policy()

--- a/python/ommx-tests/tests/test_instance_class.py
+++ b/python/ommx-tests/tests/test_instance_class.py
@@ -12,7 +12,6 @@ from ommx import (
     Instance,
     InstanceClass,
     InstanceClassClause,
-    InstanceClassMembershipReport,
     InstanceClassMismatch,
     Kind,
     OneHotConstraint,
@@ -23,10 +22,7 @@ from ommx import (
     SpecialConstraintKind,
 )
 from ommx.adapter import (
-    AdapterApplicabilityReport,
     AdapterNotApplicableError,
-    AdapterPreconditionViolation,
-    ConstraintRef,
     SolverAdapter,
 )
 
@@ -107,8 +103,6 @@ def test_degree_bound_and_clause_declaration() -> None:
     assert declared.indicator_constraint_degree_bounds == {}
     assert declared.allows_one_hot
     assert not declared.allows_sos1
-
-    assert ConstraintRef("regular", 1) != ConstraintRef("indicator", 1)
 
 
 def test_empty_classes_duplicate_labels_and_membership_is_side_effect_free() -> None:
@@ -335,6 +329,7 @@ def test_membership_is_recomputed_after_explicit_lowering() -> None:
 def test_solver_adapter_base_owns_no_input_class_or_transformation_hook() -> None:
     assert "INPUT_CLASS" not in SolverAdapter.__dict__
     assert "__init__" not in SolverAdapter.__dict__
+    assert "_check_preconditions" not in SolverAdapter.__dict__
 
 
 def test_solver_adapter_returns_a_fresh_empty_preparation_recommendation() -> None:
@@ -349,64 +344,35 @@ def test_solver_adapter_returns_a_fresh_empty_preparation_recommendation() -> No
     assert second.sense is None
 
 
-def test_solver_adapter_layers_preconditions_and_preserves_the_caller() -> None:
+def test_solver_adapter_applicability_is_input_class_membership() -> None:
     x = DecisionVariable.binary(1)
     instance = instance_with_objective(x, x)
     before = instance.to_v2_bytes()
-    violation = AdapterPreconditionViolation(
-        condition="backend_limit",
-        description="backend accepts no variables in this test",
-        variable_ids=frozenset({1}),
-        actual=1,
-        limit=0,
-    )
 
     class Adapter(SolverAdapter):
         INPUT_CLASS = binary_linear_input_class()
-        calls = 0
-
-        @classmethod
-        def _check_preconditions(cls, ommx_instance, input_membership):
-            cls.calls += 1
-            assert input_membership.is_member
-            assert ommx_instance.to_v2_bytes() == before
-            return (violation,)
 
     report = Adapter.check_applicability(instance)
-    assert not report.is_applicable
+    assert report.is_applicable
     assert report.input_membership.is_member
-    assert report.preconditions_checked
-    assert report.precondition_violations == (violation,)
     assert report.adapter.endswith(".Adapter")
-    assert Adapter.calls == 1
     assert instance.to_v2_bytes() == before
-
-    with pytest.raises(AdapterNotApplicableError) as exc_info:
-        Adapter.require_applicable(instance)
-    assert exc_info.value.report.precondition_violations == (violation,)
+    assert Adapter.require_applicable(instance).is_applicable
 
 
-def test_membership_failure_skips_preconditions_and_invalid_declarations_are_errors() -> (
-    None
-):
+def test_membership_failure_and_invalid_declarations_are_errors() -> None:
     y = DecisionVariable.continuous(1)
     outside_input_class = instance_with_objective(y, y * y)
 
     class Adapter(SolverAdapter):
         INPUT_CLASS = binary_linear_input_class()
-        calls = 0
-
-        @classmethod
-        def _check_preconditions(cls, ommx_instance, input_membership):
-            cls.calls += 1
-            return ()
 
     report = Adapter.check_applicability(outside_input_class)
     assert not report.is_applicable
     assert not report.input_membership.is_member
-    assert not report.preconditions_checked
-    assert report.precondition_violations == ()
-    assert Adapter.calls == 0
+    with pytest.raises(AdapterNotApplicableError) as exc_info:
+        Adapter.require_applicable(outside_input_class)
+    assert exc_info.value.report.input_membership == report.input_membership
 
     class MissingDeclaration(SolverAdapter):
         pass
@@ -417,65 +383,3 @@ def test_membership_failure_skips_preconditions_and_invalid_declarations_are_err
     for adapter in (MissingDeclaration, NoneDeclaration):
         with pytest.raises(TypeError, match="must declare INPUT_CLASS"):
             adapter.check_applicability(outside_input_class)
-
-
-def test_applicability_report_rejects_inconsistent_states() -> None:
-    x = DecisionVariable.binary(1)
-    member = binary_linear_input_class().check_membership(instance_with_objective(x, x))
-    y = DecisionVariable.continuous(2)
-    nonmember = binary_linear_input_class().check_membership(
-        instance_with_objective(y, y)
-    )
-    violation = AdapterPreconditionViolation(
-        condition="backend_limit",
-        description="backend limit was exceeded",
-    )
-
-    with pytest.raises(ValueError, match="exactly when input membership holds"):
-        AdapterApplicabilityReport("Adapter", member, False, ())
-    with pytest.raises(ValueError, match="exactly when input membership holds"):
-        AdapterApplicabilityReport("Adapter", nonmember, True, ())
-    with pytest.raises(ValueError, match="require adapter preconditions"):
-        AdapterApplicabilityReport("Adapter", nonmember, False, (violation,))
-
-
-def test_precondition_hook_is_isolated_and_validated() -> None:
-    x = DecisionVariable.binary(1)
-    instance = Instance.from_components(
-        sense=Sense.Minimize,
-        objective=x,
-        decision_variables=[x],
-        constraints={},
-        one_hot_constraints={30: OneHotConstraint(variables=[x])},
-    )
-    before = instance.to_v2_bytes()
-
-    class MutatingHook(SolverAdapter):
-        INPUT_CLASS = binary_linear_input_class(allows_one_hot=True)
-
-        @classmethod
-        def _check_preconditions(
-            cls,
-            ommx_instance: Instance,
-            input_membership: InstanceClassMembershipReport,
-        ) -> tuple[AdapterPreconditionViolation, ...]:
-            ommx_instance.lower_special_constraints({SpecialConstraintKind.OneHot})
-            return ()
-
-    assert MutatingHook.check_applicability(instance).is_applicable
-    assert instance.to_v2_bytes() == before
-    assert set(instance.one_hot_constraints) == {30}
-
-    class InvalidHook(SolverAdapter):
-        INPUT_CLASS = binary_linear_input_class(allows_one_hot=True)
-
-        @classmethod
-        def _check_preconditions(
-            cls,
-            ommx_instance: Instance,
-            input_membership: InstanceClassMembershipReport,
-        ) -> tuple[AdapterPreconditionViolation, ...]:
-            return cast(tuple[AdapterPreconditionViolation, ...], ("not a violation",))
-
-    with pytest.raises(TypeError, match="AdapterPreconditionViolation"):
-        InvalidHook.check_applicability(instance)

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import Any, ClassVar, Protocol, runtime_checkable
 
 from ommx._ommx_rust import DiagnosticCollector as DiagnosticCollector
@@ -51,31 +50,16 @@ class DiagnosticsSink(Protocol):
         """
 
 
-@dataclass(frozen=True, slots=True)
-class AdapterApplicabilityReport:
-    """Applicability result defined by an Adapter's input class."""
-
-    adapter: str
-    input_membership: InstanceClassMembershipReport
-
-    @property
-    def is_applicable(self) -> bool:
-        return self.input_membership.is_member
-
-    def __str__(self) -> str:
-        if not self.input_membership.is_member:
-            return f"{self.adapter} is not applicable:\n{self.input_membership}"
-        return f"{self.adapter} is applicable"
-
-
 class AdapterNotApplicableError(ValueError):
     """Raised when an instance is not applicable to an adapter."""
 
-    report: AdapterApplicabilityReport
+    adapter: str
+    report: InstanceClassMembershipReport
 
-    def __init__(self, report: AdapterApplicabilityReport):
+    def __init__(self, adapter: str, report: InstanceClassMembershipReport):
+        self.adapter = adapter
         self.report = report
-        super().__init__(str(report))
+        super().__init__(f"{adapter} is not applicable:\n{report}")
 
 
 class SolverAdapter(ABC):
@@ -101,7 +85,9 @@ class SolverAdapter(ABC):
         return PreparationPolicy()
 
     @classmethod
-    def check_applicability(cls, ommx_instance: Instance) -> AdapterApplicabilityReport:
+    def check_applicability(
+        cls, ommx_instance: Instance
+    ) -> InstanceClassMembershipReport:
         """Check ``INPUT_CLASS`` membership without mutation."""
         input_class: InstanceClass | None = getattr(cls, "INPUT_CLASS", None)
         if input_class is None:
@@ -109,19 +95,17 @@ class SolverAdapter(ABC):
                 f"{cls.__module__}.{cls.__qualname__} must declare INPUT_CLASS"
             )
 
-        input_membership = input_class.check_membership(ommx_instance)
-        adapter = f"{cls.__module__}.{cls.__qualname__}"
-        return AdapterApplicabilityReport(
-            adapter=adapter,
-            input_membership=input_membership,
-        )
+        return input_class.check_membership(ommx_instance)
 
     @classmethod
-    def require_applicable(cls, ommx_instance: Instance) -> AdapterApplicabilityReport:
-        """Return the report or raise :class:`AdapterNotApplicableError`."""
+    def require_applicable(
+        cls, ommx_instance: Instance
+    ) -> InstanceClassMembershipReport:
+        """Return the membership report or raise ``AdapterNotApplicableError``."""
         report = cls.check_applicability(ommx_instance)
-        if not report.is_applicable:
-            raise AdapterNotApplicableError(report)
+        if not report.is_member:
+            adapter = f"{cls.__module__}.{cls.__qualname__}"
+            raise AdapterNotApplicableError(adapter, report)
         return report
 
     @classmethod

--- a/python/ommx/ommx/adapter.py
+++ b/python/ommx/ommx/adapter.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import copy
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, ClassVar, Protocol, runtime_checkable
 
 from ommx._ommx_rust import DiagnosticCollector as DiagnosticCollector
@@ -54,64 +52,19 @@ class DiagnosticsSink(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
-class ConstraintRef:
-    """Constraint identity qualified by its independently scoped family."""
-
-    family: str
-    id: int
-
-
-PreconditionValue = str | int | float | bool | None
-
-
-@dataclass(frozen=True, slots=True)
-class AdapterPreconditionViolation:
-    """One adapter-owned condition that an OMMX input class cannot express."""
-
-    condition: str
-    description: str
-    variable_ids: frozenset[int] = field(default_factory=frozenset)
-    constraint_refs: frozenset[ConstraintRef] = field(default_factory=frozenset)
-    actual: PreconditionValue = None
-    limit: PreconditionValue = None
-
-
-@dataclass(frozen=True, slots=True)
 class AdapterApplicabilityReport:
-    """Combined input-class and adapter-specific applicability result."""
+    """Applicability result defined by an Adapter's input class."""
 
     adapter: str
     input_membership: InstanceClassMembershipReport
-    preconditions_checked: bool
-    precondition_violations: tuple[AdapterPreconditionViolation, ...]
-
-    def __post_init__(self) -> None:
-        if self.preconditions_checked != self.input_membership.is_member:
-            raise ValueError(
-                "preconditions_checked must be true exactly when input membership holds"
-            )
-        if not self.preconditions_checked and self.precondition_violations:
-            raise ValueError(
-                "precondition violations require adapter preconditions to be checked"
-            )
 
     @property
     def is_applicable(self) -> bool:
-        return (
-            self.input_membership.is_member
-            and self.preconditions_checked
-            and not self.precondition_violations
-        )
+        return self.input_membership.is_member
 
     def __str__(self) -> str:
         if not self.input_membership.is_member:
             return f"{self.adapter} is not applicable:\n{self.input_membership}"
-        if self.precondition_violations:
-            details = "\n".join(
-                f"- {violation.condition}: {violation.description}"
-                for violation in self.precondition_violations
-            )
-            return f"{self.adapter} preconditions failed:\n{details}"
         return f"{self.adapter} is applicable"
 
 
@@ -131,16 +84,12 @@ class SolverAdapter(ABC):
 
     See the `implementation guide <https://jij-inc-ommx.readthedocs-hosted.com/en/latest/tutorial/implement_adapter.html>`_ for more details.
 
-    Concrete subclasses own ``INPUT_CLASS`` and additional applicability
-    preconditions; callers own applying any recommended policy with
-    :meth:`ommx.Instance.prepare`.
+    Concrete subclasses define applicability with ``INPUT_CLASS``; callers own
+    applying any recommended policy with :meth:`ommx.Instance.prepare`.
     """
 
     INPUT_CLASS: ClassVar[InstanceClass]
-    """Required structural condition for an exact Adapter input.
-
-    Membership does not include adapter-owned preconditions.
-    """
+    """Required condition for an exact Adapter input."""
 
     @classmethod
     def recommended_preparation_policy(cls) -> PreparationPolicy:
@@ -153,7 +102,7 @@ class SolverAdapter(ABC):
 
     @classmethod
     def check_applicability(cls, ommx_instance: Instance) -> AdapterApplicabilityReport:
-        """Check ``INPUT_CLASS`` and adapter-owned preconditions without mutation."""
+        """Check ``INPUT_CLASS`` membership without mutation."""
         input_class: InstanceClass | None = getattr(cls, "INPUT_CLASS", None)
         if input_class is None:
             raise TypeError(
@@ -162,30 +111,9 @@ class SolverAdapter(ABC):
 
         input_membership = input_class.check_membership(ommx_instance)
         adapter = f"{cls.__module__}.{cls.__qualname__}"
-        if not input_membership.is_member:
-            return AdapterApplicabilityReport(
-                adapter=adapter,
-                input_membership=input_membership,
-                preconditions_checked=False,
-                precondition_violations=(),
-            )
-
-        violations = tuple(
-            cls._check_preconditions(copy.copy(ommx_instance), input_membership)
-        )
-        if not all(
-            isinstance(violation, AdapterPreconditionViolation)
-            for violation in violations
-        ):
-            raise TypeError(
-                f"{adapter}._check_preconditions() must return "
-                "AdapterPreconditionViolation values"
-            )
         return AdapterApplicabilityReport(
             adapter=adapter,
             input_membership=input_membership,
-            preconditions_checked=True,
-            precondition_violations=violations,
         )
 
     @classmethod
@@ -195,15 +123,6 @@ class SolverAdapter(ABC):
         if not report.is_applicable:
             raise AdapterNotApplicableError(report)
         return report
-
-    @classmethod
-    def _check_preconditions(
-        cls,
-        ommx_instance: Instance,
-        input_membership: InstanceClassMembershipReport,
-    ) -> Iterable[AdapterPreconditionViolation]:
-        """Return adapter-owned violations after input-class membership holds."""
-        return ()
 
     @classmethod
     @abstractmethod

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -466,8 +466,9 @@ derives private, ephemeral facts from the exact instance on every call and
 returns structured per-clause mismatches with affected variable or constraint
 IDs. If preparation or lowering produces another `Instance` to use as adapter
 input, membership must be checked on that exact value. Membership does not
-include adapter-specific preconditions or whether the adapter returns an
-output successfully.
+guarantee that later solver-input conversion or backend operations return an
+output successfully; those failures are not additional applicability
+conditions.
 
 [`SpecialConstraintKind`](crate::SpecialConstraintKind),
 [`Instance::active_special_constraint_kinds`](crate::Instance::active_special_constraint_kinds),

--- a/rust/ommx/src/instance_class.rs
+++ b/rust/ommx/src/instance_class.rs
@@ -6,10 +6,10 @@
 //! that set. An [`InstanceClassClause`] is one conjunctive clause in the
 //! representation; an instance class is the finite union of its clauses.
 //!
-//! Membership describes only the input's OMMX-defined structure. It does not
-//! include preparation or lowering, adapter-specific preconditions,
-//! wire-format `ommx.v2.Feature` handling, or whether the adapter returns an
-//! output successfully. If preparation produces another instance to use as
+//! Membership defines whether the exact input is applicable to an adapter. It
+//! does not perform preparation or lowering, handle wire-format
+//! `ommx.v2.Feature` values, or guarantee that later conversion and backend
+//! operations succeed. If preparation produces another instance to use as
 //! input, membership must be checked on that value.
 
 mod instance_facts;
@@ -576,8 +576,8 @@ impl InstanceClassClauseReport {
 /// Side-effect-free [`InstanceClass`] membership report.
 ///
 /// An instance is a member when at least one complete clause contains it.
-/// Adapter identity and adapter-specific preconditions belong to an adapter
-/// applicability report layered on top of this result.
+/// An adapter applicability report associates this membership result with the
+/// adapter identity; it does not add another applicability condition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstanceClassMembershipReport {
     clause_reports: Vec<InstanceClassClauseReport>,

--- a/rust/ommx/src/instance_class.rs
+++ b/rust/ommx/src/instance_class.rs
@@ -576,8 +576,8 @@ impl InstanceClassClauseReport {
 /// Side-effect-free [`InstanceClass`] membership report.
 ///
 /// An instance is a member when at least one complete clause contains it.
-/// An adapter applicability report associates this membership result with the
-/// adapter identity; it does not add another applicability condition.
+/// Adapters use this membership report directly when checking applicability;
+/// they do not add another applicability condition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstanceClassMembershipReport {
     clause_reports: Vec<InstanceClassClauseReport>,


### PR DESCRIPTION
## Summary

- make `INPUT_CLASS` membership the sole definition of adapter applicability
- return `InstanceClassMembershipReport` directly and remove the redundant `AdapterApplicabilityReport` wrapper
- remove the adapter-owned precondition hook and violation types
- move OpenJij signed-ID and finite-coefficient validation to solver-input conversion
- retain converter-local representation guards while removing redundant adapter-level preflight checks
- align adapter tests and English/Japanese documentation with the responsibility boundary

## Rationale

Adapter-owned acceptance checks can duplicate conditions already expressed by `INPUT_CLASS` and drift from its semantics. Applicability is therefore exactly input-class membership. Conversion helpers and backends may still reject representations or implementation limits while solver input is built, but those failures are conversion or backend errors rather than a second applicability result.

## Impact

`SolverAdapter.check_applicability()` and `require_applicable()` now return `InstanceClassMembershipReport` directly. Callers should use `report.is_member` and access `matching_clauses` or `clause_reports` without an `input_membership` wrapper. `AdapterNotApplicableError.report` holds the same membership report, while the adapter identity is available as `error.adapter`.

The public `AdapterApplicabilityReport`, `AdapterPreconditionViolation`, `ConstraintRef`, `_check_preconditions`, `preconditions_checked`, and `precondition_violations` surfaces are removed. Adapter implementations should express accepted-model semantics in `INPUT_CLASS` and keep defensive representation or backend validation at the solver-input conversion boundary.
