### PR TITLE
Make decision-variable construction atomic in Rust and Python

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -10995,7 +10995,7 @@
             },
             {
               "name": "new_integer",
-              "doc": "Create and add an integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)` and are normalized inward to integer\nvalues. Returns an {class}`~ommx.AttachedDecisionVariable` that can be\nused directly in expressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or contain no\ninteger value, or if no larger automatic ID can be assigned. On failure,\nno variable or modeling label is added to the instance.",
+              "doc": "Create and add an integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)` and are normalized to integer\nendpoints under `atol`: a finite lower endpoint is rounded up after\nsubtracting `atol`, and a finite upper endpoint is rounded down after\nadding `atol`. Returns an {class}`~ommx.AttachedDecisionVariable` that\ncan be used directly in expressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n- `atol`: Absolute tolerance for integer-bound normalization. If\n  omitted, the current default returned by\n  {func}`~ommx.get_default_atol` is used.\n\nRaises {class}`ValueError` if the bounds are invalid or normalization\nyields no integer value, or if no larger automatic ID can be assigned.\nOn failure, no variable or modeling label is added to the instance.",
               "signatures": [
                 {
                   "parameters": [
@@ -11090,6 +11090,24 @@
                         "children": [
                           {
                             "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    },
+                    {
+                      "name": "atol",
+                      "type_": {
+                        "display": "Optional[float]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "float",
                             "link_target": null,
                             "children": []
                           }
@@ -11231,7 +11249,7 @@
             },
             {
               "name": "new_semi_integer",
-              "doc": "Create and add a semi-integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Non-integral endpoints are\nnormalized inward. Unlike an integer variable, if the interval contains\nno integer, its bound is normalized to `[0, 0]`, preserving the zero\nalternative in the semi-integer domain. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned. On failure, no variable or modeling label\nis added to the instance.",
+              "doc": "Create and add a semi-integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Non-integral endpoints are\nnormalized under `atol` using the same endpoint rule as\n{meth}`~ommx.Instance.new_integer`. Unlike an integer variable, if the\nnormalized interval contains no integer, its bound becomes `[0, 0]`,\npreserving the zero alternative in the semi-integer domain. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n- `atol`: Absolute tolerance for integer-bound normalization. If\n  omitted, the current default returned by\n  {func}`~ommx.get_default_atol` is used.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned. On failure, no variable or modeling label\nis added to the instance.",
               "signatures": [
                 {
                   "parameters": [
@@ -11326,6 +11344,24 @@
                         "children": [
                           {
                             "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    },
+                    {
+                      "name": "atol",
+                      "type_": {
+                        "display": "Optional[float]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "float",
                             "link_target": null,
                             "children": []
                           }

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -10783,7 +10783,7 @@
             },
             {
               "name": "new_binary",
-              "doc": "Create and add a binary decision variable with an automatically assigned ID.\n\nReturns an {class}`~ommx.AttachedDecisionVariable` that can be used\ndirectly in expressions. The numeric ID remains available through its\n{attr}`~ommx.AttachedDecisionVariable.id` property.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the maximum decision-variable ID is\n`2**64 - 1` and no larger automatic ID can be assigned.",
+              "doc": "Create and add a binary decision variable with an automatically assigned ID.\n\nReturns an {class}`~ommx.AttachedDecisionVariable` that can be used\ndirectly in expressions. The numeric ID remains available through its\n{attr}`~ommx.AttachedDecisionVariable.id` property.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the maximum decision-variable ID is\n`2**64 - 1` and no larger automatic ID can be assigned. On failure, no\nvariable or modeling label is added to the instance.",
               "signatures": [
                 {
                   "parameters": [
@@ -10877,7 +10877,7 @@
             },
             {
               "name": "new_continuous",
-              "doc": "Create and add a continuous decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned.",
+              "doc": "Create and add a continuous decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned. On failure, no variable or modeling label\nis added to the instance.",
               "signatures": [
                 {
                   "parameters": [
@@ -10995,7 +10995,7 @@
             },
             {
               "name": "new_integer",
-              "doc": "Create and add an integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)` and are normalized inward to integer\nvalues. Returns an {class}`~ommx.AttachedDecisionVariable` that can be\nused directly in expressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or contain no\ninteger value, or if no larger automatic ID can be assigned.",
+              "doc": "Create and add an integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)` and are normalized inward to integer\nvalues. Returns an {class}`~ommx.AttachedDecisionVariable` that can be\nused directly in expressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or contain no\ninteger value, or if no larger automatic ID can be assigned. On failure,\nno variable or modeling label is added to the instance.",
               "signatures": [
                 {
                   "parameters": [
@@ -11113,7 +11113,7 @@
             },
             {
               "name": "new_semi_continuous",
-              "doc": "Create and add a semi-continuous decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned.",
+              "doc": "Create and add a semi-continuous decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned. On failure, no variable or modeling label\nis added to the instance.",
               "signatures": [
                 {
                   "parameters": [
@@ -11231,7 +11231,7 @@
             },
             {
               "name": "new_semi_integer",
-              "doc": "Create and add a semi-integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Non-integral endpoints are\nnormalized inward. Unlike an integer variable, if the interval contains\nno integer, its bound is normalized to `[0, 0]`, preserving the zero\nalternative in the semi-integer domain. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned.",
+              "doc": "Create and add a semi-integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Non-integral endpoints are\nnormalized inward. Unlike an integer variable, if the interval contains\nno integer, its bound is normalized to `[0, 0]`, preserving the zero\nalternative in the semi-integer domain. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned. On failure, no variable or modeling label\nis added to the instance.",
               "signatures": [
                 {
                   "parameters": [

--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -10710,7 +10710,7 @@
             },
             {
               "name": "maximize",
-              "doc": "Create an empty maximization instance with a zero objective.\n\nDecision variables and constraints can be added incrementally with\n{meth}`new_binary` and {meth}`add_constraint`.",
+              "doc": "Create an empty maximization instance with a zero objective.\n\nDecision variables and constraints can be added incrementally with the\n`new_*` methods and {meth}`add_constraint`.",
               "signatures": [
                 {
                   "parameters": [],
@@ -10726,7 +10726,7 @@
             },
             {
               "name": "minimize",
-              "doc": "Create an empty minimization instance with a zero objective.\n\nDecision variables and constraints can be added incrementally with\n{meth}`new_binary` and {meth}`add_constraint`.",
+              "doc": "Create an empty minimization instance with a zero objective.\n\nDecision variables and constraints can be added incrementally with the\n`new_*` methods and {meth}`add_constraint`.",
               "signatures": [
                 {
                   "parameters": [],
@@ -10803,6 +10803,478 @@
                       "default": {
                         "kind": "Simple",
                         "value": "None"
+                      }
+                    },
+                    {
+                      "name": "subscripts",
+                      "type_": {
+                        "display": "Sequence[int]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "int",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "[]"
+                      }
+                    },
+                    {
+                      "name": "parameters",
+                      "type_": {
+                        "display": "Mapping[str, str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "{}"
+                      }
+                    },
+                    {
+                      "name": "description",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "display": "AttachedDecisionVariable",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
+              "name": "new_continuous",
+              "doc": "Create and add a continuous decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    },
+                    {
+                      "name": "lower",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('-inf')"
+                      }
+                    },
+                    {
+                      "name": "upper",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('inf')"
+                      }
+                    },
+                    {
+                      "name": "subscripts",
+                      "type_": {
+                        "display": "Sequence[int]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "int",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "[]"
+                      }
+                    },
+                    {
+                      "name": "parameters",
+                      "type_": {
+                        "display": "Mapping[str, str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "{}"
+                      }
+                    },
+                    {
+                      "name": "description",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "display": "AttachedDecisionVariable",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
+              "name": "new_integer",
+              "doc": "Create and add an integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)` and are normalized inward to integer\nvalues. Returns an {class}`~ommx.AttachedDecisionVariable` that can be\nused directly in expressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or contain no\ninteger value, or if no larger automatic ID can be assigned.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    },
+                    {
+                      "name": "lower",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('-inf')"
+                      }
+                    },
+                    {
+                      "name": "upper",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('inf')"
+                      }
+                    },
+                    {
+                      "name": "subscripts",
+                      "type_": {
+                        "display": "Sequence[int]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "int",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "[]"
+                      }
+                    },
+                    {
+                      "name": "parameters",
+                      "type_": {
+                        "display": "Mapping[str, str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "{}"
+                      }
+                    },
+                    {
+                      "name": "description",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "display": "AttachedDecisionVariable",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
+              "name": "new_semi_continuous",
+              "doc": "Create and add a semi-continuous decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    },
+                    {
+                      "name": "lower",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('-inf')"
+                      }
+                    },
+                    {
+                      "name": "upper",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('inf')"
+                      }
+                    },
+                    {
+                      "name": "subscripts",
+                      "type_": {
+                        "display": "Sequence[int]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "int",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "[]"
+                      }
+                    },
+                    {
+                      "name": "parameters",
+                      "type_": {
+                        "display": "Mapping[str, str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          },
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "{}"
+                      }
+                    },
+                    {
+                      "name": "description",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "display": "AttachedDecisionVariable",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            },
+            {
+              "name": "new_semi_integer",
+              "doc": "Create and add a semi-integer decision variable with an automatically assigned ID.\n\nThe bounds default to `(-inf, inf)`. Non-integral endpoints are\nnormalized inward. Unlike an integer variable, if the interval contains\nno integer, its bound is normalized to `[0, 0]`, preserving the zero\nalternative in the semi-integer domain. Returns an\n{class}`~ommx.AttachedDecisionVariable` that can be used directly in\nexpressions.\n\n**Args:**\n- `name`: Optional human-readable modeling name. Names need not be unique.\n- `lower`: Lower bound of the variable.\n- `upper`: Upper bound of the variable.\n- `subscripts`: Optional integer indices from the source model.\n- `parameters`: Optional string-valued indices from the source model.\n- `description`: Optional human-readable description.\n\nRaises {class}`ValueError` if the bounds are invalid or if no larger\nautomatic ID can be assigned.",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "name",
+                      "type_": {
+                        "display": "Optional[str]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "str",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "None"
+                      }
+                    },
+                    {
+                      "name": "lower",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('-inf')"
+                      }
+                    },
+                    {
+                      "name": "upper",
+                      "type_": {
+                        "display": "float",
+                        "link_target": null,
+                        "children": []
+                      },
+                      "default": {
+                        "kind": "Simple",
+                        "value": "float('inf')"
                       }
                     },
                     {

--- a/docs/api/ommx_pyo3_stub_gen_ext.py
+++ b/docs/api/ommx_pyo3_stub_gen_ext.py
@@ -10,8 +10,21 @@ from docutils import nodes
 from sphinx.addnodes import desc_parameter, desc_parameterlist, desc_sig_operator
 
 
-_generated_parse_myst = generated_extension._parse_myst
-_generated_build_callable_signatures = generated_extension._build_callable_signatures
+_ORIGINAL_HOOKS_ATTRIBUTE = "_ommx_pyo3_stub_gen_ext_original_hooks"
+try:
+    _generated_parse_myst, _generated_build_callable_signatures = getattr(
+        generated_extension, _ORIGINAL_HOOKS_ATTRIBUTE
+    )
+except AttributeError:
+    _generated_parse_myst = generated_extension._parse_myst
+    _generated_build_callable_signatures = (
+        generated_extension._build_callable_signatures
+    )
+    setattr(
+        generated_extension,
+        _ORIGINAL_HOOKS_ATTRIBUTE,
+        (_generated_parse_myst, _generated_build_callable_signatures),
+    )
 _STUB_PATH = (
     Path(__file__).resolve().parents[2]
     / "python"
@@ -74,9 +87,10 @@ def _find_stub_parameters(fullname, signature):
     _, signatures = max(candidates, key=lambda item: len(item[0]))
     json_names = {parameter["name"] for parameter in signature["parameters"]}
     for parameters in signatures:
-        if len(parameters) == len(json_names) and {
-            name for name, _ in parameters
-        } == json_names:
+        if (
+            len(parameters) == len(json_names)
+            and {name for name, _ in parameters} == json_names
+        ):
             return parameters
     return None
 
@@ -113,7 +127,11 @@ def _restore_parameter_kinds(signature_node, signature, parameters):
         parameter_list.remove(child)
 
     grouped = {
-        kind: [rendered[name] for name, parameter_kind in parameters if parameter_kind == kind]
+        kind: [
+            rendered[name]
+            for name, parameter_kind in parameters
+            if parameter_kind == kind
+        ]
         for kind in (
             "positional_only",
             "positional_or_keyword",

--- a/docs/api/ommx_pyo3_stub_gen_ext.py
+++ b/docs/api/ommx_pyo3_stub_gen_ext.py
@@ -1,11 +1,152 @@
 """OMMX-specific rendering adaptations for pyo3-stub-gen API docs."""
 
+import ast
 import re
+from functools import lru_cache
+from pathlib import Path
 
 import pyo3_stub_gen_ext as generated_extension
+from docutils import nodes
+from sphinx.addnodes import desc_parameter, desc_parameterlist, desc_sig_operator
 
 
 _generated_parse_myst = generated_extension._parse_myst
+_generated_build_callable_signatures = generated_extension._build_callable_signatures
+_STUB_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "ommx"
+    / "ommx"
+    / "_ommx_rust"
+    / "__init__.pyi"
+)
+
+
+def _callable_parameters(node: ast.FunctionDef | ast.AsyncFunctionDef):
+    """Return the Python parameter order and kinds for one stub signature."""
+    parameters = [
+        *((argument.arg, "positional_only") for argument in node.args.posonlyargs),
+        *((argument.arg, "positional_or_keyword") for argument in node.args.args),
+    ]
+    if parameters and parameters[0][0] in {"self", "cls"}:
+        parameters.pop(0)
+    if node.args.vararg is not None:
+        parameters.append((node.args.vararg.arg, "var_positional"))
+    parameters.extend(
+        (argument.arg, "keyword_only") for argument in node.args.kwonlyargs
+    )
+    if node.args.kwarg is not None:
+        parameters.append((node.args.kwarg.arg, "var_keyword"))
+    return tuple(parameters)
+
+
+@lru_cache(maxsize=1)
+def _stub_callable_parameters():
+    """Index callable signatures from the generated stub by qualified name."""
+    tree = ast.parse(_STUB_PATH.read_text(encoding="utf-8"), filename=str(_STUB_PATH))
+    callables = {}
+
+    def visit(body, prefix=()):
+        for node in body:
+            if isinstance(node, ast.ClassDef):
+                visit(node.body, (*prefix, node.name))
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                qualified_name = ".".join((*prefix, node.name))
+                callables.setdefault(qualified_name, []).append(
+                    _callable_parameters(node)
+                )
+
+    visit(tree.body)
+    return callables
+
+
+def _find_stub_parameters(fullname, signature):
+    """Match a JSON signature to its generated-stub parameter kinds."""
+    callables = _stub_callable_parameters()
+    candidates = [
+        (qualified_name, signatures)
+        for qualified_name, signatures in callables.items()
+        if fullname == qualified_name or fullname.endswith(f".{qualified_name}")
+    ]
+    if not candidates:
+        return None
+
+    _, signatures = max(candidates, key=lambda item: len(item[0]))
+    json_names = {parameter["name"] for parameter in signature["parameters"]}
+    for parameters in signatures:
+        if len(parameters) == len(json_names) and {
+            name for name, _ in parameters
+        } == json_names:
+            return parameters
+    return None
+
+
+def _operator(text):
+    operator = desc_sig_operator()
+    operator += nodes.Text(text)
+    return operator
+
+
+def _delimiter(text):
+    parameter = desc_parameter()
+    parameter += _operator(text)
+    return parameter
+
+
+def _restore_parameter_kinds(signature_node, signature, parameters):
+    """Restore delimiters omitted from pyo3-stub-gen's documentation IR."""
+    parameter_list = next(signature_node.findall(desc_parameterlist), None)
+    if parameter_list is None:
+        return
+
+    rendered = dict(
+        zip(
+            (parameter["name"] for parameter in signature["parameters"]),
+            parameter_list.children,
+            strict=True,
+        )
+    )
+    if rendered.keys() != {name for name, _ in parameters}:
+        return
+
+    for child in list(parameter_list.children):
+        parameter_list.remove(child)
+
+    grouped = {
+        kind: [rendered[name] for name, parameter_kind in parameters if parameter_kind == kind]
+        for kind in (
+            "positional_only",
+            "positional_or_keyword",
+            "var_positional",
+            "keyword_only",
+            "var_keyword",
+        )
+    }
+
+    parameter_list.extend(grouped["positional_only"])
+    if grouped["positional_only"]:
+        parameter_list += _delimiter("/")
+    parameter_list.extend(grouped["positional_or_keyword"])
+    if grouped["var_positional"]:
+        grouped["var_positional"][0].insert(0, _operator("*"))
+        parameter_list.extend(grouped["var_positional"])
+    elif grouped["keyword_only"]:
+        parameter_list += _delimiter("*")
+    parameter_list.extend(grouped["keyword_only"])
+    if grouped["var_keyword"]:
+        grouped["var_keyword"][0].insert(0, _operator("**"))
+        parameter_list.extend(grouped["var_keyword"])
+
+
+def _build_callable_signatures(signatures, name, module_name, fullname, env):
+    signature_nodes = _generated_build_callable_signatures(
+        signatures, name, module_name, fullname, env
+    )
+    for signature, signature_node in zip(signatures, signature_nodes, strict=True):
+        parameters = _find_stub_parameters(fullname, signature)
+        if parameters is not None:
+            _restore_parameter_kinds(signature_node, signature, parameters)
+    return signature_nodes
 
 
 def _fence_bare_doctest_blocks(markdown_text: str) -> str:
@@ -77,4 +218,5 @@ def _parse_myst(markdown_text: str, env=None):
 
 def setup(app):
     generated_extension._parse_myst = _parse_myst
+    generated_extension._build_callable_signatures = _build_callable_signatures
     return {"version": "0.1", "parallel_read_safe": True}

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -37,6 +37,12 @@ are normalized inward. An integer interval with no integer value raises
 zero alternative as the bound `[0, 0]`. See the [Instance user
 guide](../user_guide/instance.md) for the incremental workflow.
 
+Each Python constructor delegates variable creation to one atomic Rust SDK
+owner operation: kind and bound normalization, automatic ID allocation, and
+row and modeling-label insertion are validated before the
+{class}`~ommx.Instance` changes. Invalid bounds and exhausted IDs leave no
+partial variable or label behind.
+
 ### 🛠 Inclusive `atol` boundaries ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
 
 Absolute-tolerance comparisons now include the exact boundary consistently.

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,6 +8,35 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
+### 🆕 Incremental constructors for interval-domain variables ([#1185](https://github.com/Jij-Inc/ommx/pull/1185))
+
+{class}`~ommx.Instance` can now create every existing interval-domain decision
+variable kind while assigning numeric IDs automatically. In addition to
+{meth}`~ommx.Instance.new_binary`, use
+{meth}`~ommx.Instance.new_integer`,
+{meth}`~ommx.Instance.new_continuous`,
+{meth}`~ommx.Instance.new_semi_integer`, or
+{meth}`~ommx.Instance.new_semi_continuous`:
+
+```python
+from ommx import Instance
+
+instance = Instance.minimize()
+count = instance.new_integer("count", lower=0, upper=10)
+amount = instance.new_continuous("amount", lower=0)
+batch = instance.new_semi_integer("batch", lower=2, upper=10)
+rate = instance.new_semi_continuous("rate", lower=0.5, upper=4)
+```
+
+Each method returns an {class}`~ommx.AttachedDecisionVariable` that can be used
+directly in expressions. `name` remains the optional positional argument, while
+`subscripts`, `parameters`, and `description` are keyword-only. The four new
+methods also accept keyword-only `lower` and `upper` bounds. Integer endpoints
+are normalized inward. An integer interval with no integer value raises
+`ValueError`, while a semi-integer interval with no integer value retains its
+zero alternative as the bound `[0, 0]`. See the [Instance user
+guide](../user_guide/instance.md) for the incremental workflow.
+
 ### 🛠 Inclusive `atol` boundaries ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
 
 Absolute-tolerance comparisons now include the exact boundary consistently.

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -31,17 +31,20 @@ rate = instance.new_semi_continuous("rate", lower=0.5, upper=4)
 Each method returns an {class}`~ommx.AttachedDecisionVariable` that can be used
 directly in expressions. `name` remains the optional positional argument, while
 `subscripts`, `parameters`, and `description` are keyword-only. The four new
-methods also accept keyword-only `lower` and `upper` bounds. Integer endpoints
-are normalized inward. An integer interval with no integer value raises
-`ValueError`, while a semi-integer interval with no integer value retains its
-zero alternative as the bound `[0, 0]`. See the [Instance user
+methods also accept keyword-only `lower` and `upper` bounds. `new_integer` and
+`new_semi_integer` additionally accept keyword-only `atol`; omitting it uses the
+current default returned by {func}`~ommx.get_default_atol`. For these two
+methods, a finite lower endpoint is normalized to `ceil(lower - atol)` and a
+finite upper endpoint to `floor(upper + atol)`. If the normalized interval has
+no integer, `new_integer` raises `ValueError`, while `new_semi_integer` retains
+its zero alternative as `[0, 0]`. See the [Instance user
 guide](../user_guide/instance.md) for the incremental workflow.
 
-Each Python constructor delegates variable creation to one atomic Rust SDK
-owner operation: kind and bound normalization, automatic ID allocation, and
-row and modeling-label insertion are validated before the
-{class}`~ommx.Instance` changes. Invalid bounds and exhausted IDs leave no
-partial variable or label behind.
+Each constructor validates the complete variable definition before committing
+the row and modeling label together to the {class}`~ommx.Instance`. An invalid
+bound or tolerance, or a maximum existing decision-variable ID of `2**64 - 1`
+that prevents assignment of a larger automatic ID, leaves no partial variable
+or label behind.
 
 ### 🛠 Inclusive `atol` boundaries ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
 

--- a/docs/en/user_guide/instance.md
+++ b/docs/en/user_guide/instance.md
@@ -52,12 +52,22 @@ All `new_*` decision-variable methods and `add_constraint` accept the complete
 modeling label: `name`, `subscripts`, `parameters`, and `description`. The last
 three fields are keyword-only. `new_integer`, `new_continuous`,
 `new_semi_integer`, and `new_semi_continuous` also accept keyword-only `lower`
-and `upper` bounds. For `add_constraint`, omitted fields preserve labels already
-stored on the input constraint.
+and `upper` bounds. `new_integer` and `new_semi_integer` additionally accept a
+keyword-only `atol`; when it is omitted, they use the current default returned
+by {func}`~ommx.get_default_atol`. For `add_constraint`, omitted fields preserve
+labels already stored on the input constraint.
+
+For Integer and SemiInteger variables, a finite lower endpoint is normalized to
+`ceil(lower - atol)` and a finite upper endpoint to `floor(upper + atol)`. If
+these normalized endpoints contain no integer, `new_integer` raises
+`ValueError`, while `new_semi_integer` uses `[0, 0]` to preserve the
+semi-integer zero alternative.
 
 Each `new_*` call validates and normalizes its complete variable definition
-before assigning the ID. If a bound is invalid or no ID remains, neither the
-variable nor its modeling label is added to the `Instance`.
+before assigning the ID. If a bound or tolerance is invalid, or if the maximum
+existing decision-variable ID is `2**64 - 1` so that no larger automatic ID can
+be assigned, neither the variable nor its modeling label is added to the
+`Instance`.
 
 Each of these components has a corresponding property. The objective function is converted into the form of {class}`~ommx.Function`, as explained in the previous section.
 

--- a/docs/en/user_guide/instance.md
+++ b/docs/en/user_guide/instance.md
@@ -55,6 +55,10 @@ three fields are keyword-only. `new_integer`, `new_continuous`,
 and `upper` bounds. For `add_constraint`, omitted fields preserve labels already
 stored on the input constraint.
 
+Each `new_*` call validates and normalizes its complete variable definition
+before assigning the ID. If a bound is invalid or no ID remains, neither the
+variable nor its modeling label is added to the `Instance`.
+
 Each of these components has a corresponding property. The objective function is converted into the form of {class}`~ommx.Function`, as explained in the previous section.
 
 ```{code-cell} ipython3

--- a/docs/en/user_guide/instance.md
+++ b/docs/en/user_guide/instance.md
@@ -48,9 +48,11 @@ returned by `add_constraint`. Use {meth}`~ommx.Instance.from_components` when
 you already have components with explicit IDs and want to assemble them in one
 operation.
 
-Both `new_binary` and `add_constraint` accept the complete modeling label:
-`name`, `subscripts`, `parameters`, and `description`. The last three fields
-are keyword-only. For `add_constraint`, omitted fields preserve labels already
+All `new_*` decision-variable methods and `add_constraint` accept the complete
+modeling label: `name`, `subscripts`, `parameters`, and `description`. The last
+three fields are keyword-only. `new_integer`, `new_continuous`,
+`new_semi_integer`, and `new_semi_continuous` also accept keyword-only `lower`
+and `upper` bounds. For `add_constraint`, omitted fields preserve labels already
 stored on the input constraint.
 
 Each of these components has a corresponding property. The objective function is converted into the form of {class}`~ommx.Function`, as explained in the previous section.
@@ -79,6 +81,18 @@ First, `kind`, `lower`, and `upper` are essential information for the mathematic
 
 - `kind` specifies the type of decision variable, which can be Binary, Integer, Continuous, SemiInteger, or SemiContinuous.
 - `lower` and `upper` are the lower and upper bounds of the decision variable. For Binary variables, this range is $[0, 1]$.
+
+Create any of these kinds directly on an `Instance` when you want it to assign
+numeric IDs automatically. The returned attached variables can be used in
+expressions just like the binary variables above.
+
+```{code-cell} ipython3
+typed = Instance.minimize()
+count = typed.new_integer("count", lower=0, upper=10)
+amount = typed.new_continuous("amount", lower=0)
+batch = typed.new_semi_integer("batch", lower=2, upper=10)
+rate = typed.new_semi_continuous("rate", lower=0.5, upper=4)
+```
 
 Additionally, OMMX is designed to handle metadata that may be needed when integrating mathematical optimization into practical data analysis. While this metadata does not affect the mathematical model itself, it is useful for data analysis and visualization.
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,6 +8,35 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
+### 🆕 区間で定義する決定変数の逐次作成 ([#1185](https://github.com/Jij-Inc/ommx/pull/1185))
+
+{class}`~ommx.Instance` が数値IDを自動で割り当てながら、既存の区間で定義する
+すべての決定変数kindを作成できるようになりました。
+{meth}`~ommx.Instance.new_binary` に加えて、
+{meth}`~ommx.Instance.new_integer`、
+{meth}`~ommx.Instance.new_continuous`、
+{meth}`~ommx.Instance.new_semi_integer`、
+{meth}`~ommx.Instance.new_semi_continuous` を利用できます。
+
+```python
+from ommx import Instance
+
+instance = Instance.minimize()
+count = instance.new_integer("count", lower=0, upper=10)
+amount = instance.new_continuous("amount", lower=0)
+batch = instance.new_semi_integer("batch", lower=2, upper=10)
+rate = instance.new_semi_continuous("rate", lower=0.5, upper=4)
+```
+
+どのメソッドも式にそのまま利用できる
+{class}`~ommx.AttachedDecisionVariable` を返します。`name` は引き続き省略可能な
+位置引数で、`subscripts`、`parameters`、`description` はキーワード専用です。
+新しい4メソッドでは、`lower` と `upper` もキーワード専用で指定できます。
+Integerの非整数endpointは区間の内側へ正規化されます。
+整数を含まないInteger区間は`ValueError`になりますが、SemiIntegerはゼロの選択肢を
+bound `[0, 0]` として保持します。逐次modeling workflowの詳細は
+[Instance user guide](../user_guide/instance.md) を参照してください。
+
 ### 🛠 境界を含む `atol` 判定 ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
 
 絶対許容誤差の比較は、差がちょうど`atol`となる境界を一貫して含むようになりました。

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -32,15 +32,18 @@ rate = instance.new_semi_continuous("rate", lower=0.5, upper=4)
 {class}`~ommx.AttachedDecisionVariable` を返します。`name` は引き続き省略可能な
 位置引数で、`subscripts`、`parameters`、`description` はキーワード専用です。
 新しい4メソッドでは、`lower` と `upper` もキーワード専用で指定できます。
-Integerの非整数endpointは区間の内側へ正規化されます。
-整数を含まないInteger区間は`ValueError`になりますが、SemiIntegerはゼロの選択肢を
-bound `[0, 0]` として保持します。逐次modeling workflowの詳細は
+さらに `new_integer` と `new_semi_integer` はキーワード専用の `atol` を受け取り、
+省略時には {func}`~ommx.get_default_atol` が返す現在の既定値を使います。この2メソッドでは、
+有限な lower endpoint を `ceil(lower - atol)`、有限な upper endpoint を
+`floor(upper + atol)` へ正規化します。正規化後の区間に整数がない場合、`new_integer` は
+`ValueError` を返し、`new_semi_integer` はゼロの選択肢を `[0, 0]` として保持します。
+逐次modeling workflowの詳細は
 [Instance user guide](../user_guide/instance.md) を参照してください。
 
-各Python constructorは、Rust SDKが所有する1回のatomicな変数作成操作を呼び出します。
-kindとboundの正規化、IDの自動割り当て、rowとmodeling labelの挿入をすべて検証してから
-{class}`~ommx.Instance` を変更します。不正なboundやIDの枯渇が発生しても、変数や
-labelの一部だけが残ることはありません。
+各constructorは決定変数の定義全体を検証してから、rowとmodeling labelをまとめて
+{class}`~ommx.Instance` へ追加します。boundまたはtoleranceが不正な場合や、既存の
+決定変数IDの最大値が `2**64 - 1` で、それより大きい自動IDを割り当てられない場合も、
+変数やlabelの一部だけが残ることはありません。
 
 ### 🛠 境界を含む `atol` 判定 ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -37,6 +37,11 @@ Integerの非整数endpointは区間の内側へ正規化されます。
 bound `[0, 0]` として保持します。逐次modeling workflowの詳細は
 [Instance user guide](../user_guide/instance.md) を参照してください。
 
+各Python constructorは、Rust SDKが所有する1回のatomicな変数作成操作を呼び出します。
+kindとboundの正規化、IDの自動割り当て、rowとmodeling labelの挿入をすべて検証してから
+{class}`~ommx.Instance` を変更します。不正なboundやIDの枯渇が発生しても、変数や
+labelの一部だけが残ることはありません。
+
 ### 🛠 境界を含む `atol` 判定 ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
 
 絶対許容誤差の比較は、差がちょうど`atol`となる境界を一貫して含むようになりました。

--- a/docs/ja/user_guide/instance.md
+++ b/docs/ja/user_guide/instance.md
@@ -46,6 +46,8 @@ instance.add_constraint(x * y == 0, "exclusive")
 
 決定変数を作成するすべての `new_*` メソッドと `add_constraint` は、`name`、`subscripts`、`parameters`、`description` からなる ModelingLabel 全体を受け取れます。後ろの 3 フィールドはキーワード専用です。`new_integer`、`new_continuous`、`new_semi_integer`、`new_semi_continuous` では、`lower` と `upper` もキーワード専用で指定できます。`add_constraint` では、省略したフィールドについて入力 Constraint が持つ既存ラベルを保持します。
 
+各 `new_*` 呼び出しは、IDを割り当てる前に決定変数の定義全体を検証し、正規化します。boundが不正な場合や利用可能なIDが残っていない場合、決定変数もModelingLabelも `Instance` には追加されません。
+
 これらのコンポーネントはそれぞれに対応するプロパティが用意されています。目的関数については前節で説明した {class}`~ommx.Function` の形に変換されます。
 
 ```{code-cell} ipython3

--- a/docs/ja/user_guide/instance.md
+++ b/docs/ja/user_guide/instance.md
@@ -44,9 +44,11 @@ instance.add_constraint(x * y == 0, "exclusive")
 
 `Instance` はモデルの構築時に決定変数と制約条件の数値 ID を自動的に割り当てます。割り当てられた ID は `x.id` や `add_constraint` が返すハンドルから確認できます。明示的な ID を持つコンポーネントを一度に組み立てる場合は、引き続き {meth}`~ommx.Instance.from_components` を使用できます。
 
-決定変数を作成するすべての `new_*` メソッドと `add_constraint` は、`name`、`subscripts`、`parameters`、`description` からなる ModelingLabel 全体を受け取れます。後ろの 3 フィールドはキーワード専用です。`new_integer`、`new_continuous`、`new_semi_integer`、`new_semi_continuous` では、`lower` と `upper` もキーワード専用で指定できます。`add_constraint` では、省略したフィールドについて入力 Constraint が持つ既存ラベルを保持します。
+決定変数を作成するすべての `new_*` メソッドと `add_constraint` は、`name`、`subscripts`、`parameters`、`description` からなる ModelingLabel 全体を受け取れます。後ろの 3 フィールドはキーワード専用です。`new_integer`、`new_continuous`、`new_semi_integer`、`new_semi_continuous` では、`lower` と `upper` もキーワード専用で指定できます。さらに `new_integer` と `new_semi_integer` はキーワード専用の `atol` を受け取り、省略時には {func}`~ommx.get_default_atol` が返す現在の既定値を使います。`add_constraint` では、省略したフィールドについて入力 Constraint が持つ既存ラベルを保持します。
 
-各 `new_*` 呼び出しは、IDを割り当てる前に決定変数の定義全体を検証し、正規化します。boundが不正な場合や利用可能なIDが残っていない場合、決定変数もModelingLabelも `Instance` には追加されません。
+Integer と SemiInteger では、有限な lower endpoint を `ceil(lower - atol)`、有限な upper endpoint を `floor(upper + atol)` へ正規化します。正規化後の区間に整数がない場合、`new_integer` は `ValueError` を返し、`new_semi_integer` は SemiInteger のゼロ選択肢を保持するため `[0, 0]` を使います。
+
+各 `new_*` 呼び出しは、IDを割り当てる前に決定変数の定義全体を検証し、正規化します。boundまたはtoleranceが不正な場合や、既存の決定変数IDの最大値が `2**64 - 1` で、それより大きい自動IDを割り当てられない場合、決定変数もModelingLabelも `Instance` には追加されません。
 
 これらのコンポーネントはそれぞれに対応するプロパティが用意されています。目的関数については前節で説明した {class}`~ommx.Function` の形に変換されます。
 

--- a/docs/ja/user_guide/instance.md
+++ b/docs/ja/user_guide/instance.md
@@ -44,7 +44,7 @@ instance.add_constraint(x * y == 0, "exclusive")
 
 `Instance` はモデルの構築時に決定変数と制約条件の数値 ID を自動的に割り当てます。割り当てられた ID は `x.id` や `add_constraint` が返すハンドルから確認できます。明示的な ID を持つコンポーネントを一度に組み立てる場合は、引き続き {meth}`~ommx.Instance.from_components` を使用できます。
 
-`new_binary` と `add_constraint` は、`name`、`subscripts`、`parameters`、`description` からなる ModelingLabel 全体を受け取れます。後ろの 3 フィールドはキーワード専用です。`add_constraint` では、省略したフィールドについて入力 Constraint が持つ既存ラベルを保持します。
+決定変数を作成するすべての `new_*` メソッドと `add_constraint` は、`name`、`subscripts`、`parameters`、`description` からなる ModelingLabel 全体を受け取れます。後ろの 3 フィールドはキーワード専用です。`new_integer`、`new_continuous`、`new_semi_integer`、`new_semi_continuous` では、`lower` と `upper` もキーワード専用で指定できます。`add_constraint` では、省略したフィールドについて入力 Constraint が持つ既存ラベルを保持します。
 
 これらのコンポーネントはそれぞれに対応するプロパティが用意されています。目的関数については前節で説明した {class}`~ommx.Function` の形に変換されます。
 
@@ -70,6 +70,16 @@ instance.decision_variables_df()
 
 - `kind` はその決定変数の種類でBinary, Integer, Continuousに加えてSemiInteger, SemiContinuousがあります。
 - `lower` と `upper` はその決定変数の下限と上限です。Binaryの場合は $[0, 1]$ になります。
+
+数値 ID を `Instance` に自動で割り当てさせる場合は、これらすべての種類の決定変数を `Instance` 上で直接作成できます。返された attached 変数は、上の binary 変数と同様に式で利用できます。
+
+```{code-cell} ipython3
+typed = Instance.minimize()
+count = typed.new_integer("count", lower=0, upper=10)
+amount = typed.new_continuous("amount", lower=0)
+batch = typed.new_semi_integer("batch", lower=2, upper=10)
+rate = typed.new_semi_continuous("rate", lower=0.5, upper=4)
+```
 
 加えてOMMXは数理最適化を実務上のデータ分析に統合した時に必要になるようなメタデータを統合的に扱う事を目指して設計されているので、決定変数のメタデータを保持することができます。これらは数理モデル自体には影響を与えないので必須の情報ではありませんがデータ分析や可視化の際に有用です。
 

--- a/python/ommx-tests/tests/test_api_doc_rendering.py
+++ b/python/ommx-tests/tests/test_api_doc_rendering.py
@@ -49,6 +49,7 @@ Tail prose.
     )
 
     original_parse_myst = generated_extension._parse_myst
+    original_builder = generated_extension._build_callable_signatures
     ommx_extension.setup(None)
     try:
         container = nodes.container()
@@ -65,6 +66,7 @@ Tail prose.
         assert "Tail prose." in container.astext()
     finally:
         setattr(generated_extension, "_parse_myst", original_parse_myst)
+        setattr(generated_extension, "_build_callable_signatures", original_builder)
 
 
 def test_keyword_only_separator_is_restored_from_generated_stub(

--- a/python/ommx-tests/tests/test_api_doc_rendering.py
+++ b/python/ommx-tests/tests/test_api_doc_rendering.py
@@ -2,6 +2,7 @@ import importlib
 from pathlib import Path
 
 from docutils import nodes
+from sphinx.addnodes import desc_parameterlist, desc_sig_operator
 
 
 API_DOCS_DIR = Path(__file__).resolve().parents[3] / "docs" / "api"
@@ -64,3 +65,53 @@ Tail prose.
         assert "Tail prose." in container.astext()
     finally:
         setattr(generated_extension, "_parse_myst", original_parse_myst)
+
+
+def test_keyword_only_separator_is_restored_from_generated_stub(
+    monkeypatch,
+) -> None:
+    monkeypatch.syspath_prepend(str(API_DOCS_DIR))
+    generated_extension = importlib.import_module("pyo3_stub_gen_ext")
+    ommx_extension = importlib.import_module("ommx_pyo3_stub_gen_ext")
+
+    type_expr = {"display": "str", "link_target": None, "children": []}
+    signature = {
+        "parameters": [
+            {"name": name, "type_": type_expr, "default": None}
+            for name in (
+                "name",
+                "lower",
+                "upper",
+                "subscripts",
+                "parameters",
+                "description",
+            )
+        ],
+        "return_type": None,
+    }
+
+    original_builder = generated_extension._build_callable_signatures
+    ommx_extension.setup(None)
+    try:
+        signature_node = generated_extension._build_callable_signatures(
+            [signature],
+            "new_integer",
+            "ommx",
+            "ommx.Instance.new_integer",
+            None,
+        )[0]
+        parameter_list = next(signature_node.findall(desc_parameterlist))
+        assert [child.astext() for child in parameter_list.children] == [
+            "name: str",
+            "*",
+            "lower: str",
+            "upper: str",
+            "subscripts: str",
+            "parameters: str",
+            "description: str",
+        ]
+        assert [
+            operator.astext() for operator in parameter_list.findall(desc_sig_operator)
+        ] == ["*"]
+    finally:
+        setattr(generated_extension, "_build_callable_signatures", original_builder)

--- a/python/ommx-tests/tests/test_api_doc_rendering.py
+++ b/python/ommx-tests/tests/test_api_doc_rendering.py
@@ -87,11 +87,13 @@ def test_keyword_only_separator_is_restored_from_generated_stub(
                 "subscripts",
                 "parameters",
                 "description",
+                "atol",
             )
         ],
         "return_type": None,
     }
 
+    original_parse_myst = generated_extension._parse_myst
     original_builder = generated_extension._build_callable_signatures
     ommx_extension.setup(None)
     try:
@@ -111,9 +113,116 @@ def test_keyword_only_separator_is_restored_from_generated_stub(
             "subscripts: str",
             "parameters: str",
             "description: str",
+            "atol: str",
         ]
         assert [
             operator.astext() for operator in parameter_list.findall(desc_sig_operator)
         ] == ["*"]
     finally:
+        setattr(generated_extension, "_parse_myst", original_parse_myst)
+        setattr(generated_extension, "_build_callable_signatures", original_builder)
+
+
+def test_positional_only_separator_is_restored_from_generated_stub(
+    monkeypatch,
+) -> None:
+    monkeypatch.syspath_prepend(str(API_DOCS_DIR))
+    generated_extension = importlib.import_module("pyo3_stub_gen_ext")
+    ommx_extension = importlib.import_module("ommx_pyo3_stub_gen_ext")
+
+    signature = {
+        "parameters": [
+            {
+                "name": "other",
+                "type_": {"display": "object", "link_target": None, "children": []},
+                "default": None,
+            }
+        ],
+        "return_type": None,
+    }
+
+    original_parse_myst = generated_extension._parse_myst
+    original_builder = generated_extension._build_callable_signatures
+    ommx_extension.setup(None)
+    try:
+        signature_node = generated_extension._build_callable_signatures(
+            [signature],
+            "__eq__",
+            "ommx",
+            "ommx.Bound.__eq__",
+            None,
+        )[0]
+        parameter_list = next(signature_node.findall(desc_parameterlist))
+        assert [child.astext() for child in parameter_list.children] == [
+            "other: object",
+            "/",
+        ]
+        assert [
+            operator.astext() for operator in parameter_list.findall(desc_sig_operator)
+        ] == ["/"]
+    finally:
+        setattr(generated_extension, "_parse_myst", original_parse_myst)
+        setattr(generated_extension, "_build_callable_signatures", original_builder)
+
+
+def test_setup_is_idempotent_across_extension_reload(monkeypatch) -> None:
+    monkeypatch.syspath_prepend(str(API_DOCS_DIR))
+    generated_extension = importlib.import_module("pyo3_stub_gen_ext")
+    ommx_extension = importlib.import_module("ommx_pyo3_stub_gen_ext")
+
+    original_parse_myst = generated_extension._parse_myst
+    original_builder = generated_extension._build_callable_signatures
+    ommx_extension.setup(None)
+    first_parse_myst = generated_extension._parse_myst
+    first_builder = generated_extension._build_callable_signatures
+
+    try:
+        reloaded_extension = importlib.reload(ommx_extension)
+        reloaded_extension.setup(None)
+
+        assert getattr(
+            generated_extension, reloaded_extension._ORIGINAL_HOOKS_ATTRIBUTE
+        ) == (original_parse_myst, original_builder)
+        assert generated_extension._parse_myst is reloaded_extension._parse_myst
+        assert (
+            generated_extension._build_callable_signatures
+            is reloaded_extension._build_callable_signatures
+        )
+        assert generated_extension._parse_myst is not first_parse_myst
+        assert generated_extension._build_callable_signatures is not first_builder
+
+        container = nodes.container()
+        container.extend(generated_extension._parse_myst(">>> value = 1\n>>> value\n1"))
+        assert [block.astext() for block in container.findall(nodes.literal_block)] == [
+            ">>> value = 1\n>>> value\n1"
+        ]
+
+        signature = {
+            "parameters": [
+                {
+                    "name": "other",
+                    "type_": {
+                        "display": "object",
+                        "link_target": None,
+                        "children": [],
+                    },
+                    "default": None,
+                }
+            ],
+            "return_type": None,
+        }
+        signature_node = generated_extension._build_callable_signatures(
+            [signature],
+            "__eq__",
+            "ommx",
+            "ommx.Bound.__eq__",
+            None,
+        )[0]
+        parameter_list = next(signature_node.findall(desc_parameterlist))
+        assert [child.astext() for child in parameter_list.children] == [
+            "other: object",
+            "/",
+        ]
+    finally:
+        setattr(generated_extension, "_parse_myst", original_parse_myst)
         setattr(generated_extension, "_build_callable_signatures", original_builder)

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -1,4 +1,7 @@
 import math
+from collections import UserDict
+from types import MappingProxyType
+from typing import Any
 
 import ommx
 import pytest
@@ -86,6 +89,39 @@ def test_new_binary_accepts_full_modeling_label():
     assert unnamed.subscripts == []
     assert unnamed.parameters == {}
     assert unnamed.description == ""
+
+
+@pytest.mark.parametrize("mapping_type", [UserDict, MappingProxyType])
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "new_binary",
+        "new_integer",
+        "new_continuous",
+        "new_semi_integer",
+        "new_semi_continuous",
+    ],
+)
+def test_new_decision_variables_accept_mapping_parameters(
+    method_name: str, mapping_type: type
+):
+    instance = Instance.minimize()
+
+    variable = getattr(instance, method_name)(
+        "x", parameters=mapping_type({"region": "east"})
+    )
+
+    assert variable.parameters == {"region": "east"}
+
+
+def test_new_decision_variable_rejects_non_string_mapping_atomically():
+    instance = Instance.minimize()
+    invalid_parameters: Any = {"region": 1}
+
+    with pytest.raises(TypeError, match=r"parameters must be a Mapping\[str, str\]"):
+        instance.new_binary("x", parameters=invalid_parameters)
+
+    assert instance.decision_variables == []
 
 
 def test_new_non_binary_variables_assign_ids_and_preserve_domains_and_labels():
@@ -194,6 +230,51 @@ def test_new_semi_integer_uses_zero_when_bounds_contain_no_integer():
     assert variable.bound.upper == 0
 
 
+def test_new_integer_atol_overrides_the_process_default_atomically():
+    initial_atol = ommx.get_default_atol()
+    try:
+        ommx.set_default_atol(0.2)
+
+        defaulted_instance = Instance.minimize()
+        defaulted = defaulted_instance.new_integer("defaulted", lower=1.1, upper=1.9)
+        assert (defaulted.bound.lower, defaulted.bound.upper) == (1, 2)
+
+        explicit_instance = Instance.minimize()
+        with pytest.raises(ValueError):
+            explicit_instance.new_integer("explicit", lower=1.1, upper=1.9, atol=1e-6)
+        assert explicit_instance.decision_variables == []
+    finally:
+        ommx.set_default_atol(initial_atol)
+
+
+def test_new_semi_integer_atol_overrides_the_process_default():
+    initial_atol = ommx.get_default_atol()
+    try:
+        ommx.set_default_atol(0.2)
+
+        defaulted = Instance.minimize().new_semi_integer(
+            "defaulted", lower=1.1, upper=1.9
+        )
+        assert (defaulted.bound.lower, defaulted.bound.upper) == (1, 2)
+
+        explicit = Instance.minimize().new_semi_integer(
+            "explicit", lower=1.1, upper=1.9, atol=1e-6
+        )
+        assert (explicit.bound.lower, explicit.bound.upper) == (0, 0)
+    finally:
+        ommx.set_default_atol(initial_atol)
+
+
+@pytest.mark.parametrize("method_name", ["new_integer", "new_semi_integer"])
+def test_new_discrete_variable_rejects_invalid_atol_atomically(method_name: str):
+    instance = Instance.minimize()
+
+    with pytest.raises(ValueError):
+        getattr(instance, method_name)("x", lower=0, upper=1, atol=0)
+
+    assert instance.decision_variables == []
+
+
 @pytest.mark.parametrize(
     "method_name",
     [
@@ -215,7 +296,10 @@ def test_new_decision_variable_raises_value_error_when_automatic_id_overflows(
         sense=Instance.MINIMIZE,
     )
 
-    with pytest.raises(ValueError, match="No available decision variable ID remains"):
+    with pytest.raises(
+        ValueError,
+        match="Insufficient capacity for automatically assigned decision variable IDs",
+    ):
         getattr(instance, method_name)("x")
 
     assert [variable.id for variable in instance.decision_variables] == [max_id]

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -3,6 +3,7 @@ import math
 import ommx
 import pytest
 from ommx import (
+    AttachedDecisionVariable,
     DecisionVariable,
     ExactIntegerSlackError,
     Function,
@@ -87,7 +88,125 @@ def test_new_binary_accepts_full_modeling_label():
     assert unnamed.description == ""
 
 
-def test_new_binary_raises_value_error_when_automatic_id_overflows():
+def test_new_non_binary_variables_assign_ids_and_preserve_domains_and_labels():
+    instance = Instance.minimize()
+    cases = [
+        (
+            instance.new_integer,
+            DecisionVariable.integer,
+            DecisionVariable.INTEGER,
+            0.2,
+            3.8,
+        ),
+        (
+            instance.new_continuous,
+            DecisionVariable.continuous,
+            DecisionVariable.CONTINUOUS,
+            0.2,
+            3.8,
+        ),
+        (
+            instance.new_semi_integer,
+            DecisionVariable.semi_integer,
+            DecisionVariable.SEMI_INTEGER,
+            1.2,
+            4.8,
+        ),
+        (
+            instance.new_semi_continuous,
+            DecisionVariable.semi_continuous,
+            DecisionVariable.SEMI_CONTINUOUS,
+            1.2,
+            4.8,
+        ),
+    ]
+
+    for expected_id, (new_variable, detached_factory, kind, lower, upper) in enumerate(
+        cases
+    ):
+        attached = new_variable(
+            "x",
+            lower=lower,
+            upper=upper,
+            subscripts=[expected_id],
+            parameters={"region": "east"},
+            description="incremental variable",
+        )
+        expected = detached_factory(expected_id, lower=lower, upper=upper)
+
+        assert isinstance(attached, AttachedDecisionVariable)
+        assert attached.id == expected_id
+        assert attached.kind == kind
+        assert attached.detach().equals_to(expected)
+        assert attached.name == "x"
+        assert attached.subscripts == [expected_id]
+        assert attached.parameters == {"region": "east"}
+        assert attached.description == "incremental variable"
+
+    unbounded = instance.new_continuous("unbounded")
+    assert unbounded.id == len(cases)
+    assert unbounded.bound.lower == -math.inf
+    assert unbounded.bound.upper == math.inf
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["new_integer", "new_continuous", "new_semi_integer", "new_semi_continuous"],
+)
+def test_new_non_binary_variable_rejects_invalid_bounds_atomically(method_name: str):
+    instance = Instance.minimize()
+
+    with pytest.raises(ValueError):
+        getattr(instance, method_name)("x", lower=2, upper=1)
+
+    assert instance.decision_variables == []
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["new_integer", "new_continuous", "new_semi_integer", "new_semi_continuous"],
+)
+def test_new_non_binary_variable_bounds_are_keyword_only(method_name: str):
+    instance = Instance.minimize()
+
+    with pytest.raises(TypeError):
+        getattr(instance, method_name)("x", 0, 1)
+
+    assert instance.decision_variables == []
+
+
+def test_new_integer_rejects_bounds_without_an_integer_atomically():
+    instance = Instance.minimize()
+
+    with pytest.raises(ValueError):
+        instance.new_integer("invalid", lower=1.1, upper=1.9)
+
+    assert instance.decision_variables == []
+    assert instance.new_integer("valid", lower=1, upper=2).id == 0
+
+
+def test_new_semi_integer_uses_zero_when_bounds_contain_no_integer():
+    instance = Instance.minimize()
+
+    variable = instance.new_semi_integer("zero-only", lower=1.1, upper=1.9)
+
+    assert variable.bound.lower == 0
+    assert variable.bound.upper == 0
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "new_binary",
+        "new_integer",
+        "new_continuous",
+        "new_semi_integer",
+        "new_semi_continuous",
+    ],
+)
+def test_new_decision_variable_raises_value_error_when_automatic_id_overflows(
+    method_name: str,
+):
     max_id = 2**64 - 1
     instance = Instance.from_components(
         decision_variables=[DecisionVariable.binary(max_id)],
@@ -97,7 +216,7 @@ def test_new_binary_raises_value_error_when_automatic_id_overflows():
     )
 
     with pytest.raises(ValueError, match="No available decision variable ID remains"):
-        instance.new_binary("x")
+        getattr(instance, method_name)("x")
 
     assert [variable.id for variable in instance.decision_variables] == [max_id]
 

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -3320,7 +3320,8 @@ class Instance:
         - `description`: Optional human-readable description.
 
         Raises {class}`ValueError` if the maximum decision-variable ID is
-        `2**64 - 1` and no larger automatic ID can be assigned.
+        `2**64 - 1` and no larger automatic ID can be assigned. On failure, no
+        variable or modeling label is added to the instance.
         """
     def new_integer(
         self,
@@ -3348,7 +3349,8 @@ class Instance:
         - `description`: Optional human-readable description.
 
         Raises {class}`ValueError` if the bounds are invalid or contain no
-        integer value, or if no larger automatic ID can be assigned.
+        integer value, or if no larger automatic ID can be assigned. On failure,
+        no variable or modeling label is added to the instance.
         """
     def new_continuous(
         self,
@@ -3376,7 +3378,8 @@ class Instance:
         - `description`: Optional human-readable description.
 
         Raises {class}`ValueError` if the bounds are invalid or if no larger
-        automatic ID can be assigned.
+        automatic ID can be assigned. On failure, no variable or modeling label
+        is added to the instance.
         """
     def new_semi_integer(
         self,
@@ -3407,7 +3410,8 @@ class Instance:
         - `description`: Optional human-readable description.
 
         Raises {class}`ValueError` if the bounds are invalid or if no larger
-        automatic ID can be assigned.
+        automatic ID can be assigned. On failure, no variable or modeling label
+        is added to the instance.
         """
     def new_semi_continuous(
         self,
@@ -3435,7 +3439,8 @@ class Instance:
         - `description`: Optional human-readable description.
 
         Raises {class}`ValueError` if the bounds are invalid or if no larger
-        automatic ID can be assigned.
+        automatic ID can be assigned. On failure, no variable or modeling label
+        is added to the instance.
         """
     def attached_decision_variable(
         self, variable_id: builtins.int

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -3303,7 +3303,7 @@ class Instance:
         name: typing.Optional[builtins.str] = None,
         *,
         subscripts: typing.Sequence[builtins.int] = [],
-        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        parameters: collections.abc.Mapping[str, str] = {},
         description: typing.Optional[builtins.str] = None,
     ) -> AttachedDecisionVariable:
         r"""
@@ -3330,15 +3330,18 @@ class Instance:
         lower: builtins.float = float("-inf"),
         upper: builtins.float = float("inf"),
         subscripts: typing.Sequence[builtins.int] = [],
-        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        parameters: collections.abc.Mapping[str, str] = {},
         description: typing.Optional[builtins.str] = None,
+        atol: typing.Optional[builtins.float] = None,
     ) -> AttachedDecisionVariable:
         r"""
         Create and add an integer decision variable with an automatically assigned ID.
 
-        The bounds default to `(-inf, inf)` and are normalized inward to integer
-        values. Returns an {class}`~ommx.AttachedDecisionVariable` that can be
-        used directly in expressions.
+        The bounds default to `(-inf, inf)` and are normalized to integer
+        endpoints under `atol`: a finite lower endpoint is rounded up after
+        subtracting `atol`, and a finite upper endpoint is rounded down after
+        adding `atol`. Returns an {class}`~ommx.AttachedDecisionVariable` that
+        can be used directly in expressions.
 
         **Args:**
         - `name`: Optional human-readable modeling name. Names need not be unique.
@@ -3347,10 +3350,13 @@ class Instance:
         - `subscripts`: Optional integer indices from the source model.
         - `parameters`: Optional string-valued indices from the source model.
         - `description`: Optional human-readable description.
+        - `atol`: Absolute tolerance for integer-bound normalization. If
+          omitted, the current default returned by
+          {func}`~ommx.get_default_atol` is used.
 
-        Raises {class}`ValueError` if the bounds are invalid or contain no
-        integer value, or if no larger automatic ID can be assigned. On failure,
-        no variable or modeling label is added to the instance.
+        Raises {class}`ValueError` if the bounds are invalid or normalization
+        yields no integer value, or if no larger automatic ID can be assigned.
+        On failure, no variable or modeling label is added to the instance.
         """
     def new_continuous(
         self,
@@ -3359,7 +3365,7 @@ class Instance:
         lower: builtins.float = float("-inf"),
         upper: builtins.float = float("inf"),
         subscripts: typing.Sequence[builtins.int] = [],
-        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        parameters: collections.abc.Mapping[str, str] = {},
         description: typing.Optional[builtins.str] = None,
     ) -> AttachedDecisionVariable:
         r"""
@@ -3388,16 +3394,18 @@ class Instance:
         lower: builtins.float = float("-inf"),
         upper: builtins.float = float("inf"),
         subscripts: typing.Sequence[builtins.int] = [],
-        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        parameters: collections.abc.Mapping[str, str] = {},
         description: typing.Optional[builtins.str] = None,
+        atol: typing.Optional[builtins.float] = None,
     ) -> AttachedDecisionVariable:
         r"""
         Create and add a semi-integer decision variable with an automatically assigned ID.
 
         The bounds default to `(-inf, inf)`. Non-integral endpoints are
-        normalized inward. Unlike an integer variable, if the interval contains
-        no integer, its bound is normalized to `[0, 0]`, preserving the zero
-        alternative in the semi-integer domain. Returns an
+        normalized under `atol` using the same endpoint rule as
+        {meth}`~ommx.Instance.new_integer`. Unlike an integer variable, if the
+        normalized interval contains no integer, its bound becomes `[0, 0]`,
+        preserving the zero alternative in the semi-integer domain. Returns an
         {class}`~ommx.AttachedDecisionVariable` that can be used directly in
         expressions.
 
@@ -3408,6 +3416,9 @@ class Instance:
         - `subscripts`: Optional integer indices from the source model.
         - `parameters`: Optional string-valued indices from the source model.
         - `description`: Optional human-readable description.
+        - `atol`: Absolute tolerance for integer-bound normalization. If
+          omitted, the current default returned by
+          {func}`~ommx.get_default_atol` is used.
 
         Raises {class}`ValueError` if the bounds are invalid or if no larger
         automatic ID can be assigned. On failure, no variable or modeling label
@@ -3420,7 +3431,7 @@ class Instance:
         lower: builtins.float = float("-inf"),
         upper: builtins.float = float("inf"),
         subscripts: typing.Sequence[builtins.int] = [],
-        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        parameters: collections.abc.Mapping[str, str] = {},
         description: typing.Optional[builtins.str] = None,
     ) -> AttachedDecisionVariable:
         r"""

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -3272,16 +3272,16 @@ class Instance:
         r"""
         Create an empty minimization instance with a zero objective.
 
-        Decision variables and constraints can be added incrementally with
-        {meth}`new_binary` and {meth}`add_constraint`.
+        Decision variables and constraints can be added incrementally with the
+        `new_*` methods and {meth}`add_constraint`.
         """
     @staticmethod
     def maximize() -> Instance:
         r"""
         Create an empty maximization instance with a zero objective.
 
-        Decision variables and constraints can be added incrementally with
-        {meth}`new_binary` and {meth}`add_constraint`.
+        Decision variables and constraints can be added incrementally with the
+        `new_*` methods and {meth}`add_constraint`.
         """
     def add_decision_variable(
         self, variable: DecisionVariable
@@ -3321,6 +3321,121 @@ class Instance:
 
         Raises {class}`ValueError` if the maximum decision-variable ID is
         `2**64 - 1` and no larger automatic ID can be assigned.
+        """
+    def new_integer(
+        self,
+        name: typing.Optional[builtins.str] = None,
+        *,
+        lower: builtins.float = float("-inf"),
+        upper: builtins.float = float("inf"),
+        subscripts: typing.Sequence[builtins.int] = [],
+        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        description: typing.Optional[builtins.str] = None,
+    ) -> AttachedDecisionVariable:
+        r"""
+        Create and add an integer decision variable with an automatically assigned ID.
+
+        The bounds default to `(-inf, inf)` and are normalized inward to integer
+        values. Returns an {class}`~ommx.AttachedDecisionVariable` that can be
+        used directly in expressions.
+
+        **Args:**
+        - `name`: Optional human-readable modeling name. Names need not be unique.
+        - `lower`: Lower bound of the variable.
+        - `upper`: Upper bound of the variable.
+        - `subscripts`: Optional integer indices from the source model.
+        - `parameters`: Optional string-valued indices from the source model.
+        - `description`: Optional human-readable description.
+
+        Raises {class}`ValueError` if the bounds are invalid or contain no
+        integer value, or if no larger automatic ID can be assigned.
+        """
+    def new_continuous(
+        self,
+        name: typing.Optional[builtins.str] = None,
+        *,
+        lower: builtins.float = float("-inf"),
+        upper: builtins.float = float("inf"),
+        subscripts: typing.Sequence[builtins.int] = [],
+        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        description: typing.Optional[builtins.str] = None,
+    ) -> AttachedDecisionVariable:
+        r"""
+        Create and add a continuous decision variable with an automatically assigned ID.
+
+        The bounds default to `(-inf, inf)`. Returns an
+        {class}`~ommx.AttachedDecisionVariable` that can be used directly in
+        expressions.
+
+        **Args:**
+        - `name`: Optional human-readable modeling name. Names need not be unique.
+        - `lower`: Lower bound of the variable.
+        - `upper`: Upper bound of the variable.
+        - `subscripts`: Optional integer indices from the source model.
+        - `parameters`: Optional string-valued indices from the source model.
+        - `description`: Optional human-readable description.
+
+        Raises {class}`ValueError` if the bounds are invalid or if no larger
+        automatic ID can be assigned.
+        """
+    def new_semi_integer(
+        self,
+        name: typing.Optional[builtins.str] = None,
+        *,
+        lower: builtins.float = float("-inf"),
+        upper: builtins.float = float("inf"),
+        subscripts: typing.Sequence[builtins.int] = [],
+        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        description: typing.Optional[builtins.str] = None,
+    ) -> AttachedDecisionVariable:
+        r"""
+        Create and add a semi-integer decision variable with an automatically assigned ID.
+
+        The bounds default to `(-inf, inf)`. Non-integral endpoints are
+        normalized inward. Unlike an integer variable, if the interval contains
+        no integer, its bound is normalized to `[0, 0]`, preserving the zero
+        alternative in the semi-integer domain. Returns an
+        {class}`~ommx.AttachedDecisionVariable` that can be used directly in
+        expressions.
+
+        **Args:**
+        - `name`: Optional human-readable modeling name. Names need not be unique.
+        - `lower`: Lower bound of the variable.
+        - `upper`: Upper bound of the variable.
+        - `subscripts`: Optional integer indices from the source model.
+        - `parameters`: Optional string-valued indices from the source model.
+        - `description`: Optional human-readable description.
+
+        Raises {class}`ValueError` if the bounds are invalid or if no larger
+        automatic ID can be assigned.
+        """
+    def new_semi_continuous(
+        self,
+        name: typing.Optional[builtins.str] = None,
+        *,
+        lower: builtins.float = float("-inf"),
+        upper: builtins.float = float("inf"),
+        subscripts: typing.Sequence[builtins.int] = [],
+        parameters: typing.Mapping[builtins.str, builtins.str] = {},
+        description: typing.Optional[builtins.str] = None,
+    ) -> AttachedDecisionVariable:
+        r"""
+        Create and add a semi-continuous decision variable with an automatically assigned ID.
+
+        The bounds default to `(-inf, inf)`. Returns an
+        {class}`~ommx.AttachedDecisionVariable` that can be used directly in
+        expressions.
+
+        **Args:**
+        - `name`: Optional human-readable modeling name. Names need not be unique.
+        - `lower`: Lower bound of the variable.
+        - `upper`: Upper bound of the variable.
+        - `subscripts`: Optional integer indices from the source model.
+        - `parameters`: Optional string-valued indices from the source model.
+        - `description`: Optional human-readable description.
+
+        Raises {class}`ValueError` if the bounds are invalid or if no larger
+        automatic ID can be assigned.
         """
     def attached_decision_variable(
         self, variable_id: builtins.int

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -110,30 +110,25 @@ impl Instance {
         )
     }
 
-    fn add_new_decision_variable(
-        slf: Bound<'_, Self>,
-        variable: ommx::DecisionVariable,
+    fn decision_variable_label(
         name: Option<String>,
         subscripts: Vec<i64>,
         parameters: HashMap<String, String>,
         description: Option<String>,
-    ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
-        let label = ommx::DecisionVariableLabel {
+    ) -> ommx::DecisionVariableLabel {
+        ommx::DecisionVariableLabel {
             name,
             subscripts,
             parameters: parameters.into_iter().collect(),
             description,
-        };
-        let id = {
-            let mut inst = slf.borrow_mut();
-            let id = inst.inner.next_variable_id()?;
-            inst.inner.add_decision_variable(id, variable, label)?;
-            id
-        };
-        Ok(crate::AttachedDecisionVariable::from_instance(
-            slf.unbind(),
-            id,
-        ))
+        }
+    }
+
+    fn attach_decision_variable(
+        slf: Bound<'_, Self>,
+        id: ommx::VariableID,
+    ) -> crate::AttachedDecisionVariable {
+        crate::AttachedDecisionVariable::from_instance(slf.unbind(), id)
     }
 }
 
@@ -507,7 +502,8 @@ impl Instance {
     /// - `description`: Optional human-readable description.
     ///
     /// Raises {class}`ValueError` if the maximum decision-variable ID is
-    /// `2**64 - 1` and no larger automatic ID can be assigned.
+    /// `2**64 - 1` and no larger automatic ID can be assigned. On failure, no
+    /// variable or modeling label is added to the instance.
     #[pyo3(signature = (name=None, *, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
     pub fn new_binary(
         slf: Bound<'_, Self>,
@@ -516,14 +512,16 @@ impl Instance {
         parameters: HashMap<String, String>,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
-        Self::add_new_decision_variable(
-            slf,
-            ommx::DecisionVariable::binary(),
-            name,
-            subscripts,
-            parameters,
-            description,
-        )
+        let label = Self::decision_variable_label(name, subscripts, parameters, description);
+        let id = {
+            slf.borrow_mut().inner.new_binary(
+                ommx::Bound::of_binary(),
+                label,
+                None,
+                ommx::ATol::default(),
+            )?
+        };
+        Ok(Self::attach_decision_variable(slf, id))
     }
 
     /// Create and add an integer decision variable with an automatically assigned ID.
@@ -541,7 +539,8 @@ impl Instance {
     /// - `description`: Optional human-readable description.
     ///
     /// Raises {class}`ValueError` if the bounds are invalid or contain no
-    /// integer value, or if no larger automatic ID can be assigned.
+    /// integer value, or if no larger automatic ID can be assigned. On failure,
+    /// no variable or modeling label is added to the instance.
     #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
     pub fn new_integer(
         slf: Bound<'_, Self>,
@@ -552,12 +551,14 @@ impl Instance {
         parameters: HashMap<String, String>,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
-        let variable = ommx::DecisionVariable::new(
-            ommx::Kind::Integer,
-            ommx::Bound::new(lower, upper)?,
-            ommx::ATol::default(),
-        )?;
-        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
+        let bound = ommx::Bound::new(lower, upper)?;
+        let label = Self::decision_variable_label(name, subscripts, parameters, description);
+        let id = {
+            slf.borrow_mut()
+                .inner
+                .new_integer(bound, label, None, ommx::ATol::default())?
+        };
+        Ok(Self::attach_decision_variable(slf, id))
     }
 
     /// Create and add a continuous decision variable with an automatically assigned ID.
@@ -575,7 +576,8 @@ impl Instance {
     /// - `description`: Optional human-readable description.
     ///
     /// Raises {class}`ValueError` if the bounds are invalid or if no larger
-    /// automatic ID can be assigned.
+    /// automatic ID can be assigned. On failure, no variable or modeling label
+    /// is added to the instance.
     #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
     pub fn new_continuous(
         slf: Bound<'_, Self>,
@@ -586,12 +588,14 @@ impl Instance {
         parameters: HashMap<String, String>,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
-        let variable = ommx::DecisionVariable::new(
-            ommx::Kind::Continuous,
-            ommx::Bound::new(lower, upper)?,
-            ommx::ATol::default(),
-        )?;
-        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
+        let bound = ommx::Bound::new(lower, upper)?;
+        let label = Self::decision_variable_label(name, subscripts, parameters, description);
+        let id = {
+            slf.borrow_mut()
+                .inner
+                .new_continuous(bound, label, None, ommx::ATol::default())?
+        };
+        Ok(Self::attach_decision_variable(slf, id))
     }
 
     /// Create and add a semi-integer decision variable with an automatically assigned ID.
@@ -612,7 +616,8 @@ impl Instance {
     /// - `description`: Optional human-readable description.
     ///
     /// Raises {class}`ValueError` if the bounds are invalid or if no larger
-    /// automatic ID can be assigned.
+    /// automatic ID can be assigned. On failure, no variable or modeling label
+    /// is added to the instance.
     #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
     pub fn new_semi_integer(
         slf: Bound<'_, Self>,
@@ -623,12 +628,14 @@ impl Instance {
         parameters: HashMap<String, String>,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
-        let variable = ommx::DecisionVariable::new(
-            ommx::Kind::SemiInteger,
-            ommx::Bound::new(lower, upper)?,
-            ommx::ATol::default(),
-        )?;
-        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
+        let bound = ommx::Bound::new(lower, upper)?;
+        let label = Self::decision_variable_label(name, subscripts, parameters, description);
+        let id = {
+            slf.borrow_mut()
+                .inner
+                .new_semi_integer(bound, label, None, ommx::ATol::default())?
+        };
+        Ok(Self::attach_decision_variable(slf, id))
     }
 
     /// Create and add a semi-continuous decision variable with an automatically assigned ID.
@@ -646,7 +653,8 @@ impl Instance {
     /// - `description`: Optional human-readable description.
     ///
     /// Raises {class}`ValueError` if the bounds are invalid or if no larger
-    /// automatic ID can be assigned.
+    /// automatic ID can be assigned. On failure, no variable or modeling label
+    /// is added to the instance.
     #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
     pub fn new_semi_continuous(
         slf: Bound<'_, Self>,
@@ -657,12 +665,14 @@ impl Instance {
         parameters: HashMap<String, String>,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
-        let variable = ommx::DecisionVariable::new(
-            ommx::Kind::SemiContinuous,
-            ommx::Bound::new(lower, upper)?,
-            ommx::ATol::default(),
-        )?;
-        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
+        let bound = ommx::Bound::new(lower, upper)?;
+        let label = Self::decision_variable_label(name, subscripts, parameters, description);
+        let id = {
+            slf.borrow_mut()
+                .inner
+                .new_semi_continuous(bound, label, None, ommx::ATol::default())?
+        };
+        Ok(Self::attach_decision_variable(slf, id))
     }
 
     /// Return an {class}`~ommx.AttachedDecisionVariable` bound to the

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -14,12 +14,61 @@ use crate::{
 };
 use ommx::{ConstraintID, Evaluate, NamedFunctionID, VariableID};
 use pyo3::{
-    exceptions::{PyKeyError, PyValueError},
+    exceptions::{PyKeyError, PyTypeError, PyValueError},
     prelude::*,
     types::{PyBytes, PyDict},
     Bound, PyAny,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+#[derive(Default)]
+struct StringMapping(HashMap<String, String>);
+
+impl<'py> FromPyObject<'_, 'py> for StringMapping {
+    type Error = PyErr;
+
+    fn extract(value: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        let type_error = || PyTypeError::new_err("parameters must be a Mapping[str, str]");
+        let items = value.call_method0("items").map_err(|_| type_error())?;
+        let mut parameters = HashMap::new();
+        for item in items.try_iter().map_err(|_| type_error())? {
+            let (key, value) = item?
+                .extract::<(String, String)>()
+                .map_err(|_| type_error())?;
+            parameters.insert(key, value);
+        }
+        Ok(Self(parameters))
+    }
+}
+
+impl pyo3_stub_gen::PyStubType for StringMapping {
+    fn type_input() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: "collections.abc.Mapping[str, str]".to_string(),
+            source_module: None,
+            import: ["collections.abc".into()].into(),
+            type_refs: Default::default(),
+        }
+    }
+
+    fn type_output() -> pyo3_stub_gen::TypeInfo {
+        Self::type_input()
+    }
+}
+
+impl<'py> IntoPyObject<'py> for StringMapping {
+    type Target = PyDict;
+    type Output = Bound<'py, PyDict>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        let mapping = PyDict::new(py);
+        for (key, value) in self.0 {
+            mapping.set_item(key, value)?;
+        }
+        Ok(mapping)
+    }
+}
 
 /// Read-only objective semantics used when evaluating solver output.
 ///
@@ -113,14 +162,21 @@ impl Instance {
     fn decision_variable_label(
         name: Option<String>,
         subscripts: Vec<i64>,
-        parameters: HashMap<String, String>,
+        parameters: StringMapping,
         description: Option<String>,
     ) -> ommx::DecisionVariableLabel {
         ommx::DecisionVariableLabel {
             name,
             subscripts,
-            parameters: parameters.into_iter().collect(),
+            parameters: parameters.0.into_iter().collect(),
             description,
+        }
+    }
+
+    fn atol_or_default(value: Option<f64>) -> OmmxPyResult<ommx::ATol> {
+        match value {
+            Some(value) => Ok(ommx::ATol::new(value)?),
+            None => Ok(ommx::ATol::default()),
         }
     }
 
@@ -504,12 +560,12 @@ impl Instance {
     /// Raises {class}`ValueError` if the maximum decision-variable ID is
     /// `2**64 - 1` and no larger automatic ID can be assigned. On failure, no
     /// variable or modeling label is added to the instance.
-    #[pyo3(signature = (name=None, *, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
-    pub fn new_binary(
+    #[pyo3(signature = (name=None, *, subscripts=Vec::new(), parameters=StringMapping::default(), description=None))]
+    fn new_binary(
         slf: Bound<'_, Self>,
         name: Option<String>,
         subscripts: Vec<i64>,
-        parameters: HashMap<String, String>,
+        parameters: StringMapping,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
         let label = Self::decision_variable_label(name, subscripts, parameters, description);
@@ -526,9 +582,11 @@ impl Instance {
 
     /// Create and add an integer decision variable with an automatically assigned ID.
     ///
-    /// The bounds default to `(-inf, inf)` and are normalized inward to integer
-    /// values. Returns an {class}`~ommx.AttachedDecisionVariable` that can be
-    /// used directly in expressions.
+    /// The bounds default to `(-inf, inf)` and are normalized to integer
+    /// endpoints under `atol`: a finite lower endpoint is rounded up after
+    /// subtracting `atol`, and a finite upper endpoint is rounded down after
+    /// adding `atol`. Returns an {class}`~ommx.AttachedDecisionVariable` that
+    /// can be used directly in expressions.
     ///
     /// **Args:**
     /// - `name`: Optional human-readable modeling name. Names need not be unique.
@@ -537,26 +595,31 @@ impl Instance {
     /// - `subscripts`: Optional integer indices from the source model.
     /// - `parameters`: Optional string-valued indices from the source model.
     /// - `description`: Optional human-readable description.
+    /// - `atol`: Absolute tolerance for integer-bound normalization. If
+    ///   omitted, the current default returned by
+    ///   {func}`~ommx.get_default_atol` is used.
     ///
-    /// Raises {class}`ValueError` if the bounds are invalid or contain no
-    /// integer value, or if no larger automatic ID can be assigned. On failure,
-    /// no variable or modeling label is added to the instance.
-    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
-    pub fn new_integer(
+    /// Raises {class}`ValueError` if the bounds are invalid or normalization
+    /// yields no integer value, or if no larger automatic ID can be assigned.
+    /// On failure, no variable or modeling label is added to the instance.
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=StringMapping::default(), description=None, atol=None))]
+    fn new_integer(
         slf: Bound<'_, Self>,
         name: Option<String>,
         lower: f64,
         upper: f64,
         subscripts: Vec<i64>,
-        parameters: HashMap<String, String>,
+        parameters: StringMapping,
         description: Option<String>,
+        atol: Option<f64>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
         let bound = ommx::Bound::new(lower, upper)?;
         let label = Self::decision_variable_label(name, subscripts, parameters, description);
+        let atol = Self::atol_or_default(atol)?;
         let id = {
             slf.borrow_mut()
                 .inner
-                .new_integer(bound, label, None, ommx::ATol::default())?
+                .new_integer(bound, label, None, atol)?
         };
         Ok(Self::attach_decision_variable(slf, id))
     }
@@ -578,14 +641,14 @@ impl Instance {
     /// Raises {class}`ValueError` if the bounds are invalid or if no larger
     /// automatic ID can be assigned. On failure, no variable or modeling label
     /// is added to the instance.
-    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
-    pub fn new_continuous(
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=StringMapping::default(), description=None))]
+    fn new_continuous(
         slf: Bound<'_, Self>,
         name: Option<String>,
         lower: f64,
         upper: f64,
         subscripts: Vec<i64>,
-        parameters: HashMap<String, String>,
+        parameters: StringMapping,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
         let bound = ommx::Bound::new(lower, upper)?;
@@ -601,9 +664,10 @@ impl Instance {
     /// Create and add a semi-integer decision variable with an automatically assigned ID.
     ///
     /// The bounds default to `(-inf, inf)`. Non-integral endpoints are
-    /// normalized inward. Unlike an integer variable, if the interval contains
-    /// no integer, its bound is normalized to `[0, 0]`, preserving the zero
-    /// alternative in the semi-integer domain. Returns an
+    /// normalized under `atol` using the same endpoint rule as
+    /// {meth}`~ommx.Instance.new_integer`. Unlike an integer variable, if the
+    /// normalized interval contains no integer, its bound becomes `[0, 0]`,
+    /// preserving the zero alternative in the semi-integer domain. Returns an
     /// {class}`~ommx.AttachedDecisionVariable` that can be used directly in
     /// expressions.
     ///
@@ -614,26 +678,31 @@ impl Instance {
     /// - `subscripts`: Optional integer indices from the source model.
     /// - `parameters`: Optional string-valued indices from the source model.
     /// - `description`: Optional human-readable description.
+    /// - `atol`: Absolute tolerance for integer-bound normalization. If
+    ///   omitted, the current default returned by
+    ///   {func}`~ommx.get_default_atol` is used.
     ///
     /// Raises {class}`ValueError` if the bounds are invalid or if no larger
     /// automatic ID can be assigned. On failure, no variable or modeling label
     /// is added to the instance.
-    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
-    pub fn new_semi_integer(
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=StringMapping::default(), description=None, atol=None))]
+    fn new_semi_integer(
         slf: Bound<'_, Self>,
         name: Option<String>,
         lower: f64,
         upper: f64,
         subscripts: Vec<i64>,
-        parameters: HashMap<String, String>,
+        parameters: StringMapping,
         description: Option<String>,
+        atol: Option<f64>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
         let bound = ommx::Bound::new(lower, upper)?;
         let label = Self::decision_variable_label(name, subscripts, parameters, description);
+        let atol = Self::atol_or_default(atol)?;
         let id = {
             slf.borrow_mut()
                 .inner
-                .new_semi_integer(bound, label, None, ommx::ATol::default())?
+                .new_semi_integer(bound, label, None, atol)?
         };
         Ok(Self::attach_decision_variable(slf, id))
     }
@@ -655,14 +724,14 @@ impl Instance {
     /// Raises {class}`ValueError` if the bounds are invalid or if no larger
     /// automatic ID can be assigned. On failure, no variable or modeling label
     /// is added to the instance.
-    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
-    pub fn new_semi_continuous(
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=StringMapping::default(), description=None))]
+    fn new_semi_continuous(
         slf: Bound<'_, Self>,
         name: Option<String>,
         lower: f64,
         upper: f64,
         subscripts: Vec<i64>,
-        parameters: HashMap<String, String>,
+        parameters: StringMapping,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
         let bound = ommx::Bound::new(lower, upper)?;

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -109,6 +109,32 @@ impl Instance {
             None,
         )
     }
+
+    fn add_new_decision_variable(
+        slf: Bound<'_, Self>,
+        variable: ommx::DecisionVariable,
+        name: Option<String>,
+        subscripts: Vec<i64>,
+        parameters: HashMap<String, String>,
+        description: Option<String>,
+    ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
+        let label = ommx::DecisionVariableLabel {
+            name,
+            subscripts,
+            parameters: parameters.into_iter().collect(),
+            description,
+        };
+        let id = {
+            let mut inst = slf.borrow_mut();
+            let id = inst.inner.next_variable_id()?;
+            inst.inner.add_decision_variable(id, variable, label)?;
+            id
+        };
+        Ok(crate::AttachedDecisionVariable::from_instance(
+            slf.unbind(),
+            id,
+        ))
+    }
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
@@ -294,8 +320,8 @@ impl Instance {
 
     /// Create an empty minimization instance with a zero objective.
     ///
-    /// Decision variables and constraints can be added incrementally with
-    /// {meth}`new_binary` and {meth}`add_constraint`.
+    /// Decision variables and constraints can be added incrementally with the
+    /// `new_*` methods and {meth}`add_constraint`.
     #[staticmethod]
     pub fn minimize() -> OmmxPyResult<Self> {
         Self::empty_with_sense(Sense::Minimize)
@@ -303,8 +329,8 @@ impl Instance {
 
     /// Create an empty maximization instance with a zero objective.
     ///
-    /// Decision variables and constraints can be added incrementally with
-    /// {meth}`new_binary` and {meth}`add_constraint`.
+    /// Decision variables and constraints can be added incrementally with the
+    /// `new_*` methods and {meth}`add_constraint`.
     #[staticmethod]
     pub fn maximize() -> OmmxPyResult<Self> {
         Self::empty_with_sense(Sense::Maximize)
@@ -490,23 +516,153 @@ impl Instance {
         parameters: HashMap<String, String>,
         description: Option<String>,
     ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
-        let label = ommx::DecisionVariableLabel {
+        Self::add_new_decision_variable(
+            slf,
+            ommx::DecisionVariable::binary(),
             name,
             subscripts,
-            parameters: parameters.into_iter().collect(),
+            parameters,
             description,
-        };
-        let id = {
-            let mut inst = slf.borrow_mut();
-            let id = inst.inner.next_variable_id()?;
-            inst.inner
-                .add_decision_variable(id, ommx::DecisionVariable::binary(), label)?;
-            id
-        };
-        Ok(crate::AttachedDecisionVariable::from_instance(
-            slf.unbind(),
-            id,
-        ))
+        )
+    }
+
+    /// Create and add an integer decision variable with an automatically assigned ID.
+    ///
+    /// The bounds default to `(-inf, inf)` and are normalized inward to integer
+    /// values. Returns an {class}`~ommx.AttachedDecisionVariable` that can be
+    /// used directly in expressions.
+    ///
+    /// **Args:**
+    /// - `name`: Optional human-readable modeling name. Names need not be unique.
+    /// - `lower`: Lower bound of the variable.
+    /// - `upper`: Upper bound of the variable.
+    /// - `subscripts`: Optional integer indices from the source model.
+    /// - `parameters`: Optional string-valued indices from the source model.
+    /// - `description`: Optional human-readable description.
+    ///
+    /// Raises {class}`ValueError` if the bounds are invalid or contain no
+    /// integer value, or if no larger automatic ID can be assigned.
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
+    pub fn new_integer(
+        slf: Bound<'_, Self>,
+        name: Option<String>,
+        lower: f64,
+        upper: f64,
+        subscripts: Vec<i64>,
+        parameters: HashMap<String, String>,
+        description: Option<String>,
+    ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
+        let variable = ommx::DecisionVariable::new(
+            ommx::Kind::Integer,
+            ommx::Bound::new(lower, upper)?,
+            ommx::ATol::default(),
+        )?;
+        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
+    }
+
+    /// Create and add a continuous decision variable with an automatically assigned ID.
+    ///
+    /// The bounds default to `(-inf, inf)`. Returns an
+    /// {class}`~ommx.AttachedDecisionVariable` that can be used directly in
+    /// expressions.
+    ///
+    /// **Args:**
+    /// - `name`: Optional human-readable modeling name. Names need not be unique.
+    /// - `lower`: Lower bound of the variable.
+    /// - `upper`: Upper bound of the variable.
+    /// - `subscripts`: Optional integer indices from the source model.
+    /// - `parameters`: Optional string-valued indices from the source model.
+    /// - `description`: Optional human-readable description.
+    ///
+    /// Raises {class}`ValueError` if the bounds are invalid or if no larger
+    /// automatic ID can be assigned.
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
+    pub fn new_continuous(
+        slf: Bound<'_, Self>,
+        name: Option<String>,
+        lower: f64,
+        upper: f64,
+        subscripts: Vec<i64>,
+        parameters: HashMap<String, String>,
+        description: Option<String>,
+    ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
+        let variable = ommx::DecisionVariable::new(
+            ommx::Kind::Continuous,
+            ommx::Bound::new(lower, upper)?,
+            ommx::ATol::default(),
+        )?;
+        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
+    }
+
+    /// Create and add a semi-integer decision variable with an automatically assigned ID.
+    ///
+    /// The bounds default to `(-inf, inf)`. Non-integral endpoints are
+    /// normalized inward. Unlike an integer variable, if the interval contains
+    /// no integer, its bound is normalized to `[0, 0]`, preserving the zero
+    /// alternative in the semi-integer domain. Returns an
+    /// {class}`~ommx.AttachedDecisionVariable` that can be used directly in
+    /// expressions.
+    ///
+    /// **Args:**
+    /// - `name`: Optional human-readable modeling name. Names need not be unique.
+    /// - `lower`: Lower bound of the variable.
+    /// - `upper`: Upper bound of the variable.
+    /// - `subscripts`: Optional integer indices from the source model.
+    /// - `parameters`: Optional string-valued indices from the source model.
+    /// - `description`: Optional human-readable description.
+    ///
+    /// Raises {class}`ValueError` if the bounds are invalid or if no larger
+    /// automatic ID can be assigned.
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
+    pub fn new_semi_integer(
+        slf: Bound<'_, Self>,
+        name: Option<String>,
+        lower: f64,
+        upper: f64,
+        subscripts: Vec<i64>,
+        parameters: HashMap<String, String>,
+        description: Option<String>,
+    ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
+        let variable = ommx::DecisionVariable::new(
+            ommx::Kind::SemiInteger,
+            ommx::Bound::new(lower, upper)?,
+            ommx::ATol::default(),
+        )?;
+        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
+    }
+
+    /// Create and add a semi-continuous decision variable with an automatically assigned ID.
+    ///
+    /// The bounds default to `(-inf, inf)`. Returns an
+    /// {class}`~ommx.AttachedDecisionVariable` that can be used directly in
+    /// expressions.
+    ///
+    /// **Args:**
+    /// - `name`: Optional human-readable modeling name. Names need not be unique.
+    /// - `lower`: Lower bound of the variable.
+    /// - `upper`: Upper bound of the variable.
+    /// - `subscripts`: Optional integer indices from the source model.
+    /// - `parameters`: Optional string-valued indices from the source model.
+    /// - `description`: Optional human-readable description.
+    ///
+    /// Raises {class}`ValueError` if the bounds are invalid or if no larger
+    /// automatic ID can be assigned.
+    #[pyo3(signature = (name=None, *, lower=f64::NEG_INFINITY, upper=f64::INFINITY, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
+    pub fn new_semi_continuous(
+        slf: Bound<'_, Self>,
+        name: Option<String>,
+        lower: f64,
+        upper: f64,
+        subscripts: Vec<i64>,
+        parameters: HashMap<String, String>,
+        description: Option<String>,
+    ) -> OmmxPyResult<crate::AttachedDecisionVariable> {
+        let variable = ommx::DecisionVariable::new(
+            ommx::Kind::SemiContinuous,
+            ommx::Bound::new(lower, upper)?,
+            ommx::ATol::default(),
+        )?;
+        Self::add_new_decision_variable(slf, variable, name, subscripts, parameters, description)
     }
 
     /// Return an {class}`~ommx.AttachedDecisionVariable` bound to the

--- a/rust/ommx/doc/migration_guide.md
+++ b/rust/ommx/doc/migration_guide.md
@@ -655,6 +655,38 @@ let evaluated = EvaluatedDecisionVariable::new(id, y, value)?;
 let sampled = SampledDecisionVariable::new(id, y, samples)?;
 ```
 
+Incremental construction on [`Instance`](crate::Instance) now follows the
+same owner boundary. The v2 `new_*` methods inserted a default row first and
+returned `&mut DecisionVariable`, which encouraged a second fallible bound
+mutation:
+
+```rust,ignore
+// ❌ Before: the unbounded row remains inserted if set_bound fails.
+instance
+    .new_integer()
+    .set_bound(bound, atol)?;
+
+// ✅ After: normalize and validate every table-owned field before insertion.
+let id = instance.new_integer(
+    bound,
+    DecisionVariableLabel {
+        name: Some("x".to_string()),
+        ..Default::default()
+    },
+    fixed_value,
+    atol,
+)?;
+```
+
+All typed constructors (`new_binary`, `new_integer`, `new_continuous`,
+`new_semi_integer`, and `new_semi_continuous`) accept the complete `Bound`,
+`DecisionVariableLabel`, optional fixed value, and `ATol`, and return
+`Result<VariableID, DecisionVariableError>`. The generic
+`new_decision_variable` additionally accepts `Kind`. They normalize the row,
+allocate the ID, validate the fixed value, and commit the row plus label and
+fixed-value sidecar as one operation. An error leaves the `Instance`
+unchanged.
+
 When constructing a created-stage table directly, use
 `DecisionVariableTable::with_fixed_values(entries, labels, fixed_values, atol)`.
 If no variables are fixed, pass an empty `fixed_values` map; this is the same
@@ -905,6 +937,10 @@ let air05_annotations = annotations.get("air05");
 - [ ] Replace `Result<T, UnknownSampleIDError>` key-lookup methods with `Option<T>` on the call site
 - [ ] Replace `DecisionVariable::new(id, kind, bound, ..., atol)` with `DecisionVariable::new(kind, bound, atol)`, and insert it under the desired `VariableID` key in the host table
 - [ ] Replace `DecisionVariable::binary(id)` / `integer(id)` / `continuous(id)` / `semi_integer(id)` / `semi_continuous(id)` / etc. with the no-argument row factories, and keep the ID on the enclosing map key
+- [ ] Replace chained `Instance::new_*().set_bound(...)` construction with one
+      fallible `Instance::new_*(bound, label, fixed_value, atol)?` call; update
+      generic `new_decision_variable` calls to pass the label before the fixed
+      value
 - [ ] Replace `DecisionVariable::substituted_value()` and `DecisionVariable::substitute(...)` with host-owned fixed values: `InstanceBuilder::fixed_decision_variable_values(...)`, `Instance::fixed_decision_variable_value(id)`, or `Instance::fixed_decision_variable_values()`
 - [ ] Replace `analyze_decision_variables()` role queries with `Instance::decision_variable_roles()`, `Instance::decision_variable_role(id)`, `Instance::fixed_decision_variables()`, `Instance::dependent_decision_variable_ids()`, or `Instance::irrelevant_decision_variable_ids()`; keep `Instance::decision_variable_usage()` only when you need reverse expression usage
 - [ ] Update `EvaluatedDecisionVariable::new(...)` and `SampledDecisionVariable::new(...)`: drop the `atol` argument, pass the `VariableID` separately for diagnostics, and keep using the enclosing `Solution` / `SampleSet` map key as the source of truth

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -384,6 +384,21 @@ For direct created-stage table construction, use
 An empty `fixed_values` map represents the same table schema with no fixed
 rows; there is no separate empty-sidecar constructor.
 
+Incremental creation now routes through the same owner. The generic
+[`Instance::new_decision_variable`](crate::Instance::new_decision_variable)
+and the typed `new_binary`, `new_integer`, `new_continuous`,
+`new_semi_integer`, and `new_semi_continuous` methods receive the complete
+bound, modeling label, optional fixed value, and tolerance before inserting
+anything. They return `Result<VariableID, DecisionVariableError>` and commit
+the normalized row, label, and fixed-value sidecar together. This replaces the
+v2 pattern of inserting a default row and then performing a separately
+fallible bound mutation; any construction failure now leaves the `Instance`
+unchanged.
+
+SOS1 Big-M conversion also checks the total fresh-indicator ID capacity before
+applying either a single conversion or a bulk conversion, so ID exhaustion
+cannot leave a partially converted instance.
+
 The deprecated `Solution::new` constructor was removed. It was a safe API that
 skipped host-level validation by wrapping `SolutionBuilder::build_unchecked`.
 Use `Solution::builder().build()` for validated construction, or call the
@@ -397,7 +412,8 @@ Related PRs: [#959](https://github.com/Jij-Inc/ommx/pull/959),
 [#960](https://github.com/Jij-Inc/ommx/pull/960),
 [#969](https://github.com/Jij-Inc/ommx/pull/969),
 [#971](https://github.com/Jij-Inc/ommx/pull/971),
-[#976](https://github.com/Jij-Inc/ommx/pull/976).
+[#976](https://github.com/Jij-Inc/ommx/pull/976),
+[#1185](https://github.com/Jij-Inc/ommx/pull/1185).
 
 ## ⚙️ Instance-owned decision-variable state
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -395,9 +395,19 @@ v2 pattern of inserting a default row and then performing a separately
 fallible bound mutation; any construction failure now leaves the `Instance`
 unchanged.
 
-SOS1 Big-M conversion also checks the total fresh-indicator ID capacity before
-applying either a single conversion or a bulk conversion, so ID exhaustion
-cannot leave a partially converted instance.
+For `Integer` and `SemiInteger`, finite endpoints are normalized to
+`ceil(lower - atol)` and `floor(upper + atol)`. If the normalized interval
+contains no integer, `new_integer` returns an error, while `new_semi_integer`
+uses `[0, 0]` to preserve the semi-integer zero alternative. When the maximum
+existing decision-variable ID is `u64::MAX`, no larger automatic ID can be
+assigned and the constructors return
+[`DecisionVariableError::NoAvailableID`](crate::DecisionVariableError::NoAvailableID)
+without changing the instance.
+
+SOS1 Big-M conversion also checks the total fresh-indicator and generated
+regular-constraint ID capacities before applying either a single conversion or
+a bulk conversion. If not enough larger IDs can be allocated above the current
+maxima, the conversion fails before changing the instance.
 
 The deprecated `Solution::new` constructor was removed. It was a safe API that
 skipped host-level validation by wrapping `SolutionBuilder::build_unchecked`.

--- a/rust/ommx/doc/tutorial/instance.md
+++ b/rust/ommx/doc/tutorial/instance.md
@@ -79,10 +79,15 @@ assert_eq!(instance.fixed_decision_variable_value(id), Some(2.0));
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-The bound is normalized for the selected kind, and the row, label, and fixed
-value are committed together under the returned ID. Invalid bounds,
-inconsistent fixed values, and exhausted IDs return
-[`DecisionVariableError`](crate::DecisionVariableError) without leaving a
-partially created variable in the instance. Use
+For `Integer` and `SemiInteger`, finite endpoints are normalized to
+`ceil(lower - atol)` and `floor(upper + atol)`. If that normalized interval
+contains no integer, `new_integer` returns an error, while `new_semi_integer`
+uses `[0, 0]` to preserve the semi-integer zero alternative.
+
+The normalized row, label, and fixed value are committed together under the
+returned ID. Invalid bounds, inconsistent fixed values, and a maximum existing
+decision-variable ID of `u64::MAX` that prevents assignment of a larger
+automatic ID return [`DecisionVariableError`](crate::DecisionVariableError)
+without leaving a partially created variable in the instance. Use
 [`Instance::new_decision_variable`](crate::Instance::new_decision_variable)
 when the kind is selected dynamically.

--- a/rust/ommx/doc/tutorial/instance.md
+++ b/rust/ommx/doc/tutorial/instance.md
@@ -47,3 +47,42 @@ assert_eq!(instance.constraints().len(), 2);
 The `new` method validates that all variable IDs used in the objective function and
 constraints are defined in the decision variables map, returning an error if any
 undefined variables are referenced.
+
+## Incremental decision-variable construction
+
+When the instance should allocate variable IDs, use its typed `new_*` methods.
+Each method receives the complete bound, modeling label, optional fixed value,
+and tolerance before changing the instance:
+
+```rust
+use ommx::{ATol, Bound, DecisionVariableLabel, Instance, Kind, VariableID};
+
+let mut instance = Instance::default();
+let id = instance.new_integer(
+    Bound::new(0.2, 3.8)?,
+    DecisionVariableLabel {
+        name: Some("count".to_string()),
+        ..Default::default()
+    },
+    Some(2.0),
+    ATol::default(),
+)?;
+
+assert_eq!(id, VariableID::from(0));
+assert_eq!(instance.decision_variables()[&id].kind(), Kind::Integer);
+assert_eq!(
+    instance.decision_variables()[&id].bound(),
+    Bound::new(1.0, 3.0)?,
+);
+assert_eq!(instance.variable_labels().name(id), Some("count"));
+assert_eq!(instance.fixed_decision_variable_value(id), Some(2.0));
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The bound is normalized for the selected kind, and the row, label, and fixed
+value are committed together under the returned ID. Invalid bounds,
+inconsistent fixed values, and exhausted IDs return
+[`DecisionVariableError`](crate::DecisionVariableError) without leaving a
+partially created variable in the instance. Use
+[`Instance::new_decision_variable`](crate::Instance::new_decision_variable)
+when the kind is selected dynamically.

--- a/rust/ommx/examples/create_qubo_manually.rs
+++ b/rust/ommx/examples/create_qubo_manually.rs
@@ -6,10 +6,12 @@
 //! Note: OMMX also provides functionality to convert general instances to QUBO format.
 //! This example shows the manual construction approach.
 //!
-//! In v3, per-variable modeling labels (name, subscripts, ...) live in
-//! the [`VariableLabelStore`] sibling field of [`Instance`] rather
-//! than on each [`DecisionVariable`]. Set it via
-//! [`Instance::set_variable_label`] after construction.
+//! In v3, per-variable modeling labels (name, subscripts, ...) live in the
+//! decision-variable table owned by [`Instance`] rather than on each
+//! [`DecisionVariable`] row. This example assembles an explicit-ID row map, so
+//! it sets the labels after constructing the root. For incremental construction
+//! with automatic IDs, `Instance::new_binary` inserts the row and label
+//! atomically.
 
 use anyhow::Result;
 use ommx::{

--- a/rust/ommx/src/constraint_type.rs
+++ b/rust/ommx/src/constraint_type.rs
@@ -683,25 +683,54 @@ impl<T: ConstraintType> ConstraintCollection<T> {
         Ok(())
     }
 
+    fn maximum_owned_id(&self) -> Option<u64> {
+        let max_active = self.active.keys().last().copied().map(Into::into);
+        let max_removed = self.removed.keys().last().copied().map(Into::into);
+        match (max_active, max_removed) {
+            (None, None) => None,
+            (Some(id), None) | (None, Some(id)) => Some(id),
+            (Some(active), Some(removed)) => Some(active.max(removed)),
+        }
+    }
+
+    /// Verify that `count` consecutive fresh IDs can be allocated.
+    ///
+    /// Crate-internal root transformations use this during their read-only
+    /// planning phase so later calls to [`Self::unused_id`] cannot panic after
+    /// the root has already been partially mutated.
+    pub(crate) fn ensure_unused_id_capacity(&self, count: usize) -> crate::Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+        let count = u64::try_from(count)
+            .map_err(|_| crate::error!("Constraint ID allocation count exceeds u64"))?;
+        if let Some(maximum_id) = self.maximum_owned_id() {
+            maximum_id.checked_add(count).ok_or_else(|| {
+                crate::error!(
+                    { maximum_id, count },
+                    "Cannot allocate {count} consecutive constraint IDs after maximum ID {maximum_id}",
+                )
+            })?;
+        }
+        Ok(())
+    }
+
     /// Return an ID that is not used by any active or removed constraint in this collection.
     ///
     /// Returns `0` when the collection is empty, otherwise `max(existing id) + 1`.
     ///
     /// # Panics
     ///
-    /// Panics if the maximum existing ID is `u64::MAX`, i.e. all IDs are exhausted.
+    /// Panics if the maximum existing ID is `u64::MAX`, so no larger automatic
+    /// ID can be assigned. Gaps below the maximum are not reused.
     pub fn unused_id(&self) -> T::ID {
-        let max_active = self.active.keys().last().copied().map(Into::into);
-        let max_removed = self.removed.keys().last().copied().map(Into::into);
-        let next = match (max_active, max_removed) {
-            (None, None) => 0u64,
-            (Some(a), None) => a.checked_add(1).expect("constraint ID space exhausted"),
-            (None, Some(r)) => r.checked_add(1).expect("constraint ID space exhausted"),
-            (Some(a), Some(r)) => a
-                .max(r)
-                .checked_add(1)
-                .expect("constraint ID space exhausted"),
-        };
+        let next = self
+            .maximum_owned_id()
+            .map(|id| {
+                id.checked_add(1)
+                    .expect("no constraint ID larger than the current maximum remains")
+            })
+            .unwrap_or(0);
         T::ID::from(next)
     }
 
@@ -1672,6 +1701,25 @@ mod tests {
         let collection = ConstraintCollection::<Constraint>::new(active, BTreeMap::new()).unwrap();
         assert_eq!(collection.active().len(), 1);
         assert_eq!(collection.removed().len(), 0);
+    }
+
+    #[test]
+    fn collection_preflights_fresh_id_capacity_across_active_and_removed_rows() {
+        let active = BTreeMap::from([(
+            ConstraintID::from(1),
+            Constraint::equal_to_zero(Function::Zero),
+        )]);
+        let removed = BTreeMap::from([(
+            ConstraintID::from(u64::MAX - 2),
+            (Constraint::equal_to_zero(Function::Zero), removed_reason()),
+        )]);
+        let collection = ConstraintCollection::<Constraint>::new(active, removed).unwrap();
+
+        collection.ensure_unused_id_capacity(2).unwrap();
+        let err = collection.ensure_unused_id_capacity(3).unwrap_err();
+
+        assert!(err.to_string().contains("Cannot allocate"));
+        assert_eq!(collection.unused_id(), ConstraintID::from(u64::MAX - 1));
     }
 
     #[test]

--- a/rust/ommx/src/decision_variable.rs
+++ b/rust/ommx/src/decision_variable.rs
@@ -372,7 +372,9 @@ pub enum DecisionVariableError {
     #[error("Duplicate decision variable ID={id}")]
     DuplicateID { id: VariableID },
 
-    #[error("No available decision variable ID remains")]
+    #[error(
+        "Insufficient capacity for automatically assigned decision variable IDs above the current maximum"
+    )]
     NoAvailableID,
 
     #[error("Decision variable value for ID={id} must be finite: value={value}")]

--- a/rust/ommx/src/decision_variable/table.rs
+++ b/rust/ommx/src/decision_variable/table.rs
@@ -378,6 +378,16 @@ impl DecisionVariableTable<Created> {
     }
 
     /// Insert one fresh row, its label, and optionally its fixed value.
+    ///
+    /// The row, label, and fixed-value column are committed together. If this
+    /// method returns an error, the table is unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecisionVariableError::DuplicateID`] when `id` already exists,
+    /// [`DecisionVariableError::NonFiniteValue`] when `fixed_value` is not
+    /// finite, or [`DecisionVariableError::SubstitutedValueInconsistent`] when
+    /// it does not belong to the row's domain.
     pub fn insert(
         &mut self,
         id: VariableID,
@@ -391,9 +401,12 @@ impl DecisionVariableTable<Created> {
         }
         if let Some(value) = fixed_value {
             row.check_value_consistency(id, value, atol)?;
+        }
+        self.insert_labeled_row(id, row, label)?;
+        if let Some(value) = fixed_value {
             self.columns.fixed_values.insert(id, value);
         }
-        self.insert_labeled_row(id, row, label)
+        Ok(())
     }
 
     /// Impose an additional bound on one row while preserving table invariants.
@@ -960,6 +973,56 @@ mod tests {
         assert_eq!(table.get(&id), Some(&original));
         assert_eq!(table.labels().name(id), None);
         assert_eq!(table.fixed_value(id), Some(1.0));
+    }
+
+    #[test]
+    fn definition_table_insert_commits_row_label_and_fixed_value_together() {
+        let id = VariableID::from(1);
+        let row = DecisionVariable::integer();
+        let label = DecisionVariableLabel {
+            name: Some("x".to_string()),
+            subscripts: vec![2, 3],
+            ..Default::default()
+        };
+        let mut table = DecisionVariableTable::<crate::Created>::default();
+
+        table
+            .insert(id, row.clone(), label.clone(), Some(1.0), ATol::default())
+            .unwrap();
+
+        assert_eq!(table.get(&id), Some(&row));
+        assert_eq!(table.labels().collect_for(id), label);
+        assert_eq!(table.fixed_value(id), Some(1.0));
+    }
+
+    #[test]
+    fn definition_table_insert_rejects_inconsistent_fixed_value_atomically() {
+        let id = VariableID::from(1);
+        let mut table = DecisionVariableTable::<crate::Created>::default();
+        let before = table.clone();
+
+        let err = table
+            .insert(
+                id,
+                DecisionVariable::integer(),
+                DecisionVariableLabel {
+                    name: Some("invalid".to_string()),
+                    ..Default::default()
+                },
+                Some(0.5),
+                ATol::default(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DecisionVariableError::SubstitutedValueInconsistent {
+                id: error_id,
+                substituted_value: 0.5,
+                ..
+            } if error_id == id
+        ));
+        assert_eq!(table, before);
     }
 
     #[test]

--- a/rust/ommx/src/instance/decision_variable.rs
+++ b/rust/ommx/src/instance/decision_variable.rs
@@ -87,23 +87,27 @@ impl Instance {
         Ok(())
     }
 
+    /// Create and atomically add a fully configured decision variable.
+    ///
+    /// The variable's `kind` and `bound` are normalized into a
+    /// [`DecisionVariable`] row, while `label` and `fixed_value` are stored in
+    /// the same [`crate::DecisionVariableTable`] entry under a newly allocated
+    /// [`VariableID`]. `fixed_value`, when present, must satisfy the normalized
+    /// kind and bound under `atol`.
+    ///
+    /// All validation completes before the instance is mutated. If this method
+    /// returns an error, the decision-variable row, label store, fixed-value
+    /// column, and next available ID are unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecisionVariableError::BoundInconsistentToKind`] when `bound`
+    /// contains no value allowed by `kind`,
+    /// [`DecisionVariableError::NoAvailableID`] when the ID space is exhausted,
+    /// [`DecisionVariableError::NonFiniteValue`] when `fixed_value` is not
+    /// finite, or [`DecisionVariableError::SubstitutedValueInconsistent`] when
+    /// it does not belong to the normalized variable domain.
     pub fn new_decision_variable(
-        &mut self,
-        kind: Kind,
-        bound: Bound,
-        fixed_value: Option<f64>,
-        atol: ATol,
-    ) -> Result<VariableID, DecisionVariableError> {
-        self.new_decision_variable_with_label(
-            kind,
-            bound,
-            DecisionVariableLabel::default(),
-            fixed_value,
-            atol,
-        )
-    }
-
-    pub(super) fn new_decision_variable_with_label(
         &mut self,
         kind: Kind,
         bound: Bound,
@@ -111,41 +115,80 @@ impl Instance {
         fixed_value: Option<f64>,
         atol: ATol,
     ) -> Result<VariableID, DecisionVariableError> {
-        let id = self.next_variable_id()?;
         let dv = DecisionVariable::new(kind, bound, atol)?;
+        let id = self.next_variable_id()?;
         self.decision_variables
             .insert(id, dv, label, fixed_value, atol)?;
         Ok(id)
     }
 
-    pub fn new_binary(&mut self) -> VariableID {
-        self.new_decision_variable(Kind::Binary, Bound::of_binary(), None, ATol::default())
-            .unwrap()
+    /// Create and atomically add a binary decision variable.
+    ///
+    /// `bound` is normalized to the allowed binary values. See
+    /// [`Self::new_decision_variable`] for the insertion and error contract.
+    pub fn new_binary(
+        &mut self,
+        bound: Bound,
+        label: DecisionVariableLabel,
+        fixed_value: Option<f64>,
+        atol: ATol,
+    ) -> Result<VariableID, DecisionVariableError> {
+        self.new_decision_variable(Kind::Binary, bound, label, fixed_value, atol)
     }
 
-    pub fn new_integer(&mut self) -> VariableID {
-        self.new_decision_variable(Kind::Integer, Bound::default(), None, ATol::default())
-            .unwrap()
+    /// Create and atomically add an integer decision variable.
+    ///
+    /// `bound` is normalized inward to integer endpoints. See
+    /// [`Self::new_decision_variable`] for the insertion and error contract.
+    pub fn new_integer(
+        &mut self,
+        bound: Bound,
+        label: DecisionVariableLabel,
+        fixed_value: Option<f64>,
+        atol: ATol,
+    ) -> Result<VariableID, DecisionVariableError> {
+        self.new_decision_variable(Kind::Integer, bound, label, fixed_value, atol)
     }
 
-    pub fn new_continuous(&mut self) -> VariableID {
-        self.new_decision_variable(Kind::Continuous, Bound::default(), None, ATol::default())
-            .unwrap()
+    /// Create and atomically add a continuous decision variable.
+    ///
+    /// See [`Self::new_decision_variable`] for the insertion and error contract.
+    pub fn new_continuous(
+        &mut self,
+        bound: Bound,
+        label: DecisionVariableLabel,
+        fixed_value: Option<f64>,
+        atol: ATol,
+    ) -> Result<VariableID, DecisionVariableError> {
+        self.new_decision_variable(Kind::Continuous, bound, label, fixed_value, atol)
     }
 
-    pub fn new_semi_integer(&mut self) -> VariableID {
-        self.new_decision_variable(Kind::SemiInteger, Bound::default(), None, ATol::default())
-            .unwrap()
+    /// Create and atomically add a semi-integer decision variable.
+    ///
+    /// `bound` is normalized inward to integer endpoints while preserving the
+    /// semi-integer zero alternative. See [`Self::new_decision_variable`] for
+    /// the insertion and error contract.
+    pub fn new_semi_integer(
+        &mut self,
+        bound: Bound,
+        label: DecisionVariableLabel,
+        fixed_value: Option<f64>,
+        atol: ATol,
+    ) -> Result<VariableID, DecisionVariableError> {
+        self.new_decision_variable(Kind::SemiInteger, bound, label, fixed_value, atol)
     }
 
-    pub fn new_semi_continuous(&mut self) -> VariableID {
-        self.new_decision_variable(
-            Kind::SemiContinuous,
-            Bound::default(),
-            None,
-            ATol::default(),
-        )
-        .unwrap()
+    /// Create and atomically add a semi-continuous decision variable.
+    ///
+    /// See [`Self::new_decision_variable`] for the insertion and error contract.
+    pub fn new_semi_continuous(
+        &mut self,
+        bound: Bound,
+        label: DecisionVariableLabel,
+        fixed_value: Option<f64>,
+        atol: ATol,
+    ) -> Result<VariableID, DecisionVariableError> {
+        self.new_decision_variable(Kind::SemiContinuous, bound, label, fixed_value, atol)
     }
 }
 
@@ -224,12 +267,236 @@ mod tests {
         )
         .unwrap();
 
-        let var1 = instance.new_binary();
+        let var1 = instance
+            .new_binary(
+                Bound::of_binary(),
+                DecisionVariableLabel::default(),
+                None,
+                ATol::default(),
+            )
+            .unwrap();
         assert_eq!(var1, VariableID::from(0));
 
-        let var2 = instance.new_binary();
+        let var2 = instance
+            .new_binary(
+                Bound::of_binary(),
+                DecisionVariableLabel::default(),
+                None,
+                ATol::default(),
+            )
+            .unwrap();
         assert_eq!(var2, VariableID::from(1));
 
         assert_eq!(instance.next_variable_id().unwrap(), VariableID::from(2));
+    }
+
+    #[test]
+    fn new_decision_variable_commits_row_label_and_fixed_value_together() {
+        let mut instance = Instance::default();
+        let mut label = DecisionVariableLabel {
+            name: Some("x".to_string()),
+            subscripts: vec![1, 2],
+            description: Some("bounded integer".to_string()),
+            ..Default::default()
+        };
+        label
+            .parameters
+            .insert("region".to_string(), "east".to_string());
+
+        let id = instance
+            .new_integer(
+                Bound::new(0.2, 3.8).unwrap(),
+                label.clone(),
+                Some(2.0),
+                ATol::default(),
+            )
+            .unwrap();
+
+        assert_eq!(id, VariableID::from(0));
+        assert_eq!(
+            instance.decision_variables()[&id].bound(),
+            Bound::new(1.0, 3.0).unwrap()
+        );
+        assert_eq!(instance.variable_labels().collect_for(id), label);
+        assert_eq!(instance.fixed_decision_variable_value(id), Some(2.0));
+        assert_eq!(instance.next_variable_id().unwrap(), VariableID::from(1));
+    }
+
+    #[test]
+    fn typed_new_decision_variables_set_kind_and_normalized_bound() {
+        let mut instance = Instance::default();
+        let atol = ATol::default();
+
+        let binary = instance
+            .new_binary(
+                Bound::new(-1.0, 2.0).unwrap(),
+                DecisionVariableLabel::default(),
+                None,
+                atol,
+            )
+            .unwrap();
+        let integer = instance
+            .new_integer(
+                Bound::new(0.2, 3.8).unwrap(),
+                DecisionVariableLabel::default(),
+                None,
+                atol,
+            )
+            .unwrap();
+        let continuous = instance
+            .new_continuous(
+                Bound::new(0.2, 3.8).unwrap(),
+                DecisionVariableLabel::default(),
+                None,
+                atol,
+            )
+            .unwrap();
+        let semi_integer = instance
+            .new_semi_integer(
+                Bound::new(1.1, 1.9).unwrap(),
+                DecisionVariableLabel::default(),
+                None,
+                atol,
+            )
+            .unwrap();
+        let semi_continuous = instance
+            .new_semi_continuous(
+                Bound::new(0.5, 4.0).unwrap(),
+                DecisionVariableLabel::default(),
+                None,
+                atol,
+            )
+            .unwrap();
+
+        let variables = instance.decision_variables();
+        assert_eq!(variables[&binary].kind(), Kind::Binary);
+        assert_eq!(variables[&binary].bound(), Bound::of_binary());
+        assert_eq!(variables[&integer].kind(), Kind::Integer);
+        assert_eq!(variables[&integer].bound(), Bound::new(1.0, 3.0).unwrap());
+        assert_eq!(variables[&continuous].kind(), Kind::Continuous);
+        assert_eq!(
+            variables[&continuous].bound(),
+            Bound::new(0.2, 3.8).unwrap()
+        );
+        assert_eq!(variables[&semi_integer].kind(), Kind::SemiInteger);
+        assert_eq!(
+            variables[&semi_integer].bound(),
+            Bound::new(0.0, 0.0).unwrap()
+        );
+        assert_eq!(variables[&semi_continuous].kind(), Kind::SemiContinuous);
+        assert_eq!(
+            variables[&semi_continuous].bound(),
+            Bound::new(0.5, 4.0).unwrap()
+        );
+    }
+
+    #[test]
+    fn new_decision_variable_rejects_inconsistent_bound_atomically() {
+        let mut instance = Instance::default();
+        let before = instance.clone();
+
+        let err = instance
+            .new_integer(
+                Bound::new(1.1, 1.9).unwrap(),
+                DecisionVariableLabel {
+                    name: Some("invalid".to_string()),
+                    ..Default::default()
+                },
+                None,
+                ATol::default(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DecisionVariableError::BoundInconsistentToKind {
+                kind: Kind::Integer,
+                ..
+            }
+        ));
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn new_decision_variable_rejects_inconsistent_fixed_value_atomically() {
+        let mut instance = Instance::default();
+        let before = instance.clone();
+
+        let err = instance
+            .new_integer(
+                Bound::new(0.0, 2.0).unwrap(),
+                DecisionVariableLabel {
+                    name: Some("invalid".to_string()),
+                    ..Default::default()
+                },
+                Some(0.5),
+                ATol::default(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DecisionVariableError::SubstitutedValueInconsistent {
+                id,
+                substituted_value: 0.5,
+                ..
+            } if id == VariableID::from(0)
+        ));
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn new_decision_variable_rejects_non_finite_fixed_value_atomically() {
+        let mut instance = Instance::default();
+        let before = instance.clone();
+
+        let err = instance
+            .new_continuous(
+                Bound::default(),
+                DecisionVariableLabel {
+                    name: Some("invalid".to_string()),
+                    ..Default::default()
+                },
+                Some(f64::NAN),
+                ATol::default(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DecisionVariableError::NonFiniteValue { id, value }
+                if id == VariableID::from(0) && value.is_nan()
+        ));
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn new_decision_variable_rejects_exhausted_id_atomically() {
+        let decision_variables = btreemap! {
+            VariableID::from(u64::MAX) => DecisionVariable::binary(),
+        };
+        let mut instance = Instance::new(
+            Sense::Minimize,
+            Function::Zero,
+            decision_variables,
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let before = instance.clone();
+
+        let err = instance
+            .new_binary(
+                Bound::of_binary(),
+                DecisionVariableLabel {
+                    name: Some("overflow".to_string()),
+                    ..Default::default()
+                },
+                None,
+                ATol::default(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, DecisionVariableError::NoAvailableID));
+        assert_eq!(instance, before);
     }
 }

--- a/rust/ommx/src/instance/decision_variable.rs
+++ b/rust/ommx/src/instance/decision_variable.rs
@@ -47,13 +47,13 @@ impl Instance {
         })
     }
 
-    /// Returns the next available [`VariableID`].
+    /// Returns the next automatically assigned [`VariableID`].
     ///
     /// Finds the maximum ID from decision variables, then adds 1.
     /// If there are no variables, returns `Ok(VariableID(0))`.
     ///
-    /// Note: This method does not track which IDs have been allocated.
-    /// Consecutive calls will return the same ID until a variable is actually added.
+    /// This allocator does not reuse gaps below the current maximum ID.
+    /// Consecutive calls return the same ID until a variable is actually added.
     ///
     /// # Errors
     ///
@@ -102,8 +102,9 @@ impl Instance {
     /// # Errors
     ///
     /// Returns [`DecisionVariableError::BoundInconsistentToKind`] when `bound`
-    /// contains no value allowed by `kind`,
-    /// [`DecisionVariableError::NoAvailableID`] when the ID space is exhausted,
+    /// cannot be normalized to a domain consistent with `kind` under `atol`,
+    /// [`DecisionVariableError::NoAvailableID`] when the largest existing ID is
+    /// `u64::MAX` and no larger automatic ID can be assigned,
     /// [`DecisionVariableError::NonFiniteValue`] when `fixed_value` is not
     /// finite, or [`DecisionVariableError::SubstitutedValueInconsistent`] when
     /// it does not belong to the normalized variable domain.
@@ -138,7 +139,8 @@ impl Instance {
 
     /// Create and atomically add an integer decision variable.
     ///
-    /// `bound` is normalized inward to integer endpoints. See
+    /// A finite lower endpoint is normalized to `ceil(lower - atol)` and a
+    /// finite upper endpoint to `floor(upper + atol)`. See
     /// [`Self::new_decision_variable`] for the insertion and error contract.
     pub fn new_integer(
         &mut self,
@@ -165,7 +167,8 @@ impl Instance {
 
     /// Create and atomically add a semi-integer decision variable.
     ///
-    /// `bound` is normalized inward to integer endpoints while preserving the
+    /// A finite lower endpoint is normalized to `ceil(lower - atol)` and a
+    /// finite upper endpoint to `floor(upper + atol)`, while preserving the
     /// semi-integer zero alternative. See [`Self::new_decision_variable`] for
     /// the insertion and error contract.
     pub fn new_semi_integer(

--- a/rust/ommx/src/instance/log_encode.rs
+++ b/rust/ommx/src/instance/log_encode.rs
@@ -1099,7 +1099,7 @@ mod tests {
         assert!(!err.is::<LogEncodingUnavailable>());
         assert!(err
             .to_string()
-            .contains("No available decision variable ID"));
+            .contains("Insufficient capacity for automatically assigned decision variable IDs"));
         assert!(instance.decision_variable_dependency.get(&id).is_none());
         assert_eq!(aux_variable_count(&instance, "ommx.log_encode"), 0);
     }

--- a/rust/ommx/src/instance/named_function.rs
+++ b/rust/ommx/src/instance/named_function.rs
@@ -229,7 +229,14 @@ mod tests {
         let mut instance = Instance::default();
 
         // Add a decision variable that the function will reference (gets ID 0)
-        instance.new_continuous();
+        instance
+            .new_continuous(
+                crate::Bound::default(),
+                crate::DecisionVariableLabel::default(),
+                None,
+                crate::ATol::default(),
+            )
+            .unwrap();
 
         // Add a named function that references variable 0
         let nf_id = instance

--- a/rust/ommx/src/instance/slack.rs
+++ b/rust/ommx/src/instance/slack.rs
@@ -150,8 +150,7 @@ impl Instance {
             .into());
         }
 
-        let slack_id = self.new_decision_variable_with_label(
-            Kind::Integer,
+        let slack_id = self.new_integer(
             slack_bound,
             crate::ModelingLabel {
                 name: Some("ommx.slack".to_string()),
@@ -267,8 +266,7 @@ impl Instance {
             Err(e) => return Err(e).context("Slack coefficient must be finite"),
         };
 
-        let slack_id = self.new_decision_variable_with_label(
-            Kind::Integer,
+        let slack_id = self.new_integer(
             slack_bound,
             crate::ModelingLabel {
                 name: Some("ommx.slack".to_string()),

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -57,6 +57,11 @@ impl Instance {
         id: Sos1ConstraintID,
     ) -> Result<Vec<ConstraintID>> {
         let plans = self.plan_sos1_conversion(id)?;
+        let fresh_indicator_count = plans
+            .iter()
+            .filter(|(_, plan)| matches!(plan, IndicatorPlan::Fresh { .. }))
+            .count();
+        self.ensure_new_decision_variable_capacity(fresh_indicator_count)?;
         self.apply_sos1_conversion(id, plans)
     }
 
@@ -88,6 +93,12 @@ impl Instance {
             let plans = self.plan_sos1_conversion(id)?;
             all_plans.push((id, plans));
         }
+        let fresh_indicator_count = all_plans
+            .iter()
+            .flat_map(|(_, plans)| plans)
+            .filter(|(_, plan)| matches!(plan, IndicatorPlan::Fresh { .. }))
+            .count();
+        self.ensure_new_decision_variable_capacity(fresh_indicator_count)?;
         // Phase 2: apply. Planned state only references variables that existed at
         // plan time; `apply_sos1_conversion` only adds fresh variables / constraints
         // and relaxes its own SOS1, so earlier applications cannot invalidate later
@@ -163,8 +174,7 @@ impl Instance {
         for (x_id, plan) in &plans {
             let y_id = match plan {
                 IndicatorPlan::Reuse => *x_id,
-                IndicatorPlan::Fresh { .. } => self.new_decision_variable_with_label(
-                    Kind::Binary,
+                IndicatorPlan::Fresh { .. } => self.new_binary(
                     Bound::of_binary(),
                     crate::ModelingLabel {
                         name: Some("ommx.sos1_indicator".to_string()),
@@ -645,5 +655,80 @@ mod tests {
         assert_eq!(instance.decision_variables, before_vars);
         assert_eq!(instance.constraints(), &before_constraints);
         assert!(instance.removed_sos1_constraints().is_empty());
+    }
+
+    #[test]
+    fn conversion_is_atomic_when_fresh_indicator_ids_are_exhausted() {
+        let dv = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let last_existing_id = VariableID::from(u64::MAX - 1);
+        let sos1 = Sos1Constraint::new(
+            [VariableID::from(0), last_existing_id]
+                .into_iter()
+                .collect(),
+        )
+        .unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(btreemap! {
+                VariableID::from(0) => dv.clone(),
+                last_existing_id => dv,
+            })
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(9), sos1)]))
+            .build()
+            .unwrap();
+        let before = instance.clone();
+
+        let err = instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap_err();
+
+        assert!(matches!(
+            err.downcast_ref::<crate::DecisionVariableError>(),
+            Some(crate::DecisionVariableError::NoAvailableID)
+        ));
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn bulk_conversion_is_atomic_when_fresh_indicator_ids_are_exhausted() {
+        let dv = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let last_existing_id = VariableID::from(u64::MAX - 1);
+        let first = Sos1Constraint::new([VariableID::from(0)].into_iter().collect()).unwrap();
+        let second = Sos1Constraint::new([last_existing_id].into_iter().collect()).unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(btreemap! {
+                VariableID::from(0) => dv.clone(),
+                last_existing_id => dv,
+            })
+            .constraints(BTreeMap::new())
+            .sos1_constraints(BTreeMap::from([
+                (Sos1ConstraintID::from(8), first),
+                (Sos1ConstraintID::from(9), second),
+            ]))
+            .build()
+            .unwrap();
+        let before = instance.clone();
+
+        let err = instance.convert_all_sos1_to_constraints().unwrap_err();
+
+        assert!(matches!(
+            err.downcast_ref::<crate::DecisionVariableError>(),
+            Some(crate::DecisionVariableError::NoAvailableID)
+        ));
+        assert_eq!(instance, before);
     }
 }

--- a/rust/ommx/src/instance/sos1.rs
+++ b/rust/ommx/src/instance/sos1.rs
@@ -18,6 +18,22 @@ enum IndicatorPlan {
     Fresh { bound: Bound },
 }
 
+fn sos1_generated_constraint_count(plans: &[(VariableID, IndicatorPlan)]) -> Result<usize> {
+    plans
+        .iter()
+        .try_fold(usize::from(!plans.is_empty()), |count, (_, plan)| {
+            let additional = match plan {
+                IndicatorPlan::Reuse => 0,
+                IndicatorPlan::Fresh { bound } => {
+                    usize::from(bound.upper() > 0.0) + usize::from(bound.lower() < 0.0)
+                }
+            };
+            count.checked_add(additional).ok_or_else(|| {
+                crate::error!("SOS1 conversion would generate too many regular constraints")
+            })
+        })
+}
+
 impl Instance {
     #[cfg_attr(doc, katexit::katexit)]
     /// Convert a SOS1 constraint to regular constraints using the Big-M method.
@@ -40,7 +56,8 @@ impl Instance {
     /// excludes $0$ (so that $y_i = 0 \Rightarrow x_i = 0$ would be infeasible), or whose
     /// kind is [`Kind::SemiInteger`] or [`Kind::SemiContinuous`] (the split domain
     /// $\{0\} \cup [l, u]$ is not uniformly implemented across the codebase, so Big-M
-    /// conversion of these kinds is not supported yet).
+    /// conversion of these kinds is not supported yet), or if the decision-variable
+    /// or regular-constraint ID space cannot hold every generated row.
     /// All validation happens before any mutation, so a failed call leaves the instance
     /// unchanged.
     ///
@@ -61,7 +78,10 @@ impl Instance {
             .iter()
             .filter(|(_, plan)| matches!(plan, IndicatorPlan::Fresh { .. }))
             .count();
+        let generated_constraint_count = sos1_generated_constraint_count(&plans)?;
         self.ensure_new_decision_variable_capacity(fresh_indicator_count)?;
+        self.constraint_collection
+            .ensure_unused_id_capacity(generated_constraint_count)?;
         self.apply_sos1_conversion(id, plans)
     }
 
@@ -69,10 +89,11 @@ impl Instance {
     ///
     /// See [`Self::convert_sos1_to_constraints`] for the conversion rule.
     ///
-    /// This is atomic: every active SOS1 is validated up front, and only once all
-    /// validations succeed are the conversions applied. If any SOS1 fails
-    /// validation (unsupported kind, non-finite bound, domain excludes 0, etc.),
-    /// no mutation happens and the instance is left untouched.
+    /// This is atomic: every active SOS1 and the total generated-ID capacity are
+    /// validated up front, and only once all validations succeed are the
+    /// conversions applied. If validation fails (unsupported kind, non-finite
+    /// bound, domain excludes 0, ID exhaustion, etc.), no mutation happens and
+    /// the instance is left untouched.
     ///
     /// Returns a map from each original [`Sos1ConstraintID`] to the IDs of the
     /// regular constraints it produced.
@@ -98,7 +119,21 @@ impl Instance {
             .flat_map(|(_, plans)| plans)
             .filter(|(_, plan)| matches!(plan, IndicatorPlan::Fresh { .. }))
             .count();
+        let generated_constraint_count =
+            all_plans
+                .iter()
+                .try_fold(0usize, |total, (_, plans)| -> Result<usize> {
+                    total
+                        .checked_add(sos1_generated_constraint_count(plans)?)
+                        .ok_or_else(|| {
+                            crate::error!(
+                                "SOS1 conversion would generate too many regular constraints"
+                            )
+                        })
+                })?;
         self.ensure_new_decision_variable_capacity(fresh_indicator_count)?;
+        self.constraint_collection
+            .ensure_unused_id_capacity(generated_constraint_count)?;
         // Phase 2: apply. Planned state only references variables that existed at
         // plan time; `apply_sos1_conversion` only adds fresh variables / constraints
         // and relaxes its own SOS1, so earlier applications cannot invalidate later
@@ -729,6 +764,107 @@ mod tests {
             err.downcast_ref::<crate::DecisionVariableError>(),
             Some(crate::DecisionVariableError::NoAvailableID)
         ));
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn conversion_can_use_the_last_regular_constraint_ids() {
+        let dv = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect()).unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(btreemap! { VariableID::from(0) => dv })
+            .constraints(BTreeMap::from([(
+                ConstraintID::from(u64::MAX - 3),
+                Constraint::equal_to_zero(Function::Zero),
+            )]))
+            .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(9), sos1)]))
+            .build()
+            .unwrap();
+
+        let ids = instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap();
+
+        assert_eq!(
+            ids,
+            vec![
+                ConstraintID::from(u64::MAX - 2),
+                ConstraintID::from(u64::MAX - 1),
+                ConstraintID::from(u64::MAX),
+            ]
+        );
+    }
+
+    #[test]
+    fn conversion_is_atomic_when_regular_constraint_ids_are_exhausted() {
+        let dv = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect()).unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(btreemap! { VariableID::from(0) => dv })
+            .constraints(BTreeMap::from([(
+                ConstraintID::from(u64::MAX),
+                Constraint::equal_to_zero(Function::Zero),
+            )]))
+            .sos1_constraints(BTreeMap::from([(Sos1ConstraintID::from(9), sos1)]))
+            .build()
+            .unwrap();
+        let before = instance.clone();
+
+        let err = instance
+            .convert_sos1_to_constraints(Sos1ConstraintID::from(9))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Cannot allocate"));
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn bulk_conversion_is_atomic_when_regular_constraint_ids_are_exhausted() {
+        let integer_variable = DecisionVariable::new(
+            Kind::Integer,
+            Bound::new(-1.0, 1.0).unwrap(),
+            crate::ATol::default(),
+        )
+        .unwrap();
+        let binary_sos1 = Sos1Constraint::new([VariableID::from(0)].into_iter().collect()).unwrap();
+        let integer_sos1 =
+            Sos1Constraint::new([VariableID::from(1)].into_iter().collect()).unwrap();
+        let mut instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(btreemap! {
+                VariableID::from(0) => DecisionVariable::binary(),
+                VariableID::from(1) => integer_variable,
+            })
+            .constraints(BTreeMap::from([(
+                ConstraintID::from(u64::MAX),
+                Constraint::equal_to_zero(Function::Zero),
+            )]))
+            .sos1_constraints(BTreeMap::from([
+                (Sos1ConstraintID::from(8), binary_sos1),
+                (Sos1ConstraintID::from(9), integer_sos1),
+            ]))
+            .build()
+            .unwrap();
+        let before = instance.clone();
+
+        let err = instance.convert_all_sos1_to_constraints().unwrap_err();
+
+        assert!(err.to_string().contains("Cannot allocate"));
         assert_eq!(instance, before);
     }
 }

--- a/rust/ommx/src/instance/unary_encode.rs
+++ b/rust/ommx/src/instance/unary_encode.rs
@@ -972,7 +972,7 @@ mod tests {
             .unwrap_err();
         assert!(err
             .to_string()
-            .contains("No available decision variable ID"));
+            .contains("Insufficient capacity for automatically assigned decision variable IDs"));
         assert!(instance.decision_variable_dependency.get(&id).is_none());
         assert_eq!(aux_variable_count(&instance, "ommx.unary_encode"), 0);
     }

--- a/rust/ommx/src/instance/unary_encode.rs
+++ b/rust/ommx/src/instance/unary_encode.rs
@@ -190,8 +190,7 @@ impl Instance {
         let mut linear = Linear::try_from(offset).unwrap();
         let coefficient = Coefficient::try_from(1.0).unwrap();
         for i in 0..num_binary_variables {
-            let binary_id = self.new_decision_variable_with_label(
-                Kind::Binary,
+            let binary_id = self.new_binary(
                 Bound::of_binary(),
                 crate::ModelingLabel {
                     name: Some("ommx.unary_encode".to_string()),


### PR DESCRIPTION
## Summary

- redesign Rust `Instance::new_decision_variable` and the typed `new_*` methods as complete owner operations that receive the bound, modeling label, optional fixed value, and tolerance before allocating an ID
- add Python `Instance.new_integer`, `new_continuous`, `new_semi_integer`, and `new_semi_continuous`, with all Python `new_*` methods delegating to the corresponding Rust constructor
- make construction failures atomic across the decision-variable row, modeling label, fixed-value sidecar, and automatic ID allocation
- preflight both fresh decision-variable IDs and generated regular-constraint IDs for single and bulk SOS1 Big-M conversion
- keep the Python runtime contract aligned with the generated API by accepting arbitrary `Mapping[str, str]` values and exposing an explicit `atol=` override for integer-bound normalization
- preserve positional-only and keyword-only delimiters in generated Sphinx signatures and make the OMMX renderer hook installation safe across extension reloads
- update generated stubs/API data, migration guidance, tutorials, and English and Japanese user-facing documentation

## Rust API change

The typed constructors now take `(bound, label, fixed_value, atol)` and return `Result<VariableID, DecisionVariableError>`. The generic constructor additionally takes `Kind`. This replaces the previous pattern of inserting a default variable and then applying a separately fallible bound mutation.

The constructors normalize and validate the complete definition before committing it to the `Instance`. Automatic allocation remains monotonic above the current maximum ID and does not reuse gaps.

## Python API

The four non-binary constructors use `name` as their optional positional argument and expose bounds and modeling-label fields as keyword-only arguments. `new_integer` and `new_semi_integer` also accept keyword-only `atol`; omitting it uses the process default returned by `get_default_atol()`.

Integer endpoints are normalized as `ceil(lower - atol)` and `floor(upper + atol)`. If that normalized interval contains no integer, `new_integer` raises `ValueError`, while `new_semi_integer` preserves its zero alternative with `[0, 0]`.

## Atomicity boundaries

Invalid bounds, invalid tolerances, inconsistent fixed values, and insufficient automatic-ID capacity leave the `Instance` unchanged. SOS1 conversion now reserves enough capacity for both fresh indicator variables and every regular constraint that the plan will emit before applying any part of the conversion.

## Scope

The Python additions cover the four existing non-binary interval-domain variable kinds. Finite-domain variables remain tracked in #1112.
