### PR TITLE
Run CodSpeed benchmarks when pull requests become ready

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,9 @@
-# Since most PRs do not affect performance, benchmarks do not run on PRs by default.
-# `main` and release tags run persistent guardrails. Performance PRs can run the
-# full suite, including diagnostic profiles, via `task codspeed:trigger`.
+# Pull requests run persistent guardrails once when they become ready for review.
+# PRs opened as ready run immediately; draft PRs wait for `ready_for_review`.
+# Pushes after that do not retrigger benchmarks: return the PR to draft and mark
+# it ready again to measure the new head commit. The full suite, including
+# diagnostic profiles, remains available via `task codspeed:trigger`.
+# `main` and release tags also run persistent guardrails.
 # Release tags (rust-*, python-*) also trigger benchmarks so each release has a
 # comparison baseline against the previous release.
 
@@ -12,6 +15,10 @@ on:
     tags:
       - rust-*
       - python-*
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
   workflow_dispatch:
     inputs:
       suite:
@@ -25,10 +32,12 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   rust:
     name: Benchmarks for Rust SDK
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -42,11 +51,11 @@ jobs:
         uses: CodSpeedHQ/action@v5.0.3
         with:
           run: cargo codspeed run -p ommx
-          token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation
 
   python:
     name: Benchmarks for Python SDK
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       UV_PYTHON: "3.13"
@@ -83,5 +92,4 @@ jobs:
             else
               uv run --no-sync pytest python/ommx-tests/tests/test_bench_*.py --codspeed -m benchmark_guardrail
             fi
-          token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,6 @@ dev = [
 [tool.pytest.ini_options]
 markers = [
   "benchmark: performance benchmark collected by pytest-codspeed",
-  "benchmark_guardrail: persistent regression guardrail run on main and release tags",
+  "benchmark_guardrail: persistent regression guardrail run on ready PRs, main, and release tags",
   "benchmark_diagnostic: profiling workload run only by the full manual benchmark suite",
 ]

--- a/rust/ommx/benches/log_encode.rs
+++ b/rust/ommx/benches/log_encode.rs
@@ -49,8 +49,8 @@
 //
 // Input rationale: 1,000/8,000/32,000 expose the dominant term while keeping
 // the largest measured case below a 25 ms simulation budget. Lifecycle/run
-// policy: retain on main; run automatically on main/releases and manually on
-// performance PRs through the benchmark workflow.
+// policy: retain as a persistent guardrail; run automatically on ready PRs,
+// main, and releases.
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
 };

--- a/rust/ommx/benches/reduce_binary_power.rs
+++ b/rust/ommx/benches/reduce_binary_power.rs
@@ -26,8 +26,8 @@
 //
 // Input rationale: 1,000/8,000/32,000 expose the dominant term while keeping
 // the largest measured case below a 25 ms simulation budget. Lifecycle/run
-// policy: retain on main; run automatically on main/releases and manually on
-// performance PRs through the benchmark workflow.
+// policy: retain as a persistent guardrail; run automatically on ready PRs,
+// main, and releases.
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
 };


### PR DESCRIPTION
## Summary

- Run persistent CodSpeed guardrails when a pull request is opened as ready or transitions from draft to ready, without rerunning on every pushed commit.
- Keep the existing `main`, release-tag, and manual full-suite behavior, and document how to remeasure a PR after its head changes.
- Replace the legacy repository upload token with CodSpeed's recommended OIDC authentication so pull-request runs do not depend on repository secrets.
- Align the Python marker and Rust benchmark lifecycle comments with the ready-for-review run policy.

## Operational behavior

Draft pull requests do not run benchmark jobs. A ready pull request is measured once; after another push, return it to draft and mark it ready again to measure the new head commit.

This workflow produces CodSpeed pull-request reports. Making `CodSpeed Performance Analysis` a required merge check remains a repository ruleset rollout after the workflow is available.
