### PR TITLE
Separate protobuf parse context from semantic errors

### DIFF
--- a/python/ommx/src/error.rs
+++ b/python/ommx/src/error.rs
@@ -614,6 +614,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_error_owner_precedes_nested_domain_signals() {
+        let solution_error = ommx::ParseError {
+            context: vec![],
+            error: ommx::SolutionError::UnknownNamedFunctionID {
+                id: ommx::NamedFunctionID::from(1),
+            }
+            .into(),
+        };
+        assert!(solution_error.error.is::<ommx::SolutionError>());
+        assert_exception::<PyValueError>(ommx::Error::from(solution_error).into());
+
+        let sample_set_error = ommx::ParseError {
+            context: vec![],
+            error: ommx::SampleSetError::UnknownSampleID {
+                id: ommx::SampleID::from(1),
+            }
+            .into(),
+        };
+        assert!(sample_set_error.error.is::<ommx::SampleSetError>());
+        assert_exception::<PyValueError>(ommx::Error::from(sample_set_error).into());
+    }
+
+    #[test]
     fn log_encoding_unavailable_maps_to_a_specific_runtime_error() {
         let mut instance = ommx::Instance::default();
         let id = ommx::VariableID::from(7);

--- a/python/ommx/src/error.rs
+++ b/python/ommx/src/error.rs
@@ -563,7 +563,9 @@ pub fn register_exceptions(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyRe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ommx::Parse as _;
     use pyo3::type_object::PyTypeInfo;
+    use std::error::Error as _;
 
     fn assert_exception<T>(error: OmmxPyError)
     where
@@ -614,25 +616,42 @@ mod tests {
     }
 
     #[test]
-    fn parse_error_owner_precedes_nested_domain_signals() {
-        let solution_error = ommx::ParseError {
-            context: vec![],
-            error: ommx::SolutionError::UnknownNamedFunctionID {
-                id: ommx::NamedFunctionID::from(1),
-            }
-            .into(),
-        };
-        assert!(solution_error.error.is::<ommx::SolutionError>());
+    fn parse_error_owner_precedes_domain_signals() {
+        let mut decision_variable = ommx::v1::DecisionVariable::default();
+        decision_variable.id = 1;
+        decision_variable.kind = ommx::v1::decision_variable::Kind::Continuous as i32;
+        let mut state = ommx::v1::State::default();
+        state.entries = [(1, 2.0)].into_iter().collect();
+        let mut solution = ommx::v1::Solution::default();
+        solution.state = Some(state);
+        solution.decision_variables = vec![decision_variable.clone(), decision_variable];
+        solution.feasible_relaxed = Some(true);
+        let solution_error = solution.parse(&()).unwrap_err();
+        assert!(solution_error
+            .source()
+            .is_some_and(|source| source.is::<ommx::SolutionError>()));
         assert_exception::<PyValueError>(ommx::Error::from(solution_error).into());
 
-        let sample_set_error = ommx::ParseError {
-            context: vec![],
-            error: ommx::SampleSetError::UnknownSampleID {
-                id: ommx::SampleID::from(1),
-            }
-            .into(),
-        };
-        assert!(sample_set_error.error.is::<ommx::SampleSetError>());
+        let sample_id = ommx::SampleID::from(0);
+        let mut entry = ommx::v1::sampled_values::SampledValuesEntry::default();
+        entry.ids = vec![sample_id.into_inner()];
+        entry.value = 1.0;
+        let mut sampled_values = ommx::v1::SampledValues::default();
+        sampled_values.entries = vec![entry];
+        let mut first_named_function = ommx::v1::SampledNamedFunction::default();
+        first_named_function.id = 1;
+        first_named_function.evaluated_values = Some(sampled_values.clone());
+        let mut second_named_function = ommx::v1::SampledNamedFunction::default();
+        second_named_function.id = 1;
+        second_named_function.evaluated_values = Some(sampled_values.clone());
+        let mut sample_set = ommx::v1::SampleSet::default();
+        sample_set.objectives = Some(sampled_values);
+        sample_set.named_functions = vec![first_named_function, second_named_function];
+        sample_set.sense = ommx::v1::instance::Sense::Minimize as i32;
+        let sample_set_error = sample_set.parse(&()).unwrap_err();
+        assert!(sample_set_error
+            .source()
+            .is_some_and(|source| source.is::<ommx::SampleSetError>()));
         assert_exception::<PyValueError>(ommx::Error::from(sample_set_error).into());
     }
 

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -352,12 +352,19 @@ an equality.
 
 **Semantic protobuf parse errors.** `RawParseError::InvalidInstance` and the
 domain-signal wrapper variants on `RawParseError` were removed during the 3.0
-beta. `ParseError::error` now stores `ommx::Error` directly. Match a curated
-signal on that value when the caller has a recovery path, for example
-`parse_error.error.downcast_ref::<SolutionError>()`; otherwise propagate the
-outer `ParseError` or render it for diagnostics. `RawParseError` now contains
-only generic protobuf-boundary failures. Dedicated message-specific parse
-signals, such as `QuadraticParseError`, are also stored directly.
+beta. The `ParseError::error` field is no longer public; `ParseError` exposes
+its immediate cause through `std::error::Error::source()` instead. Match a
+curated signal on that source when the caller has a recovery path:
+
+```rust,ignore
+let solution_error = std::error::Error::source(parse_error)
+    .and_then(|source| source.downcast_ref::<SolutionError>());
+```
+
+Otherwise propagate the outer `ParseError` or render it for diagnostics.
+`RawParseError` now contains only generic protobuf-boundary failures. Dedicated
+message-specific parse signals, such as `QuadraticParseError`, are also exposed
+directly as the source.
 
 **Key lookups now return `Option<T>`:**
 

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -350,6 +350,15 @@ an equality.
   slimmer (1-based `line_num` + rendered `message`, no variant enum),
   and no longer re-exported at the crate root.
 
+**Semantic protobuf parse errors.** `RawParseError::InvalidInstance` and the
+domain-signal wrapper variants on `RawParseError` were removed during the 3.0
+beta. `ParseError::error` now stores `ommx::Error` directly. Match a curated
+signal on that value when the caller has a recovery path, for example
+`parse_error.error.downcast_ref::<SolutionError>()`; otherwise propagate the
+outer `ParseError` or render it for diagnostics. `RawParseError` now contains
+only generic protobuf-boundary failures. Dedicated message-specific parse
+signals, such as `QuadraticParseError`, are also stored directly.
+
 **Key lookups now return `Option<T>`:**
 
 ```rust,ignore

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -543,13 +543,15 @@ downcast the top-level error to `ParseError` without depending on `prost`; the
 standard source chain still exposes the underlying wire-decoding error for
 diagnostics.
 
-`ParseError` now stores its underlying [`Error`](crate::Error) directly.
-Recoverable semantic failures remain downcastable as their owning domain
-signal, while ordinary invariant failures remain ordinary errors with the same
-protobuf-tree breadcrumbs. The catch-all `RawParseError::InvalidInstance` and
-domain-signal wrapper variants were removed; `RawParseError` is limited to
-generic protobuf-boundary failures. Dedicated message-specific parse signals
-remain directly downcastable as well.
+The `ParseError::error` field is no longer public. `ParseError` exposes its
+immediate cause as `&dyn std::error::Error` through the standard error source
+chain instead. Recoverable semantic failures remain downcastable as their
+owning domain signal, while ordinary invariant failures remain ordinary errors
+with the same protobuf-tree breadcrumbs. The catch-all
+`RawParseError::InvalidInstance` and domain-signal wrapper variants were
+removed; `RawParseError` is limited to generic protobuf-boundary failures.
+Dedicated message-specific parse signals remain directly downcastable from the
+immediate source.
 
 Artifact image-reference parsing follows the same pattern. [`ImageRef::parse`](crate::artifact::ImageRef::parse)
 keeps returning `ommx::Result`, while invalid caller input retains a

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -553,6 +553,13 @@ removed; `RawParseError` is limited to generic protobuf-boundary failures.
 Dedicated message-specific parse signals remain directly downcastable from the
 immediate source.
 
+Malformed v1 `Solution` and `SampleSet` messages that repeat a regular
+constraint ID are now rejected as
+`SolutionError::InvalidConstraintStructure` or
+`SampleSetError::InvalidConstraintStructure`. They previously overwrote the row
+and its sidecars independently, which could silently combine data from
+different repeated entries.
+
 Artifact image-reference parsing follows the same pattern. [`ImageRef::parse`](crate::artifact::ImageRef::parse)
 keeps returning `ommx::Result`, while invalid caller input retains a
 downcastable [`ImageRefParseError`](crate::artifact::ImageRefParseError) and its

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -543,6 +543,14 @@ downcast the top-level error to `ParseError` without depending on `prost`; the
 standard source chain still exposes the underlying wire-decoding error for
 diagnostics.
 
+`ParseError` now stores its underlying [`Error`](crate::Error) directly.
+Recoverable semantic failures remain downcastable as their owning domain
+signal, while ordinary invariant failures remain ordinary errors with the same
+protobuf-tree breadcrumbs. The catch-all `RawParseError::InvalidInstance` and
+domain-signal wrapper variants were removed; `RawParseError` is limited to
+generic protobuf-boundary failures. Dedicated message-specific parse signals
+remain directly downcastable as well.
+
 Artifact image-reference parsing follows the same pattern. [`ImageRef::parse`](crate::artifact::ImageRef::parse)
 keeps returning `ommx::Result`, while invalid caller input retains a
 downcastable [`ImageRefParseError`](crate::artifact::ImageRefParseError) and its
@@ -601,7 +609,8 @@ Related PRs: [#832](https://github.com/Jij-Inc/ommx/pull/832),
 [#1101](https://github.com/Jij-Inc/ommx/pull/1101),
 [#1104](https://github.com/Jij-Inc/ommx/pull/1104),
 [#1105](https://github.com/Jij-Inc/ommx/pull/1105),
-[#1107](https://github.com/Jij-Inc/ommx/pull/1107).
+[#1107](https://github.com/Jij-Inc/ommx/pull/1107),
+[#1173](https://github.com/Jij-Inc/ommx/pull/1173).
 
 ## ⚙️ Tracing-first observability
 

--- a/rust/ommx/doc/tutorial/error_handling.md
+++ b/rust/ommx/doc/tutorial/error_handling.md
@@ -141,6 +141,16 @@ ParametricInstance namespace collisions, and
 validation. This preserves the validation cause without changing the
 Python-visible parse contract.
 
+[`ParseError::error`](crate::ParseError::error) stores the underlying
+[`Error`](crate::Error) directly. Recoverable semantic failures can therefore
+be downcast to their domain signal without first matching a parse-layer
+wrapper. [`RawParseError`](crate::RawParseError) is reserved for generic
+protobuf-boundary failures such as missing fields, unknown enums, reserved
+annotation keys, and decode errors. Dedicated message-specific signals such as
+[`QuadraticParseError`](crate::QuadraticParseError) are also stored directly.
+Semantic failures without a caller recovery path remain ordinary `Error`
+values and still retain the `ParseError` breadcrumbs.
+
 ## Fail-site macros
 
 [`bail!`](crate::bail), [`error!`](crate::error!), and [`ensure!`](crate::ensure) fuse a `tracing::error!` event

--- a/rust/ommx/doc/tutorial/error_handling.md
+++ b/rust/ommx/doc/tutorial/error_handling.md
@@ -141,15 +141,25 @@ ParametricInstance namespace collisions, and
 validation. This preserves the validation cause without changing the
 Python-visible parse contract.
 
-[`ParseError::error`](crate::ParseError::error) stores the underlying
-[`Error`](crate::Error) directly. Recoverable semantic failures can therefore
-be downcast to their domain signal without first matching a parse-layer
-wrapper. [`RawParseError`](crate::RawParseError) is reserved for generic
-protobuf-boundary failures such as missing fields, unknown enums, reserved
-annotation keys, and decode errors. Dedicated message-specific signals such as
-[`QuadraticParseError`](crate::QuadraticParseError) are also stored directly.
-Semantic failures without a caller recovery path remain ordinary `Error`
-values and still retain the `ParseError` breadcrumbs.
+[`ParseError`](crate::ParseError) exposes its immediate cause through
+[`std::error::Error::source`]. Recoverable semantic failures can therefore be
+downcast directly from that source to their domain signal without matching a
+`RawParseError` wrapper. [`RawParseError`](crate::RawParseError) is
+reserved for generic protobuf-boundary failures such as missing fields,
+unknown enums, reserved annotation keys, and decode errors. Dedicated
+message-specific parse signals such as
+[`QuadraticParseError`](crate::QuadraticParseError) are also exposed directly.
+Semantic failures without a caller recovery path remain ordinary errors and
+still retain the `ParseError` breadcrumbs.
+
+```ignore
+let parse_error = error.downcast_ref::<ommx::ParseError>().unwrap();
+let cause = std::error::Error::source(parse_error).unwrap();
+
+if let Some(solution_error) = cause.downcast_ref::<ommx::SolutionError>() {
+    // Inspect the Solution-owned signal and recover if appropriate.
+}
+```
 
 ## Fail-site macros
 

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -1,6 +1,6 @@
 use crate::{
     macros::{impl_add_inverse, impl_mul_inverse},
-    parse::{Parse, ParseError, RawParseError},
+    parse::{Parse, ParseError},
     v1, ATol, VariableID,
 };
 use approx::AbsDiffEq;
@@ -37,7 +37,7 @@ impl BoundError {
 
 impl From<BoundError> for ParseError {
     fn from(e: BoundError) -> Self {
-        RawParseError::from(e).into()
+        ParseError::new(e)
     }
 }
 
@@ -539,6 +539,22 @@ mod tests {
     use approx::assert_abs_diff_eq;
 
     use super::*;
+
+    #[test]
+    fn parse_preserves_bound_error() {
+        let error = v1::Bound {
+            lower: 2.0,
+            upper: 1.0,
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(matches!(
+            error.error.downcast_ref::<BoundError>(),
+            Some(BoundError::UpperSmallerThanLower { lower, upper })
+                if *lower == 2.0 && *upper == 1.0
+        ));
+    }
 
     #[test]
     fn partial_ord() {

--- a/rust/ommx/src/bound.rs
+++ b/rust/ommx/src/bound.rs
@@ -536,6 +536,8 @@ impl Arbitrary for Bound {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use approx::assert_abs_diff_eq;
 
     use super::*;
@@ -550,7 +552,9 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            error.error.downcast_ref::<BoundError>(),
+            error
+                .source()
+                .and_then(|source| source.downcast_ref::<BoundError>()),
             Some(BoundError::UpperSmallerThanLower { lower, upper })
                 if *lower == 2.0 && *upper == 1.0
         ));

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -520,6 +520,8 @@ impl SampledConstraint {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
     use crate::{Coefficient, Evaluate};
 
@@ -610,7 +612,11 @@ mod tests {
 
         let err = proto.parse(&ATol::default()).unwrap_err();
 
-        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        let mut source = err.source();
+        while let Some(error) = source {
+            assert!(error.downcast_ref::<RawParseError>().is_none());
+            source = error.source();
+        }
         assert!(err
             .to_string()
             .contains("Inconsistent constraint feasibility"));

--- a/rust/ommx/src/constraint.rs
+++ b/rust/ommx/src/constraint.rs
@@ -294,7 +294,7 @@ fn validate_feasible_from_evaluated_value(
 ) -> Result<(), ParseError> {
     let computed_feasible = feasible_from_evaluated_value(equality, evaluated_value, atol);
     if provided_feasible != computed_feasible {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Inconsistent constraint feasibility: provided={provided_feasible}, computed={computed_feasible}",
         ))
         .context(message, "feasible"));
@@ -596,6 +596,24 @@ mod tests {
             err.to_string().contains("evaluated_value must be finite"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn parse_v2_evaluated_feasibility_mismatch_is_an_ordinary_error() {
+        let proto = crate::v2::EvaluatedRegularConstraint {
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_value: 1.0,
+            feasible: true,
+            used_decision_variable_ids: vec![],
+            dual_variable: None,
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        assert!(err
+            .to_string()
+            .contains("Inconsistent constraint feasibility"));
     }
 
     #[test]

--- a/rust/ommx/src/constraint/parse.rs
+++ b/rust/ommx/src/constraint/parse.rs
@@ -112,10 +112,9 @@ impl Parse for Vec<v1::Constraint> {
             let (id, c, context): (ConstraintID, Constraint<Created>, ConstraintContext) =
                 c.parse(&())?;
             if constraints.insert(id, c).is_some() {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Duplicated constraint ID is found in definition: {id:?}"
-                ))
-                .into());
+                )));
             }
             context_store.insert(id, context);
         }
@@ -131,19 +130,17 @@ impl Parse for Vec<v1::RemovedConstraint> {
         for c in self {
             let (id, constraint, context, reason) = c.parse(&())?;
             if constraints.contains_key(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Duplicated constraint ID is found in definition: {id:?}"
-                ))
-                .into());
+                )));
             }
             if removed_constraints
                 .insert(id, (constraint, context, reason))
                 .is_some()
             {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Duplicated constraint ID is found in definition: {id:?}"
-                ))
-                .into());
+                )));
             }
         }
         Ok(removed_constraints)
@@ -302,6 +299,21 @@ mod tests {
           └─ommx.v1.Constraint[function]
         Unsupported ommx.v1.Function is found. It is created by a newer version of OMMX SDK.
         "###);
+    }
+
+    #[test]
+    fn duplicate_constraint_ids_are_ordinary_semantic_errors() {
+        let constraint = v1::Constraint {
+            id: 1,
+            function: Some(Function::Zero.into()),
+            equality: v1::Equality::EqualToZero as i32,
+            ..Default::default()
+        };
+
+        let err = vec![constraint.clone(), constraint].parse(&()).unwrap_err();
+
+        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        assert!(err.to_string().contains("ConstraintID(1)"));
     }
 
     #[test]

--- a/rust/ommx/src/constraint/parse.rs
+++ b/rust/ommx/src/constraint/parse.rs
@@ -267,6 +267,8 @@ impl Parse for v1::SampledConstraint {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
     use crate::v1;
     use maplit::btreeset;
@@ -312,7 +314,11 @@ mod tests {
 
         let err = vec![constraint.clone(), constraint].parse(&()).unwrap_err();
 
-        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        let mut source = err.source();
+        while let Some(error) = source {
+            assert!(error.downcast_ref::<RawParseError>().is_none());
+            source = error.source();
+        }
         assert!(err.to_string().contains("ConstraintID(1)"));
     }
 

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -882,13 +882,13 @@ macro_rules! impl_parse_v2_evaluated_collection {
                     let signal = crate::SolutionError::InvalidSidecar {
                         message: e.to_string(),
                     };
-                    ParseError::new(e.context(signal)).context(message, "contexts")
+                    ParseError::new(signal).context(message, "contexts")
                 })?;
                 EvaluatedCollection::with_context(entries, removed_reasons, context).map_err(|e| {
                     let signal = crate::SolutionError::InvalidSidecar {
                         message: e.to_string(),
                     };
-                    ParseError::new(e.context(signal)).context(message, "removed_reasons")
+                    ParseError::new(signal).context(message, "removed_reasons")
                 })
             }
         }
@@ -923,13 +923,13 @@ macro_rules! impl_parse_v2_sampled_collection {
                     let signal = crate::SampleSetError::InvalidSidecar {
                         message: e.to_string(),
                     };
-                    ParseError::new(e.context(signal)).context(message, "contexts")
+                    ParseError::new(signal).context(message, "contexts")
                 })?;
                 SampledCollection::with_context(entries, removed_reasons, context).map_err(|e| {
                     let signal = crate::SampleSetError::InvalidSidecar {
                         message: e.to_string(),
                     };
-                    ParseError::new(e.context(signal)).context(message, "removed_reasons")
+                    ParseError::new(signal).context(message, "removed_reasons")
                 })
             }
         }
@@ -1538,6 +1538,17 @@ mod tests {
     use super::*;
     use crate::{coeff, constraint::ConstraintID, linear, Equality, Function, ModelingLabel};
 
+    fn parse_error_source(error: &ParseError) -> &(dyn std::error::Error + 'static) {
+        std::error::Error::source(error).expect("ParseError should expose its cause")
+    }
+
+    fn error_chain_contains<T: std::error::Error + 'static>(
+        error: &(dyn std::error::Error + 'static),
+    ) -> bool {
+        error.downcast_ref::<T>().is_some()
+            || std::error::Error::source(error).is_some_and(error_chain_contains::<T>)
+    }
+
     fn removed_reason() -> RemovedReason {
         RemovedReason {
             reason: "test".to_string(),
@@ -1916,7 +1927,7 @@ mod tests {
             err.to_string().contains("[contexts]"),
             "unexpected error: {err}"
         );
-        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
+        assert!(!error_chain_contains::<crate::RawParseError>(&err));
     }
 
     #[test]
@@ -1941,7 +1952,7 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            err.error.downcast_ref::<crate::SolutionError>(),
+            parse_error_source(&err).downcast_ref::<crate::SolutionError>(),
             Some(crate::SolutionError::InvalidSidecar { message })
                 if message.contains("unknown constraint ID")
         ));
@@ -1969,7 +1980,7 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            err.error.downcast_ref::<crate::SampleSetError>(),
+            parse_error_source(&err).downcast_ref::<crate::SampleSetError>(),
             Some(crate::SampleSetError::InvalidSidecar { message })
                 if message.contains("unknown constraint ID")
         ));
@@ -1991,7 +2002,7 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            err.error.downcast_ref::<crate::SolutionError>(),
+            parse_error_source(&err).downcast_ref::<crate::SolutionError>(),
             Some(crate::SolutionError::InvalidSidecar { message })
                 if message.contains("unknown constraint ID")
         ));
@@ -2013,7 +2024,7 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            err.error.downcast_ref::<crate::SampleSetError>(),
+            parse_error_source(&err).downcast_ref::<crate::SampleSetError>(),
             Some(crate::SampleSetError::InvalidSidecar { message })
                 if message.contains("unknown constraint ID")
         ));

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -878,18 +878,10 @@ macro_rules! impl_parse_v2_evaluated_collection {
                 let context =
                     constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
                 let owned_ids = entries.keys().copied().collect::<BTreeSet<_>>();
-                validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
-                    let signal = crate::SolutionError::InvalidSidecar {
-                        message: e.to_string(),
-                    };
-                    ParseError::new(signal).context(message, "contexts")
-                })?;
-                EvaluatedCollection::with_context(entries, removed_reasons, context).map_err(|e| {
-                    let signal = crate::SolutionError::InvalidSidecar {
-                        message: e.to_string(),
-                    };
-                    ParseError::new(signal).context(message, "removed_reasons")
-                })
+                validate_context_reference_ids(&context, &owned_ids)
+                    .map_err(|e| ParseError::new(e).context(message, "contexts"))?;
+                EvaluatedCollection::with_context(entries, removed_reasons, context)
+                    .map_err(|e| ParseError::new(e).context(message, "removed_reasons"))
             }
         }
     };
@@ -919,18 +911,10 @@ macro_rules! impl_parse_v2_sampled_collection {
                 let context =
                     constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
                 let owned_ids = entries.keys().copied().collect::<BTreeSet<_>>();
-                validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
-                    let signal = crate::SampleSetError::InvalidSidecar {
-                        message: e.to_string(),
-                    };
-                    ParseError::new(signal).context(message, "contexts")
-                })?;
-                SampledCollection::with_context(entries, removed_reasons, context).map_err(|e| {
-                    let signal = crate::SampleSetError::InvalidSidecar {
-                        message: e.to_string(),
-                    };
-                    ParseError::new(signal).context(message, "removed_reasons")
-                })
+                validate_context_reference_ids(&context, &owned_ids)
+                    .map_err(|e| ParseError::new(e).context(message, "contexts"))?;
+                SampledCollection::with_context(entries, removed_reasons, context)
+                    .map_err(|e| ParseError::new(e).context(message, "removed_reasons"))
             }
         }
     };
@@ -1542,11 +1526,23 @@ mod tests {
         std::error::Error::source(error).expect("ParseError should expose its cause")
     }
 
-    fn error_chain_contains<T: std::error::Error + 'static>(
-        error: &(dyn std::error::Error + 'static),
-    ) -> bool {
-        error.downcast_ref::<T>().is_some()
-            || std::error::Error::source(error).is_some_and(error_chain_contains::<T>)
+    fn assert_ordinary_collection_sidecar_error(
+        error: &ParseError,
+        expected_message: &'static str,
+        expected_field: &'static str,
+    ) {
+        let source = parse_error_source(error);
+        assert!(source.downcast_ref::<crate::RawParseError>().is_none());
+        assert!(source.downcast_ref::<crate::SolutionError>().is_none());
+        assert!(source.downcast_ref::<crate::SampleSetError>().is_none());
+        assert!(source.to_string().contains("unknown constraint ID"));
+
+        assert_eq!(error.context.len(), 1);
+        assert_eq!(error.context[0].message, expected_message);
+        assert_eq!(error.context[0].field, expected_field);
+        assert!(error
+            .to_string()
+            .contains(&format!("{expected_message}[{expected_field}]")));
     }
 
     fn removed_reason() -> RemovedReason {
@@ -1923,11 +1919,11 @@ mod tests {
         .parse(&())
         .unwrap_err();
 
-        assert!(
-            err.to_string().contains("[contexts]"),
-            "unexpected error: {err}"
+        assert_ordinary_collection_sidecar_error(
+            &err,
+            "crate::v2::RegularConstraintCollection",
+            "contexts",
         );
-        assert!(!error_chain_contains::<crate::RawParseError>(&err));
     }
 
     #[test]
@@ -1951,11 +1947,11 @@ mod tests {
         .parse(&atol)
         .unwrap_err();
 
-        assert!(matches!(
-            parse_error_source(&err).downcast_ref::<crate::SolutionError>(),
-            Some(crate::SolutionError::InvalidSidecar { message })
-                if message.contains("unknown constraint ID")
-        ));
+        assert_ordinary_collection_sidecar_error(
+            &err,
+            "crate::v2::EvaluatedRegularConstraintCollection",
+            "contexts",
+        );
     }
 
     #[test]
@@ -1979,15 +1975,15 @@ mod tests {
         .parse(&atol)
         .unwrap_err();
 
-        assert!(matches!(
-            parse_error_source(&err).downcast_ref::<crate::SampleSetError>(),
-            Some(crate::SampleSetError::InvalidSidecar { message })
-                if message.contains("unknown constraint ID")
-        ));
+        assert_ordinary_collection_sidecar_error(
+            &err,
+            "crate::v2::SampledRegularConstraintCollection",
+            "contexts",
+        );
     }
 
     #[test]
-    fn parse_v2_evaluated_collection_preserves_invalid_removed_reason_signal() {
+    fn parse_v2_evaluated_collection_reports_invalid_removed_reason_as_ordinary_error() {
         let err = crate::v2::EvaluatedRegularConstraintCollection {
             removed_reasons: BTreeMap::from([(
                 1,
@@ -2001,15 +1997,15 @@ mod tests {
         .parse(&ATol::default())
         .unwrap_err();
 
-        assert!(matches!(
-            parse_error_source(&err).downcast_ref::<crate::SolutionError>(),
-            Some(crate::SolutionError::InvalidSidecar { message })
-                if message.contains("unknown constraint ID")
-        ));
+        assert_ordinary_collection_sidecar_error(
+            &err,
+            "crate::v2::EvaluatedRegularConstraintCollection",
+            "removed_reasons",
+        );
     }
 
     #[test]
-    fn parse_v2_sampled_collection_preserves_invalid_removed_reason_signal() {
+    fn parse_v2_sampled_collection_reports_invalid_removed_reason_as_ordinary_error() {
         let err = crate::v2::SampledRegularConstraintCollection {
             removed_reasons: BTreeMap::from([(
                 1,
@@ -2023,10 +2019,10 @@ mod tests {
         .parse(&ATol::default())
         .unwrap_err();
 
-        assert!(matches!(
-            parse_error_source(&err).downcast_ref::<crate::SampleSetError>(),
-            Some(crate::SampleSetError::InvalidSidecar { message })
-                if message.contains("unknown constraint ID")
-        ));
+        assert_ordinary_collection_sidecar_error(
+            &err,
+            "crate::v2::SampledRegularConstraintCollection",
+            "removed_reasons",
+        );
     }
 }

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -36,8 +36,7 @@ use crate::{
         ConstraintContext, ConstraintContextStore, ConstraintID, EvaluatedConstraint,
         RemovedReason, SampledConstraint,
     },
-    v1, ATol, Constraint, Evaluate, Parse, ParseError, RawParseError, SampleID, SampleIDSet,
-    VariableIDSet,
+    v1, ATol, Constraint, Evaluate, Parse, ParseError, SampleID, SampleIDSet, VariableIDSet,
 };
 use std::sync::LazyLock;
 
@@ -846,12 +845,10 @@ macro_rules! impl_parse_v2_created_collection {
                     .chain(removed.keys())
                     .copied()
                     .collect::<BTreeSet<_>>();
-                validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string()).context(message, "contexts")
-                })?;
-                ConstraintCollection::with_context(active, removed, context).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string()).context(message, "active")
-                })
+                validate_context_reference_ids(&context, &owned_ids)
+                    .map_err(|e| ParseError::new(e).context(message, "contexts"))?;
+                ConstraintCollection::with_context(active, removed, context)
+                    .map_err(|e| ParseError::new(e).context(message, "active"))
             }
         }
     };
@@ -882,11 +879,16 @@ macro_rules! impl_parse_v2_evaluated_collection {
                     constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
                 let owned_ids = entries.keys().copied().collect::<BTreeSet<_>>();
                 validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string()).context(message, "contexts")
+                    let signal = crate::SolutionError::InvalidSidecar {
+                        message: e.to_string(),
+                    };
+                    ParseError::new(e.context(signal)).context(message, "contexts")
                 })?;
                 EvaluatedCollection::with_context(entries, removed_reasons, context).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string())
-                        .context(message, "removed_reasons")
+                    let signal = crate::SolutionError::InvalidSidecar {
+                        message: e.to_string(),
+                    };
+                    ParseError::new(e.context(signal)).context(message, "removed_reasons")
                 })
             }
         }
@@ -918,11 +920,16 @@ macro_rules! impl_parse_v2_sampled_collection {
                     constraint_context_store_from_v2_map(self.contexts, message, "contexts")?;
                 let owned_ids = entries.keys().copied().collect::<BTreeSet<_>>();
                 validate_context_reference_ids(&context, &owned_ids).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string()).context(message, "contexts")
+                    let signal = crate::SampleSetError::InvalidSidecar {
+                        message: e.to_string(),
+                    };
+                    ParseError::new(e.context(signal)).context(message, "contexts")
                 })?;
                 SampledCollection::with_context(entries, removed_reasons, context).map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string())
-                        .context(message, "removed_reasons")
+                    let signal = crate::SampleSetError::InvalidSidecar {
+                        message: e.to_string(),
+                    };
+                    ParseError::new(e.context(signal)).context(message, "removed_reasons")
                 })
             }
         }
@@ -1008,7 +1015,7 @@ where
     let mut out = BTreeMap::new();
     for (id, row) in removed {
         let reason = removed_reasons.remove(&id).ok_or_else(|| {
-            RawParseError::InvalidInstance(format!(
+            ParseError::new(crate::error!(
                 "Removed constraint ID {:?} has no removed reason",
                 ID::from(id)
             ))
@@ -1020,7 +1027,7 @@ where
         );
     }
     if let Some(id) = removed_reasons.keys().next().copied() {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Removed reason references unknown constraint ID {:?}",
             ID::from(id)
         ))
@@ -1909,6 +1916,7 @@ mod tests {
             err.to_string().contains("[contexts]"),
             "unexpected error: {err}"
         );
+        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
     }
 
     #[test]
@@ -1932,10 +1940,11 @@ mod tests {
         .parse(&atol)
         .unwrap_err();
 
-        assert!(
-            err.to_string().contains("[contexts]"),
-            "unexpected error: {err}"
-        );
+        assert!(matches!(
+            err.error.downcast_ref::<crate::SolutionError>(),
+            Some(crate::SolutionError::InvalidSidecar { message })
+                if message.contains("unknown constraint ID")
+        ));
     }
 
     #[test]
@@ -1959,9 +1968,54 @@ mod tests {
         .parse(&atol)
         .unwrap_err();
 
-        assert!(
-            err.to_string().contains("[contexts]"),
-            "unexpected error: {err}"
-        );
+        assert!(matches!(
+            err.error.downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::InvalidSidecar { message })
+                if message.contains("unknown constraint ID")
+        ));
+    }
+
+    #[test]
+    fn parse_v2_evaluated_collection_preserves_invalid_removed_reason_signal() {
+        let err = crate::v2::EvaluatedRegularConstraintCollection {
+            removed_reasons: BTreeMap::from([(
+                1,
+                crate::v2::RemovedReason {
+                    reason: "test".to_string(),
+                    parameters: Default::default(),
+                },
+            )]),
+            ..Default::default()
+        }
+        .parse(&ATol::default())
+        .unwrap_err();
+
+        assert!(matches!(
+            err.error.downcast_ref::<crate::SolutionError>(),
+            Some(crate::SolutionError::InvalidSidecar { message })
+                if message.contains("unknown constraint ID")
+        ));
+    }
+
+    #[test]
+    fn parse_v2_sampled_collection_preserves_invalid_removed_reason_signal() {
+        let err = crate::v2::SampledRegularConstraintCollection {
+            removed_reasons: BTreeMap::from([(
+                1,
+                crate::v2::RemovedReason {
+                    reason: "test".to_string(),
+                    parameters: Default::default(),
+                },
+            )]),
+            ..Default::default()
+        }
+        .parse(&ATol::default())
+        .unwrap_err();
+
+        assert!(matches!(
+            err.error.downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::InvalidSidecar { message })
+                if message.contains("unknown constraint ID")
+        ));
     }
 }

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -502,8 +502,7 @@ impl std::convert::TryFrom<crate::v1::DecisionVariable> for EvaluatedDecisionVar
             .context(message, "substituted_value"),
         )?;
 
-        EvaluatedDecisionVariable::new(parsed.id, dv, value)
-            .map_err(|e| crate::RawParseError::InvalidDecisionVariable(e).into())
+        EvaluatedDecisionVariable::new(parsed.id, dv, value).map_err(crate::ParseError::new)
     }
 }
 

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -212,6 +212,8 @@ impl TryFrom<v1::SampledDecisionVariable> for SampledDecisionVariable {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
 
     #[test]
@@ -228,7 +230,9 @@ mod tests {
         let res: Result<ParsedDecisionVariable, _> = dv.parse(&());
         let error = res.unwrap_err();
         assert!(matches!(
-            error.error.downcast_ref::<DecisionVariableError>(),
+            error
+                .source()
+                .and_then(|source| source.downcast_ref::<DecisionVariableError>()),
             Some(DecisionVariableError::InvalidDefinition { id, source })
                 if *id == VariableID::from(1)
                     && matches!(
@@ -260,7 +264,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            error.error.downcast_ref::<DecisionVariableError>(),
+            error
+                .source()
+                .and_then(|source| source.downcast_ref::<DecisionVariableError>()),
             Some(DecisionVariableError::DuplicateID { id })
                 if *id == VariableID::from(1)
         ));

--- a/rust/ommx/src/decision_variable/parse.rs
+++ b/rust/ommx/src/decision_variable/parse.rs
@@ -75,7 +75,7 @@ impl Parse for v1::DecisionVariable {
         let id = VariableID::from(self.id);
         let dv = DecisionVariable::new(kind, bound, ATol::default()) // FIXME: user should provide this
             .map_err(|source| {
-                RawParseError::InvalidDecisionVariable(DecisionVariableError::InvalidDefinition {
+                ParseError::new(DecisionVariableError::InvalidDefinition {
                     id,
                     source: Box::new(source),
                 })
@@ -84,9 +84,7 @@ impl Parse for v1::DecisionVariable {
         let fixed_value = self.substituted_value;
         if let Some(value) = fixed_value {
             dv.check_value_consistency(id, value, ATol::default())
-                .map_err(|e| {
-                    RawParseError::InvalidDecisionVariable(e).context(message, "substituted_value")
-                })?;
+                .map_err(|e| ParseError::new(e).context(message, "substituted_value"))?;
         }
         let label = DecisionVariableLabel {
             name: self.name,
@@ -125,10 +123,7 @@ impl Parse for Vec<v1::DecisionVariable> {
             let parsed: ParsedDecisionVariable = v.parse(&())?;
             let id = parsed.id;
             if decision_variables.insert(id, parsed.variable).is_some() {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "Duplicated variable ID is found in definition: {id:?}"
-                ))
-                .into());
+                return Err(ParseError::new(DecisionVariableError::DuplicateID { id }));
             }
             if let Some(value) = parsed.fixed_value {
                 fixed_values.insert(id, value);
@@ -176,16 +171,14 @@ impl Parse for v1::SampledDecisionVariable {
             let atol = ATol::default();
             for (_, &sample_value) in samples.iter() {
                 if !sample_value.is_finite() {
-                    return Err(RawParseError::InvalidDecisionVariable(
-                        DecisionVariableError::NonFiniteValue {
-                            id: parsed_dv.id,
-                            value: sample_value,
-                        },
-                    )
+                    return Err(ParseError::new(DecisionVariableError::NonFiniteValue {
+                        id: parsed_dv.id,
+                        value: sample_value,
+                    })
                     .context(message, "samples"));
                 }
                 if (sample_value - fixed_value).abs() > *atol {
-                    return Err(RawParseError::InvalidDecisionVariable(
+                    return Err(ParseError::new(
                         DecisionVariableError::SubstitutedValueOverwrite {
                             id: parsed_dv.id,
                             previous_value: fixed_value,
@@ -201,7 +194,7 @@ impl Parse for v1::SampledDecisionVariable {
         // Create SampledDecisionVariable with validation
         let sampled =
             crate::SampledDecisionVariable::new(parsed_dv.id, parsed_dv.variable, samples)
-                .map_err(RawParseError::InvalidDecisionVariable)?;
+                .map_err(ParseError::new)?;
         Ok(ParsedSampledDecisionVariable {
             id: parsed_dv.id,
             variable: sampled,
@@ -233,11 +226,44 @@ mod tests {
             ..Default::default()
         };
         let res: Result<ParsedDecisionVariable, _> = dv.parse(&());
-        insta::assert_snapshot!(res.unwrap_err(), @r###"
+        let error = res.unwrap_err();
+        assert!(matches!(
+            error.error.downcast_ref::<DecisionVariableError>(),
+            Some(DecisionVariableError::InvalidDefinition { id, source })
+                if *id == VariableID::from(1)
+                    && matches!(
+                        source.as_ref(),
+                        DecisionVariableError::BoundInconsistentToKind { .. }
+                    )
+        ));
+        insta::assert_snapshot!(error, @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.DecisionVariable[bound]
         Invalid decision variable ID=1: Bound is inconsistent to kind: kind=Integer, bound=[1.1, 1.9]
         "###);
+    }
+
+    #[test]
+    fn parse_decision_variables_preserves_duplicate_id_signal() {
+        let decision_variable = v1::DecisionVariable {
+            id: 1,
+            kind: v1::decision_variable::Kind::Binary as i32,
+            bound: Some(v1::Bound {
+                lower: 0.0,
+                upper: 1.0,
+            }),
+            ..Default::default()
+        };
+
+        let error = vec![decision_variable.clone(), decision_variable]
+            .parse(&())
+            .unwrap_err();
+
+        assert!(matches!(
+            error.error.downcast_ref::<DecisionVariableError>(),
+            Some(DecisionVariableError::DuplicateID { id })
+                if *id == VariableID::from(1)
+        ));
     }
 
     #[test]

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -610,7 +610,7 @@ impl Parse for crate::v2::DecisionVariable {
             })?
             .parse_as(&(), message, "bound")?;
         DecisionVariable::new(kind, bound, ATol::default()).map_err(|source| {
-            RawParseError::InvalidDecisionVariable(DecisionVariableError::InvalidDefinition {
+            ParseError::new(DecisionVariableError::InvalidDefinition {
                 id: *id,
                 source: Box::new(source),
             })
@@ -641,8 +641,8 @@ impl Parse for crate::v2::EvaluatedDecisionVariable {
         }
         .parse(id)?;
         EvaluatedDecisionVariable::new(*id, decision_variable, self.value)
-            .map_err(RawParseError::InvalidDecisionVariable)
-            .map_err(|e| ParseError::from(e).context("ommx.v2.EvaluatedDecisionVariable", "value"))
+            .map_err(ParseError::new)
+            .map_err(|e| e.context("ommx.v2.EvaluatedDecisionVariable", "value"))
     }
 }
 
@@ -680,8 +680,8 @@ impl Parse for crate::v2::SampledDecisionVariable {
             })?
             .parse_as(&(), message, "samples")?;
         SampledDecisionVariable::new(*id, decision_variable, samples)
-            .map_err(RawParseError::InvalidDecisionVariable)
-            .map_err(|e| ParseError::from(e).context(message, "samples"))
+            .map_err(ParseError::new)
+            .map_err(|e| e.context(message, "samples"))
     }
 }
 
@@ -717,12 +717,10 @@ impl Parse for crate::v2::DecisionVariableTable {
             .into_iter()
             .map(|(id, value)| (VariableID::from(id), value))
             .collect();
-        DecisionVariableTable::<Created>::validate_labels(&entries, &labels).map_err(|e| {
-            RawParseError::InvalidInstance(e.to_string()).context(message, "labels")
-        })?;
-        validate_created_fixed_values(&entries, &fixed_values, ATol::default()).map_err(|e| {
-            RawParseError::InvalidInstance(e.to_string()).context(message, "fixed_values")
-        })?;
+        DecisionVariableTable::<Created>::validate_labels(&entries, &labels)
+            .map_err(|e| ParseError::new(e).context(message, "labels"))?;
+        validate_created_fixed_values(&entries, &fixed_values, ATol::default())
+            .map_err(|e| ParseError::new(e).context(message, "fixed_values"))?;
         Ok(DecisionVariableTable {
             entries,
             labels,
@@ -753,7 +751,7 @@ impl Parse for crate::v2::EvaluatedDecisionVariableTable {
         }
         let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         EvaluatedDecisionVariableTable::new(entries, labels)
-            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
+            .map_err(|e| ParseError::new(e).context(message, "labels"))
     }
 }
 
@@ -779,7 +777,7 @@ impl Parse for crate::v2::SampledDecisionVariableTable {
         }
         let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
         SampledDecisionVariableTable::new(entries, labels)
-            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
+            .map_err(|e| ParseError::new(e).context(message, "labels"))
     }
 }
 
@@ -901,10 +899,14 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(
-            err.to_string().contains("Substituted value") && err.to_string().contains("ID=1"),
-            "unexpected error: {err}"
-        );
+        assert!(matches!(
+            err.downcast_ref::<DecisionVariableError>(),
+            Some(DecisionVariableError::SubstitutedValueInconsistent {
+                id: error_id,
+                substituted_value,
+                ..
+            }) if *error_id == id && *substituted_value == 0.5
+        ));
     }
 
     #[test]
@@ -1093,6 +1095,10 @@ mod tests {
         .parse(&())
         .unwrap_err();
 
+        assert_eq!(
+            err.error.to_string(),
+            "Modeling label references unknown decision variable ID VariableID(1)"
+        );
         assert!(
             err.to_string()
                 .contains("ommx.v2.DecisionVariableTable[labels]"),
@@ -1110,6 +1116,10 @@ mod tests {
         .parse(&())
         .unwrap_err();
 
+        assert_eq!(
+            err.error.to_string(),
+            "Fixed decision-variable value references unknown decision variable ID VariableID(1)"
+        );
         assert!(
             err.to_string()
                 .contains("ommx.v2.DecisionVariableTable[fixed_values]"),
@@ -1134,6 +1144,10 @@ mod tests {
         .parse(&())
         .unwrap_err();
 
+        assert_eq!(
+            err.error.to_string(),
+            "Modeling label references unknown decision variable ID VariableID(1)"
+        );
         assert!(
             err.to_string()
                 .contains("ommx.v2.EvaluatedDecisionVariableTable[labels]"),
@@ -1158,10 +1172,54 @@ mod tests {
         .parse(&())
         .unwrap_err();
 
+        assert_eq!(
+            err.error.to_string(),
+            "Modeling label references unknown decision variable ID VariableID(1)"
+        );
         assert!(
             err.to_string()
                 .contains("ommx.v2.SampledDecisionVariableTable[labels]"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn parse_v2_definition_table_preserves_inconsistent_fixed_value_signal() {
+        let error = crate::v2::DecisionVariableTable {
+            entries: BTreeMap::from([(1, DecisionVariable::integer().into())]),
+            labels: BTreeMap::new(),
+            fixed_values: BTreeMap::from([(1, 0.5)]),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(matches!(
+            error.error.downcast_ref::<DecisionVariableError>(),
+            Some(DecisionVariableError::SubstitutedValueInconsistent {
+                id,
+                substituted_value,
+                ..
+            }) if *id == VariableID::from(1) && *substituted_value == 0.5
+        ));
+        assert_eq!(error.context.len(), 1);
+        assert_eq!(error.context[0].message, "ommx.v2.DecisionVariableTable");
+        assert_eq!(error.context[0].field, "fixed_values");
+    }
+
+    #[test]
+    fn parse_v2_definition_table_preserves_non_finite_fixed_value_signal() {
+        let error = crate::v2::DecisionVariableTable {
+            entries: BTreeMap::from([(1, DecisionVariable::continuous().into())]),
+            labels: BTreeMap::new(),
+            fixed_values: BTreeMap::from([(1, f64::INFINITY)]),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert!(matches!(
+            error.error.downcast_ref::<DecisionVariableError>(),
+            Some(DecisionVariableError::NonFiniteValue { id, value })
+                if *id == VariableID::from(1) && value.is_infinite()
+        ));
     }
 }

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -802,6 +802,8 @@ impl<'a, S: DecisionVariableTableStage> IntoIterator for &'a DecisionVariableTab
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
     use crate::Bound;
 
@@ -1096,7 +1098,9 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(
-            err.error.to_string(),
+            err.source()
+                .expect("ParseError must expose the orphan-label cause")
+                .to_string(),
             "Modeling label references unknown decision variable ID VariableID(1)"
         );
         assert!(
@@ -1117,7 +1121,9 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(
-            err.error.to_string(),
+            err.source()
+                .expect("ParseError must expose the orphan-fixed-value cause")
+                .to_string(),
             "Fixed decision-variable value references unknown decision variable ID VariableID(1)"
         );
         assert!(
@@ -1145,7 +1151,9 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(
-            err.error.to_string(),
+            err.source()
+                .expect("ParseError must expose the orphan-label cause")
+                .to_string(),
             "Modeling label references unknown decision variable ID VariableID(1)"
         );
         assert!(
@@ -1173,7 +1181,9 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(
-            err.error.to_string(),
+            err.source()
+                .expect("ParseError must expose the orphan-label cause")
+                .to_string(),
             "Modeling label references unknown decision variable ID VariableID(1)"
         );
         assert!(
@@ -1194,7 +1204,9 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            error.error.downcast_ref::<DecisionVariableError>(),
+            error
+                .source()
+                .and_then(|source| source.downcast_ref::<DecisionVariableError>()),
             Some(DecisionVariableError::SubstitutedValueInconsistent {
                 id,
                 substituted_value,
@@ -1217,7 +1229,9 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(
-            error.error.downcast_ref::<DecisionVariableError>(),
+            error
+                .source()
+                .and_then(|source| source.downcast_ref::<DecisionVariableError>()),
             Some(DecisionVariableError::NonFiniteValue { id, value })
                 if *id == VariableID::from(1) && value.is_infinite()
         ));

--- a/rust/ommx/src/function/parse.rs
+++ b/rust/ommx/src/function/parse.rs
@@ -22,7 +22,7 @@ impl Parse for v1::Function {
             Constant(c) => match c.try_into() {
                 Ok(c) => Ok(Function::Constant(c)),
                 Err(CoefficientError::Zero) => Ok(Function::Zero),
-                Err(c) => Err(RawParseError::from(c).context(message, "constant")),
+                Err(c) => Err(ParseError::new(c).context(message, "constant")),
             },
             Linear(l) => Ok(Function::Linear(l.parse_as(&(), message, "linear")?)),
             Quadratic(q) => Ok(Function::Quadratic(q.parse_as(

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -438,6 +438,8 @@ impl std::fmt::Display for IndicatorConstraint<Created> {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
     use crate::{coeff, linear};
 
@@ -504,7 +506,11 @@ mod tests {
 
         let err = proto.parse(&ATol::default()).unwrap_err();
 
-        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        let mut source = err.source();
+        while let Some(error) = source {
+            assert!(error.downcast_ref::<RawParseError>().is_none());
+            source = error.source();
+        }
         assert!(err
             .to_string()
             .contains("Inconsistent indicator constraint feasibility"));

--- a/rust/ommx/src/indicator_constraint/mod.rs
+++ b/rust/ommx/src/indicator_constraint/mod.rs
@@ -290,7 +290,7 @@ fn validate_indicator_feasible_from_evaluated_value(
     let computed_feasible =
         indicator_feasible_from_evaluated_value(equality, evaluated_value, indicator_active, atol);
     if provided_feasible != computed_feasible {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Inconsistent indicator constraint feasibility: provided={provided_feasible}, computed={computed_feasible}",
         ))
         .context(message, "feasible"));
@@ -489,6 +489,25 @@ mod tests {
             err.to_string().contains("evaluated_value must be finite"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn parse_v2_evaluated_feasibility_mismatch_is_an_ordinary_error() {
+        let proto = crate::v2::EvaluatedIndicatorConstraint {
+            indicator_variable: 1,
+            equality: crate::v1::Equality::EqualToZero.into(),
+            evaluated_value: 0.0,
+            feasible: false,
+            indicator_active: false,
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        assert!(err
+            .to_string()
+            .contains("Inconsistent indicator constraint feasibility"));
     }
 
     #[test]

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -37,19 +37,19 @@ fn validate_fixed_decision_variable_partition(
     let dependent: VariableIDSet = decision_variable_dependency.keys().collect();
 
     if let Some(id) = used.intersection(&dependent).next() {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Dependent variable cannot be used in objectives or constraints: {id:?}"
         ))
         .context(message, "decision_variables"));
     }
     if let Some(id) = used.intersection(&fixed).next() {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Fixed variable {id:?} cannot be used in objectives or constraints"
         ))
         .context(message, "decision_variables"));
     }
     if let Some(id) = fixed.intersection(&dependent).next() {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Variable {id:?} cannot be both fixed and dependent"
         ))
         .context(message, "decision_variables"));
@@ -72,7 +72,7 @@ fn parse_v2_decision_variable_dependency(
         })
         .collect::<Result<BTreeMap<_, _>, ParseError>>()?;
     AcyclicAssignments::new(dependency)
-        .map_err(|e| RawParseError::from(e).context(message, "decision_variable_dependency"))
+        .map_err(|e| ParseError::new(e).context(message, "decision_variable_dependency"))
 }
 
 fn parse_v2_output_objective(
@@ -91,10 +91,10 @@ fn parse_v2_output_objective(
         .parse_as(&(), message, "output_objective.function")?;
     for id in function.required_ids() {
         if !allowed_ids.contains(&id) {
-            return Err(RawParseError::InvalidInstance(format!(
-                "Undefined variable ID is used: {id:?}"
-            ))
-            .context(message, "output_objective.function"));
+            return Err(
+                ParseError::new(crate::error!("Undefined variable ID is used: {id:?}"))
+                    .context(message, "output_objective.function"),
+            );
         }
     }
     Ok(OutputObjective::new(
@@ -118,7 +118,7 @@ fn validate_created_constraint_references<T: crate::ConstraintType>(
     ) {
         for id in constraint.required_ids() {
             if !valid_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Undefined variable ID is used: {id:?}"
                 ))
                 .context(message, field));
@@ -148,19 +148,19 @@ fn validate_fixed_dependent_partition_from_sets(
     let dependent: VariableIDSet = decision_variable_dependency.keys().collect();
 
     if let Some(id) = used.intersection(&dependent).next() {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Dependent variable cannot be used in objectives or constraints: {id:?}"
         ))
         .context(message, "decision_variables"));
     }
     if let Some(id) = used.intersection(&fixed).next() {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Fixed variable {id:?} cannot be used in objectives or constraints"
         ))
         .context(message, "decision_variables"));
     }
     if let Some(id) = fixed.intersection(&dependent).next() {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Variable {id:?} cannot be both fixed and dependent"
         ))
         .context(message, "decision_variables"));
@@ -191,15 +191,14 @@ fn validate_structural_special_constraints(
             } else {
                 format!("Indicator variable {id:?} is not defined in decision_variables")
             };
-            return Err(
-                RawParseError::InvalidInstance(detail).context(message, "indicator_constraints")
-            );
+            return Err(ParseError::new(crate::error!("{detail}"))
+                .context(message, "indicator_constraints"));
         };
         if variable.kind() != crate::decision_variable::Kind::Binary {
-            return Err(RawParseError::InvalidInstance(format!(
-                "Indicator variable {id:?} must be binary"
-            ))
-            .context(message, "indicator_constraints"));
+            return Err(
+                ParseError::new(crate::error!("Indicator variable {id:?} must be binary"))
+                    .context(message, "indicator_constraints"),
+            );
         }
     }
 
@@ -217,12 +216,11 @@ fn validate_structural_special_constraints(
                 } else {
                     format!("One-hot variable {id:?} is not defined in decision_variables")
                 };
-                return Err(
-                    RawParseError::InvalidInstance(detail).context(message, "one_hot_constraints")
-                );
+                return Err(ParseError::new(crate::error!("{detail}"))
+                    .context(message, "one_hot_constraints"));
             };
             if variable.kind() != crate::decision_variable::Kind::Binary {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "One-hot variable {id:?} must be binary"
                 ))
                 .context(message, "one_hot_constraints"));
@@ -245,7 +243,7 @@ fn validate_structural_special_constraints(
                     format!("SOS1 variable {id:?} is not defined in decision_variables")
                 };
                 return Err(
-                    RawParseError::InvalidInstance(detail).context(message, "sos1_constraints")
+                    ParseError::new(crate::error!("{detail}")).context(message, "sos1_constraints")
                 );
             }
         }
@@ -331,7 +329,7 @@ impl Parse for v1::Instance {
         let decision_variable_ids: VariableIDSet = decision_variables.keys().cloned().collect();
         for id in objective.required_ids() {
             if !decision_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Undefined variable ID is used: {id:?}"
                 ))
                 .context(message, "objective"));
@@ -346,7 +344,7 @@ impl Parse for v1::Instance {
         for constraint in constraints.values() {
             for id in constraint.required_ids() {
                 if !decision_variable_ids.contains(&id) {
-                    return Err(RawParseError::InvalidInstance(format!(
+                    return Err(ParseError::new(crate::error!(
                         "Undefined variable ID is used: {id:?}"
                     ))
                     .context(message, "constraints"));
@@ -380,7 +378,7 @@ impl Parse for v1::Instance {
         for named_function in named_functions.values() {
             for id in named_function.function.required_ids() {
                 if !decision_variable_ids.contains(&id) {
-                    return Err(RawParseError::InvalidInstance(format!(
+                    return Err(ParseError::new(crate::error!(
                         "Undefined variable ID is used: {id:?}"
                     ))
                     .context(message, "named_functions"));
@@ -397,7 +395,7 @@ impl Parse for v1::Instance {
             );
         }
         let decision_variable_dependency = AcyclicAssignments::new(decision_variable_dependency)
-            .map_err(|e| RawParseError::from(e).context(message, "decision_variable_dependency"))?;
+            .map_err(|e| ParseError::new(e).context(message, "decision_variable_dependency"))?;
 
         ignore_legacy_constraint_hints(self.constraint_hints, message);
         validate_fixed_decision_variable_partition(
@@ -413,9 +411,7 @@ impl Parse for v1::Instance {
             fixed_decision_variable_values,
             crate::ATol::default(),
         )
-        .map_err(|e| {
-            RawParseError::InvalidInstance(e.to_string()).context(message, "decision_variables")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "decision_variables"))?;
 
         Ok(Instance {
             sense,
@@ -427,9 +423,7 @@ impl Parse for v1::Instance {
                 removed_constraints,
                 constraint_context,
             )
-            .map_err(|e| {
-                RawParseError::InvalidInstance(e.to_string()).context(message, "constraints")
-            })?,
+            .map_err(|e| ParseError::new(e).context(message, "constraints"))?,
             indicator_constraint_collection: Default::default(),
             one_hot_constraint_collection: Default::default(),
             sos1_constraint_collection: Default::default(),
@@ -438,10 +432,7 @@ impl Parse for v1::Instance {
             description: self.description,
             annotations: self.annotations,
             named_functions: crate::NamedFunctionTable::new(named_functions, named_function_labels)
-                .map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string())
-                        .context(message, "named_functions")
-                })?,
+                .map_err(|e| ParseError::new(e).context(message, "named_functions"))?,
         })
     }
 }
@@ -480,7 +471,7 @@ impl Parse for v2::Instance {
             .parse_as(&(), message, "objective")?;
         for id in objective.required_ids() {
             if !decision_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Undefined variable ID is used: {id:?}"
                 ))
                 .context(message, "objective"));
@@ -552,7 +543,7 @@ impl Parse for v2::Instance {
         for named_function in named_functions.values() {
             for id in named_function.function.required_ids() {
                 if !decision_variable_ids.contains(&id) {
-                    return Err(RawParseError::InvalidInstance(format!(
+                    return Err(ParseError::new(crate::error!(
                         "Undefined variable ID is used: {id:?}"
                     ))
                     .context(message, "named_functions"));
@@ -564,7 +555,7 @@ impl Parse for v2::Instance {
             parse_v2_decision_variable_dependency(self.decision_variable_dependency, message)?;
         for id in decision_variable_dependency.keys() {
             if !decision_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Variable ID {id:?} in decision_variable_dependency is not in decision_variables"
                 ))
                 .context(message, "decision_variable_dependency"));
@@ -572,7 +563,7 @@ impl Parse for v2::Instance {
         }
         for id in decision_variable_dependency.required_ids() {
             if !decision_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Undefined variable ID is used in decision_variable_dependency: {id:?}"
                 ))
                 .context(message, "decision_variable_dependency"));
@@ -700,9 +691,8 @@ impl Parse for v1::ParametricInstance {
             .decision_variables
             .parse_as(&(), message, "decision_variables")?;
 
-        let parameters = ParameterTable::from_v1_parameters(self.parameters).map_err(|e| {
-            RawParseError::InvalidInstance(e.to_string()).context(message, "parameters")
-        })?;
+        let parameters = ParameterTable::from_v1_parameters(self.parameters)
+            .map_err(|e| ParseError::new(e).context(message, "parameters"))?;
 
         let decision_variable_ids: VariableIDSet = decision_variables.keys().cloned().collect();
         let parameter_ids: VariableIDSet = parameters.keys().cloned().collect();
@@ -712,8 +702,9 @@ impl Parse for v1::ParametricInstance {
             .collect();
         if !intersection.is_empty() {
             let id = *intersection.iter().next().unwrap();
-            return Err(RawParseError::from(crate::ParameterIDCollision { id })
-                .context(message, "parameters"));
+            return Err(
+                ParseError::new(crate::ParameterIDCollision { id }).context(message, "parameters")
+            );
         }
 
         let objective = self
@@ -731,7 +722,7 @@ impl Parse for v1::ParametricInstance {
             .collect();
         for id in objective.required_ids() {
             if !all_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Undefined variable ID is used: {id:?}"
                 ))
                 .context(message, "objective"));
@@ -747,7 +738,7 @@ impl Parse for v1::ParametricInstance {
         for constraint in constraints.values() {
             for id in constraint.required_ids() {
                 if !all_variable_ids.contains(&id) {
-                    return Err(RawParseError::InvalidInstance(format!(
+                    return Err(ParseError::new(crate::error!(
                         "Undefined variable ID is used: {id:?}"
                     ))
                     .context(message, "constraints"));
@@ -781,7 +772,7 @@ impl Parse for v1::ParametricInstance {
         for named_function in named_functions.values() {
             for id in named_function.function.required_ids() {
                 if !all_variable_ids.contains(&id) {
-                    return Err(RawParseError::InvalidInstance(format!(
+                    return Err(ParseError::new(crate::error!(
                         "Undefined variable ID is used: {id:?}"
                     ))
                     .context(message, "named_functions"));
@@ -798,7 +789,7 @@ impl Parse for v1::ParametricInstance {
             );
         }
         let decision_variable_dependency = AcyclicAssignments::new(decision_variable_dependency)
-            .map_err(|e| RawParseError::from(e).context(message, "decision_variable_dependency"))?;
+            .map_err(|e| ParseError::new(e).context(message, "decision_variable_dependency"))?;
 
         ignore_legacy_constraint_hints(self.constraint_hints, message);
         validate_fixed_decision_variable_partition(
@@ -814,9 +805,7 @@ impl Parse for v1::ParametricInstance {
             fixed_decision_variable_values,
             crate::ATol::default(),
         )
-        .map_err(|e| {
-            RawParseError::InvalidInstance(e.to_string()).context(message, "decision_variables")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "decision_variables"))?;
 
         Ok(ParametricInstance {
             sense,
@@ -829,17 +818,12 @@ impl Parse for v1::ParametricInstance {
                 removed_constraints,
                 constraint_context,
             )
-            .map_err(|e| {
-                RawParseError::InvalidInstance(e.to_string()).context(message, "constraints")
-            })?,
+            .map_err(|e| ParseError::new(e).context(message, "constraints"))?,
             indicator_constraint_collection: Default::default(),
             one_hot_constraint_collection: Default::default(),
             sos1_constraint_collection: Default::default(),
             named_functions: crate::NamedFunctionTable::new(named_functions, named_function_labels)
-                .map_err(|e| {
-                    RawParseError::InvalidInstance(e.to_string())
-                        .context(message, "named_functions")
-                })?,
+                .map_err(|e| ParseError::new(e).context(message, "named_functions"))?,
             decision_variable_dependency,
             description: self.description,
             annotations: self.annotations,
@@ -873,7 +857,7 @@ impl Parse for v2::ParametricInstance {
         let decision_variable_ids: VariableIDSet = decision_variables.keys().copied().collect();
         let parameter_ids: VariableIDSet = parameters.keys().copied().collect();
         if let Some(id) = decision_variable_ids.intersection(&parameter_ids).next() {
-            return Err(RawParseError::from(crate::ParameterIDCollision { id: *id })
+            return Err(ParseError::new(crate::ParameterIDCollision { id: *id })
                 .context(message, "parameters"));
         }
         let all_variable_ids: VariableIDSet = decision_variable_ids
@@ -890,7 +874,7 @@ impl Parse for v2::ParametricInstance {
             .parse_as(&(), message, "objective")?;
         for id in objective.required_ids() {
             if !all_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Undefined variable ID is used: {id:?}"
                 ))
                 .context(message, "objective"));
@@ -962,7 +946,7 @@ impl Parse for v2::ParametricInstance {
         for named_function in named_functions.values() {
             for id in named_function.function.required_ids() {
                 if !all_variable_ids.contains(&id) {
-                    return Err(RawParseError::InvalidInstance(format!(
+                    return Err(ParseError::new(crate::error!(
                         "Undefined variable ID is used: {id:?}"
                     ))
                     .context(message, "named_functions"));
@@ -974,7 +958,7 @@ impl Parse for v2::ParametricInstance {
             parse_v2_decision_variable_dependency(self.decision_variable_dependency, message)?;
         for id in decision_variable_dependency.keys() {
             if !decision_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Variable ID {id:?} in decision_variable_dependency is not in decision_variables"
                 ))
                 .context(message, "decision_variable_dependency"));
@@ -982,7 +966,7 @@ impl Parse for v2::ParametricInstance {
         }
         for id in decision_variable_dependency.required_ids() {
             if !all_variable_ids.contains(&id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
                     "Undefined variable ID is used in decision_variable_dependency: {id:?}"
                 ))
                 .context(message, "decision_variable_dependency"));
@@ -1132,18 +1116,16 @@ mod tests {
             .downcast_ref::<ParseError>()
             .expect("semantic byte decoding must retain ParseError as the outer owner");
         assert!(matches!(
-            &parse_error.error,
-            RawParseError::ParameterIDCollision(crate::ParameterIDCollision { id })
+            parse_error
+                .error
+                .downcast_ref::<crate::ParameterIDCollision>(),
+            Some(crate::ParameterIDCollision { id })
                 if *id == expected_id
         ));
 
-        let raw_source = parse_error
+        let signal_source = parse_error
             .source()
-            .expect("ParseError must expose its RawParseError source");
-        assert!(raw_source.downcast_ref::<RawParseError>().is_some());
-        let signal_source = raw_source
-            .source()
-            .expect("RawParseError must expose the parameter collision signal");
+            .expect("ParseError must expose the parameter collision signal");
         assert!(matches!(
             signal_source.downcast_ref::<crate::ParameterIDCollision>(),
             Some(crate::ParameterIDCollision { id }) if *id == expected_id

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -1115,14 +1115,6 @@ mod tests {
         let parse_error = error
             .downcast_ref::<ParseError>()
             .expect("semantic byte decoding must retain ParseError as the outer owner");
-        assert!(matches!(
-            parse_error
-                .error
-                .downcast_ref::<crate::ParameterIDCollision>(),
-            Some(crate::ParameterIDCollision { id })
-                if *id == expected_id
-        ));
-
         let signal_source = parse_error
             .source()
             .expect("ParseError must expose the parameter collision signal");

--- a/rust/ommx/src/instance/parse.rs
+++ b/rust/ommx/src/instance/parse.rs
@@ -1111,6 +1111,26 @@ mod tests {
             .unwrap()
     }
 
+    fn cyclic_dependency_test_instance() -> Instance {
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(0), DecisionVariable::binary()),
+                (VariableID::from(1), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::new())
+            .build()
+            .unwrap()
+    }
+
+    fn cyclic_dependency_entries() -> [(u64, v1::Function); 2] {
+        [
+            (0, Function::from(crate::linear!(1)).into()),
+            (1, Function::from(crate::linear!(0)).into()),
+        ]
+    }
+
     fn assert_parameter_id_collision_source(error: crate::Error, expected_id: VariableID) {
         let parse_error = error
             .downcast_ref::<ParseError>()
@@ -1122,6 +1142,23 @@ mod tests {
             signal_source.downcast_ref::<crate::ParameterIDCollision>(),
             Some(crate::ParameterIDCollision { id }) if *id == expected_id
         ));
+    }
+
+    fn assert_cyclic_dependency_source(error: crate::Error, expected_root: &'static str) {
+        let parse_error = error
+            .chain()
+            .next()
+            .and_then(|outer| outer.downcast_ref::<ParseError>())
+            .expect("semantic byte decoding must retain ParseError as the outer owner");
+        assert!(matches!(
+            parse_error
+                .source()
+                .and_then(|source| source.downcast_ref::<crate::SubstitutionError>()),
+            Some(crate::SubstitutionError::CyclicAssignmentDetected)
+        ));
+        assert_eq!(parse_error.context.len(), 1);
+        assert_eq!(parse_error.context[0].message, expected_root);
+        assert_eq!(parse_error.context[0].field, "decision_variable_dependency");
     }
 
     fn binary_decision_variables() -> Vec<v1::DecisionVariable> {
@@ -1495,6 +1532,44 @@ mod tests {
         let error = ParametricInstance::from_v2_bytes(&proto.encode_to_vec()).unwrap_err();
 
         assert_parameter_id_collision_source(error, id);
+    }
+
+    #[test]
+    fn public_byte_decoders_preserve_cyclic_dependency_source_and_context() {
+        let instance = cyclic_dependency_test_instance();
+        let parametric_instance = ParametricInstance::from(instance.clone());
+
+        let mut v1_instance = v1::Instance::try_from(instance.clone()).unwrap();
+        v1_instance.decision_variable_dependency =
+            cyclic_dependency_entries().into_iter().collect();
+        let v1_instance_error = Instance::from_v1_bytes(&v1_instance.encode_to_vec()).unwrap_err();
+
+        let mut v2_instance = v2::Instance::from(instance);
+        v2_instance.decision_variable_dependency =
+            cyclic_dependency_entries().into_iter().collect();
+        let v2_instance_error = Instance::from_v2_bytes(&v2_instance.encode_to_vec()).unwrap_err();
+
+        let mut v1_parametric_instance =
+            v1::ParametricInstance::try_from(parametric_instance.clone()).unwrap();
+        v1_parametric_instance.decision_variable_dependency =
+            cyclic_dependency_entries().into_iter().collect();
+        let v1_parametric_instance_error =
+            ParametricInstance::from_v1_bytes(&v1_parametric_instance.encode_to_vec()).unwrap_err();
+
+        let mut v2_parametric_instance = v2::ParametricInstance::from(parametric_instance);
+        v2_parametric_instance.decision_variable_dependency =
+            cyclic_dependency_entries().into_iter().collect();
+        let v2_parametric_instance_error =
+            ParametricInstance::from_v2_bytes(&v2_parametric_instance.encode_to_vec()).unwrap_err();
+
+        for (error, expected_root) in [
+            (v1_instance_error, "ommx.v1.Instance"),
+            (v2_instance_error, "ommx.v2.Instance"),
+            (v1_parametric_instance_error, "ommx.v1.ParametricInstance"),
+            (v2_parametric_instance_error, "ommx.v2.ParametricInstance"),
+        ] {
+            assert_cyclic_dependency_source(error, expected_root);
+        }
     }
 
     #[test]

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -287,7 +287,10 @@ mod tests {
         ParameterTable, Sampled, Sos1Constraint, Sos1ConstraintID, VariableID,
     };
     use proptest::prelude::*;
-    use std::collections::{BTreeMap, BTreeSet, HashMap};
+    use std::{
+        collections::{BTreeMap, BTreeSet, HashMap},
+        error::Error as _,
+    };
 
     fn instance_with_special_constraints() -> Instance {
         let variable_1 = VariableID::from(1);
@@ -668,7 +671,8 @@ mod tests {
         let err = crate::Solution::try_from(proto).unwrap_err();
 
         assert!(matches!(
-            err.error.downcast_ref::<crate::SolutionError>(),
+            err.source()
+                .and_then(|error| error.downcast_ref::<crate::SolutionError>()),
             Some(crate::SolutionError::InvalidConstraintStructure {
                     constraint_family: "one-hot",
                     constraint_id,

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -667,11 +667,17 @@ mod tests {
 
         let err = crate::Solution::try_from(proto).unwrap_err();
 
-        assert!(
-            err.to_string().contains("One-hot variable")
-                && err.to_string().contains("decision_variables"),
-            "unexpected error: {err}",
-        );
+        assert!(matches!(
+            &err.error,
+            crate::RawParseError::SolutionError(
+                crate::SolutionError::InvalidConstraintStructure {
+                    constraint_family: "one-hot",
+                    constraint_id,
+                    message,
+                }
+            ) if constraint_id == "OneHotConstraintID(20)"
+                && message == "variable VariableID(999) is not in decision_variables"
+        ));
     }
 
     #[test]

--- a/rust/ommx/src/instance/serialize.rs
+++ b/rust/ommx/src/instance/serialize.rs
@@ -668,14 +668,12 @@ mod tests {
         let err = crate::Solution::try_from(proto).unwrap_err();
 
         assert!(matches!(
-            &err.error,
-            crate::RawParseError::SolutionError(
-                crate::SolutionError::InvalidConstraintStructure {
+            err.error.downcast_ref::<crate::SolutionError>(),
+            Some(crate::SolutionError::InvalidConstraintStructure {
                     constraint_family: "one-hot",
                     constraint_id,
                     message,
-                }
-            ) if constraint_id == "OneHotConstraintID(20)"
+                }) if constraint_id == "OneHotConstraintID(20)"
                 && message == "variable VariableID(999) is not in decision_variables"
         ));
     }

--- a/rust/ommx/src/message_io.rs
+++ b/rust/ommx/src/message_io.rs
@@ -83,7 +83,10 @@ mod tests {
             let parse_error = error
                 .downcast_ref::<ParseError>()
                 .expect("wire decode failures must remain downcastable as ParseError");
-            assert!(matches!(&parse_error.error, RawParseError::DecodeError(_)));
+            assert!(matches!(
+                parse_error.error.downcast_ref::<RawParseError>(),
+                Some(RawParseError::DecodeError(_))
+            ));
             assert_eq!(parse_error.context.len(), 1);
             assert_eq!(parse_error.context[0].message, message);
             assert_eq!(parse_error.context[0].field, "bytes");

--- a/rust/ommx/src/message_io.rs
+++ b/rust/ommx/src/message_io.rs
@@ -83,17 +83,17 @@ mod tests {
             let parse_error = error
                 .downcast_ref::<ParseError>()
                 .expect("wire decode failures must remain downcastable as ParseError");
+            let raw_source = parse_error
+                .source()
+                .expect("ParseError must expose its RawParseError source");
             assert!(matches!(
-                parse_error.error.downcast_ref::<RawParseError>(),
+                raw_source.downcast_ref::<RawParseError>(),
                 Some(RawParseError::DecodeError(_))
             ));
             assert_eq!(parse_error.context.len(), 1);
             assert_eq!(parse_error.context[0].message, message);
             assert_eq!(parse_error.context[0].field, "bytes");
 
-            let raw_source = parse_error
-                .source()
-                .expect("ParseError must expose its RawParseError source");
             assert!(raw_source.downcast_ref::<RawParseError>().is_some());
             let decode_source = raw_source
                 .source()

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -624,6 +624,8 @@ where
 
 #[cfg(test)]
 mod table_tests {
+    use std::error::Error as _;
+
     use super::*;
 
     #[test]
@@ -656,10 +658,17 @@ mod table_tests {
         .unwrap_err();
 
         assert_eq!(
-            error.error.to_string(),
+            error
+                .source()
+                .expect("ParseError must expose the orphan-label cause")
+                .to_string(),
             "Modeling label references unknown named function ID NamedFunctionID(1)"
         );
-        assert!(error.error.downcast_ref::<RawParseError>().is_none());
+        let mut source = error.source();
+        while let Some(error) = source {
+            assert!(error.downcast_ref::<RawParseError>().is_none());
+            source = error.source();
+        }
         assert_eq!(error.context.len(), 1);
         assert_eq!(error.context[0].message, "ommx.v2.NamedFunctionTable");
         assert_eq!(error.context[0].field, "labels");

--- a/rust/ommx/src/named_function.rs
+++ b/rust/ommx/src/named_function.rs
@@ -619,7 +619,7 @@ where
         .collect::<Result<BTreeMap<_, _>, ParseError>>()?;
     let labels = crate::v2_io::modeling_label_store_from_v2_map(labels);
     NamedFunctionTable::new(entries, labels)
-        .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
+        .map_err(|e| ParseError::new(e).context(message, "labels"))
 }
 
 #[cfg(test)]
@@ -638,6 +638,31 @@ mod table_tests {
                 .contains("Modeling label references unknown named function ID"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn parse_v2_table_preserves_orphan_label_error() {
+        let error = crate::v2::NamedFunctionTable {
+            entries: BTreeMap::new(),
+            labels: BTreeMap::from([(
+                1,
+                crate::v2::ModelingLabel {
+                    name: Some("orphan".to_string()),
+                    ..Default::default()
+                },
+            )]),
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert_eq!(
+            error.error.to_string(),
+            "Modeling label references unknown named function ID NamedFunctionID(1)"
+        );
+        assert!(error.error.downcast_ref::<RawParseError>().is_none());
+        assert_eq!(error.context.len(), 1);
+        assert_eq!(error.context[0].message, "ommx.v2.NamedFunctionTable");
+        assert_eq!(error.context[0].field, "labels");
     }
 
     #[test]

--- a/rust/ommx/src/named_function/parse.rs
+++ b/rust/ommx/src/named_function/parse.rs
@@ -62,10 +62,10 @@ impl Parse for Vec<v1::NamedFunction> {
             let parsed: ParsedNamedFunction = v.parse(&())?;
             let id = parsed.id;
             if named_functions.insert(id, parsed.named_function).is_some() {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "Duplicated named function ID is found in definition: {id:?}"
-                ))
-                .into());
+                return Err(ParseError::new(crate::error!(
+                    { ?id },
+                    "Duplicated named function ID is found in definition: {id:?}",
+                )));
             }
             label_store.insert(id, parsed.label);
         }
@@ -200,7 +200,13 @@ mod tests {
             },
         ];
         let result: Result<(BTreeMap<NamedFunctionID, NamedFunction>, _), _> = nfs.parse(&());
-        insta::assert_snapshot!(result.unwrap_err(), @r###"
+        let error = result.unwrap_err();
+        assert_eq!(
+            error.error.to_string(),
+            "Duplicated named function ID is found in definition: NamedFunctionID(1)"
+        );
+        assert!(error.error.downcast_ref::<RawParseError>().is_none());
+        insta::assert_snapshot!(error, @r###"
         Traceback for OMMX Message parse error:
         Duplicated named function ID is found in definition: NamedFunctionID(1)
         "###);

--- a/rust/ommx/src/named_function/parse.rs
+++ b/rust/ommx/src/named_function/parse.rs
@@ -155,6 +155,8 @@ impl Parse for v1::SampledNamedFunction {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
     use crate::{parse::Parse, v1, VariableID};
     use maplit::btreeset;
@@ -202,10 +204,17 @@ mod tests {
         let result: Result<(BTreeMap<NamedFunctionID, NamedFunction>, _), _> = nfs.parse(&());
         let error = result.unwrap_err();
         assert_eq!(
-            error.error.to_string(),
+            error
+                .source()
+                .expect("ParseError must expose the duplicate-ID cause")
+                .to_string(),
             "Duplicated named function ID is found in definition: NamedFunctionID(1)"
         );
-        assert!(error.error.downcast_ref::<RawParseError>().is_none());
+        let mut source = error.source();
+        while let Some(error) = source {
+            assert!(error.downcast_ref::<RawParseError>().is_none());
+            source = error.source();
+        }
         insta::assert_snapshot!(error, @r###"
         Traceback for OMMX Message parse error:
         Duplicated named function ID is found in definition: NamedFunctionID(1)

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -472,6 +472,7 @@ mod tests {
         let err = proto.parse(&ATol::default()).unwrap_err();
 
         assert!(!error_chain_contains::<crate::RawParseError>(&err));
+        assert!(!error_chain_contains::<OneHotConstraintError>(&err));
         assert!(err
             .to_string()
             .contains("active_variable must be a member of variables"));

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -225,13 +225,7 @@ impl Parse for crate::v2::OneHotConstraint {
             message,
             "variables",
         )?)
-        .map_err(|error| {
-            match error.downcast::<OneHotConstraintError>() {
-                Ok(error) => crate::RawParseError::from(error),
-                Err(error) => crate::RawParseError::InvalidInstance(error.to_string()),
-            }
-            .context(message, "variables")
-        })
+        .map_err(|error| ParseError::new(error).context(message, "variables"))
     }
 }
 
@@ -264,22 +258,20 @@ impl Parse for crate::v2::EvaluatedOneHotConstraint {
         let variables =
             crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
         if variables.is_empty() {
-            return Err(crate::RawParseError::InvalidInstance(
-                "One-hot constraints must contain at least one variable".to_string(),
-            )
-            .context(message, "variables"));
+            return Err(ParseError::new(OneHotConstraintError::EmptyVariables)
+                .context(message, "variables"));
         }
         let active_variable = self.active_variable.map(VariableID::from);
         if active_variable.is_some_and(|id| !variables.contains(&id)) {
-            return Err(crate::RawParseError::InvalidInstance(
-                "One-hot active_variable must be a member of variables".to_string(),
-            )
+            return Err(ParseError::new(crate::error!(
+                "One-hot active_variable must be a member of variables"
+            ))
             .context(message, "active_variable"));
         }
         if self.feasible != active_variable.is_some() {
-            return Err(crate::RawParseError::InvalidInstance(
-                "One-hot feasible must be true exactly when active_variable is set".to_string(),
-            )
+            return Err(ParseError::new(crate::error!(
+                "One-hot feasible must be true exactly when active_variable is set"
+            ))
             .context(message, "active_variable"));
         }
         Ok(OneHotConstraint {
@@ -343,10 +335,8 @@ impl Parse for crate::v2::SampledOneHotConstraint {
         let variables =
             crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
         if variables.is_empty() {
-            return Err(crate::RawParseError::InvalidInstance(
-                "One-hot constraints must contain at least one variable".to_string(),
-            )
-            .context(message, "variables"));
+            return Err(ParseError::new(OneHotConstraintError::EmptyVariables)
+                .context(message, "variables"));
         }
         let active_variable =
             crate::v2_io::sampled_active_variable_map_from_v2(self.active_variable);
@@ -355,19 +345,18 @@ impl Parse for crate::v2::SampledOneHotConstraint {
             .flatten()
             .any(|id| !variables.contains(id))
         {
-            return Err(crate::RawParseError::InvalidInstance(
-                "One-hot active_variable values must be members of variables".to_string(),
-            )
+            return Err(ParseError::new(crate::error!(
+                "One-hot active_variable values must be members of variables"
+            ))
             .context(message, "active_variable"));
         }
         let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
         for (sample_id, feasible) in &feasible {
             if let Some(active_variable) = active_variable.get(sample_id) {
                 if *feasible != active_variable.is_some() {
-                    return Err(crate::RawParseError::InvalidInstance(
+                    return Err(ParseError::new(crate::error!(
                         "One-hot feasible must be true exactly when active_variable is set"
-                            .to_string(),
-                    )
+                    ))
                     .context(message, "active_variable"));
                 }
             }
@@ -405,7 +394,6 @@ impl std::fmt::Display for OneHotConstraint<Created> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::error::Error as _;
 
     #[test]
     fn test_create_one_hot_constraint() {
@@ -425,30 +413,55 @@ mod tests {
 
     #[test]
     fn parse_v2_preserves_empty_variables_signal() {
-        let error: crate::Error = crate::v2::OneHotConstraint { variables: vec![] }
+        let parse_error = crate::v2::OneHotConstraint { variables: vec![] }
             .parse(&())
-            .unwrap_err()
-            .into();
-        let parse_error = error
-            .downcast_ref::<ParseError>()
-            .expect("v2 semantic parse failures must remain downcastable as ParseError");
+            .unwrap_err();
 
         assert!(matches!(
-            &parse_error.error,
-            crate::RawParseError::OneHotConstraintError(OneHotConstraintError::EmptyVariables)
-        ));
-
-        let raw_source = parse_error
-            .source()
-            .expect("ParseError must expose its RawParseError source");
-        assert!(raw_source.downcast_ref::<crate::RawParseError>().is_some());
-        let signal_source = raw_source
-            .source()
-            .expect("RawParseError must expose the one-hot constraint signal");
-        assert!(matches!(
-            signal_source.downcast_ref::<OneHotConstraintError>(),
+            parse_error.error.downcast_ref::<OneHotConstraintError>(),
             Some(OneHotConstraintError::EmptyVariables)
         ));
+    }
+
+    #[test]
+    fn parse_v2_evaluated_preserves_empty_variables_signal() {
+        let parse_error = crate::v2::EvaluatedOneHotConstraint::default()
+            .parse(&ATol::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            parse_error.error.downcast_ref::<OneHotConstraintError>(),
+            Some(OneHotConstraintError::EmptyVariables)
+        ));
+    }
+
+    #[test]
+    fn parse_v2_sampled_preserves_empty_variables_signal() {
+        let parse_error = crate::v2::SampledOneHotConstraint::default()
+            .parse(&ATol::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            parse_error.error.downcast_ref::<OneHotConstraintError>(),
+            Some(OneHotConstraintError::EmptyVariables)
+        ));
+    }
+
+    #[test]
+    fn parse_v2_evaluated_invalid_active_variable_is_an_ordinary_error() {
+        let proto = crate::v2::EvaluatedOneHotConstraint {
+            variables: vec![1],
+            feasible: true,
+            active_variable: Some(2),
+            used_decision_variable_ids: vec![],
+        };
+
+        let err = proto.parse(&ATol::default()).unwrap_err();
+
+        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
+        assert!(err
+            .to_string()
+            .contains("active_variable must be a member of variables"));
     }
 
     #[test]

--- a/rust/ommx/src/one_hot_constraint/mod.rs
+++ b/rust/ommx/src/one_hot_constraint/mod.rs
@@ -394,6 +394,13 @@ impl std::fmt::Display for OneHotConstraint<Created> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
+
+    fn error_chain_contains<T: std::error::Error + 'static>(
+        error: &(dyn std::error::Error + 'static),
+    ) -> bool {
+        error.downcast_ref::<T>().is_some() || error.source().is_some_and(error_chain_contains::<T>)
+    }
 
     #[test]
     fn test_create_one_hot_constraint() {
@@ -418,7 +425,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            parse_error.error.downcast_ref::<OneHotConstraintError>(),
+            parse_error
+                .source()
+                .and_then(|error| error.downcast_ref::<OneHotConstraintError>()),
             Some(OneHotConstraintError::EmptyVariables)
         ));
     }
@@ -430,7 +439,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            parse_error.error.downcast_ref::<OneHotConstraintError>(),
+            parse_error
+                .source()
+                .and_then(|error| error.downcast_ref::<OneHotConstraintError>()),
             Some(OneHotConstraintError::EmptyVariables)
         ));
     }
@@ -442,7 +453,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            parse_error.error.downcast_ref::<OneHotConstraintError>(),
+            parse_error
+                .source()
+                .and_then(|error| error.downcast_ref::<OneHotConstraintError>()),
             Some(OneHotConstraintError::EmptyVariables)
         ));
     }
@@ -458,7 +471,7 @@ mod tests {
 
         let err = proto.parse(&ATol::default()).unwrap_err();
 
-        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
+        assert!(!error_chain_contains::<crate::RawParseError>(&err));
         assert!(err
             .to_string()
             .contains("active_variable must be a member of variables"));

--- a/rust/ommx/src/parameter.rs
+++ b/rust/ommx/src/parameter.rs
@@ -225,6 +225,7 @@ impl LogicalMemoryProfile for ParameterTable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
 
     #[test]
     fn rejects_orphan_labels() {
@@ -325,7 +326,9 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(
-            err.error.to_string(),
+            err.source()
+                .expect("ParseError must retain its cause")
+                .to_string(),
             "Duplicated parameter ID is found in ommx.v2.ParameterTable: VariableID(100)"
         );
         assert_eq!(err.context.len(), 1);
@@ -351,7 +354,9 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(
-            err.error.to_string(),
+            err.source()
+                .expect("ParseError must retain its cause")
+                .to_string(),
             "Modeling label references unknown parameter ID VariableID(100)"
         );
         assert!(

--- a/rust/ommx/src/parameter.rs
+++ b/rust/ommx/src/parameter.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeSet, HashMap};
 
 use crate::logical_memory::{LogicalMemoryProfile, LogicalMemoryVisitor, Path};
-use crate::{ModelingLabel, ModelingLabelStore, Parse, ParseError, RawParseError, VariableID};
+use crate::{ModelingLabel, ModelingLabelStore, Parse, ParseError, VariableID};
 
 /// Modeling label for parametric-instance parameters.
 pub type ParameterLabel = ModelingLabel;
@@ -201,15 +201,15 @@ impl Parse for crate::v2::ParameterTable {
         for id in self.ids {
             let id = VariableID::from(id);
             if !ids.insert(id) {
-                return Err(RawParseError::InvalidInstance(format!(
+                return Err(ParseError::new(crate::error!(
+                    { ?id },
                     "Duplicated parameter ID is found in ommx.v2.ParameterTable: {id:?}",
                 ))
                 .context(message, "ids"));
             }
         }
         let labels = crate::v2_io::modeling_label_store_from_v2_map(self.labels);
-        ParameterTable::new(ids, labels)
-            .map_err(|e| RawParseError::InvalidInstance(e.to_string()).context(message, "labels"))
+        ParameterTable::new(ids, labels).map_err(|e| ParseError::new(e).context(message, "labels"))
     }
 }
 
@@ -324,11 +324,13 @@ mod tests {
         .parse(&())
         .unwrap_err();
 
-        assert!(
-            err.to_string().contains("Duplicated parameter ID")
-                && err.to_string().contains("VariableID(100)"),
-            "unexpected error: {err}"
+        assert_eq!(
+            err.error.to_string(),
+            "Duplicated parameter ID is found in ommx.v2.ParameterTable: VariableID(100)"
         );
+        assert_eq!(err.context.len(), 1);
+        assert_eq!(err.context[0].message, "ommx.v2.ParameterTable");
+        assert_eq!(err.context[0].field, "ids");
     }
 
     #[test]
@@ -348,6 +350,10 @@ mod tests {
         .parse(&())
         .unwrap_err();
 
+        assert_eq!(
+            err.error.to_string(),
+            "Modeling label references unknown parameter ID VariableID(100)"
+        );
         assert!(
             err.to_string().contains("ommx.v2.ParameterTable[labels]"),
             "unexpected error: {err}"

--- a/rust/ommx/src/parse.rs
+++ b/rust/ommx/src/parse.rs
@@ -30,7 +30,9 @@ pub trait Parse: Sized {
 ///
 /// ```rust
 /// let error = ommx::Instance::from_v1_bytes(&[0x80]).unwrap_err();
-/// assert!(error.downcast_ref::<ommx::ParseError>().is_some());
+/// let parse_error = error.downcast_ref::<ommx::ParseError>().unwrap();
+/// let cause = std::error::Error::source(parse_error).unwrap();
+/// assert!(cause.is::<ommx::RawParseError>());
 /// ```
 #[derive(Debug)]
 pub struct ParseError {
@@ -38,10 +40,9 @@ pub struct ParseError {
     /// The wire-format, domain-signal, or ordinary semantic error that caused
     /// parsing to fail.
     ///
-    /// Callers that recover from a domain signal can downcast this value
-    /// directly, for example with
-    /// `error.error.downcast_ref::<crate::SolutionError>()`.
-    pub error: crate::Error,
+    /// Public callers access this cause as `&dyn std::error::Error` through
+    /// [`std::error::Error::source`].
+    error: crate::Error,
 }
 
 impl fmt::Display for ParseError {
@@ -69,7 +70,9 @@ impl From<RawParseError> for ParseError {
 }
 
 impl ParseError {
-    /// Create a parse error whose cause remains available for downcasting.
+    /// Crate parsing modules use this constructor to attach their owning
+    /// domain cause while this module retains the protobuf breadcrumb
+    /// envelope.
     pub(crate) fn new(error: impl Into<crate::Error>) -> Self {
         ParseError {
             context: vec![],
@@ -92,8 +95,9 @@ pub struct ParseContext {
 /// Generic failures owned by the protobuf parsing boundary.
 ///
 /// Dedicated message-specific parse signals, domain validation signals, and
-/// ordinary semantic failures are stored directly in [`ParseError::error`],
-/// rather than being wrapped in this enum.
+/// ordinary semantic failures are exposed directly through
+/// [`ParseError`]'s [`std::error::Error::source`], rather than being wrapped in
+/// this enum.
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum RawParseError {

--- a/rust/ommx/src/parse.rs
+++ b/rust/ommx/src/parse.rs
@@ -1,8 +1,4 @@
-use crate::{
-    polynomial_base::QuadraticParseError, BoundError, CoefficientError, DecisionVariable,
-    DecisionVariableError, OneHotConstraintError, ParameterIDCollision, SampleID, SampleSetError,
-    SolutionError, Sos1ConstraintError, SubstitutionError, VariableID,
-};
+use crate::{DecisionVariable, VariableID};
 use prost::DecodeError;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -39,7 +35,13 @@ pub trait Parse: Sized {
 #[derive(Debug)]
 pub struct ParseError {
     pub context: Vec<ParseContext>,
-    pub error: RawParseError,
+    /// The wire-format, domain-signal, or ordinary semantic error that caused
+    /// parsing to fail.
+    ///
+    /// Callers that recover from a domain signal can downcast this value
+    /// directly, for example with
+    /// `error.error.downcast_ref::<crate::SolutionError>()`.
+    pub error: crate::Error,
 }
 
 impl fmt::Display for ParseError {
@@ -56,20 +58,25 @@ impl fmt::Display for ParseError {
 
 impl std::error::Error for ParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.error)
+        Some(self.error.as_ref())
     }
 }
 
 impl From<RawParseError> for ParseError {
     fn from(error: RawParseError) -> Self {
-        ParseError {
-            context: vec![],
-            error,
-        }
+        Self::new(error)
     }
 }
 
 impl ParseError {
+    /// Create a parse error whose cause remains available for downcasting.
+    pub(crate) fn new(error: impl Into<crate::Error>) -> Self {
+        ParseError {
+            context: vec![],
+            error: error.into(),
+        }
+    }
+
     pub fn context(mut self, message: &'static str, field: &'static str) -> Self {
         self.context.push(ParseContext { message, field });
         self
@@ -82,7 +89,11 @@ pub struct ParseContext {
     pub field: &'static str,
 }
 
-/// Error occurred during parsing OMMX Message
+/// Generic failures owned by the protobuf parsing boundary.
+///
+/// Dedicated message-specific parse signals, domain validation signals, and
+/// ordinary semantic failures are stored directly in [`ParseError::error`],
+/// rather than being wrapped in this enum.
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum RawParseError {
@@ -115,50 +126,11 @@ pub enum RawParseError {
     #[error("Unknown or unsupported enum value {value} for {enum_name}. This may be due to an unspecified value or a newer version of the protocol.")]
     UnknownEnumValue { enum_name: &'static str, value: i32 },
 
-    /// Catch-all for [`crate::Instance`] invariant violations discovered during
-    /// parsing that have no curated recovery signal. Conditions with a stable
-    /// recovery contract use dedicated source-bearing variants below.
-    #[error("{0}")]
-    InvalidInstance(String),
-
     /// Extension annotation maps must not carry OMMX-owned metadata.
     #[error(
         "Annotation key `{key}` is reserved for OMMX metadata and cannot be stored in extension annotations."
     )]
     ReservedAnnotationKey { key: String },
-
-    #[error(transparent)]
-    SolutionError(#[from] SolutionError),
-
-    #[error(transparent)]
-    SampleSetError(#[from] SampleSetError),
-
-    #[error(transparent)]
-    SubstitutionError(#[from] SubstitutionError),
-
-    #[error(transparent)]
-    InvalidCoefficient(#[from] CoefficientError),
-
-    #[error(transparent)]
-    QuadraticParseError(#[from] QuadraticParseError),
-
-    #[error(transparent)]
-    InvalidBound(#[from] BoundError),
-
-    #[error(transparent)]
-    InvalidDecisionVariable(#[from] DecisionVariableError),
-
-    #[error("{0}")]
-    ParameterIDCollision(#[from] ParameterIDCollision),
-
-    #[error("{0}")]
-    OneHotConstraintError(#[from] OneHotConstraintError),
-
-    #[error("{0}")]
-    Sos1ConstraintError(#[from] Sos1ConstraintError),
-
-    #[error("Duplicated sample ID: {id:?}")]
-    DuplicatedSampleID { id: SampleID },
 
     /// The wire format is invalid.
     #[error("Cannot decode as a Protobuf Message: {0}")]
@@ -167,10 +139,7 @@ pub enum RawParseError {
 
 impl RawParseError {
     pub fn context(self, message: &'static str, field: &'static str) -> ParseError {
-        ParseError {
-            context: vec![ParseContext { message, field }],
-            error: self,
-        }
+        ParseError::new(self).context(message, field)
     }
 }
 
@@ -210,10 +179,9 @@ pub(crate) fn as_variable_id(
 ) -> Result<VariableID, ParseError> {
     let id = VariableID::from(id);
     if !decision_variables.contains_key(&id) {
-        return Err(RawParseError::InvalidInstance(format!(
+        return Err(ParseError::new(crate::error!(
             "Undefined variable ID is used: {id:?}"
-        ))
-        .into());
+        )));
     }
     Ok(id)
 }

--- a/rust/ommx/src/polynomial_base/parse.rs
+++ b/rust/ommx/src/polynomial_base/parse.rs
@@ -16,7 +16,7 @@ impl Parse for v1::linear::Term {
         match self.coefficient.try_into() {
             Ok(coefficient) => Ok(Some(Term { id, coefficient })),
             Err(CoefficientError::Zero) => Ok(None),
-            Err(e) => Err(RawParseError::from(e).context("ommx.v1.linear.Term", "coefficient")),
+            Err(e) => Err(ParseError::new(e).context("ommx.v1.linear.Term", "coefficient")),
         }
     }
 }
@@ -39,15 +39,15 @@ impl Parse for v1::Linear {
             let term = term.parse_as(&(), message, "terms")?;
             if let Some(term) = term {
                 out.add_term(term.id.into(), term.coefficient)
-                    .map_err(|e| RawParseError::from(e).context(message, "terms"))?;
+                    .map_err(|e| ParseError::new(e).context(message, "terms"))?;
             }
         }
         match self.constant.try_into() {
             Ok(coefficient) => out
                 .add_term(LinearMonomial::Constant, coefficient)
-                .map_err(|e| RawParseError::from(e).context(message, "constant"))?,
+                .map_err(|e| ParseError::new(e).context(message, "constant"))?,
             Err(CoefficientError::Zero) => {}
-            Err(e) => return Err(RawParseError::from(e).context(message, "constant")),
+            Err(e) => return Err(ParseError::new(e).context(message, "constant")),
         }
         Ok(out)
     }
@@ -98,16 +98,14 @@ impl Parse for v1::Quadratic {
         let mut out = Quadratic::default();
         let num_terms = self.values.len();
         if self.columns.len() != num_terms {
-            return Err(
-                RawParseError::from(QuadraticParseError::ColumnLengthMismatch {
-                    column: self.columns.len(),
-                    value: num_terms,
-                })
-                .context(message, "columns"),
-            );
+            return Err(ParseError::new(QuadraticParseError::ColumnLengthMismatch {
+                column: self.columns.len(),
+                value: num_terms,
+            })
+            .context(message, "columns"));
         }
         if self.rows.len() != num_terms {
-            return Err(RawParseError::from(QuadraticParseError::RowLengthMismatch {
+            return Err(ParseError::new(QuadraticParseError::RowLengthMismatch {
                 row: self.rows.len(),
                 value: num_terms,
             })
@@ -119,15 +117,15 @@ impl Parse for v1::Quadratic {
             match value.try_into() {
                 Ok(coefficient) => out
                     .add_term((column, row).into(), coefficient)
-                    .map_err(|e| RawParseError::from(e).context(message, "values"))?,
+                    .map_err(|e| ParseError::new(e).context(message, "values"))?,
                 Err(CoefficientError::Zero) => {}
-                Err(e) => return Err(RawParseError::from(e).context(message, "values")),
+                Err(e) => return Err(ParseError::new(e).context(message, "values")),
             }
         }
 
         if let Some(linear) = self.linear {
             let linear = linear.parse_as(&(), message, "linear")?;
-            out = (out + &linear).map_err(|e| RawParseError::from(e).context(message, "linear"))?;
+            out = (out + &linear).map_err(|e| ParseError::new(e).context(message, "linear"))?;
         }
         Ok(out)
     }
@@ -178,7 +176,7 @@ impl Parse for v1::Monomial {
         match self.coefficient.try_into() {
             Ok(coefficient) => Ok(Some((ids, coefficient))),
             Err(CoefficientError::Zero) => Ok(None),
-            Err(e) => Err(RawParseError::from(e).context(message, "coefficient")),
+            Err(e) => Err(ParseError::new(e).context(message, "coefficient")),
         }
     }
 }
@@ -194,7 +192,7 @@ impl Parse for v1::Polynomial {
                 term.parse_as(&(), "ommx.v1.Polynomial", "terms")?
             {
                 out.add_term(monomial, coefficient)
-                    .map_err(|e| RawParseError::from(e).context("ommx.v1.Polynomial", "terms"))?;
+                    .map_err(|e| ParseError::new(e).context("ommx.v1.Polynomial", "terms"))?;
             }
         }
         Ok(out)
@@ -303,7 +301,12 @@ mod tests {
             ],
             constant: 4.0,
         };
-        insta::assert_snapshot!(linear.parse(&()).unwrap_err(), @r###"
+        let error = linear.parse(&()).unwrap_err();
+        assert_eq!(
+            error.error.downcast_ref::<CoefficientError>(),
+            Some(&CoefficientError::Infinite)
+        );
+        insta::assert_snapshot!(error, @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.Linear[terms]
           └─ommx.v1.linear.Term[coefficient]
@@ -370,7 +373,12 @@ mod tests {
             values: vec![7.0, 8.0, 9.0],
             linear: None,
         };
-        insta::assert_snapshot!(quadratic.parse(&()).unwrap_err(), @r###"
+        let error = quadratic.parse(&()).unwrap_err();
+        assert!(matches!(
+            error.error.downcast_ref::<QuadraticParseError>(),
+            Some(QuadraticParseError::RowLengthMismatch { row: 2, value: 3 })
+        ));
+        insta::assert_snapshot!(error, @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.Quadratic[rows]
         Row length (2) does not match value length (3)

--- a/rust/ommx/src/polynomial_base/parse.rs
+++ b/rust/ommx/src/polynomial_base/parse.rs
@@ -228,6 +228,7 @@ mod tests {
     use super::*;
     use crate::v1::linear::Term;
     use proptest::prelude::*;
+    use std::error::Error as _;
 
     #[test]
     fn test_parse_linear() {
@@ -303,7 +304,9 @@ mod tests {
         };
         let error = linear.parse(&()).unwrap_err();
         assert_eq!(
-            error.error.downcast_ref::<CoefficientError>(),
+            error
+                .source()
+                .and_then(|error| error.downcast_ref::<CoefficientError>()),
             Some(&CoefficientError::Infinite)
         );
         insta::assert_snapshot!(error, @r###"
@@ -375,7 +378,9 @@ mod tests {
         };
         let error = quadratic.parse(&()).unwrap_err();
         assert!(matches!(
-            error.error.downcast_ref::<QuadraticParseError>(),
+            error
+                .source()
+                .and_then(|error| error.downcast_ref::<QuadraticParseError>()),
             Some(QuadraticParseError::RowLengthMismatch { row: 2, value: 3 })
         ));
         insta::assert_snapshot!(error, @r###"

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -10,7 +10,7 @@ fn invalid_sample_set_sidecar(
     let signal = crate::SampleSetError::InvalidSidecar {
         message: error.to_string(),
     };
-    ParseError::new(error.context(signal)).context(message, field)
+    ParseError::new(signal).context(message, field)
 }
 
 fn validate_sampled_indicator_structural_ids(
@@ -582,6 +582,10 @@ mod tests {
     use super::*;
     use crate::{v1, Parse};
 
+    fn parse_error_source(error: &ParseError) -> &(dyn std::error::Error + 'static) {
+        std::error::Error::source(error).expect("ParseError should expose its cause")
+    }
+
     fn sampled_decision_variables(kind: crate::Kind) -> crate::SampledDecisionVariableTable {
         let id = crate::VariableID::from(1);
         let decision_variable = crate::DecisionVariable::new(
@@ -614,7 +618,7 @@ mod tests {
         message: &str,
     ) {
         assert!(matches!(
-            error.error.downcast_ref::<crate::SampleSetError>(),
+            parse_error_source(error).downcast_ref::<crate::SampleSetError>(),
             Some(crate::SampleSetError::InvalidConstraintStructure {
                 constraint_family,
                 constraint_id: actual_constraint_id,
@@ -640,14 +644,13 @@ mod tests {
         let error = invalid_sample_set_sidecar(source, "ommx.v1.SampleSet", "constraints");
 
         assert!(matches!(
-            error.error.downcast_ref::<crate::SampleSetError>(),
+            parse_error_source(&error).downcast_ref::<crate::SampleSetError>(),
             Some(crate::SampleSetError::InvalidSidecar { message })
                 if message == "Constraint label/provenance references unknown constraint ID ConstraintID(7)"
         ));
         assert_eq!(error.context.len(), 1);
         assert_eq!(error.context[0].message, "ommx.v1.SampleSet");
         assert_eq!(error.context[0].field, "constraints");
-        assert_eq!(error.error.chain().count(), 2);
     }
 
     #[test]
@@ -1031,7 +1034,7 @@ mod tests {
         let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
         let error = result.unwrap_err();
         assert!(matches!(
-            error.error.downcast_ref::<crate::SampleSetError>(),
+            parse_error_source(&error).downcast_ref::<crate::SampleSetError>(),
             Some(crate::SampleSetError::DuplicatedVariableID { id })
                 if *id == crate::VariableID::from(1)
         ));
@@ -1077,7 +1080,7 @@ mod tests {
         let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
         let error = result.unwrap_err();
         assert!(matches!(
-            error.error.downcast_ref::<crate::SampleSetError>(),
+            parse_error_source(&error).downcast_ref::<crate::SampleSetError>(),
             Some(crate::SampleSetError::DuplicatedNamedFunctionID { id })
                 if *id == crate::NamedFunctionID::from(7)
         ));

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -180,6 +180,16 @@ impl Parse for crate::v1::SampleSet {
                 crate::ConstraintContext,
                 Option<crate::RemovedReason>,
             ) = v1_constraint.parse_as(&(), message, "constraints")?;
+            if constraints.contains_key(&id) {
+                return Err(
+                    ParseError::new(crate::SampleSetError::InvalidConstraintStructure {
+                        constraint_family: "regular",
+                        constraint_id: format!("{id:?}"),
+                        message: "duplicated constraint ID in constraints".to_string(),
+                    })
+                    .context(message, "constraints"),
+                );
+            }
             if let Some(reason) = removed_reason {
                 constraint_removed_reasons.insert(id, reason);
             }
@@ -611,6 +621,137 @@ mod tests {
         .unwrap()
     }
 
+    fn empty_v2_sample_set() -> v2::SampleSet {
+        let sample_id = crate::SampleID::from(0);
+        SampleSet::builder()
+            .decision_variables(BTreeMap::new())
+            .objectives(crate::Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::new())
+            .sense(crate::Sense::Minimize)
+            .build()
+            .unwrap()
+            .into()
+    }
+
+    fn v2_sample_set_with_indicator_constraint() -> v2::SampleSet {
+        use crate::indicator_constraint::{IndicatorSampledData, SampledIndicatorConstraint};
+
+        let variable_id = crate::VariableID::from(1);
+        let sample_id = crate::SampleID::from(0);
+        let decision_variable = crate::SampledDecisionVariable::new(
+            variable_id,
+            crate::DecisionVariable::binary(),
+            crate::Sampled::from((sample_id, 1.0)),
+        )
+        .unwrap();
+        let constraint = SampledIndicatorConstraint {
+            indicator_variable: variable_id,
+            equality: crate::Equality::EqualToZero,
+            stage: IndicatorSampledData {
+                evaluated_values: crate::Sampled::from((sample_id, 0.0)),
+                feasible: BTreeMap::from([(sample_id, true)]),
+                indicator_active: BTreeMap::from([(sample_id, true)]),
+                used_decision_variable_ids: [variable_id].into_iter().collect(),
+            },
+        };
+        SampleSet::builder()
+            .decision_variables(BTreeMap::from([(variable_id, decision_variable)]))
+            .objectives(crate::Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::new())
+            .indicator_constraints(BTreeMap::from([(
+                crate::IndicatorConstraintID::from(1),
+                constraint,
+            )]))
+            .sense(crate::Sense::Minimize)
+            .build()
+            .unwrap()
+            .into()
+    }
+
+    fn v2_sample_set_with_one_hot_constraint() -> v2::SampleSet {
+        use crate::one_hot_constraint::{OneHotSampledData, SampledOneHotConstraint};
+
+        let variable_id = crate::VariableID::from(1);
+        let sample_id = crate::SampleID::from(0);
+        let decision_variable = crate::SampledDecisionVariable::new(
+            variable_id,
+            crate::DecisionVariable::binary(),
+            crate::Sampled::from((sample_id, 1.0)),
+        )
+        .unwrap();
+        let constraint = SampledOneHotConstraint {
+            variables: BTreeSet::from([variable_id]),
+            stage: OneHotSampledData {
+                feasible: BTreeMap::from([(sample_id, true)]),
+                active_variable: BTreeMap::from([(sample_id, Some(variable_id))]),
+                used_decision_variable_ids: [variable_id].into_iter().collect(),
+            },
+        };
+        SampleSet::builder()
+            .decision_variables(BTreeMap::from([(variable_id, decision_variable)]))
+            .objectives(crate::Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::new())
+            .one_hot_constraints(BTreeMap::from([(
+                crate::OneHotConstraintID::from(1),
+                constraint,
+            )]))
+            .sense(crate::Sense::Minimize)
+            .build()
+            .unwrap()
+            .into()
+    }
+
+    fn v2_sample_set_with_sos1_constraint() -> v2::SampleSet {
+        use crate::sos1_constraint::{SampledSos1Constraint, Sos1SampledData};
+
+        let variable_id = crate::VariableID::from(1);
+        let sample_id = crate::SampleID::from(0);
+        let decision_variable = crate::SampledDecisionVariable::new(
+            variable_id,
+            crate::DecisionVariable::binary(),
+            crate::Sampled::from((sample_id, 0.0)),
+        )
+        .unwrap();
+        let constraint = SampledSos1Constraint {
+            variables: BTreeSet::from([variable_id]),
+            stage: Sos1SampledData {
+                feasible: BTreeMap::from([(sample_id, true)]),
+                active_variable: BTreeMap::from([(sample_id, None)]),
+                used_decision_variable_ids: [variable_id].into_iter().collect(),
+            },
+        };
+        SampleSet::builder()
+            .decision_variables(BTreeMap::from([(variable_id, decision_variable)]))
+            .objectives(crate::Sampled::from((sample_id, 0.0)))
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(
+                crate::Sos1ConstraintID::from(1),
+                constraint,
+            )]))
+            .sense(crate::Sense::Minimize)
+            .build()
+            .unwrap()
+            .into()
+    }
+
+    fn assert_undefined_variable_in_constraint(
+        error: &ParseError,
+        expected_variable_id: crate::VariableID,
+        expected_family: &str,
+        expected_constraint_id: &str,
+    ) {
+        assert!(matches!(
+            parse_error_source(error).downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::UndefinedVariableInConstraint {
+                id,
+                constraint_family,
+                constraint_id,
+            }) if *id == expected_variable_id
+                && *constraint_family == expected_family
+                && constraint_id == expected_constraint_id
+        ));
+    }
+
     fn assert_invalid_constraint_structure(
         error: &ParseError,
         family: &str,
@@ -791,6 +932,225 @@ mod tests {
             &error,
             "SOS1",
             "Sos1ConstraintID(5)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_undefined_used_id_in_regular_constraint() {
+        let mut proto = empty_v2_sample_set();
+        proto
+            .sampled_regular_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .insert(
+                7,
+                v2::SampledRegularConstraint {
+                    equality: v1::Equality::EqualToZero as i32,
+                    evaluated_values: Some(v1::SampledValues {
+                        entries: vec![v1::sampled_values::SampledValuesEntry {
+                            ids: vec![0],
+                            value: 0.0,
+                        }],
+                    }),
+                    feasible: BTreeMap::from([(0, true)]),
+                    used_decision_variable_ids: vec![42],
+                    dual_variables: None,
+                },
+            );
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_undefined_variable_in_constraint(
+            &error,
+            crate::VariableID::from(42),
+            "regular",
+            "ConstraintID(7)",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_undefined_used_id_in_indicator_constraint() {
+        let mut proto = v2_sample_set_with_indicator_constraint();
+        proto
+            .sampled_indicator_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .used_decision_variable_ids
+            .push(2);
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_undefined_variable_in_constraint(
+            &error,
+            crate::VariableID::from(2),
+            "indicator",
+            "IndicatorConstraintID(1)",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_undefined_used_id_in_one_hot_constraint() {
+        let mut proto = v2_sample_set_with_one_hot_constraint();
+        proto
+            .sampled_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .used_decision_variable_ids
+            .push(2);
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_undefined_variable_in_constraint(
+            &error,
+            crate::VariableID::from(2),
+            "one-hot",
+            "OneHotConstraintID(1)",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_undefined_used_id_in_sos1_constraint() {
+        let mut proto = v2_sample_set_with_sos1_constraint();
+        proto
+            .sampled_sos1_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .used_decision_variable_ids
+            .push(2);
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_undefined_variable_in_constraint(
+            &error,
+            crate::VariableID::from(2),
+            "SOS1",
+            "Sos1ConstraintID(1)",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_undefined_indicator_variable() {
+        let mut proto = v2_sample_set_with_indicator_constraint();
+        proto
+            .sampled_indicator_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .indicator_variable = 2;
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "indicator",
+            "IndicatorConstraintID(1)",
+            "indicator variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_non_binary_indicator_variable() {
+        let mut proto = v2_sample_set_with_indicator_constraint();
+        proto
+            .decision_variables
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .kind = v1::decision_variable::Kind::Continuous as i32;
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "indicator",
+            "IndicatorConstraintID(1)",
+            "indicator variable VariableID(1) must be binary",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_undefined_one_hot_variable() {
+        let mut proto = v2_sample_set_with_one_hot_constraint();
+        let row = proto
+            .sampled_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.variables = vec![2];
+        row.active_variable.insert(
+            0,
+            v2::SampledActiveVariable {
+                variable_id: Some(2),
+            },
+        );
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "one-hot",
+            "OneHotConstraintID(1)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_non_binary_one_hot_variable() {
+        let mut proto = v2_sample_set_with_one_hot_constraint();
+        proto
+            .decision_variables
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .kind = v1::decision_variable::Kind::Continuous as i32;
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "one-hot",
+            "OneHotConstraintID(1)",
+            "variable VariableID(1) must be binary",
+        );
+    }
+
+    #[test]
+    fn test_v2_sample_set_parse_classifies_undefined_sos1_variable() {
+        let mut proto = v2_sample_set_with_sos1_constraint();
+        proto
+            .sampled_sos1_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .variables = vec![2];
+
+        let error = SampleSet::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "SOS1",
+            "Sos1ConstraintID(1)",
             "variable VariableID(2) is not in decision_variables",
         );
     }
@@ -981,6 +1341,56 @@ mod tests {
         └─ommx.v1.SampleSet[feasible]
         Inconsistent feasibility for sample 0: provided=true, computed=false
         "###);
+    }
+
+    #[test]
+    fn from_v1_bytes_rejects_duplicated_sampled_constraint_ids() {
+        let sampled_values = v1::SampledValues {
+            entries: vec![v1::sampled_values::SampledValuesEntry {
+                ids: vec![0],
+                value: 0.0,
+            }],
+        };
+        let first = v1::SampledConstraint {
+            id: 7,
+            equality: v1::Equality::EqualToZero as i32,
+            evaluated_values: Some(sampled_values.clone()),
+            feasible: std::collections::HashMap::from([(0, true)]),
+            removed_reason: Some("removed first row".to_string()),
+            ..Default::default()
+        };
+        let second = v1::SampledConstraint {
+            id: 7,
+            equality: v1::Equality::EqualToZero as i32,
+            evaluated_values: Some(sampled_values.clone()),
+            feasible: std::collections::HashMap::from([(0, true)]),
+            name: Some("active second row".to_string()),
+            ..Default::default()
+        };
+        let proto = v1::SampleSet {
+            objectives: Some(sampled_values),
+            constraints: vec![first, second],
+            sense: v1::instance::Sense::Minimize as i32,
+            ..Default::default()
+        };
+
+        let error = SampleSet::from_v1_bytes(&crate::Message::encode_to_vec(&proto)).unwrap_err();
+        let parse_error = error
+            .downcast_ref::<ParseError>()
+            .expect("semantic byte decoding must retain ParseError as the outer owner");
+
+        assert!(matches!(
+            parse_error_source(parse_error).downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::InvalidConstraintStructure {
+                constraint_family: "regular",
+                constraint_id,
+                message,
+            }) if constraint_id == "ConstraintID(7)"
+                && message == "duplicated constraint ID in constraints"
+        ));
+        assert_eq!(parse_error.context.len(), 1);
+        assert_eq!(parse_error.context[0].message, "ommx.v1.SampleSet");
+        assert_eq!(parse_error.context[0].field, "constraints");
     }
 
     // Data produced by a future SDK whose format version exceeds what this SDK supports

--- a/rust/ommx/src/sample_set/parse.rs
+++ b/rust/ommx/src/sample_set/parse.rs
@@ -2,6 +2,17 @@ use super::*;
 use crate::{v2, Parse, ParseError, RawParseError};
 use std::collections::{BTreeMap, BTreeSet};
 
+fn invalid_sample_set_sidecar(
+    error: crate::Error,
+    message: &'static str,
+    field: &'static str,
+) -> ParseError {
+    let signal = crate::SampleSetError::InvalidSidecar {
+        message: error.to_string(),
+    };
+    ParseError::new(error.context(signal)).context(message, field)
+}
+
 fn validate_sampled_indicator_structural_ids(
     constraints: &crate::constraint_type::SampledCollection<crate::IndicatorConstraint>,
     decision_variables: &crate::SampledDecisionVariableTable,
@@ -10,16 +21,24 @@ fn validate_sampled_indicator_structural_ids(
     for (constraint_id, constraint) in constraints.inner() {
         let id = constraint.indicator_variable;
         let Some(variable) = decision_variables.get(&id) else {
-            return Err(RawParseError::InvalidInstance(format!(
-                "Indicator variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
-            ))
-            .context(message, "sampled_indicator_constraints"));
+            return Err(
+                ParseError::new(crate::SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "indicator",
+                    constraint_id: format!("{constraint_id:?}"),
+                    message: format!("indicator variable {id:?} is not in decision_variables"),
+                })
+                .context(message, "sampled_indicator_constraints"),
+            );
         };
         if *variable.kind() != crate::decision_variable::Kind::Binary {
-            return Err(RawParseError::InvalidInstance(format!(
-                "Indicator variable {id:?} in constraint {constraint_id:?} must be binary",
-            ))
-            .context(message, "sampled_indicator_constraints"));
+            return Err(
+                ParseError::new(crate::SampleSetError::InvalidConstraintStructure {
+                    constraint_family: "indicator",
+                    constraint_id: format!("{constraint_id:?}"),
+                    message: format!("indicator variable {id:?} must be binary"),
+                })
+                .context(message, "sampled_indicator_constraints"),
+            );
         }
     }
     Ok(())
@@ -33,16 +52,24 @@ fn validate_sampled_one_hot_structural_ids(
     for (constraint_id, constraint) in constraints.inner() {
         for id in &constraint.variables {
             let Some(variable) = decision_variables.get(id) else {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "One-hot variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
-                ))
-                .context(message, "sampled_one_hot_constraints"));
+                return Err(
+                    ParseError::new(crate::SampleSetError::InvalidConstraintStructure {
+                        constraint_family: "one-hot",
+                        constraint_id: format!("{constraint_id:?}"),
+                        message: format!("variable {id:?} is not in decision_variables"),
+                    })
+                    .context(message, "sampled_one_hot_constraints"),
+                );
             };
             if *variable.kind() != crate::decision_variable::Kind::Binary {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "One-hot variable {id:?} in constraint {constraint_id:?} must be binary",
-                ))
-                .context(message, "sampled_one_hot_constraints"));
+                return Err(
+                    ParseError::new(crate::SampleSetError::InvalidConstraintStructure {
+                        constraint_family: "one-hot",
+                        constraint_id: format!("{constraint_id:?}"),
+                        message: format!("variable {id:?} must be binary"),
+                    })
+                    .context(message, "sampled_one_hot_constraints"),
+                );
             }
         }
     }
@@ -57,10 +84,14 @@ fn validate_sampled_sos1_structural_ids(
     for (constraint_id, constraint) in constraints.inner() {
         for id in &constraint.variables {
             if !decision_variables.contains_key(id) {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "SOS1 variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
-                ))
-                .context(message, "sampled_sos1_constraints"));
+                return Err(
+                    ParseError::new(crate::SampleSetError::InvalidConstraintStructure {
+                        constraint_family: "SOS1",
+                        constraint_id: format!("{constraint_id:?}"),
+                        message: format!("variable {id:?} is not in decision_variables"),
+                    })
+                    .context(message, "sampled_sos1_constraints"),
+                );
             }
         }
     }
@@ -90,7 +121,7 @@ fn validate_sample_bool_map_ids(
     let found = map.keys().copied().collect::<SampleIDSet>();
     if &found != expected {
         return Err(
-            RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+            ParseError::new(crate::SampleSetError::InconsistentSampleIDs {
                 expected: expected.clone(),
                 found,
             })
@@ -118,10 +149,10 @@ impl Parse for crate::v1::SampleSet {
             let dv_id = parsed.id;
             variable_labels.insert(dv_id, parsed.label);
             if decision_variables.insert(dv_id, parsed.variable).is_some() {
-                return Err(crate::RawParseError::SampleSetError(
-                    crate::SampleSetError::DuplicatedVariableID { id: dv_id },
-                )
-                .context(message, "decision_variables"));
+                return Err(
+                    ParseError::new(crate::SampleSetError::DuplicatedVariableID { id: dv_id })
+                        .context(message, "decision_variables"),
+                );
             }
         }
 
@@ -167,10 +198,10 @@ impl Parse for crate::v1::SampleSet {
                 .insert(id, parsed.sampled_named_function)
                 .is_some()
             {
-                return Err(crate::RawParseError::SampleSetError(
-                    crate::SampleSetError::DuplicatedNamedFunctionID { id },
-                )
-                .context(message, "named_functions"));
+                return Err(
+                    ParseError::new(crate::SampleSetError::DuplicatedNamedFunctionID { id })
+                        .context(message, "named_functions"),
+                );
             }
             named_function_labels.insert(id, parsed.label);
         }
@@ -194,16 +225,13 @@ impl Parse for crate::v1::SampleSet {
                     constraint_removed_reasons,
                     constraint_context,
                 )
-                .map_err(|e| {
-                    crate::RawParseError::InvalidInstance(e.to_string())
-                        .context(message, "constraints")
-                })?,
+                .map_err(|error| invalid_sample_set_sidecar(error, message, "constraints"))?,
             )
             .named_functions(named_functions)
             .named_function_labels(named_function_labels)
             .sense(sense)
             .build()
-            .map_err(crate::RawParseError::SampleSetError)?;
+            .map_err(ParseError::new)?;
         let mut sample_set = sample_set;
         sample_set.metadata = self.metadata;
         sample_set.annotations = self.annotations;
@@ -213,14 +241,14 @@ impl Parse for crate::v1::SampleSet {
             let sample_id = crate::SampleID::from(sample_id_u64);
             if let Some(computed_feasible) = sample_set.is_sample_feasible(sample_id) {
                 if provided_feasible != computed_feasible {
-                    return Err(crate::RawParseError::SampleSetError(
-                        crate::SampleSetError::InconsistentFeasibility {
+                    return Err(
+                        ParseError::new(crate::SampleSetError::InconsistentFeasibility {
                             sample_id: sample_id_u64,
                             provided_feasible,
                             computed_feasible,
-                        },
-                    )
-                    .context(message, "feasible"));
+                        })
+                        .context(message, "feasible"),
+                    );
                 }
             }
         }
@@ -232,7 +260,7 @@ impl Parse for crate::v1::SampleSet {
                 sample_set.is_sample_feasible_relaxed(sample_id)
             {
                 if provided_feasible_relaxed != computed_feasible_relaxed {
-                    return Err(crate::RawParseError::SampleSetError(
+                    return Err(ParseError::new(
                         crate::SampleSetError::InconsistentFeasibilityRelaxed {
                             sample_id: sample_id_u64,
                             provided_feasible_relaxed,
@@ -307,19 +335,19 @@ impl Parse for v2::SampleSet {
         let objective_sample_ids = objectives.ids();
         for sampled_dv in decision_variables.values() {
             if !sampled_dv.samples().has_same_ids(&objective_sample_ids) {
-                return Err(RawParseError::SampleSetError(
-                    crate::SampleSetError::InconsistentSampleIDs {
+                return Err(
+                    ParseError::new(crate::SampleSetError::InconsistentSampleIDs {
                         expected: objective_sample_ids.clone(),
                         found: sampled_dv.samples().ids(),
-                    },
-                )
-                .context(message, "decision_variables"));
+                    })
+                    .context(message, "decision_variables"),
+                );
             }
         }
         constraints
             .validate_sample_ids(&objective_sample_ids)
             .map_err(|found| {
-                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                ParseError::new(crate::SampleSetError::InconsistentSampleIDs {
                     expected: objective_sample_ids.clone(),
                     found,
                 })
@@ -328,7 +356,7 @@ impl Parse for v2::SampleSet {
         indicator_constraints
             .validate_sample_ids(&objective_sample_ids)
             .map_err(|found| {
-                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                ParseError::new(crate::SampleSetError::InconsistentSampleIDs {
                     expected: objective_sample_ids.clone(),
                     found,
                 })
@@ -337,7 +365,7 @@ impl Parse for v2::SampleSet {
         one_hot_constraints
             .validate_sample_ids(&objective_sample_ids)
             .map_err(|found| {
-                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                ParseError::new(crate::SampleSetError::InconsistentSampleIDs {
                     expected: objective_sample_ids.clone(),
                     found,
                 })
@@ -346,7 +374,7 @@ impl Parse for v2::SampleSet {
         sos1_constraints
             .validate_sample_ids(&objective_sample_ids)
             .map_err(|found| {
-                RawParseError::SampleSetError(crate::SampleSetError::InconsistentSampleIDs {
+                ParseError::new(crate::SampleSetError::InconsistentSampleIDs {
                     expected: objective_sample_ids.clone(),
                     found,
                 })
@@ -355,29 +383,21 @@ impl Parse for v2::SampleSet {
 
         let decision_variable_ids = decision_variables.keys().copied().collect::<BTreeSet<_>>();
         validate_sampled_constraint_used_ids("regular", &constraints, &decision_variable_ids)
-            .map_err(|e| {
-                RawParseError::SampleSetError(e).context(message, "sampled_regular_constraints")
-            })?;
+            .map_err(|e| ParseError::new(e).context(message, "sampled_regular_constraints"))?;
         validate_sampled_constraint_used_ids(
             "indicator",
             &indicator_constraints,
             &decision_variable_ids,
         )
-        .map_err(|e| {
-            RawParseError::SampleSetError(e).context(message, "sampled_indicator_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "sampled_indicator_constraints"))?;
         validate_sampled_constraint_used_ids(
             "one-hot",
             &one_hot_constraints,
             &decision_variable_ids,
         )
-        .map_err(|e| {
-            RawParseError::SampleSetError(e).context(message, "sampled_one_hot_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "sampled_one_hot_constraints"))?;
         validate_sampled_constraint_used_ids("SOS1", &sos1_constraints, &decision_variable_ids)
-            .map_err(|e| {
-                RawParseError::SampleSetError(e).context(message, "sampled_sos1_constraints")
-            })?;
+            .map_err(|e| ParseError::new(e).context(message, "sampled_sos1_constraints"))?;
         validate_sampled_indicator_structural_ids(
             &indicator_constraints,
             &decision_variables,
@@ -394,42 +414,36 @@ impl Parse for v2::SampleSet {
             &indicator_constraints,
             feasibility_atol,
         )
-        .map_err(|e| {
-            RawParseError::SampleSetError(e).context(message, "sampled_indicator_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "sampled_indicator_constraints"))?;
         validate_sampled_one_hot_stage_values(
             &decision_variables,
             &one_hot_constraints,
             feasibility_atol,
         )
-        .map_err(|e| {
-            RawParseError::SampleSetError(e).context(message, "sampled_one_hot_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "sampled_one_hot_constraints"))?;
         validate_sampled_sos1_stage_values(
             &decision_variables,
             &sos1_constraints,
             feasibility_atol,
         )
-        .map_err(|e| {
-            RawParseError::SampleSetError(e).context(message, "sampled_sos1_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "sampled_sos1_constraints"))?;
 
         for (named_function_id, sampled_named_function) in named_functions.iter() {
             if !sampled_named_function
                 .evaluated_values()
                 .has_same_ids(&objective_sample_ids)
             {
-                return Err(RawParseError::SampleSetError(
-                    crate::SampleSetError::InconsistentSampleIDs {
+                return Err(
+                    ParseError::new(crate::SampleSetError::InconsistentSampleIDs {
                         expected: objective_sample_ids.clone(),
                         found: sampled_named_function.evaluated_values().ids(),
-                    },
-                )
-                .context(message, "sampled_named_functions"));
+                    })
+                    .context(message, "sampled_named_functions"),
+                );
             }
             for var_id in sampled_named_function.used_decision_variable_ids() {
                 if !decision_variables.contains_key(var_id) {
-                    return Err(RawParseError::SampleSetError(
+                    return Err(ParseError::new(
                         crate::SampleSetError::UndefinedVariableInNamedFunction {
                             id: *var_id,
                             named_function_id: *named_function_id,
@@ -452,14 +466,14 @@ impl Parse for v2::SampleSet {
         if let Some((sample_id, provided_feasible, computed_feasible)) =
             first_feasibility_mismatch(&feasible, &computed_feasible)
         {
-            return Err(RawParseError::SampleSetError(
-                crate::SampleSetError::InconsistentFeasibility {
+            return Err(
+                ParseError::new(crate::SampleSetError::InconsistentFeasibility {
                     sample_id: sample_id.into_inner(),
                     provided_feasible,
                     computed_feasible,
-                },
-            )
-            .context(message, "feasible"));
+                })
+                .context(message, "feasible"),
+            );
         }
         let feasible_relaxed = crate::v2_io::sample_bool_map_from_v2(self.feasible_relaxed);
         validate_sample_bool_map_ids(
@@ -471,14 +485,14 @@ impl Parse for v2::SampleSet {
         if let Some((sample_id, provided_feasible_relaxed, computed_feasible_relaxed)) =
             first_feasibility_mismatch(&feasible_relaxed, &computed_feasible_relaxed)
         {
-            return Err(RawParseError::SampleSetError(
-                crate::SampleSetError::InconsistentFeasibilityRelaxed {
+            return Err(
+                ParseError::new(crate::SampleSetError::InconsistentFeasibilityRelaxed {
                     sample_id: sample_id.into_inner(),
                     provided_feasible_relaxed,
                     computed_feasible_relaxed,
-                },
-            )
-            .context(message, "feasible_relaxed"));
+                })
+                .context(message, "feasible_relaxed"),
+            );
         }
 
         Ok(SampleSet {
@@ -567,6 +581,216 @@ impl From<SampleSet> for crate::v1::SampleSet {
 mod tests {
     use super::*;
     use crate::{v1, Parse};
+
+    fn sampled_decision_variables(kind: crate::Kind) -> crate::SampledDecisionVariableTable {
+        let id = crate::VariableID::from(1);
+        let decision_variable = crate::DecisionVariable::new(
+            kind,
+            if kind == crate::Kind::Binary {
+                crate::Bound::of_binary()
+            } else {
+                crate::Bound::default()
+            },
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let row = crate::SampledDecisionVariable::new(
+            id,
+            decision_variable,
+            crate::Sampled::from((crate::SampleID::from(0), 0.0)),
+        )
+        .unwrap();
+        crate::SampledDecisionVariableTable::new(
+            BTreeMap::from([(id, row)]),
+            crate::VariableLabelStore::default(),
+        )
+        .unwrap()
+    }
+
+    fn assert_invalid_constraint_structure(
+        error: &ParseError,
+        family: &str,
+        constraint_id: &str,
+        message: &str,
+    ) {
+        assert!(matches!(
+            error.error.downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::InvalidConstraintStructure {
+                constraint_family,
+                constraint_id: actual_constraint_id,
+                message: actual_message,
+            }) if *constraint_family == family
+                && actual_constraint_id == constraint_id
+                && actual_message == message
+        ));
+    }
+
+    #[test]
+    fn invalid_sample_set_sidecar_preserves_sample_set_error() {
+        let constraint_id = crate::ConstraintID::from(7);
+        let mut context = crate::ConstraintContextStore::default();
+        context.set_name(constraint_id, "orphan");
+        let source = crate::constraint_type::SampledCollection::<crate::Constraint>::with_context(
+            BTreeMap::new(),
+            BTreeMap::new(),
+            context,
+        )
+        .unwrap_err();
+
+        let error = invalid_sample_set_sidecar(source, "ommx.v1.SampleSet", "constraints");
+
+        assert!(matches!(
+            error.error.downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::InvalidSidecar { message })
+                if message == "Constraint label/provenance references unknown constraint ID ConstraintID(7)"
+        ));
+        assert_eq!(error.context.len(), 1);
+        assert_eq!(error.context[0].message, "ommx.v1.SampleSet");
+        assert_eq!(error.context[0].field, "constraints");
+        assert_eq!(error.error.chain().count(), 2);
+    }
+
+    #[test]
+    fn sampled_indicator_structural_checks_preserve_sample_set_error() {
+        use crate::indicator_constraint::{IndicatorSampledData, SampledIndicatorConstraint};
+
+        let variable_id = crate::VariableID::from(1);
+        let constraint_id = crate::IndicatorConstraintID::from(3);
+        let constraint = SampledIndicatorConstraint {
+            indicator_variable: crate::VariableID::from(2),
+            equality: crate::Equality::EqualToZero,
+            stage: IndicatorSampledData {
+                evaluated_values: crate::Sampled::from((crate::SampleID::from(0), 0.0)),
+                feasible: BTreeMap::from([(crate::SampleID::from(0), true)]),
+                indicator_active: BTreeMap::from([(crate::SampleID::from(0), false)]),
+                used_decision_variable_ids: [variable_id].into_iter().collect(),
+            },
+        };
+        let constraints = crate::SampledCollection::new(
+            BTreeMap::from([(constraint_id, constraint)]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let binary = sampled_decision_variables(crate::Kind::Binary);
+        let error =
+            validate_sampled_indicator_structural_ids(&constraints, &binary, "ommx.v2.SampleSet")
+                .unwrap_err();
+        assert_invalid_constraint_structure(
+            &error,
+            "indicator",
+            "IndicatorConstraintID(3)",
+            "indicator variable VariableID(2) is not in decision_variables",
+        );
+
+        let mut constraint = constraints.inner().get(&constraint_id).unwrap().clone();
+        constraint.indicator_variable = variable_id;
+        let constraints = crate::SampledCollection::new(
+            BTreeMap::from([(constraint_id, constraint)]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let continuous = sampled_decision_variables(crate::Kind::Continuous);
+        let error = validate_sampled_indicator_structural_ids(
+            &constraints,
+            &continuous,
+            "ommx.v2.SampleSet",
+        )
+        .unwrap_err();
+        assert_invalid_constraint_structure(
+            &error,
+            "indicator",
+            "IndicatorConstraintID(3)",
+            "indicator variable VariableID(1) must be binary",
+        );
+    }
+
+    #[test]
+    fn sampled_one_hot_structural_checks_preserve_sample_set_error() {
+        use crate::one_hot_constraint::{OneHotSampledData, SampledOneHotConstraint};
+
+        let variable_id = crate::VariableID::from(1);
+        let constraint_id = crate::OneHotConstraintID::from(4);
+        let make_constraints = |structural_id| {
+            crate::SampledCollection::new(
+                BTreeMap::from([(
+                    constraint_id,
+                    SampledOneHotConstraint {
+                        variables: [structural_id].into_iter().collect(),
+                        stage: OneHotSampledData {
+                            feasible: BTreeMap::from([(crate::SampleID::from(0), true)]),
+                            active_variable: BTreeMap::from([(
+                                crate::SampleID::from(0),
+                                Some(structural_id),
+                            )]),
+                            used_decision_variable_ids: [variable_id].into_iter().collect(),
+                        },
+                    },
+                )]),
+                BTreeMap::new(),
+            )
+            .unwrap()
+        };
+
+        let error = validate_sampled_one_hot_structural_ids(
+            &make_constraints(crate::VariableID::from(2)),
+            &sampled_decision_variables(crate::Kind::Binary),
+            "ommx.v2.SampleSet",
+        )
+        .unwrap_err();
+        assert_invalid_constraint_structure(
+            &error,
+            "one-hot",
+            "OneHotConstraintID(4)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+
+        let error = validate_sampled_one_hot_structural_ids(
+            &make_constraints(variable_id),
+            &sampled_decision_variables(crate::Kind::Continuous),
+            "ommx.v2.SampleSet",
+        )
+        .unwrap_err();
+        assert_invalid_constraint_structure(
+            &error,
+            "one-hot",
+            "OneHotConstraintID(4)",
+            "variable VariableID(1) must be binary",
+        );
+    }
+
+    #[test]
+    fn sampled_sos1_structural_check_preserves_sample_set_error() {
+        use crate::sos1_constraint::{SampledSos1Constraint, Sos1SampledData};
+
+        let constraint_id = crate::Sos1ConstraintID::from(5);
+        let undefined_id = crate::VariableID::from(2);
+        let constraint = SampledSos1Constraint {
+            variables: [undefined_id].into_iter().collect(),
+            stage: Sos1SampledData {
+                feasible: BTreeMap::from([(crate::SampleID::from(0), true)]),
+                active_variable: BTreeMap::from([(crate::SampleID::from(0), None)]),
+                used_decision_variable_ids: [crate::VariableID::from(1)].into_iter().collect(),
+            },
+        };
+        let constraints = crate::SampledCollection::new(
+            BTreeMap::from([(constraint_id, constraint)]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let error = validate_sampled_sos1_structural_ids(
+            &constraints,
+            &sampled_decision_variables(crate::Kind::Continuous),
+            "ommx.v2.SampleSet",
+        )
+        .unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "SOS1",
+            "Sos1ConstraintID(5)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
 
     #[test]
     fn test_sample_set_parse_rejects_reserved_annotation_key() {
@@ -807,9 +1031,9 @@ mod tests {
         let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
         let error = result.unwrap_err();
         assert!(matches!(
-            error.error,
-            crate::RawParseError::SampleSetError(crate::SampleSetError::DuplicatedVariableID { id })
-                if id == crate::VariableID::from(1)
+            error.error.downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::DuplicatedVariableID { id })
+                if *id == crate::VariableID::from(1)
         ));
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
@@ -853,10 +1077,9 @@ mod tests {
         let result: Result<SampleSet, ParseError> = v1_sample_set.parse(&());
         let error = result.unwrap_err();
         assert!(matches!(
-            error.error,
-            crate::RawParseError::SampleSetError(
-                crate::SampleSetError::DuplicatedNamedFunctionID { id }
-            ) if id == crate::NamedFunctionID::from(7)
+            error.error.downcast_ref::<crate::SampleSetError>(),
+            Some(crate::SampleSetError::DuplicatedNamedFunctionID { id })
+                if *id == crate::NamedFunctionID::from(7)
         ));
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:

--- a/rust/ommx/src/sampled/parse.rs
+++ b/rust/ommx/src/sampled/parse.rs
@@ -92,6 +92,7 @@ impl From<Sampled<f64>> for v1::SampledValues {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
 
     #[test]
     fn parse_preserves_duplicated_sample_id_error() {
@@ -106,8 +107,8 @@ mod tests {
 
         assert_eq!(
             error
-                .error
-                .downcast_ref::<DuplicatedSampleIDError>()
+                .source()
+                .and_then(|error| error.downcast_ref::<DuplicatedSampleIDError>())
                 .map(DuplicatedSampleIDError::id),
             Some(SampleID::from(7))
         );

--- a/rust/ommx/src/sampled/parse.rs
+++ b/rust/ommx/src/sampled/parse.rs
@@ -4,15 +4,9 @@ use crate::{
     v1::{self, sampled_values::SampledValuesEntry, samples::SamplesEntry},
 };
 
-impl From<DuplicatedSampleIDError> for RawParseError {
-    fn from(e: DuplicatedSampleIDError) -> Self {
-        RawParseError::DuplicatedSampleID { id: e.id() }
-    }
-}
-
 impl From<DuplicatedSampleIDError> for ParseError {
     fn from(e: DuplicatedSampleIDError) -> Self {
-        ParseError::from(RawParseError::from(e))
+        ParseError::new(e)
     }
 }
 
@@ -92,5 +86,30 @@ impl From<Sampled<f64>> for v1::SampledValues {
                 })
                 .collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_preserves_duplicated_sample_id_error() {
+        let error = v1::SampledValues {
+            entries: vec![SampledValuesEntry {
+                value: 1.0,
+                ids: vec![7, 7],
+            }],
+        }
+        .parse(&())
+        .unwrap_err();
+
+        assert_eq!(
+            error
+                .error
+                .downcast_ref::<DuplicatedSampleIDError>()
+                .map(DuplicatedSampleIDError::id),
+            Some(SampleID::from(7))
+        );
     }
 }

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -2,7 +2,7 @@ mod parse;
 mod serialize;
 
 use crate::{
-    constraint_type::EvaluatedCollection,
+    constraint_type::{EvaluatedCollection, EvaluatedConstraintBehavior},
     decision_variable::{EvaluatedDecisionVariableTable, VariableLabelStore},
     indicator_constraint::IndicatorConstraint,
     ATol, Constraint, ConstraintID, EvaluatedConstraint, EvaluatedDecisionVariable,
@@ -192,6 +192,82 @@ fn validate_evaluated_named_function_used_ids(
         }
     }
     Ok(())
+}
+
+fn validate_constraint_used_ids<T: crate::ConstraintType>(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    constraints: &EvaluatedCollection<T>,
+    classify: impl Fn(T::ID, VariableID) -> SolutionError,
+) -> Result<(), SolutionError> {
+    for (constraint_id, constraint) in constraints.inner() {
+        for variable_id in constraint.used_decision_variable_ids() {
+            if !decision_variables.contains_key(variable_id) {
+                return Err(classify(*constraint_id, *variable_id));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_solution_regular_constraint_used_ids(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    constraints: &EvaluatedCollection<Constraint>,
+) -> Result<(), SolutionError> {
+    validate_constraint_used_ids(decision_variables, constraints, |constraint_id, id| {
+        SolutionError::UndefinedVariableInConstraint { id, constraint_id }
+    })
+}
+
+fn validate_solution_indicator_constraint_used_ids(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    constraints: &EvaluatedCollection<IndicatorConstraint>,
+) -> Result<(), SolutionError> {
+    validate_constraint_used_ids(decision_variables, constraints, |constraint_id, id| {
+        SolutionError::InvalidConstraintStructure {
+            constraint_family: "indicator",
+            constraint_id: format!("{constraint_id:?}"),
+            message: format!("variable {id:?} is not in decision_variables"),
+        }
+    })
+}
+
+fn validate_solution_one_hot_constraint_used_ids(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+) -> Result<(), SolutionError> {
+    validate_constraint_used_ids(decision_variables, constraints, |constraint_id, id| {
+        SolutionError::InvalidConstraintStructure {
+            constraint_family: "one-hot",
+            constraint_id: format!("{constraint_id:?}"),
+            message: format!("variable {id:?} is not in decision_variables"),
+        }
+    })
+}
+
+fn validate_solution_sos1_constraint_used_ids(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+) -> Result<(), SolutionError> {
+    validate_constraint_used_ids(decision_variables, constraints, |constraint_id, id| {
+        SolutionError::InvalidConstraintStructure {
+            constraint_family: "SOS1",
+            constraint_id: format!("{constraint_id:?}"),
+            message: format!("variable {id:?} is not in decision_variables"),
+        }
+    })
+}
+
+fn validate_all_solution_constraint_used_ids(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    regular_constraints: &EvaluatedCollection<Constraint>,
+    indicator_constraints: &EvaluatedCollection<IndicatorConstraint>,
+    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+) -> Result<(), SolutionError> {
+    validate_solution_regular_constraint_used_ids(decision_variables, regular_constraints)?;
+    validate_solution_indicator_constraint_used_ids(decision_variables, indicator_constraints)?;
+    validate_solution_one_hot_constraint_used_ids(decision_variables, one_hot_constraints)?;
+    validate_solution_sos1_constraint_used_ids(decision_variables, sos1_constraints)
 }
 
 impl Solution {
@@ -1232,54 +1308,13 @@ impl SolutionBuilder {
             self.feasibility_atol,
         )?;
 
-        // Validate all used_decision_variable_ids in indicator constraints
-        for (ic_id, ic) in self.evaluated_indicator_constraints.iter() {
-            for var_id in &ic.stage.used_decision_variable_ids {
-                if !decision_variables.contains_key(var_id) {
-                    crate::bail!(
-                        { ?var_id, ?ic_id },
-                        "Variable {var_id:?} used in indicator constraint {ic_id:?} is not defined in decision_variables",
-                    );
-                }
-            }
-        }
-
-        // Validate all used_decision_variable_ids in one-hot constraints
-        for (oh_id, oh) in self.evaluated_one_hot_constraints.iter() {
-            for var_id in &oh.stage.used_decision_variable_ids {
-                if !decision_variables.contains_key(var_id) {
-                    crate::bail!(
-                        { ?var_id, ?oh_id },
-                        "Variable {var_id:?} used in one-hot constraint {oh_id:?} is not defined in decision_variables",
-                    );
-                }
-            }
-        }
-
-        // Validate all used_decision_variable_ids in SOS1 constraints
-        for (s1_id, s1) in self.evaluated_sos1_constraints.iter() {
-            for var_id in &s1.stage.used_decision_variable_ids {
-                if !decision_variables.contains_key(var_id) {
-                    crate::bail!(
-                        { ?var_id, ?s1_id },
-                        "Variable {var_id:?} used in SOS1 constraint {s1_id:?} is not defined in decision_variables",
-                    );
-                }
-            }
-        }
-
-        // Validate all used_decision_variable_ids are in decision_variables
-        for (constraint_id, constraint) in evaluated_constraints.iter() {
-            for var_id in &constraint.stage.used_decision_variable_ids {
-                if !decision_variables.contains_key(var_id) {
-                    return Err(SolutionError::UndefinedVariableInConstraint {
-                        id: *var_id,
-                        constraint_id: *constraint_id,
-                    }
-                    .into());
-                }
-            }
-        }
+        validate_all_solution_constraint_used_ids(
+            &decision_variables,
+            &evaluated_constraints,
+            &self.evaluated_indicator_constraints,
+            &self.evaluated_one_hot_constraints,
+            &self.evaluated_sos1_constraints,
+        )?;
         validate_evaluated_named_function_used_ids(
             &decision_variables,
             &evaluated_named_functions,
@@ -1933,6 +1968,106 @@ mod tests {
             solution_err,
             SolutionError::UndefinedVariableInConstraint { id, constraint_id: cid }
                 if *id == var_id && *cid == constraint_id
+        ));
+    }
+
+    #[test]
+    fn builder_preserves_special_constraint_used_id_signals() {
+        let structural_id = VariableID::from(1);
+        let missing_id = VariableID::from(2);
+        let decision_variables = BTreeMap::from([(
+            structural_id,
+            EvaluatedDecisionVariable::new(structural_id, crate::DecisionVariable::binary(), 1.0)
+                .unwrap(),
+        )]);
+
+        let indicator_id = crate::IndicatorConstraintID::from(3);
+        let indicator = crate::indicator_constraint::EvaluatedIndicatorConstraint {
+            indicator_variable: structural_id,
+            equality: crate::Equality::EqualToZero,
+            stage: crate::indicator_constraint::IndicatorEvaluatedData {
+                evaluated_value: 0.0,
+                feasible: true,
+                indicator_active: true,
+                used_decision_variable_ids: BTreeSet::from([missing_id]),
+            },
+        };
+        let error = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_indicator_constraints(BTreeMap::from([(indicator_id, indicator)]))
+            .decision_variables(decision_variables.clone())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<SolutionError>(),
+            Some(SolutionError::InvalidConstraintStructure {
+                constraint_family: "indicator",
+                constraint_id,
+                message,
+            }) if constraint_id == "IndicatorConstraintID(3)"
+                && message == "variable VariableID(2) is not in decision_variables"
+        ));
+
+        let one_hot_id = crate::OneHotConstraintID::from(4);
+        let one_hot = crate::one_hot_constraint::EvaluatedOneHotConstraint {
+            variables: BTreeSet::from([structural_id]),
+            stage: crate::one_hot_constraint::OneHotEvaluatedData {
+                feasible: true,
+                active_variable: Some(structural_id),
+                used_decision_variable_ids: BTreeSet::from([missing_id]),
+            },
+        };
+        let error = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_one_hot_constraints_collection(
+                EvaluatedCollection::new(BTreeMap::from([(one_hot_id, one_hot)]), BTreeMap::new())
+                    .unwrap(),
+            )
+            .decision_variables(decision_variables.clone())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<SolutionError>(),
+            Some(SolutionError::InvalidConstraintStructure {
+                constraint_family: "one-hot",
+                constraint_id,
+                message,
+            }) if constraint_id == "OneHotConstraintID(4)"
+                && message == "variable VariableID(2) is not in decision_variables"
+        ));
+
+        let sos1_id = crate::Sos1ConstraintID::from(5);
+        let sos1 = crate::sos1_constraint::EvaluatedSos1Constraint {
+            variables: BTreeSet::from([structural_id]),
+            stage: crate::sos1_constraint::Sos1EvaluatedData {
+                feasible: true,
+                active_variable: Some(structural_id),
+                used_decision_variable_ids: BTreeSet::from([missing_id]),
+            },
+        };
+        let error = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(BTreeMap::new())
+            .evaluated_sos1_constraints_collection(
+                EvaluatedCollection::new(BTreeMap::from([(sos1_id, sos1)]), BTreeMap::new())
+                    .unwrap(),
+            )
+            .decision_variables(decision_variables)
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<SolutionError>(),
+            Some(SolutionError::InvalidConstraintStructure {
+                constraint_family: "SOS1",
+                constraint_id,
+                message,
+            }) if constraint_id == "Sos1ConstraintID(5)"
+                && message == "variable VariableID(2) is not in decision_variables"
         ));
     }
 

--- a/rust/ommx/src/solution.rs
+++ b/rust/ommx/src/solution.rs
@@ -722,11 +722,9 @@ fn validate_solution_constraint_feasibility(
     Ok(())
 }
 
-fn validate_solution_special_constraint_structure(
+fn validate_solution_indicator_constraint_structure(
     decision_variables: &EvaluatedDecisionVariableTable,
     indicator_constraints: &EvaluatedCollection<IndicatorConstraint>,
-    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
-    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
 ) -> Result<(), SolutionError> {
     for (id, constraint) in indicator_constraints.inner() {
         let variable_id = constraint.indicator_variable;
@@ -746,6 +744,13 @@ fn validate_solution_special_constraint_structure(
         }
     }
 
+    Ok(())
+}
+
+fn validate_solution_one_hot_constraint_structure(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+) -> Result<(), SolutionError> {
     for (id, constraint) in one_hot_constraints.inner() {
         if constraint.variables.is_empty() {
             return Err(SolutionError::InvalidConstraintStructure {
@@ -783,6 +788,13 @@ fn validate_solution_special_constraint_structure(
         }
     }
 
+    Ok(())
+}
+
+fn validate_solution_sos1_constraint_structure(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+) -> Result<(), SolutionError> {
     for (id, constraint) in sos1_constraints.inner() {
         if constraint.variables.is_empty() {
             return Err(SolutionError::InvalidConstraintStructure {
@@ -814,6 +826,17 @@ fn validate_solution_special_constraint_structure(
     }
 
     Ok(())
+}
+
+fn validate_solution_special_constraint_structure(
+    decision_variables: &EvaluatedDecisionVariableTable,
+    indicator_constraints: &EvaluatedCollection<IndicatorConstraint>,
+    one_hot_constraints: &EvaluatedCollection<crate::OneHotConstraint>,
+    sos1_constraints: &EvaluatedCollection<crate::Sos1Constraint>,
+) -> Result<(), SolutionError> {
+    validate_solution_indicator_constraint_structure(decision_variables, indicator_constraints)?;
+    validate_solution_one_hot_constraint_structure(decision_variables, one_hot_constraints)?;
+    validate_solution_sos1_constraint_structure(decision_variables, sos1_constraints)
 }
 
 fn expected_binary_activity(

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -72,6 +72,14 @@ impl Parse for crate::v1::Solution {
                 crate::ConstraintContext,
                 Option<crate::RemovedReason>,
             ) = ec.parse_as(&(), message, "evaluated_constraints")?;
+            if evaluated_constraints.contains_key(&id) {
+                return Err(ParseError::new(SolutionError::InvalidConstraintStructure {
+                    constraint_family: "regular",
+                    constraint_id: format!("{id:?}"),
+                    message: "duplicated constraint ID in evaluated_constraints".to_string(),
+                })
+                .context(message, "evaluated_constraints"));
+            }
             if let Some(reason) = removed_reason {
                 removed_reasons.insert(id, reason);
             }
@@ -1302,6 +1310,48 @@ mod tests {
             } if *id == VariableID::from(42) && *constraint_id == ConstraintID::from(7)
         ));
         assert_eq!(error.context[0].field, "evaluated_constraints");
+    }
+
+    #[test]
+    fn from_v1_bytes_rejects_duplicated_evaluated_constraint_ids() {
+        let first = v1::EvaluatedConstraint {
+            id: 7,
+            equality: v1::Equality::EqualToZero as i32,
+            evaluated_value: 0.0,
+            removed_reason: Some("removed first row".to_string()),
+            ..Default::default()
+        };
+        let second = v1::EvaluatedConstraint {
+            id: 7,
+            equality: v1::Equality::EqualToZero as i32,
+            evaluated_value: 0.0,
+            name: Some("active second row".to_string()),
+            ..Default::default()
+        };
+        let proto = v1::Solution {
+            evaluated_constraints: vec![first, second],
+            feasible: true,
+            feasible_relaxed: Some(true),
+            ..Default::default()
+        };
+
+        let error = Solution::from_v1_bytes(&crate::Message::encode_to_vec(&proto)).unwrap_err();
+        let parse_error = error
+            .downcast_ref::<ParseError>()
+            .expect("semantic byte decoding must retain ParseError as the outer owner");
+
+        assert!(matches!(
+            parse_error_source(parse_error).downcast_ref::<SolutionError>(),
+            Some(SolutionError::InvalidConstraintStructure {
+                constraint_family: "regular",
+                constraint_id,
+                message,
+            }) if constraint_id == "ConstraintID(7)"
+                && message == "duplicated constraint ID in evaluated_constraints"
+        ));
+        assert_eq!(parse_error.context.len(), 1);
+        assert_eq!(parse_error.context[0].message, "ommx.v1.Solution");
+        assert_eq!(parse_error.context[0].field, "evaluated_constraints");
     }
 
     // Data produced by a future SDK whose format version exceeds what this SDK supports

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -21,83 +21,30 @@ fn validate_evaluated_constraint_used_ids<T: crate::ConstraintType>(
     decision_variables: &crate::EvaluatedDecisionVariableTable,
     message: &'static str,
     field: &'static str,
+    classify: impl Fn(T::ID, crate::VariableID) -> SolutionError,
 ) -> Result<(), ParseError> {
     for (constraint_id, constraint) in constraints.inner() {
         for var_id in constraint.used_decision_variable_ids() {
             if !decision_variables.contains_key(var_id) {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "Variable {var_id:?} used in constraint {constraint_id:?} is not defined in decision_variables",
-                ))
-                .context(message, field));
+                return Err(
+                    RawParseError::SolutionError(classify(*constraint_id, *var_id))
+                        .context(message, field),
+                );
             }
         }
     }
     Ok(())
 }
 
-fn validate_solution_indicator_structural_ids(
-    constraints: &crate::constraint_type::EvaluatedCollection<crate::IndicatorConstraint>,
-    decision_variables: &crate::EvaluatedDecisionVariableTable,
+fn invalid_solution_sidecar(
+    error: crate::Error,
     message: &'static str,
-) -> Result<(), ParseError> {
-    for (constraint_id, constraint) in constraints.inner() {
-        let id = constraint.indicator_variable;
-        let Some(variable) = decision_variables.get(&id) else {
-            return Err(RawParseError::InvalidInstance(format!(
-                "Indicator variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
-            ))
-            .context(message, "evaluated_indicator_constraints"));
-        };
-        if *variable.kind() != crate::decision_variable::Kind::Binary {
-            return Err(RawParseError::InvalidInstance(format!(
-                "Indicator variable {id:?} in constraint {constraint_id:?} must be binary",
-            ))
-            .context(message, "evaluated_indicator_constraints"));
-        }
-    }
-    Ok(())
-}
-
-fn validate_solution_one_hot_structural_ids(
-    constraints: &crate::constraint_type::EvaluatedCollection<crate::OneHotConstraint>,
-    decision_variables: &crate::EvaluatedDecisionVariableTable,
-    message: &'static str,
-) -> Result<(), ParseError> {
-    for (constraint_id, constraint) in constraints.inner() {
-        for id in &constraint.variables {
-            let Some(variable) = decision_variables.get(id) else {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "One-hot variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
-                ))
-                .context(message, "evaluated_one_hot_constraints"));
-            };
-            if *variable.kind() != crate::decision_variable::Kind::Binary {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "One-hot variable {id:?} in constraint {constraint_id:?} must be binary",
-                ))
-                .context(message, "evaluated_one_hot_constraints"));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_solution_sos1_structural_ids(
-    constraints: &crate::constraint_type::EvaluatedCollection<crate::Sos1Constraint>,
-    decision_variables: &crate::EvaluatedDecisionVariableTable,
-    message: &'static str,
-) -> Result<(), ParseError> {
-    for (constraint_id, constraint) in constraints.inner() {
-        for id in &constraint.variables {
-            if !decision_variables.contains_key(id) {
-                return Err(RawParseError::InvalidInstance(format!(
-                    "SOS1 variable {id:?} in constraint {constraint_id:?} is not defined in decision_variables",
-                ))
-                .context(message, "evaluated_sos1_constraints"));
-            }
-        }
-    }
-    Ok(())
+    field: &'static str,
+) -> ParseError {
+    RawParseError::SolutionError(SolutionError::InvalidSidecar {
+        message: error.to_string(),
+    })
+    .context(message, field)
 }
 
 impl Parse for crate::v1::Solution {
@@ -188,12 +135,11 @@ impl Parse for crate::v1::Solution {
                 (Some(value), None) | (None, Some(value)) => *value,
                 (Some(value), Some(substituted_value)) => {
                     if (*value - *substituted_value).abs() > *atol {
-                        return Err(crate::RawParseError::InvalidDecisionVariable(
-                            crate::DecisionVariableError::SubstitutedValueOverwrite {
-                                id: crate::VariableID::from(dv_id),
-                                previous_value: *substituted_value,
-                                new_value: *value,
-                                atol,
+                        return Err(crate::RawParseError::SolutionError(
+                            SolutionError::InconsistentVariableValue {
+                                id: dv_id,
+                                state_value: *value,
+                                substituted_value: *substituted_value,
                             },
                         )
                         .context(message, "decision_variables"));
@@ -239,20 +185,10 @@ impl Parse for crate::v1::Solution {
 
         let evaluated_named_functions =
             crate::NamedFunctionTable::new(evaluated_named_functions, named_function_labels)
-                .map_err(|e| {
-                    crate::RawParseError::SolutionError(crate::SolutionError::InvalidSidecar {
-                        message: e.to_string(),
-                    })
-                    .context(message, "evaluated_named_functions")
-                })?;
+                .map_err(|e| invalid_solution_sidecar(e, message, "evaluated_named_functions"))?;
         let decision_variables =
             crate::EvaluatedDecisionVariableTable::new(decision_variables, variable_labels)
-                .map_err(|e| {
-                    crate::RawParseError::SolutionError(crate::SolutionError::InvalidSidecar {
-                        message: e.to_string(),
-                    })
-                    .context(message, "decision_variables")
-                })?;
+                .map_err(|e| invalid_solution_sidecar(e, message, "decision_variables"))?;
         validate_evaluated_named_function_used_ids(&decision_variables, &evaluated_named_functions)
             .map_err(|e| {
                 crate::RawParseError::SolutionError(e).context(message, "evaluated_named_functions")
@@ -265,10 +201,7 @@ impl Parse for crate::v1::Solution {
                 removed_reasons,
                 constraint_context,
             )
-            .map_err(|e| {
-                crate::RawParseError::InvalidInstance(e.to_string())
-                    .context(message, "evaluated_constraints")
-            })?,
+            .map_err(|e| invalid_solution_sidecar(e, message, "evaluated_constraints"))?,
             evaluated_indicator_constraints: Default::default(),
             evaluated_one_hot_constraints: Default::default(),
             evaluated_sos1_constraints: Default::default(),
@@ -365,44 +298,66 @@ impl Parse for v2::Solution {
             .map(|value| value.parse_as(&(), message, "evaluated_named_functions"))
             .transpose()?
             .unwrap_or_default();
+        validate_solution_indicator_constraint_structure(
+            &decision_variables,
+            &evaluated_indicator_constraints,
+        )
+        .map_err(|e| {
+            RawParseError::SolutionError(e).context(message, "evaluated_indicator_constraints")
+        })?;
+        validate_solution_one_hot_constraint_structure(
+            &decision_variables,
+            &evaluated_one_hot_constraints,
+        )
+        .map_err(|e| {
+            RawParseError::SolutionError(e).context(message, "evaluated_one_hot_constraints")
+        })?;
+        validate_solution_sos1_constraint_structure(
+            &decision_variables,
+            &evaluated_sos1_constraints,
+        )
+        .map_err(|e| {
+            RawParseError::SolutionError(e).context(message, "evaluated_sos1_constraints")
+        })?;
         validate_evaluated_constraint_used_ids(
             &evaluated_constraints,
             &decision_variables,
             message,
             "evaluated_regular_constraints",
+            |constraint_id, id| SolutionError::UndefinedVariableInConstraint { id, constraint_id },
         )?;
         validate_evaluated_constraint_used_ids(
             &evaluated_indicator_constraints,
             &decision_variables,
             message,
             "evaluated_indicator_constraints",
+            |constraint_id, id| SolutionError::InvalidConstraintStructure {
+                constraint_family: "indicator",
+                constraint_id: format!("{constraint_id:?}"),
+                message: format!("variable {id:?} is not in decision_variables"),
+            },
         )?;
         validate_evaluated_constraint_used_ids(
             &evaluated_one_hot_constraints,
             &decision_variables,
             message,
             "evaluated_one_hot_constraints",
+            |constraint_id, id| SolutionError::InvalidConstraintStructure {
+                constraint_family: "one-hot",
+                constraint_id: format!("{constraint_id:?}"),
+                message: format!("variable {id:?} is not in decision_variables"),
+            },
         )?;
         validate_evaluated_constraint_used_ids(
             &evaluated_sos1_constraints,
             &decision_variables,
             message,
             "evaluated_sos1_constraints",
-        )?;
-        validate_solution_indicator_structural_ids(
-            &evaluated_indicator_constraints,
-            &decision_variables,
-            message,
-        )?;
-        validate_solution_one_hot_structural_ids(
-            &evaluated_one_hot_constraints,
-            &decision_variables,
-            message,
-        )?;
-        validate_solution_sos1_structural_ids(
-            &evaluated_sos1_constraints,
-            &decision_variables,
-            message,
+            |constraint_id, id| SolutionError::InvalidConstraintStructure {
+                constraint_family: "SOS1",
+                constraint_id: format!("{constraint_id:?}"),
+                message: format!("variable {id:?} is not in decision_variables"),
+            },
         )?;
         validate_solution_indicator_stage_values(
             &decision_variables,
@@ -569,7 +524,366 @@ impl From<Solution> for crate::v1::Solution {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{v1, Parse};
+    use crate::{v1, DecisionVariable, Parse};
+
+    fn empty_v2_solution() -> v2::Solution {
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(std::collections::BTreeMap::new())
+            .decision_variables(std::collections::BTreeMap::new())
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+        solution.into()
+    }
+
+    fn v2_solution_with_indicator_constraint() -> v2::Solution {
+        let variable_id = VariableID::from(1);
+        let decision_variable =
+            EvaluatedDecisionVariable::new(variable_id, DecisionVariable::binary(), 1.0).unwrap();
+        let constraint = crate::indicator_constraint::EvaluatedIndicatorConstraint {
+            indicator_variable: variable_id,
+            equality: crate::Equality::EqualToZero,
+            stage: crate::indicator_constraint::IndicatorEvaluatedData {
+                evaluated_value: 0.0,
+                feasible: true,
+                indicator_active: true,
+                used_decision_variable_ids: [variable_id].into_iter().collect(),
+            },
+        };
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(std::collections::BTreeMap::new())
+            .evaluated_indicator_constraints(std::collections::BTreeMap::from([(
+                crate::IndicatorConstraintID::from(1),
+                constraint,
+            )]))
+            .decision_variables(std::collections::BTreeMap::from([(
+                variable_id,
+                decision_variable,
+            )]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+        solution.into()
+    }
+
+    fn v2_solution_with_one_hot_constraint() -> v2::Solution {
+        let variable_id = VariableID::from(1);
+        let decision_variable =
+            EvaluatedDecisionVariable::new(variable_id, DecisionVariable::binary(), 1.0).unwrap();
+        let constraint = crate::one_hot_constraint::EvaluatedOneHotConstraint {
+            variables: std::collections::BTreeSet::from([variable_id]),
+            stage: crate::one_hot_constraint::OneHotEvaluatedData {
+                feasible: true,
+                active_variable: Some(variable_id),
+                used_decision_variable_ids: [variable_id].into_iter().collect(),
+            },
+        };
+        let collection = crate::constraint_type::EvaluatedCollection::new(
+            std::collections::BTreeMap::from([(crate::OneHotConstraintID::from(1), constraint)]),
+            std::collections::BTreeMap::new(),
+        )
+        .unwrap();
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(std::collections::BTreeMap::new())
+            .evaluated_one_hot_constraints_collection(collection)
+            .decision_variables(std::collections::BTreeMap::from([(
+                variable_id,
+                decision_variable,
+            )]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+        solution.into()
+    }
+
+    fn v2_solution_with_sos1_constraint() -> v2::Solution {
+        let variable_id = VariableID::from(1);
+        let decision_variable =
+            EvaluatedDecisionVariable::new(variable_id, DecisionVariable::binary(), 0.0).unwrap();
+        let constraint = crate::sos1_constraint::EvaluatedSos1Constraint {
+            variables: std::collections::BTreeSet::from([variable_id]),
+            stage: crate::sos1_constraint::Sos1EvaluatedData {
+                feasible: true,
+                active_variable: None,
+                used_decision_variable_ids: [variable_id].into_iter().collect(),
+            },
+        };
+        let collection = crate::constraint_type::EvaluatedCollection::new(
+            std::collections::BTreeMap::from([(crate::Sos1ConstraintID::from(1), constraint)]),
+            std::collections::BTreeMap::new(),
+        )
+        .unwrap();
+        let solution = Solution::builder()
+            .objective(0.0)
+            .evaluated_constraints(std::collections::BTreeMap::new())
+            .evaluated_sos1_constraints_collection(collection)
+            .decision_variables(std::collections::BTreeMap::from([(
+                variable_id,
+                decision_variable,
+            )]))
+            .sense(Sense::Minimize)
+            .build()
+            .unwrap();
+        solution.into()
+    }
+
+    fn assert_invalid_constraint_structure(
+        error: &ParseError,
+        expected_family: &str,
+        expected_constraint_id: &str,
+        expected_message: &str,
+    ) {
+        assert!(
+            matches!(
+                &error.error,
+                RawParseError::SolutionError(SolutionError::InvalidConstraintStructure {
+                    constraint_family,
+                    constraint_id,
+                    message,
+                }) if *constraint_family == expected_family
+                    && constraint_id.as_str() == expected_constraint_id
+                    && message.as_str() == expected_message
+            ),
+            "unexpected error: {error}",
+        );
+    }
+
+    #[test]
+    fn invalid_solution_sidecar_preserves_solution_error() {
+        let constraint_id = ConstraintID::from(7);
+        let mut context = crate::ConstraintContextStore::default();
+        context.set_name(constraint_id, "orphan");
+        let source = crate::constraint_type::EvaluatedCollection::<Constraint>::with_context(
+            std::collections::BTreeMap::new(),
+            std::collections::BTreeMap::new(),
+            context,
+        )
+        .unwrap_err();
+
+        let error = invalid_solution_sidecar(source, "ommx.v1.Solution", "evaluated_constraints");
+
+        assert!(matches!(
+            &error.error,
+            RawParseError::SolutionError(SolutionError::InvalidSidecar { message })
+                if message.as_str() == "Constraint label/provenance references unknown constraint ID ConstraintID(7)"
+        ));
+        assert_eq!(error.context.len(), 1);
+        assert_eq!(error.context[0].message, "ommx.v1.Solution");
+        assert_eq!(error.context[0].field, "evaluated_constraints");
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_undefined_variable_in_regular_constraint() {
+        let mut proto = empty_v2_solution();
+        proto
+            .evaluated_regular_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .insert(
+                7,
+                v2::EvaluatedRegularConstraint {
+                    equality: v1::Equality::EqualToZero as i32,
+                    evaluated_value: 0.0,
+                    feasible: true,
+                    used_decision_variable_ids: vec![42],
+                    dual_variable: None,
+                },
+            );
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert!(matches!(
+            &error.error,
+            RawParseError::SolutionError(SolutionError::UndefinedVariableInConstraint {
+                id,
+                constraint_id,
+            }) if *id == VariableID::from(42) && *constraint_id == ConstraintID::from(7)
+        ));
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_undefined_used_id_in_indicator_constraint() {
+        let mut proto = v2_solution_with_indicator_constraint();
+        proto
+            .evaluated_indicator_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .used_decision_variable_ids
+            .push(2);
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "indicator",
+            "IndicatorConstraintID(1)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_undefined_used_id_in_one_hot_constraint() {
+        let mut proto = v2_solution_with_one_hot_constraint();
+        proto
+            .evaluated_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .used_decision_variable_ids
+            .push(2);
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "one-hot",
+            "OneHotConstraintID(1)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_undefined_used_id_in_sos1_constraint() {
+        let mut proto = v2_solution_with_sos1_constraint();
+        proto
+            .evaluated_sos1_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .used_decision_variable_ids
+            .push(2);
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "SOS1",
+            "Sos1ConstraintID(1)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_undefined_indicator_variable() {
+        let mut proto = v2_solution_with_indicator_constraint();
+        proto
+            .evaluated_indicator_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .indicator_variable = 2;
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "indicator",
+            "IndicatorConstraintID(1)",
+            "indicator variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_non_binary_indicator_variable() {
+        let mut proto = v2_solution_with_indicator_constraint();
+        proto
+            .decision_variables
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .kind = v1::decision_variable::Kind::Continuous as i32;
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "indicator",
+            "IndicatorConstraintID(1)",
+            "indicator variable VariableID(1) must be binary",
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_undefined_one_hot_variable() {
+        let mut proto = v2_solution_with_one_hot_constraint();
+        let row = proto
+            .evaluated_one_hot_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap();
+        row.variables = vec![2];
+        row.active_variable = Some(2);
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "one-hot",
+            "OneHotConstraintID(1)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_non_binary_one_hot_variable() {
+        let mut proto = v2_solution_with_one_hot_constraint();
+        proto
+            .decision_variables
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .kind = v1::decision_variable::Kind::Continuous as i32;
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "one-hot",
+            "OneHotConstraintID(1)",
+            "variable VariableID(1) must be binary",
+        );
+    }
+
+    #[test]
+    fn test_v2_solution_parse_classifies_undefined_sos1_variable() {
+        let mut proto = v2_solution_with_sos1_constraint();
+        proto
+            .evaluated_sos1_constraints
+            .as_mut()
+            .unwrap()
+            .entries
+            .get_mut(&1)
+            .unwrap()
+            .variables = vec![2];
+
+        let error = Solution::try_from(proto).unwrap_err();
+
+        assert_invalid_constraint_structure(
+            &error,
+            "SOS1",
+            "Sos1ConstraintID(1)",
+            "variable VariableID(2) is not in decision_variables",
+        );
+    }
 
     #[test]
     fn test_solution_parse_rejects_reserved_annotation_key() {
@@ -809,10 +1123,18 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
+        assert!(matches!(
+            &error.error,
+            RawParseError::SolutionError(SolutionError::InconsistentVariableValue {
+                id,
+                state_value,
+                substituted_value,
+            }) if *id == 1 && *state_value == 2.0 && *substituted_value == 3.0
+        ));
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[decision_variables]
-        Substituted value for ID=1 cannot be overwritten: previous=3, new=2, atol=ATol(1e-6)
+        Inconsistent value for variable 1: state=2, substituted_value=3
         "###);
     }
 

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -23,7 +23,7 @@ fn invalid_solution_sidecar(
     let signal = SolutionError::InvalidSidecar {
         message: error.to_string(),
     };
-    ParseError::new(error.context(signal)).context(message, field)
+    ParseError::new(signal).context(message, field)
 }
 
 impl Parse for crate::v1::Solution {
@@ -464,6 +464,10 @@ mod tests {
     use super::*;
     use crate::{v1, DecisionVariable, Parse};
 
+    fn parse_error_source(error: &ParseError) -> &(dyn std::error::Error + 'static) {
+        std::error::Error::source(error).expect("ParseError should expose its cause")
+    }
+
     fn empty_v2_solution() -> v2::Solution {
         let solution = Solution::builder()
             .objective(0.0)
@@ -574,8 +578,7 @@ mod tests {
         expected_constraint_id: &str,
         expected_message: &str,
     ) {
-        let error = error
-            .error
+        let error = parse_error_source(error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(
@@ -607,8 +610,7 @@ mod tests {
 
         let error = invalid_solution_sidecar(source, "ommx.v1.Solution", "evaluated_constraints");
 
-        let solution_error = error
-            .error
+        let solution_error = parse_error_source(&error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(matches!(
@@ -619,7 +621,6 @@ mod tests {
         assert_eq!(error.context.len(), 1);
         assert_eq!(error.context[0].message, "ommx.v1.Solution");
         assert_eq!(error.context[0].field, "evaluated_constraints");
-        assert_eq!(error.error.chain().count(), 2);
     }
 
     #[test]
@@ -643,8 +644,7 @@ mod tests {
 
         let error = Solution::try_from(proto).unwrap_err();
 
-        let solution_error = error
-            .error
+        let solution_error = parse_error_source(&error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(matches!(
@@ -1074,8 +1074,7 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
-        let solution_error = error
-            .error
+        let solution_error = parse_error_source(&error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(matches!(
@@ -1183,8 +1182,7 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
-        let solution_error = error
-            .error
+        let solution_error = parse_error_source(&error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(matches!(
@@ -1224,8 +1222,7 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
-        let solution_error = error
-            .error
+        let solution_error = parse_error_source(&error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(matches!(
@@ -1259,8 +1256,7 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
-        let solution_error = error
-            .error
+        let solution_error = parse_error_source(&error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(matches!(
@@ -1295,8 +1291,7 @@ mod tests {
 
         let error = v1_solution.parse(&()).unwrap_err();
 
-        let solution_error = error
-            .error
+        let solution_error = parse_error_source(&error)
             .downcast_ref::<SolutionError>()
             .expect("expected SolutionError");
         assert!(matches!(

--- a/rust/ommx/src/solution/parse.rs
+++ b/rust/ommx/src/solution/parse.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::constraint_type::EvaluatedConstraintBehavior;
 use crate::{v2, ATol, Parse, ParseError, RawParseError, SolutionError};
 
 fn parse_v2_solution_sense(value: i32, message: &'static str) -> Result<Option<Sense>, ParseError> {
@@ -16,35 +15,15 @@ fn parse_v2_solution_sense(value: i32, message: &'static str) -> Result<Option<S
     })
 }
 
-fn validate_evaluated_constraint_used_ids<T: crate::ConstraintType>(
-    constraints: &crate::constraint_type::EvaluatedCollection<T>,
-    decision_variables: &crate::EvaluatedDecisionVariableTable,
-    message: &'static str,
-    field: &'static str,
-    classify: impl Fn(T::ID, crate::VariableID) -> SolutionError,
-) -> Result<(), ParseError> {
-    for (constraint_id, constraint) in constraints.inner() {
-        for var_id in constraint.used_decision_variable_ids() {
-            if !decision_variables.contains_key(var_id) {
-                return Err(
-                    RawParseError::SolutionError(classify(*constraint_id, *var_id))
-                        .context(message, field),
-                );
-            }
-        }
-    }
-    Ok(())
-}
-
 fn invalid_solution_sidecar(
     error: crate::Error,
     message: &'static str,
     field: &'static str,
 ) -> ParseError {
-    RawParseError::SolutionError(SolutionError::InvalidSidecar {
+    let signal = SolutionError::InvalidSidecar {
         message: error.to_string(),
-    })
-    .context(message, field)
+    };
+    ParseError::new(error.context(signal)).context(message, field)
 }
 
 impl Parse for crate::v1::Solution {
@@ -109,10 +88,10 @@ impl Parse for crate::v1::Solution {
                 .insert(id, parsed.evaluated_named_function)
                 .is_some()
             {
-                return Err(crate::RawParseError::SolutionError(
-                    SolutionError::DuplicatedNamedFunctionID { id },
-                )
-                .context(message, "evaluated_named_functions"));
+                return Err(
+                    ParseError::new(SolutionError::DuplicatedNamedFunctionID { id })
+                        .context(message, "evaluated_named_functions"),
+                );
             }
             named_function_labels.insert(id, parsed.label);
         }
@@ -135,35 +114,33 @@ impl Parse for crate::v1::Solution {
                 (Some(value), None) | (None, Some(value)) => *value,
                 (Some(value), Some(substituted_value)) => {
                     if (*value - *substituted_value).abs() > *atol {
-                        return Err(crate::RawParseError::SolutionError(
-                            SolutionError::InconsistentVariableValue {
-                                id: dv_id,
-                                state_value: *value,
-                                substituted_value: *substituted_value,
-                            },
-                        )
+                        return Err(ParseError::new(SolutionError::InconsistentVariableValue {
+                            id: dv_id,
+                            state_value: *value,
+                            substituted_value: *substituted_value,
+                        })
                         .context(message, "decision_variables"));
                     }
                     *value
                 }
                 (None, None) => {
-                    return Err(crate::RawParseError::SolutionError(
-                        SolutionError::MissingVariableValue { id: dv_id },
-                    )
-                    .context(message, "decision_variables"));
+                    return Err(
+                        ParseError::new(SolutionError::MissingVariableValue { id: dv_id })
+                            .context(message, "decision_variables"),
+                    );
                 }
             };
 
-            let evaluated_dv = crate::EvaluatedDecisionVariable::new(parsed_id, parsed_dv, value)
-                .map_err(crate::RawParseError::InvalidDecisionVariable)
-                .map_err(|e| ParseError::from(e).context(message, "decision_variables"))?;
+            let evaluated_dv =
+                crate::EvaluatedDecisionVariable::new(parsed_id, parsed_dv, value)
+                    .map_err(|e| ParseError::new(e).context(message, "decision_variables"))?;
 
             variable_labels.insert(parsed_id, label);
             if decision_variables.insert(parsed_id, evaluated_dv).is_some() {
-                return Err(crate::RawParseError::SolutionError(
-                    SolutionError::DuplicatedVariableID { id: parsed_id },
-                )
-                .context(message, "decision_variables"));
+                return Err(
+                    ParseError::new(SolutionError::DuplicatedVariableID { id: parsed_id })
+                        .context(message, "decision_variables"),
+                );
             }
         }
         let optimality = self
@@ -190,18 +167,20 @@ impl Parse for crate::v1::Solution {
             crate::EvaluatedDecisionVariableTable::new(decision_variables, variable_labels)
                 .map_err(|e| invalid_solution_sidecar(e, message, "decision_variables"))?;
         validate_evaluated_named_function_used_ids(&decision_variables, &evaluated_named_functions)
-            .map_err(|e| {
-                crate::RawParseError::SolutionError(e).context(message, "evaluated_named_functions")
-            })?;
+            .map_err(|e| ParseError::new(e).context(message, "evaluated_named_functions"))?;
+
+        let evaluated_constraints = crate::constraint_type::EvaluatedCollection::with_context(
+            evaluated_constraints,
+            removed_reasons,
+            constraint_context,
+        )
+        .map_err(|e| invalid_solution_sidecar(e, message, "evaluated_constraints"))?;
+        validate_solution_regular_constraint_used_ids(&decision_variables, &evaluated_constraints)
+            .map_err(|e| ParseError::new(e).context(message, "evaluated_constraints"))?;
 
         let solution = Solution {
             objective,
-            evaluated_constraints: crate::constraint_type::EvaluatedCollection::with_context(
-                evaluated_constraints,
-                removed_reasons,
-                constraint_context,
-            )
-            .map_err(|e| invalid_solution_sidecar(e, message, "evaluated_constraints"))?,
+            evaluated_constraints,
             evaluated_indicator_constraints: Default::default(),
             evaluated_one_hot_constraints: Default::default(),
             evaluated_sos1_constraints: Default::default(),
@@ -220,23 +199,21 @@ impl Parse for crate::v1::Solution {
         let computed_feasible_relaxed = solution.feasible_relaxed();
 
         if computed_feasible != provided_feasible {
-            return Err(crate::RawParseError::SolutionError(
-                SolutionError::InconsistentFeasibility {
-                    provided_feasible,
-                    computed_feasible,
-                },
-            )
+            return Err(ParseError::new(SolutionError::InconsistentFeasibility {
+                provided_feasible,
+                computed_feasible,
+            })
             .context(message, "feasible"));
         }
 
         if computed_feasible_relaxed != provided_feasible_relaxed {
-            return Err(crate::RawParseError::SolutionError(
-                SolutionError::InconsistentFeasibilityRelaxed {
+            return Err(
+                ParseError::new(SolutionError::InconsistentFeasibilityRelaxed {
                     provided_feasible_relaxed,
                     computed_feasible_relaxed,
-                },
-            )
-            .context(message, "feasible_relaxed"));
+                })
+                .context(message, "feasible_relaxed"),
+            );
         }
 
         Ok(solution)
@@ -302,91 +279,54 @@ impl Parse for v2::Solution {
             &decision_variables,
             &evaluated_indicator_constraints,
         )
-        .map_err(|e| {
-            RawParseError::SolutionError(e).context(message, "evaluated_indicator_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_indicator_constraints"))?;
         validate_solution_one_hot_constraint_structure(
             &decision_variables,
             &evaluated_one_hot_constraints,
         )
-        .map_err(|e| {
-            RawParseError::SolutionError(e).context(message, "evaluated_one_hot_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_one_hot_constraints"))?;
         validate_solution_sos1_constraint_structure(
             &decision_variables,
             &evaluated_sos1_constraints,
         )
-        .map_err(|e| {
-            RawParseError::SolutionError(e).context(message, "evaluated_sos1_constraints")
-        })?;
-        validate_evaluated_constraint_used_ids(
-            &evaluated_constraints,
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_sos1_constraints"))?;
+        validate_solution_regular_constraint_used_ids(&decision_variables, &evaluated_constraints)
+            .map_err(|e| ParseError::new(e).context(message, "evaluated_regular_constraints"))?;
+        validate_solution_indicator_constraint_used_ids(
             &decision_variables,
-            message,
-            "evaluated_regular_constraints",
-            |constraint_id, id| SolutionError::UndefinedVariableInConstraint { id, constraint_id },
-        )?;
-        validate_evaluated_constraint_used_ids(
             &evaluated_indicator_constraints,
+        )
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_indicator_constraints"))?;
+        validate_solution_one_hot_constraint_used_ids(
             &decision_variables,
-            message,
-            "evaluated_indicator_constraints",
-            |constraint_id, id| SolutionError::InvalidConstraintStructure {
-                constraint_family: "indicator",
-                constraint_id: format!("{constraint_id:?}"),
-                message: format!("variable {id:?} is not in decision_variables"),
-            },
-        )?;
-        validate_evaluated_constraint_used_ids(
             &evaluated_one_hot_constraints,
+        )
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_one_hot_constraints"))?;
+        validate_solution_sos1_constraint_used_ids(
             &decision_variables,
-            message,
-            "evaluated_one_hot_constraints",
-            |constraint_id, id| SolutionError::InvalidConstraintStructure {
-                constraint_family: "one-hot",
-                constraint_id: format!("{constraint_id:?}"),
-                message: format!("variable {id:?} is not in decision_variables"),
-            },
-        )?;
-        validate_evaluated_constraint_used_ids(
             &evaluated_sos1_constraints,
-            &decision_variables,
-            message,
-            "evaluated_sos1_constraints",
-            |constraint_id, id| SolutionError::InvalidConstraintStructure {
-                constraint_family: "SOS1",
-                constraint_id: format!("{constraint_id:?}"),
-                message: format!("variable {id:?} is not in decision_variables"),
-            },
-        )?;
+        )
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_sos1_constraints"))?;
         validate_solution_indicator_stage_values(
             &decision_variables,
             &evaluated_indicator_constraints,
             feasibility_atol,
         )
-        .map_err(|e| {
-            RawParseError::SolutionError(e).context(message, "evaluated_indicator_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_indicator_constraints"))?;
         validate_solution_one_hot_stage_values(
             &decision_variables,
             &evaluated_one_hot_constraints,
             feasibility_atol,
         )
-        .map_err(|e| {
-            RawParseError::SolutionError(e).context(message, "evaluated_one_hot_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_one_hot_constraints"))?;
         validate_solution_sos1_stage_values(
             &decision_variables,
             &evaluated_sos1_constraints,
             feasibility_atol,
         )
-        .map_err(|e| {
-            RawParseError::SolutionError(e).context(message, "evaluated_sos1_constraints")
-        })?;
+        .map_err(|e| ParseError::new(e).context(message, "evaluated_sos1_constraints"))?;
         validate_evaluated_named_function_used_ids(&decision_variables, &evaluated_named_functions)
-            .map_err(|e| {
-                RawParseError::SolutionError(e).context(message, "evaluated_named_functions")
-            })?;
+            .map_err(|e| ParseError::new(e).context(message, "evaluated_named_functions"))?;
 
         let optimality = crate::v1::Optimality::try_from(self.optimality)
             .map_err(|_| RawParseError::UnknownEnumValue {
@@ -420,24 +360,22 @@ impl Parse for v2::Solution {
 
         let computed_feasible = solution.feasible();
         if computed_feasible != self.feasible {
-            return Err(
-                RawParseError::SolutionError(SolutionError::InconsistentFeasibility {
-                    provided_feasible: self.feasible,
-                    computed_feasible,
-                })
-                .context(message, "feasible"),
-            );
+            return Err(ParseError::new(SolutionError::InconsistentFeasibility {
+                provided_feasible: self.feasible,
+                computed_feasible,
+            })
+            .context(message, "feasible"));
         }
         let provided_feasible_relaxed = self.feasible_relaxed.unwrap_or(self.feasible);
         let computed_feasible_relaxed = solution.feasible_relaxed();
         if computed_feasible_relaxed != provided_feasible_relaxed {
-            return Err(RawParseError::SolutionError(
-                SolutionError::InconsistentFeasibilityRelaxed {
+            return Err(
+                ParseError::new(SolutionError::InconsistentFeasibilityRelaxed {
                     provided_feasible_relaxed,
                     computed_feasible_relaxed,
-                },
-            )
-            .context(message, "feasible_relaxed"));
+                })
+                .context(message, "feasible_relaxed"),
+            );
         }
 
         Ok(solution)
@@ -636,14 +574,18 @@ mod tests {
         expected_constraint_id: &str,
         expected_message: &str,
     ) {
+        let error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
         assert!(
             matches!(
-                &error.error,
-                RawParseError::SolutionError(SolutionError::InvalidConstraintStructure {
+                error,
+                SolutionError::InvalidConstraintStructure {
                     constraint_family,
                     constraint_id,
                     message,
-                }) if *constraint_family == expected_family
+                } if *constraint_family == expected_family
                     && constraint_id.as_str() == expected_constraint_id
                     && message.as_str() == expected_message
             ),
@@ -665,14 +607,19 @@ mod tests {
 
         let error = invalid_solution_sidecar(source, "ommx.v1.Solution", "evaluated_constraints");
 
+        let solution_error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
         assert!(matches!(
-            &error.error,
-            RawParseError::SolutionError(SolutionError::InvalidSidecar { message })
+            solution_error,
+            SolutionError::InvalidSidecar { message }
                 if message.as_str() == "Constraint label/provenance references unknown constraint ID ConstraintID(7)"
         ));
         assert_eq!(error.context.len(), 1);
         assert_eq!(error.context[0].message, "ommx.v1.Solution");
         assert_eq!(error.context[0].field, "evaluated_constraints");
+        assert_eq!(error.error.chain().count(), 2);
     }
 
     #[test]
@@ -696,12 +643,16 @@ mod tests {
 
         let error = Solution::try_from(proto).unwrap_err();
 
+        let solution_error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
         assert!(matches!(
-            &error.error,
-            RawParseError::SolutionError(SolutionError::UndefinedVariableInConstraint {
+            solution_error,
+            SolutionError::UndefinedVariableInConstraint {
                 id,
                 constraint_id,
-            }) if *id == VariableID::from(42) && *constraint_id == ConstraintID::from(7)
+            } if *id == VariableID::from(42) && *constraint_id == ConstraintID::from(7)
         ));
     }
 
@@ -1123,13 +1074,17 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
+        let solution_error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
         assert!(matches!(
-            &error.error,
-            RawParseError::SolutionError(SolutionError::InconsistentVariableValue {
+            solution_error,
+            SolutionError::InconsistentVariableValue {
                 id,
                 state_value,
                 substituted_value,
-            }) if *id == 1 && *state_value == 2.0 && *substituted_value == 3.0
+            } if *id == 1 && *state_value == 2.0 && *substituted_value == 3.0
         ));
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
@@ -1228,10 +1183,14 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
+        let solution_error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
         assert!(matches!(
-            error.error,
-            crate::RawParseError::SolutionError(SolutionError::DuplicatedVariableID { id })
-                if id == crate::VariableID::from(1)
+            solution_error,
+            SolutionError::DuplicatedVariableID { id }
+                if *id == crate::VariableID::from(1)
         ));
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
@@ -1265,11 +1224,14 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
+        let solution_error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
         assert!(matches!(
-            error.error,
-            crate::RawParseError::SolutionError(
-                SolutionError::DuplicatedNamedFunctionID { id }
-            ) if id == crate::NamedFunctionID::from(7)
+            solution_error,
+            SolutionError::DuplicatedNamedFunctionID { id }
+                if *id == crate::NamedFunctionID::from(7)
         ));
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
@@ -1297,21 +1259,54 @@ mod tests {
 
         let result: Result<Solution, ParseError> = v1_solution.parse(&());
         let error = result.unwrap_err();
+        let solution_error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
         assert!(matches!(
-            error.error,
-            crate::RawParseError::SolutionError(
-                SolutionError::UndefinedVariableInNamedFunction {
-                    id,
-                    named_function_id,
-                }
-            ) if id == crate::VariableID::from(1)
-                && named_function_id == crate::NamedFunctionID::from(7)
+            solution_error,
+            SolutionError::UndefinedVariableInNamedFunction {
+                id,
+                named_function_id,
+            } if *id == crate::VariableID::from(1)
+                && *named_function_id == crate::NamedFunctionID::from(7)
         ));
         insta::assert_snapshot!(error.to_string(), @r###"
         Traceback for OMMX Message parse error:
         └─ommx.v1.Solution[evaluated_named_functions]
         Variable ID VariableID(1) used in named function NamedFunctionID(7) is not in decision_variables
         "###);
+    }
+
+    #[test]
+    fn test_v1_solution_parse_classifies_undefined_variable_in_regular_constraint() {
+        let v1_solution = v1::Solution {
+            evaluated_constraints: vec![v1::EvaluatedConstraint {
+                id: 7,
+                equality: v1::Equality::EqualToZero as i32,
+                evaluated_value: 0.0,
+                used_decision_variable_ids: vec![42],
+                ..Default::default()
+            }],
+            feasible: true,
+            feasible_relaxed: Some(true),
+            ..Default::default()
+        };
+
+        let error = v1_solution.parse(&()).unwrap_err();
+
+        let solution_error = error
+            .error
+            .downcast_ref::<SolutionError>()
+            .expect("expected SolutionError");
+        assert!(matches!(
+            solution_error,
+            SolutionError::UndefinedVariableInConstraint {
+                id,
+                constraint_id,
+            } if *id == VariableID::from(42) && *constraint_id == ConstraintID::from(7)
+        ));
+        assert_eq!(error.context[0].field, "evaluated_constraints");
     }
 
     // Data produced by a future SDK whose format version exceeds what this SDK supports

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -225,13 +225,7 @@ impl Parse for crate::v2::Sos1Constraint {
             message,
             "variables",
         )?)
-        .map_err(|error| {
-            match error.downcast::<Sos1ConstraintError>() {
-                Ok(error) => crate::RawParseError::from(error),
-                Err(error) => crate::RawParseError::InvalidInstance(error.to_string()),
-            }
-            .context(message, "variables")
-        })
+        .map_err(|error| ParseError::new(error).context(message, "variables"))
     }
 }
 
@@ -264,22 +258,21 @@ impl Parse for crate::v2::EvaluatedSos1Constraint {
         let variables =
             crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
         if variables.is_empty() {
-            return Err(crate::RawParseError::InvalidInstance(
-                "SOS1 constraints must contain at least one variable".to_string(),
-            )
-            .context(message, "variables"));
+            return Err(
+                ParseError::new(Sos1ConstraintError::EmptyVariables).context(message, "variables")
+            );
         }
         let active_variable = self.active_variable.map(VariableID::from);
         if active_variable.is_some_and(|id| !variables.contains(&id)) {
-            return Err(crate::RawParseError::InvalidInstance(
-                "SOS1 active_variable must be a member of variables".to_string(),
-            )
+            return Err(ParseError::new(crate::error!(
+                "SOS1 active_variable must be a member of variables"
+            ))
             .context(message, "active_variable"));
         }
         if active_variable.is_some() && !self.feasible {
-            return Err(crate::RawParseError::InvalidInstance(
-                "SOS1 active_variable must be unset when feasible is false".to_string(),
-            )
+            return Err(ParseError::new(crate::error!(
+                "SOS1 active_variable must be unset when feasible is false"
+            ))
             .context(message, "active_variable"));
         }
         Ok(Sos1Constraint {
@@ -343,10 +336,9 @@ impl Parse for crate::v2::SampledSos1Constraint {
         let variables =
             crate::v2_io::variable_id_set_from_v2(self.variables, message, "variables")?;
         if variables.is_empty() {
-            return Err(crate::RawParseError::InvalidInstance(
-                "SOS1 constraints must contain at least one variable".to_string(),
-            )
-            .context(message, "variables"));
+            return Err(
+                ParseError::new(Sos1ConstraintError::EmptyVariables).context(message, "variables")
+            );
         }
         let active_variable =
             crate::v2_io::sampled_active_variable_map_from_v2(self.active_variable);
@@ -355,9 +347,9 @@ impl Parse for crate::v2::SampledSos1Constraint {
             .flatten()
             .any(|id| !variables.contains(id))
         {
-            return Err(crate::RawParseError::InvalidInstance(
-                "SOS1 active_variable values must be members of variables".to_string(),
-            )
+            return Err(ParseError::new(crate::error!(
+                "SOS1 active_variable values must be members of variables"
+            ))
             .context(message, "active_variable"));
         }
         let feasible = crate::v2_io::sample_bool_map_from_v2(self.feasible);
@@ -365,9 +357,9 @@ impl Parse for crate::v2::SampledSos1Constraint {
             if active_variable.is_some()
                 && feasible.get(sample_id).is_some_and(|feasible| !feasible)
             {
-                return Err(crate::RawParseError::InvalidInstance(
-                    "SOS1 active_variable must be unset when feasible is false".to_string(),
-                )
+                return Err(ParseError::new(crate::error!(
+                    "SOS1 active_variable must be unset when feasible is false"
+                ))
                 .context(message, "active_variable"));
             }
         }
@@ -404,7 +396,6 @@ impl std::fmt::Display for Sos1Constraint<Created> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::error::Error as _;
 
     #[test]
     fn test_create_sos1_constraint() {
@@ -424,28 +415,36 @@ mod tests {
 
     #[test]
     fn parse_v2_preserves_empty_variables_signal() {
-        let error: crate::Error = crate::v2::Sos1Constraint { variables: vec![] }
+        let parse_error = crate::v2::Sos1Constraint { variables: vec![] }
             .parse(&())
-            .unwrap_err()
-            .into();
-        let parse_error = error
-            .downcast_ref::<ParseError>()
-            .expect("v2 semantic parse failures must remain downcastable as ParseError");
+            .unwrap_err();
 
         assert!(matches!(
-            &parse_error.error,
-            crate::RawParseError::Sos1ConstraintError(Sos1ConstraintError::EmptyVariables)
+            parse_error.error.downcast_ref::<Sos1ConstraintError>(),
+            Some(Sos1ConstraintError::EmptyVariables)
         ));
+    }
 
-        let raw_source = parse_error
-            .source()
-            .expect("ParseError must expose its RawParseError source");
-        assert!(raw_source.downcast_ref::<crate::RawParseError>().is_some());
-        let signal_source = raw_source
-            .source()
-            .expect("RawParseError must expose the SOS1 constraint signal");
+    #[test]
+    fn parse_v2_evaluated_preserves_empty_variables_signal() {
+        let parse_error = crate::v2::EvaluatedSos1Constraint::default()
+            .parse(&ATol::default())
+            .unwrap_err();
+
         assert!(matches!(
-            signal_source.downcast_ref::<Sos1ConstraintError>(),
+            parse_error.error.downcast_ref::<Sos1ConstraintError>(),
+            Some(Sos1ConstraintError::EmptyVariables)
+        ));
+    }
+
+    #[test]
+    fn parse_v2_sampled_preserves_empty_variables_signal() {
+        let parse_error = crate::v2::SampledSos1Constraint::default()
+            .parse(&ATol::default())
+            .unwrap_err();
+
+        assert!(matches!(
+            parse_error.error.downcast_ref::<Sos1ConstraintError>(),
             Some(Sos1ConstraintError::EmptyVariables)
         ));
     }
@@ -461,6 +460,7 @@ mod tests {
 
         let err = proto.parse(&ATol::default()).unwrap_err();
 
+        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
         assert!(
             err.to_string()
                 .contains("active_variable must be unset when feasible is false"),
@@ -484,6 +484,7 @@ mod tests {
 
         let err = proto.parse(&ATol::default()).unwrap_err();
 
+        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
         assert!(
             err.to_string()
                 .contains("active_variable must be unset when feasible is false"),

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -474,6 +474,7 @@ mod tests {
         let err = proto.parse(&ATol::default()).unwrap_err();
 
         assert!(!error_chain_contains::<crate::RawParseError>(&err));
+        assert!(!error_chain_contains::<Sos1ConstraintError>(&err));
         assert!(
             err.to_string()
                 .contains("active_variable must be unset when feasible is false"),
@@ -498,6 +499,7 @@ mod tests {
         let err = proto.parse(&ATol::default()).unwrap_err();
 
         assert!(!error_chain_contains::<crate::RawParseError>(&err));
+        assert!(!error_chain_contains::<Sos1ConstraintError>(&err));
         assert!(
             err.to_string()
                 .contains("active_variable must be unset when feasible is false"),

--- a/rust/ommx/src/sos1_constraint/mod.rs
+++ b/rust/ommx/src/sos1_constraint/mod.rs
@@ -396,6 +396,13 @@ impl std::fmt::Display for Sos1Constraint<Created> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
+
+    fn error_chain_contains<T: std::error::Error + 'static>(
+        error: &(dyn std::error::Error + 'static),
+    ) -> bool {
+        error.downcast_ref::<T>().is_some() || error.source().is_some_and(error_chain_contains::<T>)
+    }
 
     #[test]
     fn test_create_sos1_constraint() {
@@ -420,7 +427,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            parse_error.error.downcast_ref::<Sos1ConstraintError>(),
+            parse_error
+                .source()
+                .and_then(|error| error.downcast_ref::<Sos1ConstraintError>()),
             Some(Sos1ConstraintError::EmptyVariables)
         ));
     }
@@ -432,7 +441,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            parse_error.error.downcast_ref::<Sos1ConstraintError>(),
+            parse_error
+                .source()
+                .and_then(|error| error.downcast_ref::<Sos1ConstraintError>()),
             Some(Sos1ConstraintError::EmptyVariables)
         ));
     }
@@ -444,7 +455,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(
-            parse_error.error.downcast_ref::<Sos1ConstraintError>(),
+            parse_error
+                .source()
+                .and_then(|error| error.downcast_ref::<Sos1ConstraintError>()),
             Some(Sos1ConstraintError::EmptyVariables)
         ));
     }
@@ -460,7 +473,7 @@ mod tests {
 
         let err = proto.parse(&ATol::default()).unwrap_err();
 
-        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
+        assert!(!error_chain_contains::<crate::RawParseError>(&err));
         assert!(
             err.to_string()
                 .contains("active_variable must be unset when feasible is false"),
@@ -484,7 +497,7 @@ mod tests {
 
         let err = proto.parse(&ATol::default()).unwrap_err();
 
-        assert!(err.error.downcast_ref::<crate::RawParseError>().is_none());
+        assert!(!error_chain_contains::<crate::RawParseError>(&err));
         assert!(
             err.to_string()
                 .contains("active_variable must be unset when feasible is false"),

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -80,77 +80,6 @@ pub fn validate_required_features(
     Ok(())
 }
 
-#[cfg(test)]
-mod required_features_tests {
-    use super::*;
-
-    #[test]
-    fn accepts_known_features() {
-        validate_required_features(
-            vec![
-                Feature::ConstraintIndicator as i32,
-                Feature::ConstraintOneHot as i32,
-                Feature::ConstraintSos1 as i32,
-                Feature::OutputObjective as i32,
-            ],
-            "test.Message",
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn rejects_unspecified_and_unknown_features() {
-        for feature in [Feature::Unspecified as i32, i32::MAX] {
-            assert!(validate_required_features(vec![feature], "test.Message").is_err());
-        }
-    }
-
-    #[test]
-    fn parse_feasibility_atol_preserves_atol_signals() {
-        for value in [0.0, -1.0] {
-            let err = parse_feasibility_atol(Some(value), "test.Message").unwrap_err();
-            assert!(matches!(
-                err.error.downcast_ref::<crate::AtolError>(),
-                Some(crate::AtolError::NonPositive { value: actual }) if *actual == value
-            ));
-        }
-
-        let err = parse_feasibility_atol(Some(f64::NAN), "test.Message").unwrap_err();
-        assert!(matches!(
-            err.error.downcast_ref::<crate::AtolError>(),
-            Some(crate::AtolError::NaN)
-        ));
-    }
-
-    #[test]
-    fn parse_feasibility_atol_keeps_infinity_as_an_ordinary_error() {
-        for value in [f64::NEG_INFINITY, f64::INFINITY] {
-            let err = parse_feasibility_atol(Some(value), "test.Message").unwrap_err();
-            assert!(err.error.downcast_ref::<crate::AtolError>().is_none());
-            assert!(err.error.downcast_ref::<RawParseError>().is_none());
-            assert!(err.to_string().contains("feasibility_atol must be finite"));
-        }
-    }
-
-    #[test]
-    fn non_finite_values_are_ordinary_semantic_errors() {
-        let err = validate_finite_f64(f64::NAN, "test.Message", "value").unwrap_err();
-        assert!(err.error.downcast_ref::<RawParseError>().is_none());
-
-        let values = Sampled::from((SampleID::from(7), f64::INFINITY));
-        let err = validate_sampled_f64_values(&values, "test.Message", "values").unwrap_err();
-        assert!(err.error.downcast_ref::<RawParseError>().is_none());
-        assert!(err.to_string().contains("SampleID(7)"));
-    }
-
-    #[test]
-    fn duplicated_variable_references_are_ordinary_semantic_errors() {
-        let err = variable_id_set_from_v2(vec![1, 1], "test.Message", "variables").unwrap_err();
-        assert!(err.error.downcast_ref::<RawParseError>().is_none());
-        assert!(err.to_string().contains("VariableID(1)"));
-    }
-}
-
 pub fn parse_feasibility_atol(
     value: Option<f64>,
     message: &'static str,
@@ -271,4 +200,84 @@ pub fn modeling_label_store_from_v2_map<ID: IDType>(
         store.insert(ID::from(id), label.into());
     }
     store
+}
+
+#[cfg(test)]
+mod required_features_tests {
+    use super::*;
+    use std::error::Error as _;
+
+    fn error_chain_contains<T: std::error::Error + 'static>(
+        error: &(dyn std::error::Error + 'static),
+    ) -> bool {
+        error.downcast_ref::<T>().is_some() || error.source().is_some_and(error_chain_contains::<T>)
+    }
+
+    #[test]
+    fn accepts_known_features() {
+        validate_required_features(
+            vec![
+                Feature::ConstraintIndicator as i32,
+                Feature::ConstraintOneHot as i32,
+                Feature::ConstraintSos1 as i32,
+                Feature::OutputObjective as i32,
+            ],
+            "test.Message",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_unspecified_and_unknown_features() {
+        for feature in [Feature::Unspecified as i32, i32::MAX] {
+            assert!(validate_required_features(vec![feature], "test.Message").is_err());
+        }
+    }
+
+    #[test]
+    fn parse_feasibility_atol_preserves_atol_signals() {
+        for value in [0.0, -1.0] {
+            let err = parse_feasibility_atol(Some(value), "test.Message").unwrap_err();
+            assert!(matches!(
+                err.source()
+                    .and_then(|error| error.downcast_ref::<crate::AtolError>()),
+                Some(crate::AtolError::NonPositive { value: actual }) if *actual == value
+            ));
+        }
+
+        let err = parse_feasibility_atol(Some(f64::NAN), "test.Message").unwrap_err();
+        assert!(matches!(
+            err.source()
+                .and_then(|error| error.downcast_ref::<crate::AtolError>()),
+            Some(crate::AtolError::NaN)
+        ));
+    }
+
+    #[test]
+    fn parse_feasibility_atol_keeps_infinity_as_an_ordinary_error() {
+        for value in [f64::NEG_INFINITY, f64::INFINITY] {
+            let err = parse_feasibility_atol(Some(value), "test.Message").unwrap_err();
+            assert!(!error_chain_contains::<crate::AtolError>(&err));
+            assert!(!error_chain_contains::<RawParseError>(&err));
+            assert!(err.to_string().contains("feasibility_atol must be finite"));
+        }
+    }
+
+    #[test]
+    fn non_finite_values_are_ordinary_semantic_errors() {
+        let err = validate_finite_f64(f64::NAN, "test.Message", "value").unwrap_err();
+        assert!(!error_chain_contains::<RawParseError>(&err));
+
+        let values = Sampled::from((SampleID::from(7), f64::INFINITY));
+        let err = validate_sampled_f64_values(&values, "test.Message", "values").unwrap_err();
+        assert!(!error_chain_contains::<RawParseError>(&err));
+        assert!(err.to_string().contains("SampleID(7)"));
+    }
+
+    #[test]
+    fn duplicated_variable_references_are_ordinary_semantic_errors() {
+        let err = variable_id_set_from_v2(vec![1, 1], "test.Message", "variables").unwrap_err();
+        assert!(!error_chain_contains::<RawParseError>(&err));
+        assert!(err.to_string().contains("VariableID(1)"));
+    }
 }

--- a/rust/ommx/src/v2_io.rs
+++ b/rust/ommx/src/v2_io.rs
@@ -104,6 +104,51 @@ mod required_features_tests {
             assert!(validate_required_features(vec![feature], "test.Message").is_err());
         }
     }
+
+    #[test]
+    fn parse_feasibility_atol_preserves_atol_signals() {
+        for value in [0.0, -1.0] {
+            let err = parse_feasibility_atol(Some(value), "test.Message").unwrap_err();
+            assert!(matches!(
+                err.error.downcast_ref::<crate::AtolError>(),
+                Some(crate::AtolError::NonPositive { value: actual }) if *actual == value
+            ));
+        }
+
+        let err = parse_feasibility_atol(Some(f64::NAN), "test.Message").unwrap_err();
+        assert!(matches!(
+            err.error.downcast_ref::<crate::AtolError>(),
+            Some(crate::AtolError::NaN)
+        ));
+    }
+
+    #[test]
+    fn parse_feasibility_atol_keeps_infinity_as_an_ordinary_error() {
+        for value in [f64::NEG_INFINITY, f64::INFINITY] {
+            let err = parse_feasibility_atol(Some(value), "test.Message").unwrap_err();
+            assert!(err.error.downcast_ref::<crate::AtolError>().is_none());
+            assert!(err.error.downcast_ref::<RawParseError>().is_none());
+            assert!(err.to_string().contains("feasibility_atol must be finite"));
+        }
+    }
+
+    #[test]
+    fn non_finite_values_are_ordinary_semantic_errors() {
+        let err = validate_finite_f64(f64::NAN, "test.Message", "value").unwrap_err();
+        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+
+        let values = Sampled::from((SampleID::from(7), f64::INFINITY));
+        let err = validate_sampled_f64_values(&values, "test.Message", "values").unwrap_err();
+        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        assert!(err.to_string().contains("SampleID(7)"));
+    }
+
+    #[test]
+    fn duplicated_variable_references_are_ordinary_semantic_errors() {
+        let err = variable_id_set_from_v2(vec![1, 1], "test.Message", "variables").unwrap_err();
+        assert!(err.error.downcast_ref::<RawParseError>().is_none());
+        assert!(err.to_string().contains("VariableID(1)"));
+    }
 }
 
 pub fn parse_feasibility_atol(
@@ -113,15 +158,13 @@ pub fn parse_feasibility_atol(
     let Some(value) = value else {
         return Ok(ATol::default());
     };
-    if !value.is_finite() {
-        return Err(RawParseError::InvalidInstance(format!(
+    if value.is_infinite() {
+        return Err(ParseError::new(crate::error!(
             "feasibility_atol must be finite: value={value}",
         ))
         .context(message, "feasibility_atol"));
     }
-    ATol::new(value).map_err(|e| {
-        RawParseError::InvalidInstance(e.to_string()).context(message, "feasibility_atol")
-    })
+    ATol::new(value).map_err(|error| ParseError::new(error).context(message, "feasibility_atol"))
 }
 
 pub fn validate_finite_f64(
@@ -133,7 +176,7 @@ pub fn validate_finite_f64(
         Ok(())
     } else {
         Err(
-            RawParseError::InvalidInstance(format!("{field} must be finite: value={value}",))
+            ParseError::new(crate::error!("{field} must be finite: value={value}",))
                 .context(message, field),
         )
     }
@@ -164,7 +207,7 @@ pub fn validate_sampled_f64_values(
 ) -> Result<(), ParseError> {
     for (sample_id, value) in values.iter() {
         if !value.is_finite() {
-            return Err(RawParseError::InvalidInstance(format!(
+            return Err(ParseError::new(crate::error!(
                 "{field} must be finite for sample {sample_id:?}: value={value}",
             ))
             .context(message, field));
@@ -182,7 +225,7 @@ pub fn variable_id_set_from_v2(
     for id in ids {
         let id = VariableID::from(id);
         if !out.insert(id) {
-            return Err(RawParseError::InvalidInstance(format!(
+            return Err(ParseError::new(crate::error!(
                 "Duplicated variable ID is found in {field}: {id:?}",
             ))
             .context(message, field));


### PR DESCRIPTION
## Summary

- Keep `ParseError` as the OMMX-owned envelope for protobuf-tree breadcrumbs while exposing its immediate cause through `std::error::Error::source()`.
- Make the inner `ParseError::error` field private and remove the catch-all `RawParseError::InvalidInstance` plus domain-error wrapper variants.
- Restrict `RawParseError` to generic protobuf-boundary failures such as malformed wire data, missing fields, unsupported versions, unknown enum values, and reserved annotation keys.
- Preserve recoverable semantic failures directly as their existing domain-owned signals, while keeping failures without a stable recovery contract as ordinary `ommx::Error` causes.
- Classify Solution and SampleSet cross-table and structural invariant failures under their owning error types, and reject repeated v1 regular-constraint IDs before rows and sidecars can be combined.
- Document the Rust 3.0 migration and error-source contract.

## Error ownership

`ParseError` continues to own the parsing operation and its structured protobuf path. Its immediate standard source now carries the actual failure reason: a generic `RawParseError`, a message-specific parser signal, a domain-owned signal, or an ordinary semantic error.

This removes the need for `RawParseError` to act as an SDK-wide umbrella. Recoverable causes such as `SolutionError`, `SampleSetError`, `DecisionVariableError`, `AtolError`, coefficient and bound errors, substitution errors, and special-constraint errors remain directly downcastable from `ParseError::source()`. Public byte decoders still preserve `ParseError` as the outer error, including the `RawParseError::DecodeError` to `prost::DecodeError` source chain.

Collection-local sidecar consistency remains owned by the collection parser and is retained as an ordinary cause. A collection parser does not report `SolutionError` or `SampleSetError` merely because an evaluated or sampled collection is commonly embedded in those hosts.

Python continues to classify the outer `ParseError` as `ValueError`; nested Rust domain signals do not override that parsing-boundary contract.

## Domain invariant classification

Solution parsing reports undefined variables used by evaluated constraints as `SolutionError::UndefinedVariableInConstraint`, invalid Indicator, OneHot, and SOS1 structural variables as `SolutionError::InvalidConstraintStructure`, and v1 host-assembly sidecar failures as `SolutionError::InvalidSidecar`.

Equivalent SampleSet paths use the corresponding `SampleSetError` variants. Solution-owned variable-reference validators are shared by builders and protobuf parser versions so the same invariant produces the same signal across construction paths. Root-parser coverage exercises every regular and special constraint family, and cyclic Instance dependencies retain `SubstitutionError` directly across v1 and v2 byte decoders.

Malformed v1 Solution and SampleSet messages with repeated regular-constraint IDs are rejected as `InvalidConstraintStructure` before any row, context, or removed-reason sidecar is inserted. This prevents silent overwrites from combining sidecars from one repeated entry with the row from another.

Semantic validation without an intentional caller recovery path remains an ordinary error instead of acquiring a diagnostic-only public variant.

## Breaking changes

`ParseError::error` is no longer public. Callers should obtain the immediate cause with `std::error::Error::source()` and downcast the returned trait object when recovery is appropriate.

Code matching `RawParseError::InvalidInstance` or one of the removed domain wrapper variants must instead inspect the immediate source for an existing domain signal or propagate the outer `ParseError` for ordinary failures.
