### PR TITLE
Add checked OneHot promotion request

### DIFF
--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -1284,7 +1284,10 @@ moves to removed history while its context is copied to a new first-class
 [`OneHotConstraint`](crate::OneHotConstraint). The returned map has exactly one
 entry per requested source ID, whose value is either the new OneHot ID or that
 source's rejection reason. An invalid source does not prevent independent valid
-sources from being promoted.
+sources from being promoted. Promotion preserves the exact feasible set over
+binary assignments. Approximate feasibility can differ because a regular row
+checks one scaled residual while a OneHot constraint classifies each member as
+zero or one under the evaluation tolerance.
 
 Legacy v1 `ConstraintHints` remain advisory during deserialization. The v1
 readers preserve the referenced regular constraints and context but do not

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -1276,13 +1276,15 @@ history instead of returning a history-free replacement model.
 
 [`Instance::promote_one_hot`](crate::Instance::promote_one_hot) provides the
 corresponding checked promotion for regular one-hot equalities. It accepts a
-batch of untrusted [`OneHotPromotionRequest`](crate::OneHotPromotionRequest)
-values, requires each promoted active row to be exactly a non-zero scalar
-multiple of `sum(members) - 1 = 0` over the claimed Binary variables, and
-moves every compatible row to removed history while copying its context to a
-new first-class [`OneHotConstraint`](crate::OneHotConstraint). Results remain
-aligned with the requests, so individually invalid or conflicting requests do
-not prevent independent valid requests from being promoted.
+[`OneHotPromotionRequest`](crate::OneHotPromotionRequest) containing the set of
+regular constraint IDs to inspect, derives each member set from the current
+source row, and requires every promoted row to be exactly a non-zero scalar
+multiple of `sum(members) - 1 = 0` over Binary variables. Every compatible row
+moves to removed history while its context is copied to a new first-class
+[`OneHotConstraint`](crate::OneHotConstraint). The returned map has exactly one
+entry per requested source ID, whose value is either the new OneHot ID or that
+source's rejection reason. An invalid source does not prevent independent valid
+sources from being promoted.
 
 Legacy v1 `ConstraintHints` remain advisory during deserialization. The v1
 readers preserve the referenced regular constraints and context but do not

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -1274,6 +1274,14 @@ Unsupported Rust-side structures are rejected conservatively rather than
 discarded, and the transformed `Instance` retains the complete formulation
 history instead of returning a history-free replacement model.
 
+[`Instance::promote_one_hot`](crate::Instance::promote_one_hot) provides the
+corresponding checked promotion for a regular one-hot equality. It accepts an
+untrusted [`OneHotPromotionRequest`](crate::OneHotPromotionRequest), requires
+the active row to be exactly a non-zero scalar multiple of
+`sum(members) - 1 = 0` over the claimed Binary variables, and atomically moves
+that row to removed history while copying its context to a new first-class
+[`OneHotConstraint`](crate::OneHotConstraint).
+
 Legacy v1 `ConstraintHints` remain advisory during deserialization. The v1
 readers preserve the referenced regular constraints and context but do not
 promote unverified hints into first-class one-hot or SOS1 constraints.
@@ -1289,7 +1297,8 @@ Related PRs: [#1010](https://github.com/Jij-Inc/ommx/pull/1010),
 [#1149](https://github.com/Jij-Inc/ommx/pull/1149),
 [#1154](https://github.com/Jij-Inc/ommx/pull/1154),
 [#1167](https://github.com/Jij-Inc/ommx/pull/1167),
-[#1192](https://github.com/Jij-Inc/ommx/pull/1192).
+[#1192](https://github.com/Jij-Inc/ommx/pull/1192),
+[#1193](https://github.com/Jij-Inc/ommx/pull/1193).
 
 ## ⚙️ Formatting and property-test domains
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -1275,12 +1275,14 @@ discarded, and the transformed `Instance` retains the complete formulation
 history instead of returning a history-free replacement model.
 
 [`Instance::promote_one_hot`](crate::Instance::promote_one_hot) provides the
-corresponding checked promotion for a regular one-hot equality. It accepts an
-untrusted [`OneHotPromotionRequest`](crate::OneHotPromotionRequest), requires
-the active row to be exactly a non-zero scalar multiple of
-`sum(members) - 1 = 0` over the claimed Binary variables, and atomically moves
-that row to removed history while copying its context to a new first-class
-[`OneHotConstraint`](crate::OneHotConstraint).
+corresponding checked promotion for regular one-hot equalities. It accepts a
+batch of untrusted [`OneHotPromotionRequest`](crate::OneHotPromotionRequest)
+values, requires each promoted active row to be exactly a non-zero scalar
+multiple of `sum(members) - 1 = 0` over the claimed Binary variables, and
+moves every compatible row to removed history while copying its context to a
+new first-class [`OneHotConstraint`](crate::OneHotConstraint). Results remain
+aligned with the requests, so individually invalid or conflicting requests do
+not prevent independent valid requests from being promoted.
 
 Legacy v1 `ConstraintHints` remain advisory during deserialization. The v1
 readers preserve the referenced regular constraints and context but do not

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -37,7 +37,7 @@ mod unary_encode;
 pub use analysis::{DecisionVariableRole, DecisionVariableUsage, DecisionVariableUsageEntry};
 pub use arbitrary::{InstanceParameters, InstanceSpace};
 pub use builder::*;
-pub use one_hot_promotion::OneHotPromotionRequest;
+pub use one_hot_promotion::{OneHotPromotion, OneHotPromotionRequest};
 pub use parametric_builder::*;
 pub use preparation::{
     BinaryPowerPreparation, FixedPenaltyPreparation, IntegerEncodingPreparation,

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -37,7 +37,7 @@ mod unary_encode;
 pub use analysis::{DecisionVariableRole, DecisionVariableUsage, DecisionVariableUsageEntry};
 pub use arbitrary::{InstanceParameters, InstanceSpace};
 pub use builder::*;
-pub use one_hot_promotion::{OneHotPromotion, OneHotPromotionRequest};
+pub use one_hot_promotion::OneHotPromotionRequest;
 pub use parametric_builder::*;
 pub use preparation::{
     BinaryPowerPreparation, FixedPenaltyPreparation, IntegerEncodingPreparation,

--- a/rust/ommx/src/instance.rs
+++ b/rust/ommx/src/instance.rs
@@ -15,6 +15,7 @@ mod logical_memory;
 mod named_function;
 mod new;
 mod one_hot;
+mod one_hot_promotion;
 mod parametric_builder;
 mod parse;
 mod pass;
@@ -36,6 +37,7 @@ mod unary_encode;
 pub use analysis::{DecisionVariableRole, DecisionVariableUsage, DecisionVariableUsageEntry};
 pub use arbitrary::{InstanceParameters, InstanceSpace};
 pub use builder::*;
+pub use one_hot_promotion::{OneHotPromotion, OneHotPromotionRequest};
 pub use parametric_builder::*;
 pub use preparation::{
     BinaryPowerPreparation, FixedPenaltyPreparation, IntegerEncodingPreparation,

--- a/rust/ommx/src/instance/one_hot_promotion.rs
+++ b/rust/ommx/src/instance/one_hot_promotion.rs
@@ -6,11 +6,10 @@
 //! allowed only when the active source is exactly a non-zero scalar multiple of
 //! `sum(variables) - 1 = 0` over binary variables.
 //!
-//! Even the single-request API uses a private batch plan. All candidates are
-//! checked against one unchanged source instance before target IDs are
-//! allocated. The batch plan proves that every aggregate storage effect must
-//! succeed, so applying it never clones the [`Instance`] and cannot return a
-//! recoverable error.
+//! The public API is batch-oriented. All candidates are checked against one
+//! unchanged source instance before target IDs are allocated. The batch plan
+//! proves that every aggregate storage effect must succeed, so applying it
+//! never clones the [`Instance`] and cannot return a recoverable error.
 
 use super::Instance;
 use crate::{
@@ -149,10 +148,11 @@ struct OneHotPromotionBatchPlanning {
 }
 
 impl Instance {
-    /// Promote an exact regular equality to a one-hot constraint.
+    /// Promote compatible exact regular equalities to one-hot constraints as a
+    /// single batch.
     ///
-    /// The request is untrusted. This method verifies against the current
-    /// instance that:
+    /// The requests are untrusted. This method verifies each candidate against
+    /// the current instance, requiring that:
     ///
     /// - the claimed member set is non-empty;
     /// - the source is an active regular equality;
@@ -162,26 +162,16 @@ impl Instance {
     /// - for one common non-zero coefficient `c`, the row is exactly
     ///   `c * (sum(variables) - 1) = 0`.
     ///
-    /// On success the source moves to `removed_constraints`, its context is
-    /// copied to the new active one-hot constraint, and the removal reason
-    /// records the allocated target ID. The operation is atomic: any returned
-    /// error leaves this instance unchanged.
-    pub fn promote_one_hot(
-        &mut self,
-        request: &OneHotPromotionRequest,
-    ) -> crate::Result<OneHotPromotion> {
-        self.promote_compatible_one_hot(std::slice::from_ref(request))
-            .pop()
-            .expect("one request must produce one aligned OneHot promotion outcome")
-    }
-
-    /// Check, reconcile, and apply OneHot promotion requests as one batch.
+    /// Results remain aligned with `requests`. Individually invalid requests
+    /// and every request sharing a source row with another individually valid
+    /// request are rejected, while compatible requests are all applied.
     ///
-    /// Results remain aligned with the input requests. Individually invalid
-    /// requests and every request sharing a source row with another
-    /// individually valid request are rejected. All remaining requests are
-    /// applied together through one [`OneHotPromotionBatchPlan`].
-    fn promote_compatible_one_hot(
+    /// On each successful entry the source moves to `removed_constraints`, its
+    /// context is copied to the new active one-hot constraint, and the removal
+    /// reason records the allocated target ID. Planning is atomic: rejected
+    /// requests leave their rows unchanged, and applying the resulting private
+    /// plan is infallible by construction.
+    pub fn promote_one_hot(
         &mut self,
         requests: &[OneHotPromotionRequest],
     ) -> Vec<crate::Result<OneHotPromotion>> {
@@ -538,7 +528,11 @@ mod tests {
     ) {
         let regular_before = instance.constraint_collection.clone();
         let one_hot_before = instance.one_hot_constraint_collection.clone();
-        let error = instance.promote_one_hot(request).unwrap_err();
+        let error = instance
+            .promote_one_hot(std::slice::from_ref(request))
+            .pop()
+            .unwrap()
+            .unwrap_err();
         assert!(
             error.to_string().contains(message),
             "unexpected error: {error:#}"
@@ -595,7 +589,11 @@ mod tests {
                 .set_constraint_context(ConstraintID::from(10), context.clone())
                 .unwrap();
 
-            let promotion = instance.promote_one_hot(&request([1, 2, 3])).unwrap();
+            let promotion = instance
+                .promote_one_hot(&[request([1, 2, 3])])
+                .pop()
+                .unwrap()
+                .unwrap();
 
             assert_eq!(
                 promotion.one_hot_constraint_id(),
@@ -638,7 +636,7 @@ mod tests {
     fn batch_promotes_disjoint_rows_with_a_shared_member() {
         let (mut instance, requests) = batch_instance();
 
-        let outcomes = instance.promote_compatible_one_hot(&requests);
+        let outcomes = instance.promote_one_hot(&requests);
 
         let promotions = outcomes
             .iter()
@@ -673,7 +671,7 @@ mod tests {
             requests[1].clone(),
         ];
 
-        let outcomes = instance.promote_compatible_one_hot(&requests);
+        let outcomes = instance.promote_one_hot(&requests);
 
         assert!(outcomes[0]
             .as_ref()
@@ -686,6 +684,37 @@ mod tests {
             OneHotConstraintID::from(0)
         );
         assert!(instance.constraints().contains_key(&ConstraintID::from(10)));
+        assert!(instance
+            .removed_constraints()
+            .contains_key(&ConstraintID::from(20)));
+        assert_eq!(instance.one_hot_constraints().len(), 1);
+    }
+
+    #[test]
+    fn batch_promotes_valid_requests_while_rejecting_individually_invalid_requests() {
+        let (mut instance, requests) = batch_instance();
+        let requests = vec![
+            OneHotPromotionRequest {
+                source_constraint_id: ConstraintID::from(99),
+                variables: variables([1, 2]),
+            },
+            requests[1].clone(),
+        ];
+
+        let outcomes = instance.promote_one_hot(&requests);
+
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes[0]
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("was not found"));
+        assert_eq!(
+            outcomes[1].as_ref().unwrap().one_hot_constraint_id(),
+            OneHotConstraintID::from(0)
+        );
+        assert!(instance.constraints().contains_key(&ConstraintID::from(10)));
+        assert!(!instance.constraints().contains_key(&ConstraintID::from(20)));
         assert!(instance
             .removed_constraints()
             .contains_key(&ConstraintID::from(20)));
@@ -706,7 +735,7 @@ mod tests {
         let regular_before = instance.constraint_collection.clone();
         let one_hot_before = instance.one_hot_constraint_collection.clone();
 
-        let outcomes = instance.promote_compatible_one_hot(&requests);
+        let outcomes = instance.promote_one_hot(&requests);
 
         assert!(outcomes.iter().all(Result::is_err));
         assert!(outcomes.iter().all(|outcome| outcome

--- a/rust/ommx/src/instance/one_hot_promotion.rs
+++ b/rust/ommx/src/instance/one_hot_promotion.rs
@@ -1,0 +1,482 @@
+//! Checked promotion of exact regular equalities to one-hot constraints.
+//!
+//! A promotion request is deliberately untrusted. It carries only stable IDs
+//! and claimed one-hot membership; the current [`Instance`] remains the source
+//! of truth for the regular row and decision-variable domains. Promotion is
+//! allowed only when the active source is exactly a non-zero scalar multiple of
+//! `sum(variables) - 1 = 0` over binary variables.
+
+use super::Instance;
+use crate::{
+    Coefficient, ConstraintContext, ConstraintID, Equality, Kind, LinearMonomial, OneHotConstraint,
+    OneHotConstraintID, RemovedReason, VariableID, VariableIDSet,
+};
+use std::collections::BTreeMap;
+
+const PROMOTION_REASON: &str = "promoted validated one-hot equality";
+const TARGET_ID_PARAMETER: &str = "one_hot_constraint_id";
+
+/// Untrusted stable-ID request for one one-hot promotion.
+///
+/// The request claims that `source_constraint_id` identifies an active regular
+/// equality whose exact support is `variables`. Callers may construct invalid
+/// requests directly; [`Instance::promote_one_hot`] checks the source row,
+/// relation, coefficients, and current variable domains before mutation.
+///
+/// No target ID is supplied. A fresh [`OneHotConstraintID`] is allocated from
+/// the current [`Instance`] only after the request has been verified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneHotPromotionRequest {
+    /// Active regular constraint claimed to encode one-hot membership.
+    pub source_constraint_id: ConstraintID,
+    /// Claimed one-hot members.
+    pub variables: VariableIDSet,
+}
+
+impl OneHotPromotionRequest {
+    /// Convert one legacy v1 one-hot hint into an untrusted request.
+    ///
+    /// This conversion is independent of any [`Instance`]. It validates only
+    /// the wire-level set shape: the member list must be non-empty and contain
+    /// no duplicate IDs. Domain and source-row validation is deferred to
+    /// [`Instance::promote_one_hot`]. Constraint ID `0` is a valid stable ID.
+    pub fn from_v1_hint(hint: &crate::v1::OneHot) -> crate::Result<Self> {
+        if hint.decision_variables.is_empty() {
+            crate::bail!("Legacy v1 one-hot hint must contain at least one member");
+        }
+
+        let mut variables = VariableIDSet::new();
+        for &raw_id in &hint.decision_variables {
+            let id = VariableID::from(raw_id);
+            if !variables.insert(id) {
+                crate::bail!(
+                    { ?id },
+                    "Legacy v1 one-hot hint repeats member {id:?}"
+                );
+            }
+        }
+
+        Ok(Self {
+            source_constraint_id: ConstraintID::from(hint.constraint_id),
+            variables,
+        })
+    }
+}
+
+/// Result of one checked one-hot promotion.
+///
+/// The source regular constraint remains in the same [`Instance`] as removed
+/// history, and the new one-hot constraint receives a copy of its context.
+#[must_use = "the result identifies the promoted constraint and retained source"]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneHotPromotion {
+    one_hot_constraint_id: OneHotConstraintID,
+    variables: VariableIDSet,
+    relaxed_constraint_id: ConstraintID,
+}
+
+impl OneHotPromotion {
+    /// ID allocated to the promoted one-hot constraint.
+    pub fn one_hot_constraint_id(&self) -> OneHotConstraintID {
+        self.one_hot_constraint_id
+    }
+
+    /// Verified one-hot members.
+    pub fn variables(&self) -> &VariableIDSet {
+        &self.variables
+    }
+
+    /// Regular source constraint moved from active to removed.
+    pub fn relaxed_constraint_id(&self) -> ConstraintID {
+        self.relaxed_constraint_id
+    }
+}
+
+#[derive(Debug)]
+struct OneHotPromotionPlan {
+    result: OneHotPromotion,
+    one_hot_constraint: OneHotConstraint,
+    context: ConstraintContext,
+}
+
+impl Instance {
+    /// Promote an exact regular equality to a one-hot constraint.
+    ///
+    /// The request is untrusted. This method verifies against the current
+    /// instance that:
+    ///
+    /// - the claimed member set is non-empty;
+    /// - the source is an active regular equality;
+    /// - its function is exactly linear;
+    /// - its support is exactly the claimed member set;
+    /// - every member is a binary decision variable; and
+    /// - for one common non-zero coefficient `c`, the row is exactly
+    ///   `c * (sum(variables) - 1) = 0`.
+    ///
+    /// On success the source moves to `removed_constraints`, its context is
+    /// copied to the new active one-hot constraint, and the removal reason
+    /// records the allocated target ID. The operation is atomic: any returned
+    /// error leaves this instance unchanged.
+    pub fn promote_one_hot(
+        &mut self,
+        request: &OneHotPromotionRequest,
+    ) -> crate::Result<OneHotPromotion> {
+        let plan = self.plan_one_hot_promotion(request)?;
+        let result = plan.result.clone();
+
+        // Commit to a rollback copy so even a storage-layer invariant failure
+        // cannot expose a partially promoted Instance.
+        let mut staged = self.clone();
+        staged
+            .constraint_collection
+            .move_active_rows_to_removed_with_reasons(BTreeMap::from([(
+                result.relaxed_constraint_id,
+                RemovedReason {
+                    reason: PROMOTION_REASON.to_string(),
+                    parameters: [(
+                        TARGET_ID_PARAMETER.to_string(),
+                        result.one_hot_constraint_id.into_inner().to_string(),
+                    )]
+                    .into_iter()
+                    .collect(),
+                },
+            )]))?;
+        staged
+            .one_hot_constraint_collection
+            .insert_active_with_context(
+                result.one_hot_constraint_id,
+                plan.one_hot_constraint,
+                plan.context,
+            )?;
+        *self = staged;
+
+        Ok(result)
+    }
+
+    fn plan_one_hot_promotion(
+        &self,
+        request: &OneHotPromotionRequest,
+    ) -> crate::Result<OneHotPromotionPlan> {
+        if request.variables.is_empty() {
+            crate::bail!("One-hot promotion request must contain at least one member");
+        }
+
+        let source = self
+            .constraint_collection
+            .active()
+            .get(&request.source_constraint_id)
+            .ok_or_else(|| {
+                crate::error!(
+                    { source_constraint_id = ?request.source_constraint_id },
+                    "Active regular constraint {:?} was not found",
+                    request.source_constraint_id
+                )
+            })?;
+        if source.equality != Equality::EqualToZero {
+            crate::bail!(
+                { source_constraint_id = ?request.source_constraint_id },
+                "Regular constraint {:?} is not an equality-to-zero constraint",
+                request.source_constraint_id
+            );
+        }
+
+        let linear = source.function().as_linear().ok_or_else(|| {
+            crate::error!(
+                { source_constraint_id = ?request.source_constraint_id },
+                "Regular constraint {:?} is not exactly linear",
+                request.source_constraint_id
+            )
+        })?;
+        let coefficients: BTreeMap<VariableID, Coefficient> = linear.linear_terms().collect();
+        let support: VariableIDSet = coefficients.keys().copied().collect();
+        if support != request.variables {
+            crate::bail!(
+                {
+                    source_constraint_id = ?request.source_constraint_id,
+                    ?support,
+                    claimed_variables = ?request.variables
+                },
+                "Regular constraint {:?} has linear support {support:?}, expected {:?}",
+                request.source_constraint_id,
+                request.variables
+            );
+        }
+
+        for &variable_id in &request.variables {
+            let variable = self.decision_variables.get(&variable_id).ok_or_else(|| {
+                crate::error!(
+                    { ?variable_id },
+                    "One-hot promotion member {variable_id:?} is not a decision variable"
+                )
+            })?;
+            if variable.kind() != Kind::Binary {
+                crate::bail!(
+                    { ?variable_id, kind = ?variable.kind() },
+                    "One-hot promotion member {variable_id:?} must be binary"
+                );
+            }
+        }
+
+        let common_coefficient = coefficients
+            .values()
+            .next()
+            .copied()
+            .expect("non-empty verified support has a coefficient");
+        if coefficients
+            .values()
+            .any(|&coefficient| coefficient != common_coefficient)
+        {
+            crate::bail!(
+                { source_constraint_id = ?request.source_constraint_id },
+                "Regular constraint {:?} does not use one common coefficient for all one-hot members",
+                request.source_constraint_id
+            );
+        }
+
+        let constant = linear.get(&LinearMonomial::Constant);
+        if constant != Some(-common_coefficient) {
+            crate::bail!(
+                {
+                    source_constraint_id = ?request.source_constraint_id,
+                    ?constant,
+                    expected = ?(-common_coefficient)
+                },
+                "Regular constraint {:?} has constant coefficient {constant:?}, expected {:?}",
+                request.source_constraint_id,
+                -common_coefficient
+            );
+        }
+
+        self.one_hot_constraint_collection
+            .ensure_unused_id_capacity(1)?;
+        let one_hot_constraint_id = self.one_hot_constraint_collection.unused_id();
+        let one_hot_constraint = OneHotConstraint::new(request.variables.clone())?;
+        let context = self
+            .constraint_collection
+            .context()
+            .collect_for(request.source_constraint_id);
+
+        Ok(OneHotPromotionPlan {
+            result: OneHotPromotion {
+                one_hot_constraint_id,
+                variables: request.variables.clone(),
+                relaxed_constraint_id: request.source_constraint_id,
+            },
+            one_hot_constraint,
+            context,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        coeff, linear, quadratic, Constraint, ConstraintContext, DecisionVariable, Function,
+        Linear, ModelingLabel, Sense,
+    };
+
+    fn variables(ids: impl IntoIterator<Item = u64>) -> VariableIDSet {
+        ids.into_iter().map(VariableID::from).collect()
+    }
+
+    fn exact_scaled_one_hot(ids: &[u64], coefficient: f64) -> Function {
+        let coefficient = Coefficient::try_from(coefficient).unwrap();
+        let linear = ids.iter().copied().fold(
+            Linear::single_term(LinearMonomial::Constant, -coefficient),
+            |sum, id| (sum + Linear::single_term(LinearMonomial::from(id), coefficient)).unwrap(),
+        );
+        Function::from(linear)
+    }
+
+    fn instance_with_source(source: Constraint) -> Instance {
+        Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), DecisionVariable::binary()),
+                (VariableID::from(2), DecisionVariable::binary()),
+                (VariableID::from(3), DecisionVariable::binary()),
+                (VariableID::from(4), DecisionVariable::integer()),
+            ]))
+            .constraints(BTreeMap::from([(ConstraintID::from(10), source)]))
+            .build()
+            .unwrap()
+    }
+
+    fn request(ids: impl IntoIterator<Item = u64>) -> OneHotPromotionRequest {
+        OneHotPromotionRequest {
+            source_constraint_id: ConstraintID::from(10),
+            variables: variables(ids),
+        }
+    }
+
+    fn assert_atomic_rejection(
+        mut instance: Instance,
+        request: &OneHotPromotionRequest,
+        message: &str,
+    ) {
+        let before = instance.clone();
+        let error = instance.promote_one_hot(request).unwrap_err();
+        assert!(
+            error.to_string().contains(message),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(instance, before);
+    }
+
+    #[test]
+    fn converts_v1_hint_without_instance_and_rejects_invalid_member_lists() {
+        let hint = crate::v1::OneHot {
+            constraint_id: 0,
+            decision_variables: vec![2, 1],
+        };
+        assert_eq!(
+            OneHotPromotionRequest::from_v1_hint(&hint).unwrap(),
+            OneHotPromotionRequest {
+                source_constraint_id: ConstraintID::from(0),
+                variables: variables([1, 2]),
+            }
+        );
+
+        for (members, expected) in [
+            (vec![], "at least one member"),
+            (vec![1, 1], "repeats member"),
+        ] {
+            let error = OneHotPromotionRequest::from_v1_hint(&crate::v1::OneHot {
+                constraint_id: 7,
+                decision_variables: members,
+            })
+            .unwrap_err();
+            assert!(error.to_string().contains(expected));
+        }
+    }
+
+    #[test]
+    fn promotes_exact_scaled_equality_and_preserves_history_and_context() {
+        for coefficient in [1.0, 2.5, -3.0] {
+            let mut instance = instance_with_source(Constraint::equal_to_zero(
+                exact_scaled_one_hot(&[1, 2, 3], coefficient),
+            ));
+            let context = ConstraintContext {
+                label: ModelingLabel {
+                    name: Some("choose".to_string()),
+                    subscripts: vec![4, 2],
+                    description: Some("exactly one".to_string()),
+                    ..Default::default()
+                },
+                provenance: vec![crate::Provenance::Sos1Constraint(
+                    crate::Sos1ConstraintID::from(9),
+                )],
+            };
+            instance
+                .set_constraint_context(ConstraintID::from(10), context.clone())
+                .unwrap();
+
+            let promotion = instance.promote_one_hot(&request([1, 2, 3])).unwrap();
+
+            assert_eq!(
+                promotion.one_hot_constraint_id(),
+                OneHotConstraintID::from(0)
+            );
+            assert_eq!(promotion.variables(), &variables([1, 2, 3]));
+            assert_eq!(promotion.relaxed_constraint_id(), ConstraintID::from(10));
+            assert!(instance.constraints().is_empty());
+            assert_eq!(
+                instance.one_hot_constraints()[&OneHotConstraintID::from(0)].variables,
+                variables([1, 2, 3])
+            );
+
+            let (_, reason) = &instance.removed_constraints()[&ConstraintID::from(10)];
+            assert_eq!(reason.reason, PROMOTION_REASON);
+            assert_eq!(
+                reason
+                    .parameters
+                    .get(TARGET_ID_PARAMETER)
+                    .map(String::as_str),
+                Some("0")
+            );
+            assert_eq!(
+                instance
+                    .constraint_collection()
+                    .context()
+                    .collect_for(ConstraintID::from(10)),
+                context
+            );
+            assert_eq!(
+                instance
+                    .one_hot_constraint_context()
+                    .collect_for(OneHotConstraintID::from(0)),
+                context
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_wrong_relation_support_or_variable_domain_atomically() {
+        let exact = Constraint::equal_to_zero(exact_scaled_one_hot(&[1, 2, 3], 1.0));
+        assert_atomic_rejection(
+            instance_with_source(exact.clone()),
+            &OneHotPromotionRequest {
+                source_constraint_id: ConstraintID::from(99),
+                variables: variables([1, 2, 3]),
+            },
+            "was not found",
+        );
+        assert_atomic_rejection(
+            instance_with_source(Constraint::less_than_or_equal_to_zero(
+                exact_scaled_one_hot(&[1, 2, 3], 1.0),
+            )),
+            &request([1, 2, 3]),
+            "not an equality-to-zero",
+        );
+        assert_atomic_rejection(
+            instance_with_source(exact.clone()),
+            &request([]),
+            "at least one member",
+        );
+        assert_atomic_rejection(
+            instance_with_source(exact),
+            &request([1, 2]),
+            "linear support",
+        );
+        assert_atomic_rejection(
+            instance_with_source(Constraint::equal_to_zero(exact_scaled_one_hot(
+                &[1, 2, 4],
+                1.0,
+            ))),
+            &request([1, 2, 4]),
+            "must be binary",
+        );
+    }
+
+    #[test]
+    fn rejects_non_exact_coefficients_constant_and_nonlinear_function_atomically() {
+        let unequal = Function::from(
+            ((linear!(1) + (coeff!(2.0) * linear!(2)).unwrap()).unwrap() + coeff!(-1.0)).unwrap(),
+        );
+        assert_atomic_rejection(
+            instance_with_source(Constraint::equal_to_zero(unequal)),
+            &request([1, 2]),
+            "common coefficient",
+        );
+
+        let wrong_constant =
+            Function::from(((linear!(1) + linear!(2)).unwrap() + coeff!(-2.0)).unwrap());
+        assert_atomic_rejection(
+            instance_with_source(Constraint::equal_to_zero(wrong_constant)),
+            &request([1, 2]),
+            "constant coefficient",
+        );
+
+        let nonlinear = Function::from(
+            (((quadratic!(1) + quadratic!(2)).unwrap() + quadratic!(1, 2)).unwrap() + coeff!(-1.0))
+                .unwrap(),
+        );
+        assert_atomic_rejection(
+            instance_with_source(Constraint::equal_to_zero(nonlinear)),
+            &request([1, 2]),
+            "not exactly linear",
+        );
+    }
+}

--- a/rust/ommx/src/instance/one_hot_promotion.rs
+++ b/rust/ommx/src/instance/one_hot_promotion.rs
@@ -21,7 +21,7 @@ use std::collections::{BTreeMap, BTreeSet};
 const PROMOTION_REASON: &str = "promoted validated one-hot equality";
 const TARGET_ID_PARAMETER: &str = "one_hot_constraint_id";
 
-/// Stable-ID request for a batch of one-hot promotion attempts.
+/// Stable regular-constraint IDs requested for one best-effort promotion batch.
 ///
 /// Each ID selects an active regular constraint to inspect. The current
 /// [`Instance`] determines the member set from the row itself and validates its
@@ -30,51 +30,26 @@ const TARGET_ID_PARAMETER: &str = "one_hot_constraint_id";
 /// The set representation makes duplicate source claims unrepresentable. No
 /// target IDs are supplied; fresh [`OneHotConstraintID`] values are allocated
 /// together only after every source has been inspected.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct OneHotPromotionRequest {
-    constraint_ids: BTreeSet<ConstraintID>,
-}
+pub type OneHotPromotionRequest = BTreeSet<ConstraintID>;
 
-impl OneHotPromotionRequest {
-    /// Construct a request from regular constraint IDs to inspect.
-    pub fn new(constraint_ids: impl IntoIterator<Item = ConstraintID>) -> Self {
-        Self {
-            constraint_ids: constraint_ids.into_iter().collect(),
-        }
-    }
-
-    /// Regular constraint IDs requested for promotion.
-    pub fn constraint_ids(&self) -> &BTreeSet<ConstraintID> {
-        &self.constraint_ids
-    }
-
-    /// Convert one legacy v1 one-hot hint into an untrusted request.
-    ///
-    /// This conversion is independent of any [`Instance`] and uses only the
-    /// referenced regular constraint ID. Legacy `decision_variables` are
-    /// advisory data rather than a certificate; membership is re-derived from
-    /// the current source row by [`Instance::promote_one_hot`]. Constraint ID
-    /// `0` is a valid stable ID.
-    pub fn from_v1_hint(hint: &crate::v1::OneHot) -> Self {
-        Self::new([ConstraintID::from(hint.constraint_id)])
-    }
-}
-
-impl FromIterator<ConstraintID> for OneHotPromotionRequest {
-    fn from_iter<T: IntoIterator<Item = ConstraintID>>(iter: T) -> Self {
-        Self::new(iter)
-    }
-}
-
-/// Individually validated OneHot candidate before target-ID allocation.
+/// Result of one best-effort OneHot promotion batch, keyed by requested source.
 ///
-/// This intermediate state separates fallible source-row validation from
-/// aggregate ID allocation. Target IDs are deliberately absent; only the batch
-/// plan allocates them.
-#[derive(Debug)]
-struct CheckedOneHotPromotionCandidate {
-    one_hot_constraint: OneHotConstraint,
-    context: ConstraintContext,
+/// The map has exactly the same keys as its [`OneHotPromotionRequest`]. Each
+/// value is either the allocated [`OneHotConstraintID`] or that source's
+/// rejection reason.
+pub type OneHotPromotion = BTreeMap<ConstraintID, crate::Result<OneHotConstraintID>>;
+
+/// Convert one legacy v1 one-hot hint into an untrusted request.
+///
+/// This conversion is independent of any [`Instance`] and uses only the
+/// referenced regular constraint ID. Legacy `decision_variables` are advisory
+/// data rather than a certificate; membership is re-derived from the current
+/// source row by [`Instance::promote_one_hot`]. Constraint ID `0` is a valid
+/// stable ID.
+impl From<&crate::v1::OneHot> for OneHotPromotionRequest {
+    fn from(hint: &crate::v1::OneHot) -> Self {
+        BTreeSet::from([ConstraintID::from(hint.constraint_id)])
+    }
 }
 
 /// Fully planned OneHot insertion for one validated source row.
@@ -89,15 +64,15 @@ struct PlannedOneHot {
 ///
 /// # Invariants
 ///
-/// - `instance` is the exact [`Instance`] against which every entry was
+/// - `instance` is the exact [`Instance`] against which every request was
 ///   validated, and its exclusive borrow prevents any mutation before Apply;
-/// - every source row remains active in that instance;
-/// - source row IDs are pairwise distinct;
-/// - target OneHot IDs are pairwise distinct and absent from both active and
-///   removed OneHot collections;
-/// - every structural constraint is non-empty and all of its members are
-///   registered Binary variables; and
-/// - every source context was captured before mutation.
+/// - `plans` has exactly one entry for every requested source ID;
+/// - every successful plan's source row remains active in that instance;
+/// - successful target OneHot IDs are pairwise distinct and absent from both
+///   active and removed OneHot collections;
+/// - every successful structural constraint is non-empty and all of its
+///   members are registered Binary variables; and
+/// - every successful source context was captured before mutation.
 ///
 /// The plan is private and Apply consumes it. It cannot be applied to another
 /// instance or become stale between checking and mutation, so every aggregate
@@ -105,42 +80,42 @@ struct PlannedOneHot {
 #[derive(Debug)]
 struct OneHotPromotionBatchPlan<'a> {
     instance: &'a mut Instance,
-    entries: BTreeMap<ConstraintID, PlannedOneHot>,
-    rejections: BTreeMap<ConstraintID, crate::Error>,
+    plans: BTreeMap<ConstraintID, crate::Result<PlannedOneHot>>,
 }
 
 impl<'a> OneHotPromotionBatchPlan<'a> {
     fn new(instance: &'a mut Instance, request: &OneHotPromotionRequest) -> Self {
-        let mut checked = BTreeMap::new();
-        let mut rejections = BTreeMap::new();
-        for &source_constraint_id in request.constraint_ids() {
-            match instance.check_one_hot_promotion(source_constraint_id) {
-                Ok(candidate) => {
-                    checked.insert(source_constraint_id, candidate);
-                }
-                Err(error) => {
-                    rejections.insert(source_constraint_id, error);
-                }
-            }
-        }
+        let checked: BTreeMap<_, _> = request
+            .iter()
+            .copied()
+            .map(|source_constraint_id| {
+                (
+                    source_constraint_id,
+                    instance.build_one_hot_promotion_candidate(source_constraint_id),
+                )
+            })
+            .collect();
 
-        let survivor_count = checked.len();
+        let survivor_count = checked.values().filter(|result| result.is_ok()).count();
         if let Err(error) = instance
             .one_hot_constraint_collection
             .ensure_unused_id_capacity(survivor_count)
         {
             let message = error.to_string();
-            for source_constraint_id in checked.keys().copied() {
-                rejections.insert(source_constraint_id, crate::error!(
-                        { ?source_constraint_id, survivor_count },
-                        "Cannot allocate OneHot constraint IDs for the compatible promotion batch: {message}"
-                    ));
-            }
-            return Self {
-                instance,
-                entries: BTreeMap::new(),
-                rejections,
-            };
+            let plans = checked
+                .into_iter()
+                .map(|(source_constraint_id, result)| {
+                    let plan = match result {
+                        Ok(_) => Err(crate::error!(
+                            { ?source_constraint_id, survivor_count },
+                            "Cannot allocate OneHot constraint IDs for the compatible promotion batch: {message}"
+                        )),
+                        Err(error) => Err(error),
+                    };
+                    (source_constraint_id, plan)
+                })
+                .collect();
+            return Self { instance, plans };
         }
 
         let first_id = (survivor_count > 0).then(|| {
@@ -149,53 +124,39 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
                 .unused_id()
                 .into_inner()
         });
-        let mut entries = BTreeMap::new();
-        for (offset, (source_constraint_id, candidate)) in checked.into_iter().enumerate() {
-            let offset = u64::try_from(offset)
-                .expect("batch size was converted to u64 during ID capacity validation");
-            let one_hot_constraint_id = OneHotConstraintID::from(
-                first_id
-                    .expect("a non-empty compatible batch has a first OneHot ID")
-                    .checked_add(offset)
-                    .expect("batch ID capacity was validated before allocation"),
-            );
-            entries.insert(
-                source_constraint_id,
-                PlannedOneHot {
-                    one_hot_constraint_id,
-                    one_hot_constraint: candidate.one_hot_constraint,
-                    context: candidate.context,
-                },
-            );
-        }
-
-        Self {
-            instance,
-            entries,
-            rejections,
-        }
-    }
-
-    fn apply(self) -> BTreeMap<ConstraintID, crate::Result<OneHotConstraintID>> {
-        let Self {
-            instance,
-            entries,
-            rejections,
-        } = self;
-
-        let mut results: BTreeMap<_, _> = rejections
+        let mut offset = 0_u64;
+        let plans = checked
             .into_iter()
-            .map(|(source_constraint_id, error)| (source_constraint_id, Err(error)))
+            .map(|(source_constraint_id, result)| {
+                let plan = result.map(|(one_hot_constraint, context)| {
+                    let one_hot_constraint_id = OneHotConstraintID::from(
+                        first_id
+                            .expect("a non-empty compatible batch has a first OneHot ID")
+                            .checked_add(offset)
+                            .expect("batch ID capacity was validated before allocation"),
+                    );
+                    offset += 1;
+                    PlannedOneHot {
+                        one_hot_constraint_id,
+                        one_hot_constraint,
+                        context,
+                    }
+                });
+                (source_constraint_id, plan)
+            })
             .collect();
 
-        if entries.is_empty() {
-            return results;
-        }
+        Self { instance, plans }
+    }
 
-        let removal_reasons = entries
+    fn apply(self) -> OneHotPromotion {
+        let Self { instance, plans } = self;
+
+        let removal_reasons = plans
             .iter()
-            .map(|(&source_constraint_id, planned)| {
-                (
+            .filter_map(|(&source_constraint_id, result)| {
+                let planned = result.as_ref().ok()?;
+                Some((
                     source_constraint_id,
                     RemovedReason {
                         reason: PROMOTION_REASON.to_string(),
@@ -206,7 +167,7 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
                         .into_iter()
                         .collect(),
                     },
-                )
+                ))
             })
             .collect();
         instance
@@ -214,22 +175,25 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
             .move_active_rows_to_removed_with_reasons(removal_reasons)
             .expect("source rows and bound Instance were validated by OneHotPromotionBatchPlan");
 
-        for (source_constraint_id, planned) in entries {
-            instance
-                .one_hot_constraint_collection
-                .insert_active_with_context(
-                    planned.one_hot_constraint_id,
-                    planned.one_hot_constraint,
-                    planned.context,
-                )
-                .expect(
-                    "target IDs, member IDs, and bound Instance were validated by OneHotPromotionBatchPlan",
-                );
-            let previous = results.insert(source_constraint_id, Ok(planned.one_hot_constraint_id));
-            debug_assert!(previous.is_none());
-        }
-
-        results
+        plans
+            .into_iter()
+            .map(|(source_constraint_id, result)| {
+                let result = result.map(|planned| {
+                    instance
+                        .one_hot_constraint_collection
+                        .insert_active_with_context(
+                            planned.one_hot_constraint_id,
+                            planned.one_hot_constraint,
+                            planned.context,
+                        )
+                        .expect(
+                            "target IDs, member IDs, and bound Instance were validated by OneHotPromotionBatchPlan",
+                        );
+                    planned.one_hot_constraint_id
+                });
+                (source_constraint_id, result)
+            })
+            .collect()
     }
 }
 
@@ -258,17 +222,14 @@ impl Instance {
     /// requests leave their rows unchanged. The private plan exclusively
     /// borrows this instance until its infallible Apply consumes the plan.
     #[must_use = "each requested source has a success or rejection result"]
-    pub fn promote_one_hot(
-        &mut self,
-        request: &OneHotPromotionRequest,
-    ) -> BTreeMap<ConstraintID, crate::Result<OneHotConstraintID>> {
+    pub fn promote_one_hot(&mut self, request: &OneHotPromotionRequest) -> OneHotPromotion {
         OneHotPromotionBatchPlan::new(self, request).apply()
     }
 
-    fn check_one_hot_promotion(
+    fn build_one_hot_promotion_candidate(
         &self,
         source_constraint_id: ConstraintID,
-    ) -> crate::Result<CheckedOneHotPromotionCandidate> {
+    ) -> crate::Result<(OneHotConstraint, ConstraintContext)> {
         let source = self
             .constraint_collection
             .active()
@@ -355,10 +316,7 @@ impl Instance {
             .context()
             .collect_for(source_constraint_id);
 
-        Ok(CheckedOneHotPromotionCandidate {
-            one_hot_constraint,
-            context,
-        })
+        Ok((one_hot_constraint, context))
     }
 }
 
@@ -399,7 +357,7 @@ mod tests {
     }
 
     fn batch_instance() -> (Instance, OneHotPromotionRequest) {
-        let request = OneHotPromotionRequest::new([ConstraintID::from(10), ConstraintID::from(20)]);
+        let request = BTreeSet::from([ConstraintID::from(10), ConstraintID::from(20)]);
         let instance = Instance::builder()
             .sense(Sense::Minimize)
             .objective(Function::Zero)
@@ -424,7 +382,7 @@ mod tests {
     }
 
     fn request(ids: impl IntoIterator<Item = u64>) -> OneHotPromotionRequest {
-        OneHotPromotionRequest::new(ids.into_iter().map(ConstraintID::from))
+        ids.into_iter().map(ConstraintID::from).collect()
     }
 
     fn assert_atomic_rejection(
@@ -434,8 +392,7 @@ mod tests {
     ) {
         let regular_before = instance.constraint_collection.clone();
         let one_hot_before = instance.one_hot_constraint_collection.clone();
-        let results =
-            instance.promote_one_hot(&OneHotPromotionRequest::new([source_constraint_id]));
+        let results = instance.promote_one_hot(&BTreeSet::from([source_constraint_id]));
         assert_eq!(results.len(), 1);
         let error = results[&source_constraint_id].as_ref().unwrap_err();
         assert!(
@@ -449,14 +406,11 @@ mod tests {
     #[test]
     fn converts_v1_hint_to_a_singleton_request_without_using_claimed_members() {
         for members in [vec![], vec![2, 1], vec![1, 1]] {
-            let request = OneHotPromotionRequest::from_v1_hint(&crate::v1::OneHot {
+            let request = OneHotPromotionRequest::from(&crate::v1::OneHot {
                 constraint_id: 7,
                 decision_variables: members,
             });
-            assert_eq!(
-                request.constraint_ids(),
-                &BTreeSet::from([ConstraintID::from(7)])
-            );
+            assert_eq!(request, BTreeSet::from([ConstraintID::from(7)]));
         }
     }
 
@@ -549,29 +503,28 @@ mod tests {
 
     #[test]
     fn request_deduplicates_source_ids_by_construction() {
-        let request = OneHotPromotionRequest::new([
+        let request: OneHotPromotionRequest = [
             ConstraintID::from(10),
             ConstraintID::from(10),
             ConstraintID::from(20),
-        ]);
+        ]
+        .into_iter()
+        .collect();
 
         assert_eq!(
-            request.constraint_ids(),
-            &BTreeSet::from([ConstraintID::from(10), ConstraintID::from(20)])
+            request,
+            BTreeSet::from([ConstraintID::from(10), ConstraintID::from(20)])
         )
     }
 
     #[test]
     fn batch_promotes_valid_requests_while_rejecting_individually_invalid_requests() {
         let (mut instance, _) = batch_instance();
-        let request = OneHotPromotionRequest::new([ConstraintID::from(99), ConstraintID::from(20)]);
+        let request = BTreeSet::from([ConstraintID::from(99), ConstraintID::from(20)]);
 
         let results = instance.promote_one_hot(&request);
 
-        assert_eq!(
-            results.keys().copied().collect::<BTreeSet<_>>(),
-            request.constraint_ids().clone()
-        );
+        assert_eq!(results.keys().copied().collect::<BTreeSet<_>>(), request);
         assert_eq!(
             results[&ConstraintID::from(20)].as_ref().unwrap(),
             &OneHotConstraintID::from(0)
@@ -606,10 +559,7 @@ mod tests {
 
         let results = instance.promote_one_hot(&request);
 
-        assert_eq!(
-            results.keys().copied().collect::<BTreeSet<_>>(),
-            request.constraint_ids().clone()
-        );
+        assert_eq!(results.keys().copied().collect::<BTreeSet<_>>(), request);
         assert!(results.values().all(|result| result
             .as_ref()
             .unwrap_err()

--- a/rust/ommx/src/instance/one_hot_promotion.rs
+++ b/rust/ommx/src/instance/one_hot_promotion.rs
@@ -5,6 +5,10 @@
 //! membership, and the decision-variable domains. Promotion is allowed only
 //! when the active source is exactly a non-zero scalar multiple of
 //! `sum(variables) - 1 = 0` over binary variables.
+//! This preserves the exact feasible set over binary assignments. It does not
+//! promise identical approximate-feasibility classification: regular rows test
+//! one scaled residual, while OneHot constraints classify each member as zero
+//! or one under the caller's [`crate::ATol`].
 //!
 //! The public API is batch-oriented. All candidates are checked against one
 //! unchanged source instance before target IDs are allocated. The batch plan
@@ -96,10 +100,10 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
             })
             .collect();
 
-        let survivor_count = checked.values().filter(|result| result.is_ok()).count();
+        let promotion_count = checked.values().filter(|result| result.is_ok()).count();
         if let Err(error) = instance
             .one_hot_constraint_collection
-            .ensure_unused_id_capacity(survivor_count)
+            .ensure_unused_id_capacity(promotion_count)
         {
             let message = error.to_string();
             let plans = checked
@@ -107,7 +111,7 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
                 .map(|(source_constraint_id, result)| {
                     let plan = match result {
                         Ok(_) => Err(crate::error!(
-                            { ?source_constraint_id, survivor_count },
+                            { ?source_constraint_id, promotion_count },
                             "Cannot allocate OneHot constraint IDs for the compatible promotion batch: {message}"
                         )),
                         Err(error) => Err(error),
@@ -118,7 +122,7 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
             return Self { instance, plans };
         }
 
-        let first_id = (survivor_count > 0).then(|| {
+        let first_id = (promotion_count > 0).then(|| {
             instance
                 .one_hot_constraint_collection
                 .unused_id()
@@ -210,6 +214,11 @@ impl Instance {
     ///   variable; and
     /// - for one common non-zero coefficient `c`, the row is exactly
     ///   `c * (sum(variables) - 1) = 0`.
+    ///
+    /// This preserves the exact feasible set over binary assignments. At a
+    /// nonzero [`crate::ATol`], the regular row's scaled-residual check and the
+    /// OneHot constraint's per-variable zero/one classification can differ for
+    /// approximate assignments.
     ///
     /// The returned map has exactly one entry per requested source ID. Each
     /// value is either the allocated OneHot ID or that source's rejection
@@ -310,7 +319,8 @@ impl Instance {
             );
         }
 
-        let one_hot_constraint = OneHotConstraint::new(support)?;
+        let one_hot_constraint = OneHotConstraint::new(support)
+            .expect("candidate support was checked as non-empty before construction");
         let context = self
             .constraint_collection
             .context()
@@ -405,12 +415,13 @@ mod tests {
 
     #[test]
     fn converts_v1_hint_to_a_singleton_request_without_using_claimed_members() {
-        for members in [vec![], vec![2, 1], vec![1, 1]] {
+        for (constraint_id, members) in [(0, vec![]), (7, vec![]), (7, vec![2, 1]), (7, vec![1, 1])]
+        {
             let request = OneHotPromotionRequest::from(&crate::v1::OneHot {
-                constraint_id: 7,
+                constraint_id,
                 decision_variables: members,
             });
-            assert_eq!(request, BTreeSet::from([ConstraintID::from(7)]));
+            assert_eq!(request, BTreeSet::from([ConstraintID::from(constraint_id)]));
         }
     }
 
@@ -518,6 +529,19 @@ mod tests {
     }
 
     #[test]
+    fn empty_request_is_a_no_op() {
+        let (mut instance, _) = batch_instance();
+        let regular_before = instance.constraint_collection.clone();
+        let one_hot_before = instance.one_hot_constraint_collection.clone();
+
+        let results = instance.promote_one_hot(&OneHotPromotionRequest::new());
+
+        assert!(results.is_empty());
+        assert_eq!(instance.constraint_collection, regular_before);
+        assert_eq!(instance.one_hot_constraint_collection, one_hot_before);
+    }
+
+    #[test]
     fn batch_promotes_valid_requests_while_rejecting_individually_invalid_requests() {
         let (mut instance, _) = batch_instance();
         let request = BTreeSet::from([ConstraintID::from(99), ConstraintID::from(20)]);
@@ -544,8 +568,37 @@ mod tests {
     }
 
     #[test]
-    fn batch_rejects_id_exhaustion_before_any_mutation() {
+    fn batch_leaves_an_existing_rejected_row_active_while_promoting_a_valid_row() {
         let (mut instance, request) = batch_instance();
+        let rejected = Constraint::less_than_or_equal_to_zero(exact_scaled_one_hot(&[1, 2], 1.0));
+        instance
+            .insert_constraint(ConstraintID::from(10), rejected.clone())
+            .unwrap();
+
+        let results = instance.promote_one_hot(&request);
+
+        assert!(results[&ConstraintID::from(10)]
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("not an equality-to-zero"));
+        assert_eq!(
+            results[&ConstraintID::from(20)].as_ref().unwrap(),
+            &OneHotConstraintID::from(0)
+        );
+        assert_eq!(instance.constraints()[&ConstraintID::from(10)], rejected);
+        assert!(!instance
+            .removed_constraints()
+            .contains_key(&ConstraintID::from(10)));
+        assert!(instance
+            .removed_constraints()
+            .contains_key(&ConstraintID::from(20)));
+    }
+
+    #[test]
+    fn batch_keeps_individual_rejections_when_id_exhaustion_rejects_valid_rows() {
+        let (mut instance, mut request) = batch_instance();
+        request.insert(ConstraintID::from(99));
         instance
             .one_hot_constraint_collection
             .insert_active_with_context(
@@ -560,11 +613,18 @@ mod tests {
         let results = instance.promote_one_hot(&request);
 
         assert_eq!(results.keys().copied().collect::<BTreeSet<_>>(), request);
-        assert!(results.values().all(|result| result
+        for source_constraint_id in [ConstraintID::from(10), ConstraintID::from(20)] {
+            assert!(results[&source_constraint_id]
+                .as_ref()
+                .unwrap_err()
+                .to_string()
+                .contains("Cannot allocate OneHot constraint IDs"));
+        }
+        assert!(results[&ConstraintID::from(99)]
             .as_ref()
             .unwrap_err()
             .to_string()
-            .contains("Cannot allocate OneHot constraint IDs")));
+            .contains("was not found"));
         assert_eq!(instance.constraint_collection, regular_before);
         assert_eq!(instance.one_hot_constraint_collection, one_hot_before);
     }

--- a/rust/ommx/src/instance/one_hot_promotion.rs
+++ b/rust/ommx/src/instance/one_hot_promotion.rs
@@ -68,54 +68,46 @@ impl OneHotPromotionRequest {
     }
 }
 
-/// Result of one checked one-hot promotion.
+/// Stable-ID mapping produced by one checked one-hot promotion.
 ///
-/// The source regular constraint remains in the same [`Instance`] as removed
-/// history, and the new one-hot constraint receives a copy of its context.
-#[must_use = "the result identifies the promoted constraint and retained source"]
+/// All promoted constraint data remains queryable from the mutated
+/// [`Instance`]; this value records only which regular source became which
+/// first-class OneHot constraint.
+#[must_use = "the result identifies the source-to-OneHot promotion mapping"]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OneHotPromotion {
+    source_constraint_id: ConstraintID,
     one_hot_constraint_id: OneHotConstraintID,
-    variables: VariableIDSet,
-    relaxed_constraint_id: ConstraintID,
 }
 
 impl OneHotPromotion {
+    /// Regular source constraint moved from active to removed.
+    pub fn source_constraint_id(&self) -> ConstraintID {
+        self.source_constraint_id
+    }
+
     /// ID allocated to the promoted one-hot constraint.
     pub fn one_hot_constraint_id(&self) -> OneHotConstraintID {
         self.one_hot_constraint_id
     }
-
-    /// Verified one-hot members.
-    pub fn variables(&self) -> &VariableIDSet {
-        &self.variables
-    }
-
-    /// Regular source constraint moved from active to removed.
-    pub fn relaxed_constraint_id(&self) -> ConstraintID {
-        self.relaxed_constraint_id
-    }
 }
 
-/// Instance-validated OneHot formulation before target-ID allocation.
+/// Individually validated OneHot candidate before batch compatibility and
+/// target-ID allocation.
 ///
-/// Multiple requests are checked against the same source snapshot, so target
-/// IDs are deliberately absent here. Only batch planning may allocate them.
+/// This intermediate state separates fallible request validation from
+/// cross-request conflict resolution. Target IDs are deliberately absent;
+/// only the batch plan allocates them after rejecting duplicate source claims.
 #[derive(Debug)]
-struct CheckedOneHotFormulation {
-    variables: VariableIDSet,
+struct CheckedOneHotPromotionCandidate {
     source_constraint_id: ConstraintID,
     one_hot_constraint: OneHotConstraint,
     context: ConstraintContext,
 }
 
-/// Fully validated, instance-bound plan for one OneHot promotion.
-///
-/// This value is constructed only while building a
-/// [`OneHotPromotionBatchPlan`] and is applied as part of that aggregate plan
-/// to the same, otherwise-unmodified [`Instance`].
+/// Fully validated entry in one OneHot promotion batch.
 #[derive(Debug)]
-struct OneHotPromotionPlan {
+struct OneHotPromotionPlanEntry {
     result: OneHotPromotion,
     one_hot_constraint: OneHotConstraint,
     context: ConstraintContext,
@@ -125,7 +117,9 @@ struct OneHotPromotionPlan {
 ///
 /// # Invariants
 ///
-/// - every source row was active on one unchanged source [`Instance`];
+/// - `instance` is the exact [`Instance`] against which every entry was
+///   validated, and its exclusive borrow prevents any mutation before Apply;
+/// - every source row remains active in that instance;
 /// - source row IDs are pairwise distinct;
 /// - target OneHot IDs are pairwise distinct and absent from both active and
 ///   removed OneHot collections;
@@ -133,18 +127,175 @@ struct OneHotPromotionPlan {
 ///   registered Binary variables; and
 /// - every source context was captured before mutation.
 ///
-/// The plan is private, constructed and immediately consumed by the OneHot
-/// owner module. Consequently no caller can stale it between checking and
-/// applying it, and aggregate Apply cannot produce a recoverable error.
+/// The plan is private and Apply consumes it. It cannot be applied to another
+/// instance or become stale between checking and mutation, so every aggregate
+/// storage effect is infallible under these invariants.
 #[derive(Debug)]
-struct OneHotPromotionBatchPlan {
-    entries: Vec<(usize, OneHotPromotionPlan)>,
+struct OneHotPromotionBatchPlan<'a> {
+    instance: &'a mut Instance,
+    entries: Vec<(usize, OneHotPromotionPlanEntry)>,
+    rejections: Vec<Option<crate::Error>>,
 }
 
-#[derive(Debug)]
-struct OneHotPromotionBatchPlanning {
-    plan: OneHotPromotionBatchPlan,
-    rejections: Vec<Option<crate::Error>>,
+impl<'a> OneHotPromotionBatchPlan<'a> {
+    fn new(instance: &'a mut Instance, requests: &[OneHotPromotionRequest]) -> Self {
+        let mut checked = Vec::with_capacity(requests.len());
+        let mut rejections = Vec::with_capacity(requests.len());
+        for request in requests {
+            match instance.check_one_hot_promotion(request) {
+                Ok(candidate) => {
+                    checked.push(Some(candidate));
+                    rejections.push(None);
+                }
+                Err(error) => {
+                    checked.push(None);
+                    rejections.push(Some(error));
+                }
+            }
+        }
+
+        let mut source_claimants = BTreeMap::<ConstraintID, Vec<usize>>::new();
+        for (index, candidate) in checked.iter().enumerate() {
+            if let Some(candidate) = candidate {
+                source_claimants
+                    .entry(candidate.source_constraint_id)
+                    .or_default()
+                    .push(index);
+            }
+        }
+        for (source_constraint_id, claimants) in source_claimants {
+            if claimants.len() <= 1 {
+                continue;
+            }
+            for index in claimants {
+                checked[index] = None;
+                rejections[index] = Some(crate::error!(
+                    { index, ?source_constraint_id },
+                    "OneHot promotion request at index {index} conflicts with another individually valid request over source row {source_constraint_id:?}"
+                ));
+            }
+        }
+
+        let survivor_count = checked.iter().filter(|entry| entry.is_some()).count();
+        if let Err(error) = instance
+            .one_hot_constraint_collection
+            .ensure_unused_id_capacity(survivor_count)
+        {
+            let message = error.to_string();
+            for (index, candidate) in checked.iter_mut().enumerate() {
+                if candidate.take().is_some() {
+                    rejections[index] = Some(crate::error!(
+                        { index, survivor_count },
+                        "Cannot allocate OneHot constraint IDs for the compatible promotion batch: {message}"
+                    ));
+                }
+            }
+            return Self {
+                instance,
+                entries: Vec::new(),
+                rejections,
+            };
+        }
+
+        let first_id = (survivor_count > 0).then(|| {
+            instance
+                .one_hot_constraint_collection
+                .unused_id()
+                .into_inner()
+        });
+        let mut offset = 0_u64;
+        let mut entries = Vec::with_capacity(survivor_count);
+        for (index, candidate) in checked.into_iter().enumerate() {
+            let Some(candidate) = candidate else {
+                continue;
+            };
+            let one_hot_constraint_id = OneHotConstraintID::from(
+                first_id
+                    .expect("a non-empty compatible batch has a first OneHot ID")
+                    .checked_add(offset)
+                    .expect("batch ID capacity was validated before allocation"),
+            );
+            offset += 1;
+            entries.push((
+                index,
+                OneHotPromotionPlanEntry {
+                    result: OneHotPromotion {
+                        source_constraint_id: candidate.source_constraint_id,
+                        one_hot_constraint_id,
+                    },
+                    one_hot_constraint: candidate.one_hot_constraint,
+                    context: candidate.context,
+                },
+            ));
+        }
+
+        Self {
+            instance,
+            entries,
+            rejections,
+        }
+    }
+
+    fn apply(self) -> Vec<crate::Result<OneHotPromotion>> {
+        let Self {
+            instance,
+            entries,
+            rejections,
+        } = self;
+        let mut outcomes = rejections
+            .into_iter()
+            .map(|error| error.map(Err))
+            .collect::<Vec<_>>();
+
+        if entries.is_empty() {
+            return outcomes
+                .into_iter()
+                .map(|outcome| outcome.expect("every OneHot request must receive one outcome"))
+                .collect();
+        }
+
+        let removal_reasons = entries
+            .iter()
+            .map(|(_, entry)| {
+                (
+                    entry.result.source_constraint_id,
+                    RemovedReason {
+                        reason: PROMOTION_REASON.to_string(),
+                        parameters: [(
+                            TARGET_ID_PARAMETER.to_string(),
+                            entry.result.one_hot_constraint_id.into_inner().to_string(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    },
+                )
+            })
+            .collect();
+        instance
+            .constraint_collection
+            .move_active_rows_to_removed_with_reasons(removal_reasons)
+            .expect("source rows and bound Instance were validated by OneHotPromotionBatchPlan");
+
+        for (index, entry) in entries {
+            instance
+                .one_hot_constraint_collection
+                .insert_active_with_context(
+                    entry.result.one_hot_constraint_id,
+                    entry.one_hot_constraint,
+                    entry.context,
+                )
+                .expect(
+                    "target IDs, member IDs, and bound Instance were validated by OneHotPromotionBatchPlan",
+                );
+            debug_assert!(outcomes[index].is_none());
+            outcomes[index] = Some(Ok(entry.result));
+        }
+
+        outcomes
+            .into_iter()
+            .map(|outcome| outcome.expect("every OneHot request must receive one outcome"))
+            .collect()
+    }
 }
 
 impl Instance {
@@ -169,176 +320,19 @@ impl Instance {
     /// On each successful entry the source moves to `removed_constraints`, its
     /// context is copied to the new active one-hot constraint, and the removal
     /// reason records the allocated target ID. Planning is atomic: rejected
-    /// requests leave their rows unchanged, and applying the resulting private
-    /// plan is infallible by construction.
+    /// requests leave their rows unchanged. The private plan exclusively
+    /// borrows this instance until its infallible Apply consumes the plan.
     pub fn promote_one_hot(
         &mut self,
         requests: &[OneHotPromotionRequest],
     ) -> Vec<crate::Result<OneHotPromotion>> {
-        let OneHotPromotionBatchPlanning { plan, rejections } =
-            self.plan_compatible_one_hot_promotions(requests);
-        let mut outcomes = rejections
-            .into_iter()
-            .map(|error| error.map(Err))
-            .collect::<Vec<_>>();
-
-        for (index, promotion) in self.apply_one_hot_promotion_batch(plan) {
-            debug_assert!(outcomes[index].is_none());
-            outcomes[index] = Some(Ok(promotion));
-        }
-
-        outcomes
-            .into_iter()
-            .map(|outcome| outcome.expect("every OneHot request must receive one outcome"))
-            .collect()
-    }
-
-    fn apply_one_hot_promotion_batch(
-        &mut self,
-        plan: OneHotPromotionBatchPlan,
-    ) -> Vec<(usize, OneHotPromotion)> {
-        if plan.entries.is_empty() {
-            return Vec::new();
-        }
-
-        let removal_reasons = plan
-            .entries
-            .iter()
-            .map(|(_, plan)| {
-                (
-                    plan.result.relaxed_constraint_id,
-                    RemovedReason {
-                        reason: PROMOTION_REASON.to_string(),
-                        parameters: [(
-                            TARGET_ID_PARAMETER.to_string(),
-                            plan.result.one_hot_constraint_id.into_inner().to_string(),
-                        )]
-                        .into_iter()
-                        .collect(),
-                    },
-                )
-            })
-            .collect();
-        self.constraint_collection
-            .move_active_rows_to_removed_with_reasons(removal_reasons)
-            .expect("source rows were validated by OneHotPromotionBatchPlan");
-
-        let mut promotions = Vec::with_capacity(plan.entries.len());
-        for (index, plan) in plan.entries {
-            self.one_hot_constraint_collection
-                .insert_active_with_context(
-                    plan.result.one_hot_constraint_id,
-                    plan.one_hot_constraint,
-                    plan.context,
-                )
-                .expect("target IDs and member IDs were validated by OneHotPromotionBatchPlan");
-            promotions.push((index, plan.result));
-        }
-        promotions
-    }
-
-    fn plan_compatible_one_hot_promotions(
-        &self,
-        requests: &[OneHotPromotionRequest],
-    ) -> OneHotPromotionBatchPlanning {
-        let mut checked = Vec::with_capacity(requests.len());
-        let mut rejections = Vec::with_capacity(requests.len());
-        for request in requests {
-            match self.check_one_hot_promotion(request) {
-                Ok(formulation) => {
-                    checked.push(Some(formulation));
-                    rejections.push(None);
-                }
-                Err(error) => {
-                    checked.push(None);
-                    rejections.push(Some(error));
-                }
-            }
-        }
-
-        let mut source_claimants = BTreeMap::<ConstraintID, Vec<usize>>::new();
-        for (index, formulation) in checked.iter().enumerate() {
-            if let Some(formulation) = formulation {
-                source_claimants
-                    .entry(formulation.source_constraint_id)
-                    .or_default()
-                    .push(index);
-            }
-        }
-        for (source_constraint_id, claimants) in source_claimants {
-            if claimants.len() <= 1 {
-                continue;
-            }
-            for index in claimants {
-                checked[index] = None;
-                rejections[index] = Some(crate::error!(
-                    { index, ?source_constraint_id },
-                    "OneHot promotion request at index {index} conflicts with another individually valid request over source row {source_constraint_id:?}"
-                ));
-            }
-        }
-
-        let survivor_count = checked.iter().filter(|entry| entry.is_some()).count();
-        if let Err(error) = self
-            .one_hot_constraint_collection
-            .ensure_unused_id_capacity(survivor_count)
-        {
-            let message = error.to_string();
-            for (index, formulation) in checked.iter_mut().enumerate() {
-                if formulation.take().is_some() {
-                    rejections[index] = Some(crate::error!(
-                        { index, survivor_count },
-                        "Cannot allocate OneHot constraint IDs for the compatible promotion batch: {message}"
-                    ));
-                }
-            }
-            return OneHotPromotionBatchPlanning {
-                plan: OneHotPromotionBatchPlan {
-                    entries: Vec::new(),
-                },
-                rejections,
-            };
-        }
-
-        let first_id = (survivor_count > 0)
-            .then(|| self.one_hot_constraint_collection.unused_id().into_inner());
-        let mut offset = 0_u64;
-        let mut entries = Vec::with_capacity(survivor_count);
-        for (index, formulation) in checked.into_iter().enumerate() {
-            let Some(formulation) = formulation else {
-                continue;
-            };
-            let one_hot_constraint_id = OneHotConstraintID::from(
-                first_id
-                    .expect("a non-empty compatible batch has a first OneHot ID")
-                    .checked_add(offset)
-                    .expect("batch ID capacity was validated before allocation"),
-            );
-            offset += 1;
-            entries.push((
-                index,
-                OneHotPromotionPlan {
-                    result: OneHotPromotion {
-                        one_hot_constraint_id,
-                        variables: formulation.variables,
-                        relaxed_constraint_id: formulation.source_constraint_id,
-                    },
-                    one_hot_constraint: formulation.one_hot_constraint,
-                    context: formulation.context,
-                },
-            ));
-        }
-
-        OneHotPromotionBatchPlanning {
-            plan: OneHotPromotionBatchPlan { entries },
-            rejections,
-        }
+        OneHotPromotionBatchPlan::new(self, requests).apply()
     }
 
     fn check_one_hot_promotion(
         &self,
         request: &OneHotPromotionRequest,
-    ) -> crate::Result<CheckedOneHotFormulation> {
+    ) -> crate::Result<CheckedOneHotPromotionCandidate> {
         if request.variables.is_empty() {
             crate::bail!("One-hot promotion request must contain at least one member");
         }
@@ -435,8 +429,7 @@ impl Instance {
             .context()
             .collect_for(request.source_constraint_id);
 
-        Ok(CheckedOneHotFormulation {
-            variables: request.variables.clone(),
+        Ok(CheckedOneHotPromotionCandidate {
             source_constraint_id: request.source_constraint_id,
             one_hot_constraint,
             context,
@@ -599,8 +592,7 @@ mod tests {
                 promotion.one_hot_constraint_id(),
                 OneHotConstraintID::from(0)
             );
-            assert_eq!(promotion.variables(), &variables([1, 2, 3]));
-            assert_eq!(promotion.relaxed_constraint_id(), ConstraintID::from(10));
+            assert_eq!(promotion.source_constraint_id(), ConstraintID::from(10));
             assert!(instance.constraints().is_empty());
             assert_eq!(
                 instance.one_hot_constraints()[&OneHotConstraintID::from(0)].variables,

--- a/rust/ommx/src/instance/one_hot_promotion.rs
+++ b/rust/ommx/src/instance/one_hot_promotion.rs
@@ -5,6 +5,12 @@
 //! of truth for the regular row and decision-variable domains. Promotion is
 //! allowed only when the active source is exactly a non-zero scalar multiple of
 //! `sum(variables) - 1 = 0` over binary variables.
+//!
+//! Even the single-request API uses a private batch plan. All candidates are
+//! checked against one unchanged source instance before target IDs are
+//! allocated. The batch plan proves that every aggregate storage effect must
+//! succeed, so applying it never clones the [`Instance`] and cannot return a
+//! recoverable error.
 
 use super::Instance;
 use crate::{
@@ -92,11 +98,54 @@ impl OneHotPromotion {
     }
 }
 
+/// Instance-validated OneHot formulation before target-ID allocation.
+///
+/// Multiple requests are checked against the same source snapshot, so target
+/// IDs are deliberately absent here. Only batch planning may allocate them.
+#[derive(Debug)]
+struct CheckedOneHotFormulation {
+    variables: VariableIDSet,
+    source_constraint_id: ConstraintID,
+    one_hot_constraint: OneHotConstraint,
+    context: ConstraintContext,
+}
+
+/// Fully validated, instance-bound plan for one OneHot promotion.
+///
+/// This value is constructed only while building a
+/// [`OneHotPromotionBatchPlan`] and is applied as part of that aggregate plan
+/// to the same, otherwise-unmodified [`Instance`].
 #[derive(Debug)]
 struct OneHotPromotionPlan {
     result: OneHotPromotion,
     one_hot_constraint: OneHotConstraint,
     context: ConstraintContext,
+}
+
+/// Aggregate proof object for applying compatible OneHot promotions.
+///
+/// # Invariants
+///
+/// - every source row was active on one unchanged source [`Instance`];
+/// - source row IDs are pairwise distinct;
+/// - target OneHot IDs are pairwise distinct and absent from both active and
+///   removed OneHot collections;
+/// - every structural constraint is non-empty and all of its members are
+///   registered Binary variables; and
+/// - every source context was captured before mutation.
+///
+/// The plan is private, constructed and immediately consumed by the OneHot
+/// owner module. Consequently no caller can stale it between checking and
+/// applying it, and aggregate Apply cannot produce a recoverable error.
+#[derive(Debug)]
+struct OneHotPromotionBatchPlan {
+    entries: Vec<(usize, OneHotPromotionPlan)>,
+}
+
+#[derive(Debug)]
+struct OneHotPromotionBatchPlanning {
+    plan: OneHotPromotionBatchPlan,
+    rejections: Vec<Option<crate::Error>>,
 }
 
 impl Instance {
@@ -121,42 +170,185 @@ impl Instance {
         &mut self,
         request: &OneHotPromotionRequest,
     ) -> crate::Result<OneHotPromotion> {
-        let plan = self.plan_one_hot_promotion(request)?;
-        let result = plan.result.clone();
-
-        // Commit to a rollback copy so even a storage-layer invariant failure
-        // cannot expose a partially promoted Instance.
-        let mut staged = self.clone();
-        staged
-            .constraint_collection
-            .move_active_rows_to_removed_with_reasons(BTreeMap::from([(
-                result.relaxed_constraint_id,
-                RemovedReason {
-                    reason: PROMOTION_REASON.to_string(),
-                    parameters: [(
-                        TARGET_ID_PARAMETER.to_string(),
-                        result.one_hot_constraint_id.into_inner().to_string(),
-                    )]
-                    .into_iter()
-                    .collect(),
-                },
-            )]))?;
-        staged
-            .one_hot_constraint_collection
-            .insert_active_with_context(
-                result.one_hot_constraint_id,
-                plan.one_hot_constraint,
-                plan.context,
-            )?;
-        *self = staged;
-
-        Ok(result)
+        self.promote_compatible_one_hot(std::slice::from_ref(request))
+            .pop()
+            .expect("one request must produce one aligned OneHot promotion outcome")
     }
 
-    fn plan_one_hot_promotion(
+    /// Check, reconcile, and apply OneHot promotion requests as one batch.
+    ///
+    /// Results remain aligned with the input requests. Individually invalid
+    /// requests and every request sharing a source row with another
+    /// individually valid request are rejected. All remaining requests are
+    /// applied together through one [`OneHotPromotionBatchPlan`].
+    fn promote_compatible_one_hot(
+        &mut self,
+        requests: &[OneHotPromotionRequest],
+    ) -> Vec<crate::Result<OneHotPromotion>> {
+        let OneHotPromotionBatchPlanning { plan, rejections } =
+            self.plan_compatible_one_hot_promotions(requests);
+        let mut outcomes = rejections
+            .into_iter()
+            .map(|error| error.map(Err))
+            .collect::<Vec<_>>();
+
+        for (index, promotion) in self.apply_one_hot_promotion_batch(plan) {
+            debug_assert!(outcomes[index].is_none());
+            outcomes[index] = Some(Ok(promotion));
+        }
+
+        outcomes
+            .into_iter()
+            .map(|outcome| outcome.expect("every OneHot request must receive one outcome"))
+            .collect()
+    }
+
+    fn apply_one_hot_promotion_batch(
+        &mut self,
+        plan: OneHotPromotionBatchPlan,
+    ) -> Vec<(usize, OneHotPromotion)> {
+        if plan.entries.is_empty() {
+            return Vec::new();
+        }
+
+        let removal_reasons = plan
+            .entries
+            .iter()
+            .map(|(_, plan)| {
+                (
+                    plan.result.relaxed_constraint_id,
+                    RemovedReason {
+                        reason: PROMOTION_REASON.to_string(),
+                        parameters: [(
+                            TARGET_ID_PARAMETER.to_string(),
+                            plan.result.one_hot_constraint_id.into_inner().to_string(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    },
+                )
+            })
+            .collect();
+        self.constraint_collection
+            .move_active_rows_to_removed_with_reasons(removal_reasons)
+            .expect("source rows were validated by OneHotPromotionBatchPlan");
+
+        let mut promotions = Vec::with_capacity(plan.entries.len());
+        for (index, plan) in plan.entries {
+            self.one_hot_constraint_collection
+                .insert_active_with_context(
+                    plan.result.one_hot_constraint_id,
+                    plan.one_hot_constraint,
+                    plan.context,
+                )
+                .expect("target IDs and member IDs were validated by OneHotPromotionBatchPlan");
+            promotions.push((index, plan.result));
+        }
+        promotions
+    }
+
+    fn plan_compatible_one_hot_promotions(
+        &self,
+        requests: &[OneHotPromotionRequest],
+    ) -> OneHotPromotionBatchPlanning {
+        let mut checked = Vec::with_capacity(requests.len());
+        let mut rejections = Vec::with_capacity(requests.len());
+        for request in requests {
+            match self.check_one_hot_promotion(request) {
+                Ok(formulation) => {
+                    checked.push(Some(formulation));
+                    rejections.push(None);
+                }
+                Err(error) => {
+                    checked.push(None);
+                    rejections.push(Some(error));
+                }
+            }
+        }
+
+        let mut source_claimants = BTreeMap::<ConstraintID, Vec<usize>>::new();
+        for (index, formulation) in checked.iter().enumerate() {
+            if let Some(formulation) = formulation {
+                source_claimants
+                    .entry(formulation.source_constraint_id)
+                    .or_default()
+                    .push(index);
+            }
+        }
+        for (source_constraint_id, claimants) in source_claimants {
+            if claimants.len() <= 1 {
+                continue;
+            }
+            for index in claimants {
+                checked[index] = None;
+                rejections[index] = Some(crate::error!(
+                    { index, ?source_constraint_id },
+                    "OneHot promotion request at index {index} conflicts with another individually valid request over source row {source_constraint_id:?}"
+                ));
+            }
+        }
+
+        let survivor_count = checked.iter().filter(|entry| entry.is_some()).count();
+        if let Err(error) = self
+            .one_hot_constraint_collection
+            .ensure_unused_id_capacity(survivor_count)
+        {
+            let message = error.to_string();
+            for (index, formulation) in checked.iter_mut().enumerate() {
+                if formulation.take().is_some() {
+                    rejections[index] = Some(crate::error!(
+                        { index, survivor_count },
+                        "Cannot allocate OneHot constraint IDs for the compatible promotion batch: {message}"
+                    ));
+                }
+            }
+            return OneHotPromotionBatchPlanning {
+                plan: OneHotPromotionBatchPlan {
+                    entries: Vec::new(),
+                },
+                rejections,
+            };
+        }
+
+        let first_id = (survivor_count > 0)
+            .then(|| self.one_hot_constraint_collection.unused_id().into_inner());
+        let mut offset = 0_u64;
+        let mut entries = Vec::with_capacity(survivor_count);
+        for (index, formulation) in checked.into_iter().enumerate() {
+            let Some(formulation) = formulation else {
+                continue;
+            };
+            let one_hot_constraint_id = OneHotConstraintID::from(
+                first_id
+                    .expect("a non-empty compatible batch has a first OneHot ID")
+                    .checked_add(offset)
+                    .expect("batch ID capacity was validated before allocation"),
+            );
+            offset += 1;
+            entries.push((
+                index,
+                OneHotPromotionPlan {
+                    result: OneHotPromotion {
+                        one_hot_constraint_id,
+                        variables: formulation.variables,
+                        relaxed_constraint_id: formulation.source_constraint_id,
+                    },
+                    one_hot_constraint: formulation.one_hot_constraint,
+                    context: formulation.context,
+                },
+            ));
+        }
+
+        OneHotPromotionBatchPlanning {
+            plan: OneHotPromotionBatchPlan { entries },
+            rejections,
+        }
+    }
+
+    fn check_one_hot_promotion(
         &self,
         request: &OneHotPromotionRequest,
-    ) -> crate::Result<OneHotPromotionPlan> {
+    ) -> crate::Result<CheckedOneHotFormulation> {
         if request.variables.is_empty() {
             crate::bail!("One-hot promotion request must contain at least one member");
         }
@@ -247,21 +439,15 @@ impl Instance {
             );
         }
 
-        self.one_hot_constraint_collection
-            .ensure_unused_id_capacity(1)?;
-        let one_hot_constraint_id = self.one_hot_constraint_collection.unused_id();
         let one_hot_constraint = OneHotConstraint::new(request.variables.clone())?;
         let context = self
             .constraint_collection
             .context()
             .collect_for(request.source_constraint_id);
 
-        Ok(OneHotPromotionPlan {
-            result: OneHotPromotion {
-                one_hot_constraint_id,
-                variables: request.variables.clone(),
-                relaxed_constraint_id: request.source_constraint_id,
-            },
+        Ok(CheckedOneHotFormulation {
+            variables: request.variables.clone(),
+            source_constraint_id: request.source_constraint_id,
             one_hot_constraint,
             context,
         })
@@ -304,6 +490,40 @@ mod tests {
             .unwrap()
     }
 
+    fn batch_instance() -> (Instance, Vec<OneHotPromotionRequest>) {
+        let requests = vec![
+            OneHotPromotionRequest {
+                source_constraint_id: ConstraintID::from(10),
+                variables: variables([1, 2]),
+            },
+            OneHotPromotionRequest {
+                source_constraint_id: ConstraintID::from(20),
+                variables: variables([2, 3]),
+            },
+        ];
+        let instance = Instance::builder()
+            .sense(Sense::Minimize)
+            .objective(Function::Zero)
+            .decision_variables(BTreeMap::from([
+                (VariableID::from(1), DecisionVariable::binary()),
+                (VariableID::from(2), DecisionVariable::binary()),
+                (VariableID::from(3), DecisionVariable::binary()),
+            ]))
+            .constraints(BTreeMap::from([
+                (
+                    ConstraintID::from(10),
+                    Constraint::equal_to_zero(exact_scaled_one_hot(&[1, 2], 1.0)),
+                ),
+                (
+                    ConstraintID::from(20),
+                    Constraint::equal_to_zero(exact_scaled_one_hot(&[2, 3], -2.0)),
+                ),
+            ]))
+            .build()
+            .unwrap();
+        (instance, requests)
+    }
+
     fn request(ids: impl IntoIterator<Item = u64>) -> OneHotPromotionRequest {
         OneHotPromotionRequest {
             source_constraint_id: ConstraintID::from(10),
@@ -316,13 +536,15 @@ mod tests {
         request: &OneHotPromotionRequest,
         message: &str,
     ) {
-        let before = instance.clone();
+        let regular_before = instance.constraint_collection.clone();
+        let one_hot_before = instance.one_hot_constraint_collection.clone();
         let error = instance.promote_one_hot(request).unwrap_err();
         assert!(
             error.to_string().contains(message),
             "unexpected error: {error:#}"
         );
-        assert_eq!(instance, before);
+        assert_eq!(instance.constraint_collection, regular_before);
+        assert_eq!(instance.one_hot_constraint_collection, one_hot_before);
     }
 
     #[test]
@@ -410,6 +632,90 @@ mod tests {
                 context
             );
         }
+    }
+
+    #[test]
+    fn batch_promotes_disjoint_rows_with_a_shared_member() {
+        let (mut instance, requests) = batch_instance();
+
+        let outcomes = instance.promote_compatible_one_hot(&requests);
+
+        let promotions = outcomes
+            .iter()
+            .map(|outcome| outcome.as_ref().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            promotions
+                .iter()
+                .map(|promotion| promotion.one_hot_constraint_id())
+                .collect::<Vec<_>>(),
+            vec![OneHotConstraintID::from(0), OneHotConstraintID::from(1)]
+        );
+        assert!(instance.constraints().is_empty());
+        assert_eq!(instance.removed_constraints().len(), 2);
+        assert_eq!(instance.one_hot_constraints().len(), 2);
+        assert_eq!(
+            instance.one_hot_constraints()[&OneHotConstraintID::from(0)].variables,
+            variables([1, 2])
+        );
+        assert_eq!(
+            instance.one_hot_constraints()[&OneHotConstraintID::from(1)].variables,
+            variables([2, 3])
+        );
+    }
+
+    #[test]
+    fn batch_rejects_all_duplicate_source_claims_and_promotes_unrelated_request() {
+        let (mut instance, requests) = batch_instance();
+        let requests = vec![
+            requests[0].clone(),
+            requests[0].clone(),
+            requests[1].clone(),
+        ];
+
+        let outcomes = instance.promote_compatible_one_hot(&requests);
+
+        assert!(outcomes[0]
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("conflicts with another individually valid request"));
+        assert!(outcomes[1].is_err());
+        assert_eq!(
+            outcomes[2].as_ref().unwrap().one_hot_constraint_id(),
+            OneHotConstraintID::from(0)
+        );
+        assert!(instance.constraints().contains_key(&ConstraintID::from(10)));
+        assert!(instance
+            .removed_constraints()
+            .contains_key(&ConstraintID::from(20)));
+        assert_eq!(instance.one_hot_constraints().len(), 1);
+    }
+
+    #[test]
+    fn batch_rejects_id_exhaustion_before_any_mutation() {
+        let (mut instance, requests) = batch_instance();
+        instance
+            .one_hot_constraint_collection
+            .insert_active_with_context(
+                OneHotConstraintID::from(u64::MAX),
+                OneHotConstraint::new(variables([1])).unwrap(),
+                ConstraintContext::default(),
+            )
+            .unwrap();
+        let regular_before = instance.constraint_collection.clone();
+        let one_hot_before = instance.one_hot_constraint_collection.clone();
+
+        let outcomes = instance.promote_compatible_one_hot(&requests);
+
+        assert!(outcomes.iter().all(Result::is_err));
+        assert!(outcomes.iter().all(|outcome| outcome
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot allocate OneHot constraint IDs")));
+        assert_eq!(instance.constraint_collection, regular_before);
+        assert_eq!(instance.one_hot_constraint_collection, one_hot_before);
     }
 
     #[test]

--- a/rust/ommx/src/instance/one_hot_promotion.rs
+++ b/rust/ommx/src/instance/one_hot_promotion.rs
@@ -1,9 +1,9 @@
 //! Checked promotion of exact regular equalities to one-hot constraints.
 //!
-//! A promotion request is deliberately untrusted. It carries only stable IDs
-//! and claimed one-hot membership; the current [`Instance`] remains the source
-//! of truth for the regular row and decision-variable domains. Promotion is
-//! allowed only when the active source is exactly a non-zero scalar multiple of
+//! A promotion request carries only stable regular-constraint IDs. The current
+//! [`Instance`] remains the source of truth for the row, its inferred one-hot
+//! membership, and the decision-variable domains. Promotion is allowed only
+//! when the active source is exactly a non-zero scalar multiple of
 //! `sum(variables) - 1 = 0` over binary variables.
 //!
 //! The public API is batch-oriented. All candidates are checked against one
@@ -16,99 +16,71 @@ use crate::{
     Coefficient, ConstraintContext, ConstraintID, Equality, Kind, LinearMonomial, OneHotConstraint,
     OneHotConstraintID, RemovedReason, VariableID, VariableIDSet,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 const PROMOTION_REASON: &str = "promoted validated one-hot equality";
 const TARGET_ID_PARAMETER: &str = "one_hot_constraint_id";
 
-/// Untrusted stable-ID request for one one-hot promotion.
+/// Stable-ID request for a batch of one-hot promotion attempts.
 ///
-/// The request claims that `source_constraint_id` identifies an active regular
-/// equality whose exact support is `variables`. Callers may construct invalid
-/// requests directly; [`Instance::promote_one_hot`] checks the source row,
+/// Each ID selects an active regular constraint to inspect. The current
+/// [`Instance`] determines the member set from the row itself and validates its
 /// relation, coefficients, and current variable domains before mutation.
 ///
-/// No target ID is supplied. A fresh [`OneHotConstraintID`] is allocated from
-/// the current [`Instance`] only after the request has been verified.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// The set representation makes duplicate source claims unrepresentable. No
+/// target IDs are supplied; fresh [`OneHotConstraintID`] values are allocated
+/// together only after every source has been inspected.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OneHotPromotionRequest {
-    /// Active regular constraint claimed to encode one-hot membership.
-    pub source_constraint_id: ConstraintID,
-    /// Claimed one-hot members.
-    pub variables: VariableIDSet,
+    constraint_ids: BTreeSet<ConstraintID>,
 }
 
 impl OneHotPromotionRequest {
+    /// Construct a request from regular constraint IDs to inspect.
+    pub fn new(constraint_ids: impl IntoIterator<Item = ConstraintID>) -> Self {
+        Self {
+            constraint_ids: constraint_ids.into_iter().collect(),
+        }
+    }
+
+    /// Regular constraint IDs requested for promotion.
+    pub fn constraint_ids(&self) -> &BTreeSet<ConstraintID> {
+        &self.constraint_ids
+    }
+
     /// Convert one legacy v1 one-hot hint into an untrusted request.
     ///
-    /// This conversion is independent of any [`Instance`]. It validates only
-    /// the wire-level set shape: the member list must be non-empty and contain
-    /// no duplicate IDs. Domain and source-row validation is deferred to
-    /// [`Instance::promote_one_hot`]. Constraint ID `0` is a valid stable ID.
-    pub fn from_v1_hint(hint: &crate::v1::OneHot) -> crate::Result<Self> {
-        if hint.decision_variables.is_empty() {
-            crate::bail!("Legacy v1 one-hot hint must contain at least one member");
-        }
-
-        let mut variables = VariableIDSet::new();
-        for &raw_id in &hint.decision_variables {
-            let id = VariableID::from(raw_id);
-            if !variables.insert(id) {
-                crate::bail!(
-                    { ?id },
-                    "Legacy v1 one-hot hint repeats member {id:?}"
-                );
-            }
-        }
-
-        Ok(Self {
-            source_constraint_id: ConstraintID::from(hint.constraint_id),
-            variables,
-        })
+    /// This conversion is independent of any [`Instance`] and uses only the
+    /// referenced regular constraint ID. Legacy `decision_variables` are
+    /// advisory data rather than a certificate; membership is re-derived from
+    /// the current source row by [`Instance::promote_one_hot`]. Constraint ID
+    /// `0` is a valid stable ID.
+    pub fn from_v1_hint(hint: &crate::v1::OneHot) -> Self {
+        Self::new([ConstraintID::from(hint.constraint_id)])
     }
 }
 
-/// Stable-ID mapping produced by one checked one-hot promotion.
+impl FromIterator<ConstraintID> for OneHotPromotionRequest {
+    fn from_iter<T: IntoIterator<Item = ConstraintID>>(iter: T) -> Self {
+        Self::new(iter)
+    }
+}
+
+/// Individually validated OneHot candidate before target-ID allocation.
 ///
-/// All promoted constraint data remains queryable from the mutated
-/// [`Instance`]; this value records only which regular source became which
-/// first-class OneHot constraint.
-#[must_use = "the result identifies the source-to-OneHot promotion mapping"]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OneHotPromotion {
-    source_constraint_id: ConstraintID,
-    one_hot_constraint_id: OneHotConstraintID,
-}
-
-impl OneHotPromotion {
-    /// Regular source constraint moved from active to removed.
-    pub fn source_constraint_id(&self) -> ConstraintID {
-        self.source_constraint_id
-    }
-
-    /// ID allocated to the promoted one-hot constraint.
-    pub fn one_hot_constraint_id(&self) -> OneHotConstraintID {
-        self.one_hot_constraint_id
-    }
-}
-
-/// Individually validated OneHot candidate before batch compatibility and
-/// target-ID allocation.
-///
-/// This intermediate state separates fallible request validation from
-/// cross-request conflict resolution. Target IDs are deliberately absent;
-/// only the batch plan allocates them after rejecting duplicate source claims.
+/// This intermediate state separates fallible source-row validation from
+/// aggregate ID allocation. Target IDs are deliberately absent; only the batch
+/// plan allocates them.
 #[derive(Debug)]
 struct CheckedOneHotPromotionCandidate {
-    source_constraint_id: ConstraintID,
     one_hot_constraint: OneHotConstraint,
     context: ConstraintContext,
 }
 
-/// Fully validated entry in one OneHot promotion batch.
+/// Fully planned OneHot insertion for one validated source row.
 #[derive(Debug)]
-struct OneHotPromotionPlanEntry {
-    result: OneHotPromotion,
+struct PlannedOneHot {
+    one_hot_constraint_id: OneHotConstraintID,
     one_hot_constraint: OneHotConstraint,
     context: ConstraintContext,
 }
@@ -133,66 +105,40 @@ struct OneHotPromotionPlanEntry {
 #[derive(Debug)]
 struct OneHotPromotionBatchPlan<'a> {
     instance: &'a mut Instance,
-    entries: Vec<(usize, OneHotPromotionPlanEntry)>,
-    rejections: Vec<Option<crate::Error>>,
+    entries: BTreeMap<ConstraintID, PlannedOneHot>,
+    rejections: BTreeMap<ConstraintID, crate::Error>,
 }
 
 impl<'a> OneHotPromotionBatchPlan<'a> {
-    fn new(instance: &'a mut Instance, requests: &[OneHotPromotionRequest]) -> Self {
-        let mut checked = Vec::with_capacity(requests.len());
-        let mut rejections = Vec::with_capacity(requests.len());
-        for request in requests {
-            match instance.check_one_hot_promotion(request) {
+    fn new(instance: &'a mut Instance, request: &OneHotPromotionRequest) -> Self {
+        let mut checked = BTreeMap::new();
+        let mut rejections = BTreeMap::new();
+        for &source_constraint_id in request.constraint_ids() {
+            match instance.check_one_hot_promotion(source_constraint_id) {
                 Ok(candidate) => {
-                    checked.push(Some(candidate));
-                    rejections.push(None);
+                    checked.insert(source_constraint_id, candidate);
                 }
                 Err(error) => {
-                    checked.push(None);
-                    rejections.push(Some(error));
+                    rejections.insert(source_constraint_id, error);
                 }
             }
         }
 
-        let mut source_claimants = BTreeMap::<ConstraintID, Vec<usize>>::new();
-        for (index, candidate) in checked.iter().enumerate() {
-            if let Some(candidate) = candidate {
-                source_claimants
-                    .entry(candidate.source_constraint_id)
-                    .or_default()
-                    .push(index);
-            }
-        }
-        for (source_constraint_id, claimants) in source_claimants {
-            if claimants.len() <= 1 {
-                continue;
-            }
-            for index in claimants {
-                checked[index] = None;
-                rejections[index] = Some(crate::error!(
-                    { index, ?source_constraint_id },
-                    "OneHot promotion request at index {index} conflicts with another individually valid request over source row {source_constraint_id:?}"
-                ));
-            }
-        }
-
-        let survivor_count = checked.iter().filter(|entry| entry.is_some()).count();
+        let survivor_count = checked.len();
         if let Err(error) = instance
             .one_hot_constraint_collection
             .ensure_unused_id_capacity(survivor_count)
         {
             let message = error.to_string();
-            for (index, candidate) in checked.iter_mut().enumerate() {
-                if candidate.take().is_some() {
-                    rejections[index] = Some(crate::error!(
-                        { index, survivor_count },
+            for source_constraint_id in checked.keys().copied() {
+                rejections.insert(source_constraint_id, crate::error!(
+                        { ?source_constraint_id, survivor_count },
                         "Cannot allocate OneHot constraint IDs for the compatible promotion batch: {message}"
                     ));
-                }
             }
             return Self {
                 instance,
-                entries: Vec::new(),
+                entries: BTreeMap::new(),
                 rejections,
             };
         }
@@ -203,30 +149,24 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
                 .unused_id()
                 .into_inner()
         });
-        let mut offset = 0_u64;
-        let mut entries = Vec::with_capacity(survivor_count);
-        for (index, candidate) in checked.into_iter().enumerate() {
-            let Some(candidate) = candidate else {
-                continue;
-            };
+        let mut entries = BTreeMap::new();
+        for (offset, (source_constraint_id, candidate)) in checked.into_iter().enumerate() {
+            let offset = u64::try_from(offset)
+                .expect("batch size was converted to u64 during ID capacity validation");
             let one_hot_constraint_id = OneHotConstraintID::from(
                 first_id
                     .expect("a non-empty compatible batch has a first OneHot ID")
                     .checked_add(offset)
                     .expect("batch ID capacity was validated before allocation"),
             );
-            offset += 1;
-            entries.push((
-                index,
-                OneHotPromotionPlanEntry {
-                    result: OneHotPromotion {
-                        source_constraint_id: candidate.source_constraint_id,
-                        one_hot_constraint_id,
-                    },
+            entries.insert(
+                source_constraint_id,
+                PlannedOneHot {
+                    one_hot_constraint_id,
                     one_hot_constraint: candidate.one_hot_constraint,
                     context: candidate.context,
                 },
-            ));
+            );
         }
 
         Self {
@@ -236,34 +176,32 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
         }
     }
 
-    fn apply(self) -> Vec<crate::Result<OneHotPromotion>> {
+    fn apply(self) -> BTreeMap<ConstraintID, crate::Result<OneHotConstraintID>> {
         let Self {
             instance,
             entries,
             rejections,
         } = self;
-        let mut outcomes = rejections
+
+        let mut results: BTreeMap<_, _> = rejections
             .into_iter()
-            .map(|error| error.map(Err))
-            .collect::<Vec<_>>();
+            .map(|(source_constraint_id, error)| (source_constraint_id, Err(error)))
+            .collect();
 
         if entries.is_empty() {
-            return outcomes
-                .into_iter()
-                .map(|outcome| outcome.expect("every OneHot request must receive one outcome"))
-                .collect();
+            return results;
         }
 
         let removal_reasons = entries
             .iter()
-            .map(|(_, entry)| {
+            .map(|(&source_constraint_id, planned)| {
                 (
-                    entry.result.source_constraint_id,
+                    source_constraint_id,
                     RemovedReason {
                         reason: PROMOTION_REASON.to_string(),
                         parameters: [(
                             TARGET_ID_PARAMETER.to_string(),
-                            entry.result.one_hot_constraint_id.into_inner().to_string(),
+                            planned.one_hot_constraint_id.into_inner().to_string(),
                         )]
                         .into_iter()
                         .collect(),
@@ -276,25 +214,22 @@ impl<'a> OneHotPromotionBatchPlan<'a> {
             .move_active_rows_to_removed_with_reasons(removal_reasons)
             .expect("source rows and bound Instance were validated by OneHotPromotionBatchPlan");
 
-        for (index, entry) in entries {
+        for (source_constraint_id, planned) in entries {
             instance
                 .one_hot_constraint_collection
                 .insert_active_with_context(
-                    entry.result.one_hot_constraint_id,
-                    entry.one_hot_constraint,
-                    entry.context,
+                    planned.one_hot_constraint_id,
+                    planned.one_hot_constraint,
+                    planned.context,
                 )
                 .expect(
                     "target IDs, member IDs, and bound Instance were validated by OneHotPromotionBatchPlan",
                 );
-            debug_assert!(outcomes[index].is_none());
-            outcomes[index] = Some(Ok(entry.result));
+            let previous = results.insert(source_constraint_id, Ok(planned.one_hot_constraint_id));
+            debug_assert!(previous.is_none());
         }
 
-        outcomes
-            .into_iter()
-            .map(|outcome| outcome.expect("every OneHot request must receive one outcome"))
-            .collect()
+        results
     }
 }
 
@@ -302,83 +237,74 @@ impl Instance {
     /// Promote compatible exact regular equalities to one-hot constraints as a
     /// single batch.
     ///
-    /// The requests are untrusted. This method verifies each candidate against
+    /// The request IDs are untrusted. This method verifies each source against
     /// the current instance, requiring that:
     ///
-    /// - the claimed member set is non-empty;
     /// - the source is an active regular equality;
     /// - its function is exactly linear;
-    /// - its support is exactly the claimed member set;
-    /// - every member is a binary decision variable; and
+    /// - its support is non-empty and every member is a binary decision
+    ///   variable; and
     /// - for one common non-zero coefficient `c`, the row is exactly
     ///   `c * (sum(variables) - 1) = 0`.
     ///
-    /// Results remain aligned with `requests`. Individually invalid requests
-    /// and every request sharing a source row with another individually valid
-    /// request are rejected, while compatible requests are all applied.
+    /// The returned map has exactly one entry per requested source ID. Each
+    /// value is either the allocated OneHot ID or that source's rejection
+    /// reason. An invalid source does not prevent independent valid sources in
+    /// the same request from being promoted.
     ///
     /// On each successful entry the source moves to `removed_constraints`, its
     /// context is copied to the new active one-hot constraint, and the removal
     /// reason records the allocated target ID. Planning is atomic: rejected
     /// requests leave their rows unchanged. The private plan exclusively
     /// borrows this instance until its infallible Apply consumes the plan.
+    #[must_use = "each requested source has a success or rejection result"]
     pub fn promote_one_hot(
         &mut self,
-        requests: &[OneHotPromotionRequest],
-    ) -> Vec<crate::Result<OneHotPromotion>> {
-        OneHotPromotionBatchPlan::new(self, requests).apply()
+        request: &OneHotPromotionRequest,
+    ) -> BTreeMap<ConstraintID, crate::Result<OneHotConstraintID>> {
+        OneHotPromotionBatchPlan::new(self, request).apply()
     }
 
     fn check_one_hot_promotion(
         &self,
-        request: &OneHotPromotionRequest,
+        source_constraint_id: ConstraintID,
     ) -> crate::Result<CheckedOneHotPromotionCandidate> {
-        if request.variables.is_empty() {
-            crate::bail!("One-hot promotion request must contain at least one member");
-        }
-
         let source = self
             .constraint_collection
             .active()
-            .get(&request.source_constraint_id)
+            .get(&source_constraint_id)
             .ok_or_else(|| {
                 crate::error!(
-                    { source_constraint_id = ?request.source_constraint_id },
+                    { ?source_constraint_id },
                     "Active regular constraint {:?} was not found",
-                    request.source_constraint_id
+                    source_constraint_id
                 )
             })?;
         if source.equality != Equality::EqualToZero {
             crate::bail!(
-                { source_constraint_id = ?request.source_constraint_id },
+                { ?source_constraint_id },
                 "Regular constraint {:?} is not an equality-to-zero constraint",
-                request.source_constraint_id
+                source_constraint_id
             );
         }
 
         let linear = source.function().as_linear().ok_or_else(|| {
             crate::error!(
-                { source_constraint_id = ?request.source_constraint_id },
+                { ?source_constraint_id },
                 "Regular constraint {:?} is not exactly linear",
-                request.source_constraint_id
+                source_constraint_id
             )
         })?;
         let coefficients: BTreeMap<VariableID, Coefficient> = linear.linear_terms().collect();
         let support: VariableIDSet = coefficients.keys().copied().collect();
-        if support != request.variables {
+        if support.is_empty() {
             crate::bail!(
-                {
-                    source_constraint_id = ?request.source_constraint_id,
-                    ?support,
-                    claimed_variables = ?request.variables
-                },
-                "Regular constraint {:?} has linear support {support:?}, expected {:?}",
-                request.source_constraint_id,
-                request.variables
+                { ?source_constraint_id },
+                "Regular constraint {source_constraint_id:?} has no one-hot members"
             );
         }
 
-        for &variable_id in &request.variables {
+        for &variable_id in &support {
             let variable = self.decision_variables.get(&variable_id).ok_or_else(|| {
                 crate::error!(
                     { ?variable_id },
@@ -403,9 +329,9 @@ impl Instance {
             .any(|&coefficient| coefficient != common_coefficient)
         {
             crate::bail!(
-                { source_constraint_id = ?request.source_constraint_id },
+                { ?source_constraint_id },
                 "Regular constraint {:?} does not use one common coefficient for all one-hot members",
-                request.source_constraint_id
+                source_constraint_id
             );
         }
 
@@ -413,24 +339,23 @@ impl Instance {
         if constant != Some(-common_coefficient) {
             crate::bail!(
                 {
-                    source_constraint_id = ?request.source_constraint_id,
+                    ?source_constraint_id,
                     ?constant,
                     expected = ?(-common_coefficient)
                 },
                 "Regular constraint {:?} has constant coefficient {constant:?}, expected {:?}",
-                request.source_constraint_id,
+                source_constraint_id,
                 -common_coefficient
             );
         }
 
-        let one_hot_constraint = OneHotConstraint::new(request.variables.clone())?;
+        let one_hot_constraint = OneHotConstraint::new(support)?;
         let context = self
             .constraint_collection
             .context()
-            .collect_for(request.source_constraint_id);
+            .collect_for(source_constraint_id);
 
         Ok(CheckedOneHotPromotionCandidate {
-            source_constraint_id: request.source_constraint_id,
             one_hot_constraint,
             context,
         })
@@ -473,17 +398,8 @@ mod tests {
             .unwrap()
     }
 
-    fn batch_instance() -> (Instance, Vec<OneHotPromotionRequest>) {
-        let requests = vec![
-            OneHotPromotionRequest {
-                source_constraint_id: ConstraintID::from(10),
-                variables: variables([1, 2]),
-            },
-            OneHotPromotionRequest {
-                source_constraint_id: ConstraintID::from(20),
-                variables: variables([2, 3]),
-            },
-        ];
+    fn batch_instance() -> (Instance, OneHotPromotionRequest) {
+        let request = OneHotPromotionRequest::new([ConstraintID::from(10), ConstraintID::from(20)]);
         let instance = Instance::builder()
             .sense(Sense::Minimize)
             .objective(Function::Zero)
@@ -504,28 +420,24 @@ mod tests {
             ]))
             .build()
             .unwrap();
-        (instance, requests)
+        (instance, request)
     }
 
     fn request(ids: impl IntoIterator<Item = u64>) -> OneHotPromotionRequest {
-        OneHotPromotionRequest {
-            source_constraint_id: ConstraintID::from(10),
-            variables: variables(ids),
-        }
+        OneHotPromotionRequest::new(ids.into_iter().map(ConstraintID::from))
     }
 
     fn assert_atomic_rejection(
         mut instance: Instance,
-        request: &OneHotPromotionRequest,
+        source_constraint_id: ConstraintID,
         message: &str,
     ) {
         let regular_before = instance.constraint_collection.clone();
         let one_hot_before = instance.one_hot_constraint_collection.clone();
-        let error = instance
-            .promote_one_hot(std::slice::from_ref(request))
-            .pop()
-            .unwrap()
-            .unwrap_err();
+        let results =
+            instance.promote_one_hot(&OneHotPromotionRequest::new([source_constraint_id]));
+        assert_eq!(results.len(), 1);
+        let error = results[&source_constraint_id].as_ref().unwrap_err();
         assert!(
             error.to_string().contains(message),
             "unexpected error: {error:#}"
@@ -535,29 +447,16 @@ mod tests {
     }
 
     #[test]
-    fn converts_v1_hint_without_instance_and_rejects_invalid_member_lists() {
-        let hint = crate::v1::OneHot {
-            constraint_id: 0,
-            decision_variables: vec![2, 1],
-        };
-        assert_eq!(
-            OneHotPromotionRequest::from_v1_hint(&hint).unwrap(),
-            OneHotPromotionRequest {
-                source_constraint_id: ConstraintID::from(0),
-                variables: variables([1, 2]),
-            }
-        );
-
-        for (members, expected) in [
-            (vec![], "at least one member"),
-            (vec![1, 1], "repeats member"),
-        ] {
-            let error = OneHotPromotionRequest::from_v1_hint(&crate::v1::OneHot {
+    fn converts_v1_hint_to_a_singleton_request_without_using_claimed_members() {
+        for members in [vec![], vec![2, 1], vec![1, 1]] {
+            let request = OneHotPromotionRequest::from_v1_hint(&crate::v1::OneHot {
                 constraint_id: 7,
                 decision_variables: members,
-            })
-            .unwrap_err();
-            assert!(error.to_string().contains(expected));
+            });
+            assert_eq!(
+                request.constraint_ids(),
+                &BTreeSet::from([ConstraintID::from(7)])
+            );
         }
     }
 
@@ -582,17 +481,13 @@ mod tests {
                 .set_constraint_context(ConstraintID::from(10), context.clone())
                 .unwrap();
 
-            let promotion = instance
-                .promote_one_hot(&[request([1, 2, 3])])
-                .pop()
-                .unwrap()
-                .unwrap();
+            let results = instance.promote_one_hot(&request([10]));
 
             assert_eq!(
-                promotion.one_hot_constraint_id(),
-                OneHotConstraintID::from(0)
+                results[&ConstraintID::from(10)].as_ref().unwrap(),
+                &OneHotConstraintID::from(0)
             );
-            assert_eq!(promotion.source_constraint_id(), ConstraintID::from(10));
+            assert_eq!(results.len(), 1);
             assert!(instance.constraints().is_empty());
             assert_eq!(
                 instance.one_hot_constraints()[&OneHotConstraintID::from(0)].variables,
@@ -626,21 +521,19 @@ mod tests {
 
     #[test]
     fn batch_promotes_disjoint_rows_with_a_shared_member() {
-        let (mut instance, requests) = batch_instance();
+        let (mut instance, request) = batch_instance();
 
-        let outcomes = instance.promote_one_hot(&requests);
+        let results = instance.promote_one_hot(&request);
 
-        let promotions = outcomes
-            .iter()
-            .map(|outcome| outcome.as_ref().unwrap())
-            .collect::<Vec<_>>();
         assert_eq!(
-            promotions
-                .iter()
-                .map(|promotion| promotion.one_hot_constraint_id())
-                .collect::<Vec<_>>(),
-            vec![OneHotConstraintID::from(0), OneHotConstraintID::from(1)]
+            results[&ConstraintID::from(10)].as_ref().unwrap(),
+            &OneHotConstraintID::from(0)
         );
+        assert_eq!(
+            results[&ConstraintID::from(20)].as_ref().unwrap(),
+            &OneHotConstraintID::from(1)
+        );
+        assert_eq!(results.len(), 2);
         assert!(instance.constraints().is_empty());
         assert_eq!(instance.removed_constraints().len(), 2);
         assert_eq!(instance.one_hot_constraints().len(), 2);
@@ -655,56 +548,40 @@ mod tests {
     }
 
     #[test]
-    fn batch_rejects_all_duplicate_source_claims_and_promotes_unrelated_request() {
-        let (mut instance, requests) = batch_instance();
-        let requests = vec![
-            requests[0].clone(),
-            requests[0].clone(),
-            requests[1].clone(),
-        ];
+    fn request_deduplicates_source_ids_by_construction() {
+        let request = OneHotPromotionRequest::new([
+            ConstraintID::from(10),
+            ConstraintID::from(10),
+            ConstraintID::from(20),
+        ]);
 
-        let outcomes = instance.promote_one_hot(&requests);
-
-        assert!(outcomes[0]
-            .as_ref()
-            .unwrap_err()
-            .to_string()
-            .contains("conflicts with another individually valid request"));
-        assert!(outcomes[1].is_err());
         assert_eq!(
-            outcomes[2].as_ref().unwrap().one_hot_constraint_id(),
-            OneHotConstraintID::from(0)
-        );
-        assert!(instance.constraints().contains_key(&ConstraintID::from(10)));
-        assert!(instance
-            .removed_constraints()
-            .contains_key(&ConstraintID::from(20)));
-        assert_eq!(instance.one_hot_constraints().len(), 1);
+            request.constraint_ids(),
+            &BTreeSet::from([ConstraintID::from(10), ConstraintID::from(20)])
+        )
     }
 
     #[test]
     fn batch_promotes_valid_requests_while_rejecting_individually_invalid_requests() {
-        let (mut instance, requests) = batch_instance();
-        let requests = vec![
-            OneHotPromotionRequest {
-                source_constraint_id: ConstraintID::from(99),
-                variables: variables([1, 2]),
-            },
-            requests[1].clone(),
-        ];
+        let (mut instance, _) = batch_instance();
+        let request = OneHotPromotionRequest::new([ConstraintID::from(99), ConstraintID::from(20)]);
 
-        let outcomes = instance.promote_one_hot(&requests);
+        let results = instance.promote_one_hot(&request);
 
-        assert_eq!(outcomes.len(), 2);
-        assert!(outcomes[0]
+        assert_eq!(
+            results.keys().copied().collect::<BTreeSet<_>>(),
+            request.constraint_ids().clone()
+        );
+        assert_eq!(
+            results[&ConstraintID::from(20)].as_ref().unwrap(),
+            &OneHotConstraintID::from(0)
+        );
+        assert!(results[&ConstraintID::from(99)]
             .as_ref()
             .unwrap_err()
             .to_string()
             .contains("was not found"));
-        assert_eq!(
-            outcomes[1].as_ref().unwrap().one_hot_constraint_id(),
-            OneHotConstraintID::from(0)
-        );
+        assert_eq!(results.len(), 2);
         assert!(instance.constraints().contains_key(&ConstraintID::from(10)));
         assert!(!instance.constraints().contains_key(&ConstraintID::from(20)));
         assert!(instance
@@ -715,7 +592,7 @@ mod tests {
 
     #[test]
     fn batch_rejects_id_exhaustion_before_any_mutation() {
-        let (mut instance, requests) = batch_instance();
+        let (mut instance, request) = batch_instance();
         instance
             .one_hot_constraint_collection
             .insert_active_with_context(
@@ -727,10 +604,13 @@ mod tests {
         let regular_before = instance.constraint_collection.clone();
         let one_hot_before = instance.one_hot_constraint_collection.clone();
 
-        let outcomes = instance.promote_one_hot(&requests);
+        let results = instance.promote_one_hot(&request);
 
-        assert!(outcomes.iter().all(Result::is_err));
-        assert!(outcomes.iter().all(|outcome| outcome
+        assert_eq!(
+            results.keys().copied().collect::<BTreeSet<_>>(),
+            request.constraint_ids().clone()
+        );
+        assert!(results.values().all(|result| result
             .as_ref()
             .unwrap_err()
             .to_string()
@@ -744,36 +624,33 @@ mod tests {
         let exact = Constraint::equal_to_zero(exact_scaled_one_hot(&[1, 2, 3], 1.0));
         assert_atomic_rejection(
             instance_with_source(exact.clone()),
-            &OneHotPromotionRequest {
-                source_constraint_id: ConstraintID::from(99),
-                variables: variables([1, 2, 3]),
-            },
+            ConstraintID::from(99),
             "was not found",
         );
         assert_atomic_rejection(
             instance_with_source(Constraint::less_than_or_equal_to_zero(
                 exact_scaled_one_hot(&[1, 2, 3], 1.0),
             )),
-            &request([1, 2, 3]),
+            ConstraintID::from(10),
             "not an equality-to-zero",
-        );
-        assert_atomic_rejection(
-            instance_with_source(exact.clone()),
-            &request([]),
-            "at least one member",
-        );
-        assert_atomic_rejection(
-            instance_with_source(exact),
-            &request([1, 2]),
-            "linear support",
         );
         assert_atomic_rejection(
             instance_with_source(Constraint::equal_to_zero(exact_scaled_one_hot(
                 &[1, 2, 4],
                 1.0,
             ))),
-            &request([1, 2, 4]),
+            ConstraintID::from(10),
             "must be binary",
+        );
+
+        let constant_only = Function::from(Linear::single_term(
+            LinearMonomial::Constant,
+            Coefficient::try_from(-1.0).unwrap(),
+        ));
+        assert_atomic_rejection(
+            instance_with_source(Constraint::equal_to_zero(constant_only)),
+            ConstraintID::from(10),
+            "has no one-hot members",
         );
     }
 
@@ -784,7 +661,7 @@ mod tests {
         );
         assert_atomic_rejection(
             instance_with_source(Constraint::equal_to_zero(unequal)),
-            &request([1, 2]),
+            ConstraintID::from(10),
             "common coefficient",
         );
 
@@ -792,7 +669,7 @@ mod tests {
             Function::from(((linear!(1) + linear!(2)).unwrap() + coeff!(-2.0)).unwrap());
         assert_atomic_rejection(
             instance_with_source(Constraint::equal_to_zero(wrong_constant)),
-            &request([1, 2]),
+            ConstraintID::from(10),
             "constant coefficient",
         );
 
@@ -802,7 +679,7 @@ mod tests {
         );
         assert_atomic_rejection(
             instance_with_source(Constraint::equal_to_zero(nonlinear)),
-            &request([1, 2]),
+            ConstraintID::from(10),
             "not exactly linear",
         );
     }


### PR DESCRIPTION
## Summary

- Add `OneHotPromotionRequest` as a `BTreeSet<ConstraintID>` alias for best-effort batch promotion.
- Add `OneHotPromotion` as a `BTreeMap<ConstraintID, Result<OneHotConstraintID>>` alias with one result per requested source ID.
- Add an instance-independent `From<&v1::OneHot>` conversion that retains the referenced constraint ID without trusting legacy member claims.
- Add `Instance::promote_one_hot` as the owner operation that constructs and applies the promotion batch.
- Preserve promoted source rows as removed history, copy their contexts to the new OneHot constraints, and apply valid entries without cloning the `Instance`.

## Semantics

The current `Instance` is the source of truth for each requested row and its OneHot members. Promotion accepts only an active regular equality whose linear function is exactly a non-zero scalar multiple of `sum(members) - 1`, with non-empty support consisting entirely of current Binary decision variables.

This preserves the exact feasible set over binary assignments. It intentionally does not claim identical approximate-feasibility classification: a regular equality tests one scaled residual, while a OneHot constraint classifies each member as zero or one under the evaluation tolerance.

The request uses a `BTreeSet`, so duplicate source IDs are eliminated by representation. The returned `BTreeMap<ConstraintID, Result<OneHotConstraintID>>` has exactly the same key set as the request: each source ID maps to either its allocated OneHot ID or its own rejection reason. An invalid source does not prevent independent valid sources from being promoted, and regular rows may share OneHot members.

The private batch plan checks all candidates before allocation and holds an exclusive mutable reference to the exact `Instance` it validated. Its own `BTreeMap<ConstraintID, Result<PlannedOneHot>>` has one entry per request, preserving the same success-or-rejection partition structurally. This prevents mutation or application to another instance between planning and Apply. The plan establishes active-source, fresh-target-ID, variable-domain, and context invariants before its infallible Apply consumes it; no instance clone or rollback path is used.

## Scope

This PR introduces the standalone OneHot request conversion and same-family batch promotion operation. It does not add new provenance representation, OneHot/SOS1 cross-family orchestration, or v1 byte-loader integration.
