### PR TITLE
Prepare Rust and Python SDK 3.0.0 Beta 5 release notes

### DIFF
--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,6 +8,132 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
+## 3.0.0 Beta 5
+
+[![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b5-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b5)
+
+### 🛠 Inclusive `atol` boundaries ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
+
+Absolute-tolerance comparisons now include the exact boundary consistently.
+Equality residuals are feasible when $|f(x)| \leq \mathtt{atol}$, while
+inequality residuals are feasible when $f(x) < 0$ or
+$|f(x)| \leq \mathtt{atol}$. The same rule is used by scalar and sample
+evaluation, regular and Indicator constraints, `Solution` and `SampleSet`
+validation, and v1/v2 deserialization.
+
+Function zero-sensitive operations, Indicator activation, OneHot and SOS1
+classification, discrete solver-state canonicalization, and fixed-value
+consistency checks also include values exactly `atol` from their target.
+Values just outside the boundary remain outside. APIs that own finite-value
+validation continue to reject NaN and infinity before reporting domain or
+consistency errors.
+
+### 🛠 Canonical solver states during evaluation ([#1174](https://github.com/Jij-Inc/ommx/pull/1174), [#1181](https://github.com/Jij-Inc/ommx/pull/1181))
+
+{meth}`~ommx.Instance.populate_state`, {meth}`~ommx.Instance.evaluate`, and
+{meth}`~ommx.Instance.evaluate_samples` now canonicalize finite supplied
+coordinates that are neither fixed nor dependent, as well as values derived for
+dependent targets, according to each decision-variable kind and the caller's
+`atol`. For those coordinates, Binary values whose distance from `0` or `1` is
+at most `atol`, and Integer or SemiInteger values whose distance from an integer
+is at most `atol`, are stored as the corresponding exact discrete value,
+including values exactly at the tolerance boundary. Kind and bound feasibility
+continue to be checked separately under their existing rules. Continuous and
+SemiContinuous values are never rounded. Other
+finite values are preserved so a returned {class}`~ommx.Solution` can report
+their feasibility, while non-finite state values remain rejected.
+
+A caller-supplied fixed or dependent value remains a consistency assertion.
+After validation, the returned state uses the Instance-owned fixed value
+unchanged or the dependency-derived value canonicalized for its target kind.
+Dependencies are evaluated from canonicalized inputs, so an explicitly supplied
+dependent assertion computed from the raw solver vector can now be rejected if
+it is not within `atol` of that derived value. Scalar and sample evaluation use
+the same rule while preserving SampleID membership.
+
+{meth}`~ommx.Instance.partial_evaluate` applies the same rule to its validated
+input before special-constraint propagation, expression substitution, and
+constant dependency evaluation. Evaluating the rewritten Instance therefore
+uses the same canonical coordinates as directly evaluating the original
+Instance. Existing Instance-owned fixed values remain unchanged, and values
+outside partial evaluation's existing kind and bound acceptance contract remain
+rejected.
+
+### ⚠ Composed `Function` operations ([#1158](https://github.com/Jij-Inc/ommx/pull/1158), [#1178](https://github.com/Jij-Inc/ommx/pull/1178), [#1181](https://github.com/Jij-Inc/ommx/pull/1181), [#1184](https://github.com/Jij-Inc/ommx/pull/1184))
+
+{class}`~ommx.Function` can now represent composed expressions as well as
+compact polynomials. Python users can construct absolute values, sign
+functions, minima, maxima, divisions, and signed 32-bit integer powers directly:
+
+```python
+from ommx import DecisionVariable, Function
+
+x = Function(DecisionVariable.continuous(1))
+y = Function(DecisionVariable.continuous(2))
+z = Function(DecisionVariable.continuous(3))
+
+f = abs(x - 2).maximum(y) / (z + 1)
+g = f**2
+h = f.powi(-2)
+```
+
+Use {meth}`~ommx.Function.signum`, {meth}`~ommx.Function.minimum`, and
+{meth}`~ommx.Function.maximum` for the named operations. `f**n` and
+{meth}`~ommx.Function.powi` are equivalent; floating-point or function-valued
+exponents and reverse exponentiation are not supported. At evaluation,
+`abs(value) <= atol` is classified as zero, including the boundary: `signum`
+returns `0`, while division by such a denominator and raising such a value to a
+negative integer power raise `ValueError`. Composed expressions are serialized
+as flat reverse Polish notation (RPN) instruction sequences in OMMX protobuf
+payloads. All bundled adapters—HiGHS, Python-MIP, PySCIPOpt, and OpenJij—
+currently declare polynomial-only input classes and therefore reject composed
+expressions in the function positions they accept.
+
+Zero-sensitive `Signum`, `Div`, and negative `Powi` nodes are retained through
+construction, substitution, and partial evaluation so that a later evaluation
+call supplies the `atol` that determines their result or domain error. In
+particular, dividing a `Function` by a constant or coefficient remains a
+composed expression. `Function.evaluate_bound(..., atol=...)` applies the same
+zero classification to interval bounds. Indicator Big-M conversion,
+special-constraint lowering, and integer-slack conversion also accept an
+optional `atol=` for bounds they derive. This aligns zero-sensitive Function
+body evaluation; algebraic lowering still assumes exact discrete values and
+does not canonicalize approximate solver output near 0 or 1. Omitting `atol`
+uses `DEFAULT_ATOL`. Integer-slack conversion classifies an inequality with the
+same inclusive rule used by evaluation, $f(x) < 0$ or
+$|f(x)| \leq \mathtt{atol}$, before coefficient normalization, so a small
+positive value is not silently reclassified by scaling. Exact polynomial
+normalization retains every finite nonzero coefficient and does not apply an
+implicit tolerance-based cleanup. A future approximate-cleanup API would be
+separate and explicit. Subtraction follows the same canonicalization as
+addition with a negated right-hand side, so `x - (-y)` compacts to a polynomial
+when possible and coefficient overflow is raised immediately as `ValueError`.
+
+Because a `Function` is no longer necessarily a polynomial,
+{meth}`~ommx.Function.degree` and {meth}`~ommx.Function.num_terms` return
+`None` for composed expressions. Polynomial-term accessors and
+{meth}`~ommx.Function.content_factor` raise `TypeError` instead of treating a
+composed expression as an empty polynomial. See the
+[Function user guide](../user_guide/function.md) for operation ordering,
+evaluation errors, and serialization details.
+
+The instance-class API now names that polynomial requirement explicitly. This
+is a breaking rename from the API published in Python SDK 3.0.0 Beta 4:
+
+| Before | After |
+|---|---|
+| `DegreeBound` | `PolynomialRequirement` |
+| `DegreeBound.at_most(n)` | `PolynomialRequirement.at_most(n)` |
+| `DegreeBound.unbounded()` | `PolynomialRequirement.any_degree()` |
+| `bound.maximum` | `requirement.maximum_degree` |
+| `bound.includes(degree)` | `requirement.accepts_degree(degree)` |
+| `objective_degree_bound` | `objective_polynomial_requirement` |
+| `regular_constraint_degree_bounds` | `regular_constraint_polynomial_requirements` |
+| `indicator_constraint_degree_bounds` | `indicator_body_polynomial_requirements` |
+
+`PolynomialRequirement.any_degree()` accepts a polynomial of any degree; it
+does not admit a composed, non-polynomial `Function`.
+
 ### 🆕 Checked SOS1 Big-M promotion ([#1186](https://github.com/Jij-Inc/ommx/pull/1186))
 
 An {ref}`SOS1 constraint <sos1-constraint>` allows at most one member to be
@@ -82,125 +208,9 @@ bound or tolerance, or a maximum existing decision-variable ID of `2**64 - 1`
 that prevents assignment of a larger automatic ID, leaves no partial variable
 or label behind.
 
-### 🛠 Inclusive `atol` boundaries ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
+## 3.0.0 Beta 4
 
-Absolute-tolerance comparisons now include the exact boundary consistently.
-Equality residuals are feasible when $|f(x)| \leq \mathtt{atol}$, while
-inequality residuals are feasible when $f(x) < 0$ or
-$|f(x)| \leq \mathtt{atol}$. The same rule is used by scalar and sample
-evaluation, regular and Indicator constraints, `Solution` and `SampleSet`
-validation, and v1/v2 deserialization.
-
-Function zero-sensitive operations, Indicator activation, OneHot and SOS1
-classification, discrete solver-state canonicalization, and fixed-value
-consistency checks also include values exactly `atol` from their target.
-Values just outside the boundary remain outside. APIs that own finite-value
-validation continue to reject NaN and infinity before reporting domain or
-consistency errors.
-
-### ⚠ Composed `Function` operations ([#1158](https://github.com/Jij-Inc/ommx/pull/1158), [#1178](https://github.com/Jij-Inc/ommx/pull/1178), [#1181](https://github.com/Jij-Inc/ommx/pull/1181))
-
-{class}`~ommx.Function` can now represent composed expressions as well as
-compact polynomials. Python users can construct absolute values, sign
-functions, minima, maxima, divisions, and signed 32-bit integer powers directly:
-
-```python
-from ommx import DecisionVariable, Function
-
-x = Function(DecisionVariable.continuous(1))
-y = Function(DecisionVariable.continuous(2))
-z = Function(DecisionVariable.continuous(3))
-
-f = abs(x - 2).maximum(y) / (z + 1)
-g = f**2
-h = f.powi(-2)
-```
-
-Use {meth}`~ommx.Function.signum`, {meth}`~ommx.Function.minimum`, and
-{meth}`~ommx.Function.maximum` for the named operations. `f**n` and
-{meth}`~ommx.Function.powi` are equivalent; floating-point or function-valued
-exponents and reverse exponentiation are not supported. At evaluation,
-`abs(value) <= atol` is classified as zero, including the boundary: `signum`
-returns `0`, while division by such a denominator and raising such a value to a
-negative integer power raise `ValueError`. Composed expressions are serialized
-as flat reverse Polish notation (RPN) instruction sequences in OMMX protobuf
-payloads. All bundled adapters—HiGHS, Python-MIP, PySCIPOpt, and OpenJij—
-currently declare polynomial-only input classes and therefore reject composed
-expressions in the function positions they accept.
-
-Zero-sensitive `Signum`, `Div`, and negative `Powi` nodes are retained through
-construction, substitution, and partial evaluation so that a later evaluation
-call supplies the `atol` that determines their result or domain error. In
-particular, dividing a `Function` by a constant or coefficient remains a
-composed expression. `Function.evaluate_bound(..., atol=...)` applies the same
-zero classification to interval bounds. Indicator Big-M conversion,
-special-constraint lowering, and integer-slack conversion also accept an
-optional `atol=` for bounds they derive. This aligns zero-sensitive Function
-body evaluation; algebraic lowering still assumes exact discrete values and
-does not canonicalize approximate solver output near 0 or 1. Omitting `atol`
-uses `DEFAULT_ATOL`. Integer-slack conversion classifies an inequality with the
-same inclusive rule used by evaluation, $f(x) < 0$ or
-$|f(x)| \leq \mathtt{atol}$, before coefficient normalization, so a small
-positive value is not silently reclassified by scaling. Exact polynomial
-normalization retains every finite nonzero coefficient and does not apply an
-implicit tolerance-based cleanup. A future approximate-cleanup API would be
-separate and explicit.
-
-Because a `Function` is no longer necessarily a polynomial,
-{meth}`~ommx.Function.degree` and {meth}`~ommx.Function.num_terms` return
-`None` for composed expressions. Polynomial-term accessors and
-{meth}`~ommx.Function.content_factor` raise `TypeError` instead of treating a
-composed expression as an empty polynomial. See the
-[Function user guide](../user_guide/function.md) for operation ordering,
-evaluation errors, and serialization details.
-
-The instance-class API now names that polynomial requirement explicitly. This
-is a breaking rename from the API published in Python SDK 3.0.0 Beta 4:
-
-| Before | After |
-|---|---|
-| `DegreeBound` | `PolynomialRequirement` |
-| `DegreeBound.at_most(n)` | `PolynomialRequirement.at_most(n)` |
-| `DegreeBound.unbounded()` | `PolynomialRequirement.any_degree()` |
-| `bound.maximum` | `requirement.maximum_degree` |
-| `bound.includes(degree)` | `requirement.accepts_degree(degree)` |
-| `objective_degree_bound` | `objective_polynomial_requirement` |
-| `regular_constraint_degree_bounds` | `regular_constraint_polynomial_requirements` |
-| `indicator_constraint_degree_bounds` | `indicator_body_polynomial_requirements` |
-
-`PolynomialRequirement.any_degree()` accepts a polynomial of any degree; it
-does not admit a composed, non-polynomial `Function`.
-
-### 🛠 Canonical solver states during evaluation ([#1174](https://github.com/Jij-Inc/ommx/pull/1174), [#1181](https://github.com/Jij-Inc/ommx/pull/1181))
-
-{meth}`~ommx.Instance.populate_state`, {meth}`~ommx.Instance.evaluate`, and
-{meth}`~ommx.Instance.evaluate_samples` now canonicalize finite supplied
-coordinates that are neither fixed nor dependent, as well as values derived for
-dependent targets, according to each decision-variable kind and the caller's
-`atol`. For those coordinates, Binary values whose distance from `0` or `1` is
-at most `atol`, and Integer or SemiInteger values whose distance from an integer
-is at most `atol`, are stored as the corresponding exact discrete value,
-including values exactly at the tolerance boundary. Kind and bound feasibility
-continue to be checked separately under their existing rules. Continuous and
-SemiContinuous values are never rounded. Other
-finite values are preserved so a returned {class}`~ommx.Solution` can report
-their feasibility, while non-finite state values remain rejected.
-
-A caller-supplied fixed or dependent value remains a consistency assertion.
-After validation, the returned state uses the Instance-owned fixed value
-unchanged or the dependency-derived value canonicalized for its target kind.
-Dependencies are evaluated from canonicalized inputs, so an explicitly supplied
-dependent assertion computed from the raw solver vector can now be rejected if
-it is not within `atol` of that derived value. Scalar and sample evaluation use
-the same rule while preserving SampleID membership.
-
-{meth}`~ommx.Instance.partial_evaluate` applies the same rule to its validated
-input before special-constraint propagation, expression substitution, and
-constant dependency evaluation. Evaluating the rewritten Instance therefore
-uses the same canonical coordinates as directly evaluating the original
-Instance. Existing Instance-owned fixed values remain unchanged, and values
-outside partial evaluation's existing kind and bound acceptance contract remain
-rejected.
+[![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b4-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b4)
 
 ### ⚠ `solve()` and `sample()` now prepare inputs automatically ([#1166](https://github.com/Jij-Inc/ommx/pull/1166))
 

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,6 +8,118 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
+## 3.0.0 Beta 5
+
+[![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b5-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b5)
+
+### 🛠 境界を含む `atol` 判定 ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
+
+絶対許容誤差の比較は、差がちょうど`atol`となる境界を一貫して含むようになりました。
+等式のresidualは $|f(x)| \leq \mathtt{atol}$ のときfeasible、不等式のresidualは
+$f(x) < 0$ または $|f(x)| \leq \mathtt{atol}$ のときfeasibleです。scalar / sample
+evaluation、regular / Indicator constraint、`Solution` / `SampleSet`の検証、v1 / v2の
+deserializeで同じ規則を使います。
+
+Functionのゼロ依存演算、Indicatorのactivation、OneHot / SOS1の分類、solver stateの
+離散値canonicalization、fixed valueの整合性検証でも、targetとの差がちょうど`atol`の
+値を含みます。境界をわずかに超える値は引き続き範囲外です。有限値の検証を所有するAPIは、
+domain errorや整合性errorを返す前にNaNと無限大を引き続き拒否します。
+
+### 🛠 evaluation時のsolver stateをcanonicalize ([#1174](https://github.com/Jij-Inc/ommx/pull/1174), [#1181](https://github.com/Jij-Inc/ommx/pull/1181))
+
+{meth}`~ommx.Instance.populate_state`、{meth}`~ommx.Instance.evaluate`、
+{meth}`~ommx.Instance.evaluate_samples`は、fixedでもdependentでもない有限な入力値と、
+dependent targetの導出値を、decision variableのkindと呼び出し側の`atol`に従って
+canonicalizeするようになりました。これらの値について、`0`または`1`との差が`atol`
+以下のBinary値と、整数との差が`atol`以下のInteger / SemiInteger値は、境界上の値も含めて
+対応する厳密な離散値として格納されます。canonicalizationとは
+別に、kindとboundのfeasibilityを既存の規則で判定します。
+ContinuousとSemiContinuousは丸めません。それ以外の有限値は、返された
+{class}`~ommx.Solution`がfeasibilityを判定できるように保持し、非有限なstate値は
+引き続き拒否します。
+
+呼び出し側がfixedまたはdependent variableの値を渡した場合、その値は引き続き
+整合性assertionとして扱います。検証後のstateには、Instanceが所有するfixed valueを
+変更せずに格納するか、dependencyから導出してtarget kindに従いcanonicalizeした値を
+格納します。dependencyはcanonicalized inputから評価するため、丸め前のsolver vectorを
+もとに明示したdependent assertionが、導出値の`atol`内に入らず拒否される場合があります。
+scalar / sample evaluationは同じ規則を使い、SampleIDの対応関係を保持します。
+
+{meth}`~ommx.Instance.partial_evaluate`も、入力を検証した後、special constraintのpropagation、
+expressionへの代入、定数化したdependencyの評価より前に同じ規則を適用します。そのため、
+書き換え後のInstanceを評価した結果は、元のInstanceを直接評価した場合と同じcanonical
+coordinateを使います。Instanceが既に所有するfixed valueは変更せず、既存のkind / bound
+検証でpartial evaluationの受理範囲外となる値は引き続き拒否します。
+
+### ⚠ 複合 `Function` 演算 ([#1158](https://github.com/Jij-Inc/ommx/pull/1158), [#1178](https://github.com/Jij-Inc/ommx/pull/1178), [#1181](https://github.com/Jij-Inc/ommx/pull/1181), [#1184](https://github.com/Jij-Inc/ommx/pull/1184))
+
+{class}`~ommx.Function` はcompactなpolynomialに加えて、複合式も表現できるように
+なりました。絶対値、符号関数、最小値、最大値、除算、符号付き32 bit整数による
+累乗をPythonから直接構築できます。
+
+```python
+from ommx import DecisionVariable, Function
+
+x = Function(DecisionVariable.continuous(1))
+y = Function(DecisionVariable.continuous(2))
+z = Function(DecisionVariable.continuous(3))
+
+f = abs(x - 2).maximum(y) / (z + 1)
+g = f**2
+h = f.powi(-2)
+```
+
+名前付きの演算には {meth}`~ommx.Function.signum`、
+{meth}`~ommx.Function.minimum`、{meth}`~ommx.Function.maximum` を使用します。
+`f**n` と {meth}`~ommx.Function.powi` は同じ演算です。浮動小数や関数値の指数、
+および反転累乗はサポートしません。評価時には、境界を含む
+`abs(value) <= atol`をゼロと判定します。`signum`は`0`を返し、そのように
+判定された値を分母にする除算や負の整数による累乗は`ValueError`になります。
+複合式はOMMX protobuf payloadへ
+flat な逆ポーランド記法（RPN）の命令列としてserializeされます。現在提供している
+HiGHS、Python-MIP、PySCIPOpt、OpenJijの全adapterはpolynomialのみを受け付ける
+input classを宣言しているため、各adapterが受け付けるfunction positionの複合式を
+拒否します。
+
+ゼロに依存する`Signum`、`Div`、負の`Powi`ノードは、式の構築、代入、部分評価を
+経ても保持されます。後続の評価処理に渡す`atol`が、結果または定義域エラーを
+決定します。特に、`Function`を定数や係数で除算した場合も複合式のままです。
+`Function.evaluate_bound(..., atol=...)`も同じゼロ判定を区間評価へ適用します。
+IndicatorのBig-M変換、特殊制約のlowering、integer slack変換も、導出するbound用の
+`atol=`を受け取ります。これによりFunction bodyのゼロ判定は整合しますが、代数的な
+loweringは離散値が厳密であることを仮定し、0や1に近いsolver出力を丸める処理は
+行いません。省略時は`DEFAULT_ATOL`が使われます。integer slack変換は係数の正規化前に、
+評価と同じ境界を含む条件 $f(x) < 0$ または
+$|f(x)| \leq \mathtt{atol}$ で不等式を分類するため、微小な正値が
+scaleによって暗黙に再分類されることはありません。厳密な多項式正規化は有限かつ
+非ゼロの係数をすべて保持し、許容誤差によるcleanupを暗黙には行いません。近似的な
+cleanupを将来提供する場合は、別の明示的なAPIになります。減算も、右辺を符号反転して
+加算する場合と同じcanonicalizationに従います。そのため `x - (-y)` は可能ならcompact
+polynomialへ戻り、係数overflowは遅延せず直ちに`ValueError`として通知されます。
+
+`Function`が常にpolynomialとは限らなくなったため、複合式に対する
+{meth}`~ommx.Function.degree` と {meth}`~ommx.Function.num_terms` は`None`を返します。
+polynomial termのaccessorと {meth}`~ommx.Function.content_factor` は、複合式を空の
+polynomialとして扱わず`TypeError`を送出します。演算順序、evaluation error、
+serializationの詳細は [Function user guide](../user_guide/function.md) を参照してください。
+
+Instance class APIでは、このpolynomial要件を名前から明示するようにしました。
+Python SDK 3.0.0 Beta 4で公開したAPIから、次の破壊的なrenameが含まれます。
+
+| 変更前 | 変更後 |
+|---|---|
+| `DegreeBound` | `PolynomialRequirement` |
+| `DegreeBound.at_most(n)` | `PolynomialRequirement.at_most(n)` |
+| `DegreeBound.unbounded()` | `PolynomialRequirement.any_degree()` |
+| `bound.maximum` | `requirement.maximum_degree` |
+| `bound.includes(degree)` | `requirement.accepts_degree(degree)` |
+| `objective_degree_bound` | `objective_polynomial_requirement` |
+| `regular_constraint_degree_bounds` | `regular_constraint_polynomial_requirements` |
+| `indicator_constraint_degree_bounds` | `indicator_body_polynomial_requirements` |
+
+`PolynomialRequirement.any_degree()`が受け付けるのは任意次数のpolynomialであり、
+複合された非polynomialの`Function`は含みません。
+
 ### 🆕 検証付きSOS1 Big-M promotion ([#1186](https://github.com/Jij-Inc/ommx/pull/1186))
 
 {ref}`SOS1制約 <sos1-constraint>`は、memberのうち高々1つだけが
@@ -80,111 +192,9 @@ rate = instance.new_semi_continuous("rate", lower=0.5, upper=4)
 決定変数IDの最大値が `2**64 - 1` で、それより大きい自動IDを割り当てられない場合も、
 変数やlabelの一部だけが残ることはありません。
 
-### 🛠 境界を含む `atol` 判定 ([#1181](https://github.com/Jij-Inc/ommx/pull/1181))
+## 3.0.0 Beta 4
 
-絶対許容誤差の比較は、差がちょうど`atol`となる境界を一貫して含むようになりました。
-等式のresidualは $|f(x)| \leq \mathtt{atol}$ のときfeasible、不等式のresidualは
-$f(x) < 0$ または $|f(x)| \leq \mathtt{atol}$ のときfeasibleです。scalar / sample
-evaluation、regular / Indicator constraint、`Solution` / `SampleSet`の検証、v1 / v2の
-deserializeで同じ規則を使います。
-
-Functionのゼロ依存演算、Indicatorのactivation、OneHot / SOS1の分類、solver stateの
-離散値canonicalization、fixed valueの整合性検証でも、targetとの差がちょうど`atol`の
-値を含みます。境界をわずかに超える値は引き続き範囲外です。有限値の検証を所有するAPIは、
-domain errorや整合性errorを返す前にNaNと無限大を引き続き拒否します。
-
-### ⚠ 複合 `Function` 演算 ([#1158](https://github.com/Jij-Inc/ommx/pull/1158), [#1178](https://github.com/Jij-Inc/ommx/pull/1178), [#1181](https://github.com/Jij-Inc/ommx/pull/1181))
-
-{class}`~ommx.Function` はcompactなpolynomialに加えて、複合式も表現できるように
-なりました。絶対値、符号関数、最小値、最大値、除算、符号付き32 bit整数による
-累乗をPythonから直接構築できます。
-
-```python
-from ommx import DecisionVariable, Function
-
-x = Function(DecisionVariable.continuous(1))
-y = Function(DecisionVariable.continuous(2))
-z = Function(DecisionVariable.continuous(3))
-
-f = abs(x - 2).maximum(y) / (z + 1)
-g = f**2
-h = f.powi(-2)
-```
-
-名前付きの演算には {meth}`~ommx.Function.signum`、
-{meth}`~ommx.Function.minimum`、{meth}`~ommx.Function.maximum` を使用します。
-`f**n` と {meth}`~ommx.Function.powi` は同じ演算です。浮動小数や関数値の指数、
-および反転累乗はサポートしません。評価時には、境界を含む
-`abs(value) <= atol`をゼロと判定します。`signum`は`0`を返し、そのように
-判定された値を分母にする除算や負の整数による累乗は`ValueError`になります。
-複合式はOMMX protobuf payloadへ
-flat な逆ポーランド記法（RPN）の命令列としてserializeされます。現在提供している
-HiGHS、Python-MIP、PySCIPOpt、OpenJijの全adapterはpolynomialのみを受け付ける
-input classを宣言しているため、各adapterが受け付けるfunction positionの複合式を
-拒否します。
-
-ゼロに依存する`Signum`、`Div`、負の`Powi`ノードは、式の構築、代入、部分評価を
-経ても保持されます。後続の評価処理に渡す`atol`が、結果または定義域エラーを
-決定します。特に、`Function`を定数や係数で除算した場合も複合式のままです。
-`Function.evaluate_bound(..., atol=...)`も同じゼロ判定を区間評価へ適用します。
-IndicatorのBig-M変換、特殊制約のlowering、integer slack変換も、導出するbound用の
-`atol=`を受け取ります。これによりFunction bodyのゼロ判定は整合しますが、代数的な
-loweringは離散値が厳密であることを仮定し、0や1に近いsolver出力を丸める処理は
-行いません。省略時は`DEFAULT_ATOL`が使われます。integer slack変換は係数の正規化前に、
-評価と同じ境界を含む条件 $f(x) < 0$ または
-$|f(x)| \leq \mathtt{atol}$ で不等式を分類するため、微小な正値が
-scaleによって暗黙に再分類されることはありません。厳密な多項式正規化は有限かつ
-非ゼロの係数をすべて保持し、許容誤差によるcleanupを暗黙には行いません。近似的な
-cleanupを将来提供する場合は、別の明示的なAPIになります。
-
-`Function`が常にpolynomialとは限らなくなったため、複合式に対する
-{meth}`~ommx.Function.degree` と {meth}`~ommx.Function.num_terms` は`None`を返します。
-polynomial termのaccessorと {meth}`~ommx.Function.content_factor` は、複合式を空の
-polynomialとして扱わず`TypeError`を送出します。演算順序、evaluation error、
-serializationの詳細は [Function user guide](../user_guide/function.md) を参照してください。
-
-Instance class APIでは、このpolynomial要件を名前から明示するようにしました。
-Python SDK 3.0.0 Beta 4で公開したAPIから、次の破壊的なrenameが含まれます。
-
-| 変更前 | 変更後 |
-|---|---|
-| `DegreeBound` | `PolynomialRequirement` |
-| `DegreeBound.at_most(n)` | `PolynomialRequirement.at_most(n)` |
-| `DegreeBound.unbounded()` | `PolynomialRequirement.any_degree()` |
-| `bound.maximum` | `requirement.maximum_degree` |
-| `bound.includes(degree)` | `requirement.accepts_degree(degree)` |
-| `objective_degree_bound` | `objective_polynomial_requirement` |
-| `regular_constraint_degree_bounds` | `regular_constraint_polynomial_requirements` |
-| `indicator_constraint_degree_bounds` | `indicator_body_polynomial_requirements` |
-
-`PolynomialRequirement.any_degree()`が受け付けるのは任意次数のpolynomialであり、
-複合された非polynomialの`Function`は含みません。
-
-### 🛠 evaluation時のsolver stateをcanonicalize ([#1174](https://github.com/Jij-Inc/ommx/pull/1174), [#1181](https://github.com/Jij-Inc/ommx/pull/1181))
-
-{meth}`~ommx.Instance.populate_state`、{meth}`~ommx.Instance.evaluate`、
-{meth}`~ommx.Instance.evaluate_samples`は、fixedでもdependentでもない有限な入力値と、
-dependent targetの導出値を、decision variableのkindと呼び出し側の`atol`に従って
-canonicalizeするようになりました。これらの値について、`0`または`1`との差が`atol`
-以下のBinary値と、整数との差が`atol`以下のInteger / SemiInteger値は、境界上の値も含めて
-対応する厳密な離散値として格納されます。canonicalizationとは
-別に、kindとboundのfeasibilityを既存の規則で判定します。
-ContinuousとSemiContinuousは丸めません。それ以外の有限値は、返された
-{class}`~ommx.Solution`がfeasibilityを判定できるように保持し、非有限なstate値は
-引き続き拒否します。
-
-呼び出し側がfixedまたはdependent variableの値を渡した場合、その値は引き続き
-整合性assertionとして扱います。検証後のstateには、Instanceが所有するfixed valueを
-変更せずに格納するか、dependencyから導出してtarget kindに従いcanonicalizeした値を
-格納します。dependencyはcanonicalized inputから評価するため、丸め前のsolver vectorを
-もとに明示したdependent assertionが、導出値の`atol`内に入らず拒否される場合があります。
-scalar / sample evaluationは同じ規則を使い、SampleIDの対応関係を保持します。
-
-{meth}`~ommx.Instance.partial_evaluate`も、入力を検証した後、special constraintのpropagation、
-expressionへの代入、定数化したdependencyの評価より前に同じ規則を適用します。そのため、
-書き換え後のInstanceを評価した結果は、元のInstanceを直接評価した場合と同じcanonical
-coordinateを使います。Instanceが既に所有するfixed valueは変更せず、既存のkind / bound
-検証でpartial evaluationの受理範囲外となる値は引き続き拒否します。
+[![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b4-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b4)
 
 ### ⚠ `solve()`と`sample()`が入力を自動的にPrepare ([#1166](https://github.com/Jij-Inc/ommx/pull/1166))
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -595,7 +595,9 @@ Related PRs: [#790](https://github.com/Jij-Inc/ommx/pull/790),
 [#811](https://github.com/Jij-Inc/ommx/pull/811),
 [#814](https://github.com/Jij-Inc/ommx/pull/814),
 [#1083](https://github.com/Jij-Inc/ommx/pull/1083),
-[#1088](https://github.com/Jij-Inc/ommx/pull/1088).
+[#1088](https://github.com/Jij-Inc/ommx/pull/1088),
+[#1158](https://github.com/Jij-Inc/ommx/pull/1158),
+[#1178](https://github.com/Jij-Inc/ommx/pull/1178).
 
 ## ⚙️ Unified error surface
 
@@ -794,7 +796,9 @@ for construction and operator examples.
 Related PRs: [#621](https://github.com/Jij-Inc/ommx/pull/621),
 [#952](https://github.com/Jij-Inc/ommx/pull/952),
 [#953](https://github.com/Jij-Inc/ommx/pull/953),
-[#990](https://github.com/Jij-Inc/ommx/pull/990).
+[#990](https://github.com/Jij-Inc/ommx/pull/990),
+[#1158](https://github.com/Jij-Inc/ommx/pull/1158),
+[#1178](https://github.com/Jij-Inc/ommx/pull/1178).
 
 ## 🧮 Composed `Function` expressions
 
@@ -808,7 +812,11 @@ non-folded composition uses the single
 [`Function::Expression`](crate::Function::Expression) variant. Function
 division remains composed even when its divisor is a constant
 [`Coefficient`](crate::Coefficient). Each associative instruction combines two
-stack values, preserving exact grouping and left-to-right operand order.
+stack values, preserving exact grouping and left-to-right operand order. Owned
+and borrowed subtraction use the same canonical dispatch after negating the
+right-hand side, so eliminating a double negation can normalize back to a
+compact polynomial and coefficient overflow is reported eagerly in every
+ownership form.
 
 The evaluation contract is explicit. The caller's [`ATol`](crate::ATol)
 classifies a value as zero when `abs(value) <= atol`, including the boundary.
@@ -856,7 +864,8 @@ strategies remain explicitly polynomial.
 
 Related PRs: [#1158](https://github.com/Jij-Inc/ommx/pull/1158),
 [#1178](https://github.com/Jij-Inc/ommx/pull/1178),
-[#1181](https://github.com/Jij-Inc/ommx/pull/1181).
+[#1181](https://github.com/Jij-Inc/ommx/pull/1181),
+[#1184](https://github.com/Jij-Inc/ommx/pull/1184).
 
 ## ⚙️ OMMX Artifact lifecycle and OCI representation
 


### PR DESCRIPTION
## Summary

- Promote the English and Japanese Python SDK notes into a 3.0.0 Beta 5 section and order fixes, breaking changes, and new features by user impact.
- Backfill the missing Python SDK Beta 4 boundary and release badges so preparation-related changes remain attributed to the release that shipped them.
- Document the corrected `Function` subtraction behavior and add PR #1184 to the Python and Rust provenance.
- Complete the Rust 3.0 topic provenance for composed functions across adapter input classes, fallible arithmetic, and expression behavior.
