### PR TITLE
Use typed enums consistently in the Python SDK

### DIFF
--- a/docs/api/api_reference.json
+++ b/docs/api/api_reference.json
@@ -1555,7 +1555,7 @@
               "name": "kind",
               "doc": "",
               "type_": {
-                "display": "int",
+                "display": "Kind",
                 "link_target": null,
                 "children": []
               },
@@ -3892,7 +3892,7 @@
           "attributes": [
             {
               "name": "EQUAL_TO_ZERO",
-              "doc": "Class constant for equality type: equal to zero (==)",
+              "doc": "Compatibility alias for {attr}`Equality.EqualToZero`.",
               "type_": {
                 "display": "Equality",
                 "link_target": null,
@@ -3901,7 +3901,7 @@
             },
             {
               "name": "LESS_THAN_OR_EQUAL_TO_ZERO",
-              "doc": "Class constant for equality type: less than or equal to zero (<=)",
+              "doc": "Compatibility alias for {attr}`Equality.LessThanOrEqualToZero`.",
               "type_": {
                 "display": "Equality",
                 "link_target": null,
@@ -4031,7 +4031,7 @@
         {
           "kind": "Class",
           "name": "DecisionVariable",
-          "doc": "Decision variable in an optimization problem.\n\nThis class represents a variable that will be optimized in a mathematical programming problem.\nIt supports various types (binary, integer, continuous, semi-integer, semi-continuous) and\ncan be used in arithmetic expressions to build objective functions and constraints.\nConstruction raises ValueError when the kind discriminator is unknown or\nthe requested bound cannot be normalized for the selected variable kind.\n\nNote that this object overloads `==` for creating a constraint, not for equality comparison.\n\n# Examples\n\n>>> x = DecisionVariable.integer(1)\n>>> x == 1  # Returns Constraint, not bool\nConstraint(...)\n\nFor object equality comparison, use the ``equals_to()`` method or compare IDs:\n\n>>> y = DecisionVariable.integer(2)\n>>> x.id == y.id\nFalse",
+          "doc": "Decision variable in an optimization problem.\n\nThis class represents a variable that will be optimized in a mathematical programming problem.\nIt supports various types (binary, integer, continuous, semi-integer, semi-continuous) and\ncan be used in arithmetic expressions to build objective functions and constraints.\nConstruction requires a {class}`~ommx.Kind` and raises ValueError when the\nrequested bound cannot be normalized for the selected variable kind.\n\nNote that this object overloads `==` for creating a constraint, not for equality comparison.\n\n# Examples\n\n>>> x = DecisionVariable.integer(1)\n>>> x == 1  # Returns Constraint, not bool\nConstraint(...)\n\nFor object equality comparison, use the ``equals_to()`` method or compare IDs:\n\n>>> y = DecisionVariable.integer(2)\n>>> x.id == y.id\nFalse",
           "bases": [],
           "methods": [
             {
@@ -4401,7 +4401,7 @@
                     {
                       "name": "kind",
                       "type_": {
-                        "display": "int",
+                        "display": "Kind",
                         "link_target": null,
                         "children": []
                       },
@@ -5551,45 +5551,45 @@
           "attributes": [
             {
               "name": "BINARY",
-              "doc": "",
+              "doc": "Compatibility alias for {attr}`Kind.Binary`.",
               "type_": {
-                "display": "int",
+                "display": "Kind",
                 "link_target": null,
                 "children": []
               }
             },
             {
               "name": "CONTINUOUS",
-              "doc": "",
+              "doc": "Compatibility alias for {attr}`Kind.Continuous`.",
               "type_": {
-                "display": "int",
+                "display": "Kind",
                 "link_target": null,
                 "children": []
               }
             },
             {
               "name": "INTEGER",
-              "doc": "",
+              "doc": "Compatibility alias for {attr}`Kind.Integer`.",
               "type_": {
-                "display": "int",
+                "display": "Kind",
                 "link_target": null,
                 "children": []
               }
             },
             {
               "name": "SEMI_CONTINUOUS",
-              "doc": "",
+              "doc": "Compatibility alias for {attr}`Kind.SemiContinuous`.",
               "type_": {
-                "display": "int",
+                "display": "Kind",
                 "link_target": null,
                 "children": []
               }
             },
             {
               "name": "SEMI_INTEGER",
-              "doc": "",
+              "doc": "Compatibility alias for {attr}`Kind.SemiInteger`.",
               "type_": {
-                "display": "int",
+                "display": "Kind",
                 "link_target": null,
                 "children": []
               }
@@ -5631,7 +5631,7 @@
               "name": "kind",
               "doc": "",
               "type_": {
-                "display": "int",
+                "display": "Kind",
                 "link_target": null,
                 "children": []
               },
@@ -9431,7 +9431,7 @@
             },
             {
               "name": "convert_all_one_hots_to_constraints",
-              "doc": "Convert every active one-hot constraint to a regular equality constraint.\n\nSee {meth}`~ommx.Instance.convert_one_hot_to_constraint` for the conversion rule.\nReturns the IDs of the newly created regular constraints.\n\n# Examples\n\n>>> from ommx import Instance, DecisionVariable, OneHotConstraint\n>>> x = [DecisionVariable.binary(i) for i in range(4)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     one_hot_constraints={\n...         1: OneHotConstraint(variables=x[:2]),\n...         2: OneHotConstraint(variables=x[2:]),\n...     },\n...     sense=Instance.MINIMIZE,\n... )\n>>> instance.convert_all_one_hots_to_constraints()\n[0, 1]\n>>> instance.one_hot_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 - 1 == 0), 1: Constraint(x2 + x3 - 1 == 0)}",
+              "doc": "Convert every active one-hot constraint to a regular equality constraint.\n\nSee {meth}`~ommx.Instance.convert_one_hot_to_constraint` for the conversion rule.\nReturns the IDs of the newly created regular constraints.\n\n# Examples\n\n>>> from ommx import Instance, DecisionVariable, OneHotConstraint, Sense\n>>> x = [DecisionVariable.binary(i) for i in range(4)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     one_hot_constraints={\n...         1: OneHotConstraint(variables=x[:2]),\n...         2: OneHotConstraint(variables=x[2:]),\n...     },\n...     sense=Sense.Minimize,\n... )\n>>> instance.convert_all_one_hots_to_constraints()\n[0, 1]\n>>> instance.one_hot_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 - 1 == 0), 1: Constraint(x2 + x3 - 1 == 0)}",
               "signatures": [
                 {
                   "parameters": [],
@@ -9453,7 +9453,7 @@
             },
             {
               "name": "convert_all_sos1_to_constraints",
-              "doc": "Convert every active SOS1 constraint to regular constraints using Big-M.\n\nSee {meth}`~ommx.Instance.convert_sos1_to_constraints` for the conversion\nrule. Returns a dict mapping each original SOS1 ID to the list of regular\nconstraint IDs it produced.\n\nAtomic: every active SOS1 is validated up front, and only if every one is\nconvertible are the conversions applied. If any SOS1 fails validation\n(unsupported kind, non-finite bound, domain excludes 0, etc.), no mutation\nhappens and the instance is left untouched.\n\n# Examples\n\n>>> from ommx import Instance, DecisionVariable, Sos1Constraint\n>>> x = [DecisionVariable.binary(i) for i in range(4)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     sos1_constraints={\n...         1: Sos1Constraint(variables=x[:2]),\n...         2: Sos1Constraint(variables=x[2:]),\n...     },\n...     sense=Instance.MINIMIZE,\n... )\n>>> instance.convert_all_sos1_to_constraints()\n{1: [0], 2: [1]}\n>>> instance.sos1_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 - 1 <= 0), 1: Constraint(x2 + x3 - 1 <= 0)}",
+              "doc": "Convert every active SOS1 constraint to regular constraints using Big-M.\n\nSee {meth}`~ommx.Instance.convert_sos1_to_constraints` for the conversion\nrule. Returns a dict mapping each original SOS1 ID to the list of regular\nconstraint IDs it produced.\n\nAtomic: every active SOS1 is validated up front, and only if every one is\nconvertible are the conversions applied. If any SOS1 fails validation\n(unsupported kind, non-finite bound, domain excludes 0, etc.), no mutation\nhappens and the instance is left untouched.\n\n# Examples\n\n>>> from ommx import Instance, DecisionVariable, Sense, Sos1Constraint\n>>> x = [DecisionVariable.binary(i) for i in range(4)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     sos1_constraints={\n...         1: Sos1Constraint(variables=x[:2]),\n...         2: Sos1Constraint(variables=x[2:]),\n...     },\n...     sense=Sense.Minimize,\n... )\n>>> instance.convert_all_sos1_to_constraints()\n{1: [0], 2: [1]}\n>>> instance.sos1_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 - 1 <= 0), 1: Constraint(x2 + x3 - 1 <= 0)}",
               "signatures": [
                 {
                   "parameters": [],
@@ -9486,7 +9486,7 @@
             },
             {
               "name": "convert_indicator_to_constraint",
-              "doc": "Convert an indicator constraint to regular constraints using the Big-M method.\n\nAn indicator constraint ``y = 1 → f(x) <= 0`` (or ``= 0``) is encoded with\nupper and lower Big-M sides computed from the interval bounds of $f(x)$:\n\n$$\nf(x) + u y - u \\leq 0, \\qquad -f(x) - l y + l \\leq 0,\n$$\n\nwhere $u \\geq \\sup f(x)$ and $l \\leq \\inf f(x)$ are the upper and lower\nbounds of $f$ over the decision variables' domains.\n\nSide emission:\n\n- For ``<=`` indicators, only the upper side is considered; it is emitted\n  iff $u > 0$. If $u \\leq 0$ the constraint is already implied by the\n  variable bounds and no Big-M is emitted.\n- For ``=`` indicators, both sides are considered independently: upper\n  emitted iff $u > 0$, lower emitted iff $l < 0$.\n\nWhen an equality side is skipped, the remaining constraints still enforce\nthe implication correctly because the skipped inequality is already implied\nby the variable bounds: e.g. $u \\leq 0$ together with the emitted lower side\nforces $f(x) = 0$ at $y = 1$ when $u = 0$, or renders $y = 1$ infeasible\nwhen $u < 0$ (correctly reflecting that $f(x) = 0$ has no solution under the\ngiven bounds). When both $u = 0$ and $l = 0$, the bound says $f(x) \\equiv 0$\nso the equality is vacuously satisfied and nothing is emitted.\n\nReturns the list of newly created regular constraint IDs in insertion order\n(upper first, then lower). The list is empty when both sides are redundant.\n\nRaises if the bound needed for an emitted side is non-finite, or if $f(x)$\nreferences a semi-continuous / semi-integer variable (the split domain\n$\\{0\\} \\cup [l, u]$ is not uniformly implemented, so Big-M conversion could\nsilently drop the upper side when $0 \\notin [l, u]$). The instance is not\nmutated on error.\n\n``atol`` controls which Function-body values the bound evaluator treats\nas zero. If omitted, :attr:`DEFAULT_ATOL` is used. Big-M algebra assumes\nthe indicator variable is exactly binary; this does not canonicalize an\napproximate solver value near 0 or 1.\n\n# Examples\n\nConvert an inequality indicator where the upper side is active:\n\n>>> from ommx import (\n...     Instance, DecisionVariable, IndicatorConstraint, Equality,\n... )\n>>> x = DecisionVariable.continuous(0, lower=0.0, upper=5.0)\n>>> y = DecisionVariable.binary(1)\n>>> ic = IndicatorConstraint(\n...     indicator_variable=y,\n...     function=x - 2,\n...     equality=Equality.LessThanOrEqualToZero,\n... )\n>>> instance = Instance.from_components(\n...     decision_variables=[x, y],\n...     objective=x,\n...     constraints={},\n...     indicator_constraints={1: ic},\n...     sense=Instance.MINIMIZE,\n... )\n>>> instance.convert_indicator_to_constraint(1)\n[0]\n>>> instance.indicator_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + 3*x1 - 5 <= 0)}",
+              "doc": "Convert an indicator constraint to regular constraints using the Big-M method.\n\nAn indicator constraint ``y = 1 → f(x) <= 0`` (or ``= 0``) is encoded with\nupper and lower Big-M sides computed from the interval bounds of $f(x)$:\n\n$$\nf(x) + u y - u \\leq 0, \\qquad -f(x) - l y + l \\leq 0,\n$$\n\nwhere $u \\geq \\sup f(x)$ and $l \\leq \\inf f(x)$ are the upper and lower\nbounds of $f$ over the decision variables' domains.\n\nSide emission:\n\n- For ``<=`` indicators, only the upper side is considered; it is emitted\n  iff $u > 0$. If $u \\leq 0$ the constraint is already implied by the\n  variable bounds and no Big-M is emitted.\n- For ``=`` indicators, both sides are considered independently: upper\n  emitted iff $u > 0$, lower emitted iff $l < 0$.\n\nWhen an equality side is skipped, the remaining constraints still enforce\nthe implication correctly because the skipped inequality is already implied\nby the variable bounds: e.g. $u \\leq 0$ together with the emitted lower side\nforces $f(x) = 0$ at $y = 1$ when $u = 0$, or renders $y = 1$ infeasible\nwhen $u < 0$ (correctly reflecting that $f(x) = 0$ has no solution under the\ngiven bounds). When both $u = 0$ and $l = 0$, the bound says $f(x) \\equiv 0$\nso the equality is vacuously satisfied and nothing is emitted.\n\nReturns the list of newly created regular constraint IDs in insertion order\n(upper first, then lower). The list is empty when both sides are redundant.\n\nRaises if the bound needed for an emitted side is non-finite, or if $f(x)$\nreferences a semi-continuous / semi-integer variable (the split domain\n$\\{0\\} \\cup [l, u]$ is not uniformly implemented, so Big-M conversion could\nsilently drop the upper side when $0 \\notin [l, u]$). The instance is not\nmutated on error.\n\n``atol`` controls which Function-body values the bound evaluator treats\nas zero. If omitted, :attr:`DEFAULT_ATOL` is used. Big-M algebra assumes\nthe indicator variable is exactly binary; this does not canonicalize an\napproximate solver value near 0 or 1.\n\n# Examples\n\nConvert an inequality indicator where the upper side is active:\n\n>>> from ommx import (\n...     Instance, DecisionVariable, IndicatorConstraint, Equality, Sense,\n... )\n>>> x = DecisionVariable.continuous(0, lower=0.0, upper=5.0)\n>>> y = DecisionVariable.binary(1)\n>>> ic = IndicatorConstraint(\n...     indicator_variable=y,\n...     function=x - 2,\n...     equality=Equality.LessThanOrEqualToZero,\n... )\n>>> instance = Instance.from_components(\n...     decision_variables=[x, y],\n...     objective=x,\n...     constraints={},\n...     indicator_constraints={1: ic},\n...     sense=Sense.Minimize,\n... )\n>>> instance.convert_indicator_to_constraint(1)\n[0]\n>>> instance.indicator_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + 3*x1 - 5 <= 0)}",
               "signatures": [
                 {
                   "parameters": [
@@ -9589,7 +9589,7 @@
             },
             {
               "name": "convert_one_hot_to_constraint",
-              "doc": "Convert a one-hot constraint to a regular equality constraint.\n\nA one-hot constraint over ``{x_1, ..., x_n}`` is mathematically equivalent to the\nlinear equality ``x_1 + ... + x_n - 1 == 0``. This method inserts that equality\nas a new regular constraint and moves the one-hot constraint into\n{attr}`~ommx.Instance.removed_one_hot_constraints` with\n``reason=\"ommx.Instance.convert_one_hot_to_constraint\"`` and a\n``constraint_id`` parameter pointing to the new regular constraint.\n\nReturns the ID of the newly created regular constraint.\n\n# Examples\n\n>>> from ommx import Instance, DecisionVariable, OneHotConstraint\n>>> x = [DecisionVariable.binary(i) for i in range(3)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     one_hot_constraints={1: OneHotConstraint(variables=x)},\n...     sense=Instance.MINIMIZE,\n... )\n>>> new_id = instance.convert_one_hot_to_constraint(1)\n>>> instance.one_hot_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 + x2 - 1 == 0)}\n>>> instance.removed_one_hot_constraints\n{1: RemovedOneHotConstraint(OneHotConstraint(exactly one of {x0, x1, x2} = 1), reason=ommx.Instance.convert_one_hot_to_constraint, constraint_id=0)}",
+              "doc": "Convert a one-hot constraint to a regular equality constraint.\n\nA one-hot constraint over ``{x_1, ..., x_n}`` is mathematically equivalent to the\nlinear equality ``x_1 + ... + x_n - 1 == 0``. This method inserts that equality\nas a new regular constraint and moves the one-hot constraint into\n{attr}`~ommx.Instance.removed_one_hot_constraints` with\n``reason=\"ommx.Instance.convert_one_hot_to_constraint\"`` and a\n``constraint_id`` parameter pointing to the new regular constraint.\n\nReturns the ID of the newly created regular constraint.\n\n# Examples\n\n>>> from ommx import Instance, DecisionVariable, OneHotConstraint, Sense\n>>> x = [DecisionVariable.binary(i) for i in range(3)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     one_hot_constraints={1: OneHotConstraint(variables=x)},\n...     sense=Sense.Minimize,\n... )\n>>> new_id = instance.convert_one_hot_to_constraint(1)\n>>> instance.one_hot_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 + x2 - 1 == 0)}\n>>> instance.removed_one_hot_constraints\n{1: RemovedOneHotConstraint(OneHotConstraint(exactly one of {x0, x1, x2} = 1), reason=ommx.Instance.convert_one_hot_to_constraint, constraint_id=0)}",
               "signatures": [
                 {
                   "parameters": [
@@ -9615,7 +9615,7 @@
             },
             {
               "name": "convert_sos1_to_constraints",
-              "doc": "Convert a SOS1 constraint to regular constraints using the Big-M method.\n\nA SOS1 constraint over $\\{x_1, \\ldots, x_n\\}$ with each $x_i \\in [l_i, u_i]$\nasserts that at most one $x_i$ is non-zero. Per variable, a binary indicator\n$y_i$ is introduced with the Big-M pair\n\n$$\nx_i - u_i y_i \\leq 0, \\qquad l_i y_i - x_i \\leq 0\n$$\n\n(trivial sides $u_i = 0$ or $l_i = 0$ are skipped), together with the single\ncardinality constraint\n\n$$\n\\sum_i y_i - 1 \\leq 0.\n$$\n\nIf $x_i$ is already binary with bound $[0, 1]$, $x_i$ itself is reused as its\nindicator (no new variable, no Big-M pair).\n\nReturns the list of newly created regular constraint IDs in insertion order\n(Big-M upper/lower pairs per non-binary variable, followed by the cardinality\nsum).\n\nRaises if any $x_i$ has a non-binary bound that is not finite, if its domain\nexcludes $0$, or if its kind is semi-continuous / semi-integer (the split\ndomain $\\{0\\} \\cup [l, u]$ is not uniformly implemented across the codebase\nyet, so Big-M conversion of these kinds is not supported).\nThe instance is not mutated on error.\n\n# Examples\n\nAll-binary SOS1 reduces to ``sum(x_i) - 1 <= 0`` without extra variables:\n\n>>> from ommx import Instance, DecisionVariable, Sos1Constraint\n>>> x = [DecisionVariable.binary(i) for i in range(3)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     sos1_constraints={1: Sos1Constraint(variables=x)},\n...     sense=Instance.MINIMIZE,\n... )\n>>> instance.convert_sos1_to_constraints(1)\n[0]\n>>> instance.sos1_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 + x2 - 1 <= 0)}\n>>> instance.removed_sos1_constraints\n{1: RemovedSos1Constraint(Sos1Constraint(at most one of {x0, x1, x2} ≠ 0), reason=ommx.Instance.convert_sos1_to_constraints, constraint_ids=0)}",
+              "doc": "Convert a SOS1 constraint to regular constraints using the Big-M method.\n\nA SOS1 constraint over $\\{x_1, \\ldots, x_n\\}$ with each $x_i \\in [l_i, u_i]$\nasserts that at most one $x_i$ is non-zero. Per variable, a binary indicator\n$y_i$ is introduced with the Big-M pair\n\n$$\nx_i - u_i y_i \\leq 0, \\qquad l_i y_i - x_i \\leq 0\n$$\n\n(trivial sides $u_i = 0$ or $l_i = 0$ are skipped), together with the single\ncardinality constraint\n\n$$\n\\sum_i y_i - 1 \\leq 0.\n$$\n\nIf $x_i$ is already binary with bound $[0, 1]$, $x_i$ itself is reused as its\nindicator (no new variable, no Big-M pair).\n\nReturns the list of newly created regular constraint IDs in insertion order\n(Big-M upper/lower pairs per non-binary variable, followed by the cardinality\nsum).\n\nRaises if any $x_i$ has a non-binary bound that is not finite, if its domain\nexcludes $0$, or if its kind is semi-continuous / semi-integer (the split\ndomain $\\{0\\} \\cup [l, u]$ is not uniformly implemented across the codebase\nyet, so Big-M conversion of these kinds is not supported).\nThe instance is not mutated on error.\n\n# Examples\n\nAll-binary SOS1 reduces to ``sum(x_i) - 1 <= 0`` without extra variables:\n\n>>> from ommx import Instance, DecisionVariable, Sense, Sos1Constraint\n>>> x = [DecisionVariable.binary(i) for i in range(3)]\n>>> instance = Instance.from_components(\n...     decision_variables=x,\n...     objective=sum(x),\n...     constraints={},\n...     sos1_constraints={1: Sos1Constraint(variables=x)},\n...     sense=Sense.Minimize,\n... )\n>>> instance.convert_sos1_to_constraints(1)\n[0]\n>>> instance.sos1_constraints\n{}\n>>> instance.constraints\n{0: Constraint(x0 + x1 + x2 - 1 <= 0)}\n>>> instance.removed_sos1_constraints\n{1: RemovedSos1Constraint(Sos1Constraint(at most one of {x0, x1, x2} ≠ 0), reason=ommx.Instance.convert_sos1_to_constraints, constraint_ids=0)}",
               "signatures": [
                 {
                   "parameters": [
@@ -9836,7 +9836,7 @@
             },
             {
               "name": "empty",
-              "doc": "Create trivial empty instance of minimization with zero objective, no constraints, and no decision variables.\n\n# Examples\n\n>>> from ommx import Instance\n>>> instance = Instance.minimize()\n>>> instance.sense == Instance.MINIMIZE\nTrue",
+              "doc": "Create trivial empty instance of minimization with zero objective, no constraints, and no decision variables.\n\n# Examples\n\n>>> from ommx import Instance, Sense\n>>> instance = Instance.minimize()\n>>> instance.sense == Sense.Minimize\nTrue",
               "signatures": [
                 {
                   "parameters": [],
@@ -12334,7 +12334,7 @@
             },
             {
               "name": "MAXIMIZE",
-              "doc": "",
+              "doc": "Compatibility alias for {attr}`Sense.Maximize`.",
               "type_": {
                 "display": "Sense",
                 "link_target": null,
@@ -12343,7 +12343,7 @@
             },
             {
               "name": "MINIMIZE",
-              "doc": "",
+              "doc": "Compatibility alias for {attr}`Sense.Minimize`.",
               "type_": {
                 "display": "Sense",
                 "link_target": null,

--- a/docs/en/migration/python_sdk_v2_to_v3.md
+++ b/docs/en/migration/python_sdk_v2_to_v3.md
@@ -36,7 +36,7 @@ from ommx.v1.solution_pb2 import State
 
 **After (v3)**:
 ```python
-from ommx import Constraint, Equality, Function, Linear, State
+from ommx import Constraint, Equality, Function, Kind, Linear, Sense, State
 ```
 
 The `.from_protobuf()` / `.to_protobuf()` bridge methods on `Constraint`, `RemovedConstraint`, `DecisionVariable`, etc. are removed along with the protobuf objects they produced. Use explicit versioned bytes APIs on whole serialization roots instead. Prefer `to_v2_bytes` / `from_v2_bytes` when producing new serialized bytes; use `to_v1_bytes` / `from_v1_bytes` only when you need to interoperate with legacy v1 payloads.
@@ -112,14 +112,14 @@ s1 = Sos1Constraint(id=11, variables=[0, 1])
 
 **After (v3)**:
 ```python
-c  = Constraint(function=x + y, equality=Constraint.EQUAL_TO_ZERO, name="cap")
+c  = Constraint(function=x + y, equality=Equality.EqualToZero, name="cap")
 xs = [DecisionVariable.binary(i) for i in range(3)]
 oh = OneHotConstraint(variables=xs)
 s1 = Sos1Constraint(variables=xs[:2])
 
 # IDs are assigned by the enclosing Instance:
 instance = Instance.from_components(
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
     objective=...,
     decision_variables=[...],
     constraints={5: c},
@@ -178,7 +178,7 @@ Instance.from_components(
 **After (v3)**:
 ```python
 Instance.from_components(
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
     objective=obj,
     decision_variables=[x0, x1],
     constraints={0: c0, 1: c1},           # dict keyed by constraint ID
@@ -394,21 +394,29 @@ polynomial.terms()
 
 `Linear.linear_terms`, `Quadratic.linear_terms` / `quadratic_terms`, and `Polynomial.constant_term` stay properties.
 
-### 6.3 `DecisionVariable.BINARY`/`INTEGER`/… are `int` sentinels (`3.0.0a1`, [#770](https://github.com/Jij-Inc/ommx/pull/770))
+### 6.3 `DecisionVariable.kind` is a typed `Kind` enum
 
-In v2.5.1 these class constants were `Kind` enum members. In v3 they are the underlying `int` values, and `DecisionVariable.kind` returns `int` (the protobuf wire value).
+The initial v3 alpha migration in `3.0.0a1` ([#770](https://github.com/Jij-Inc/ommx/pull/770)) accidentally exposed the protobuf integer representation through the `DecisionVariable` constructor and `kind` properties. The v3 API now consistently accepts and returns the top-level `Kind` enum for detached, attached, evaluated, and sampled decision variables.
+
+Use `Kind.Binary`, `Kind.Integer`, and the other `Kind` members in new code. The old `DecisionVariable.BINARY`/`INTEGER`/… names remain as typed compatibility aliases with the same enum values.
+
+The same compatibility policy applies to `Constraint.EQUAL_TO_ZERO` / `LESS_THAN_OR_EQUAL_TO_ZERO` and `Instance.MINIMIZE` / `MAXIMIZE`: they remain typed aliases, while new code should use `Equality.*` and `Sense.*`.
 
 ```python
-# v2.5.1
-DecisionVariable.BINARY        # Kind.Binary
-if var.kind == DecisionVariable.INTEGER:  # Kind.Integer == Kind.Integer
-    ...
+from ommx import Bound, DecisionVariable, Kind
 
-# v3
-DecisionVariable.BINARY        # 1 (int)
-if var.kind == DecisionVariable.INTEGER:  # int == int
-    ...
-# If you want the enum, construct it: Kind(var.kind)
+var = DecisionVariable(0, Kind.Binary, Bound(0, 1))
+assert var.kind == Kind.Binary
+
+# Typed compatibility alias.
+assert DecisionVariable.BINARY == Kind.Binary
+```
+
+The enums retain comparison and hash compatibility with their protobuf integer values, so explicit boundary checks continue to work. The regular SDK constructor and properties nevertheless use the enum type.
+
+```python
+assert Kind.Binary == 1
+assert hash(Kind.Binary) == hash(1)
 ```
 
 ### 6.4 `SampleSet.sample_ids` changed from list-property to set-method (`3.0.0a1`, [#775](https://github.com/Jij-Inc/ommx/pull/775))
@@ -761,7 +769,7 @@ dv      = DecisionVariable.from_bytes(dv_blob)
 # After (3.0.0a3) — wrap in the enclosing container and round-trip that.
 # Use v2 bytes for newly serialized payloads.
 instance      = Instance.from_components(
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
     objective=my_function,
     decision_variables=[decision_variable],
     constraints={},

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -10,50 +10,15 @@ Changes merged after the most recent release will be appended here as they land,
 
 ### 🛠 Restore typed enum model discriminators ([#1196](https://github.com/Jij-Inc/ommx/pull/1196))
 
-The v3 PyO3 rewrite accidentally exposed raw protobuf integer discriminators
-through the {class}`~ommx.DecisionVariable` constructor and the `kind`
-properties of detached and attached variables. These APIs now accept and return
-{class}`~ommx.Kind` consistently, matching the stable v2 Python API and the
-already-typed {class}`~ommx.Equality` and {class}`~ommx.Sense` APIs.
+The v3 rewrite accidentally exposed protobuf integer discriminators through
+{class}`~ommx.DecisionVariable`. Its constructor and `kind` properties now use
+{class}`~ommx.Kind` consistently, restoring the stable-v2 behavior. Existing
+`DecisionVariable.*`, `Constraint.*`, and `Instance.*` names remain
+non-deprecated typed aliases.
 
-The stable-v2 usage remains valid after the normal v3 import migration:
-
-```python
-# v2
-from ommx.v1 import DecisionVariable
-
-x = DecisionVariable.binary(0)
-assert x.kind == DecisionVariable.BINARY
-```
-
-```python
-# v3
-from ommx import DecisionVariable, Kind
-
-x = DecisionVariable.binary(0)
-assert x.kind == DecisionVariable.BINARY
-assert x.kind == Kind.Binary
-```
-
-`DecisionVariable.BINARY` / `INTEGER` / …, `Constraint.EQUAL_TO_ZERO` / …,
-and `Instance.MINIMIZE` / `MAXIMIZE` remain non-deprecated typed compatibility
-aliases. Enum members also retain equality and hash compatibility with their
-protobuf integer values.
-
-Only code written against the accidental integer surface in v3 prereleases
-needs to change. Pass the typed enum member instead of a raw discriminator:
-
-```python
-from ommx import Bound, DecisionVariable, Kind
-
-# Accepted by early v3 prereleases, but not by the stable v2 public API.
-# x = DecisionVariable(0, 1, Bound(0, 1))
-
-x = DecisionVariable(0, Kind.Binary, Bound(0, 1))
-```
-
-See the [Python SDK v2 to v3 Migration Guide](../migration/python_sdk_v2_to_v3.md)
-for the complete enum compatibility policy.
+Only v3 prerelease code passing raw integers directly must switch to typed enum
+members. Enum/integer equality and hash compatibility is retained. See the
+[migration guide](../migration/python_sdk_v2_to_v3.md) for details.
 
 ### 🛠 Unified bound and constraint tolerance semantics ([#1192](https://github.com/Jij-Inc/ommx/pull/1192))
 

--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -8,6 +8,53 @@ Python SDK 3.0.0 contains breaking API changes. A migration guide is available i
 
 Changes merged after the most recent release will be appended here as they land, and promoted to a new version section when the next release is cut.
 
+### 🛠 Restore typed enum model discriminators ([#1196](https://github.com/Jij-Inc/ommx/pull/1196))
+
+The v3 PyO3 rewrite accidentally exposed raw protobuf integer discriminators
+through the {class}`~ommx.DecisionVariable` constructor and the `kind`
+properties of detached and attached variables. These APIs now accept and return
+{class}`~ommx.Kind` consistently, matching the stable v2 Python API and the
+already-typed {class}`~ommx.Equality` and {class}`~ommx.Sense` APIs.
+
+The stable-v2 usage remains valid after the normal v3 import migration:
+
+```python
+# v2
+from ommx.v1 import DecisionVariable
+
+x = DecisionVariable.binary(0)
+assert x.kind == DecisionVariable.BINARY
+```
+
+```python
+# v3
+from ommx import DecisionVariable, Kind
+
+x = DecisionVariable.binary(0)
+assert x.kind == DecisionVariable.BINARY
+assert x.kind == Kind.Binary
+```
+
+`DecisionVariable.BINARY` / `INTEGER` / …, `Constraint.EQUAL_TO_ZERO` / …,
+and `Instance.MINIMIZE` / `MAXIMIZE` remain non-deprecated typed compatibility
+aliases. Enum members also retain equality and hash compatibility with their
+protobuf integer values.
+
+Only code written against the accidental integer surface in v3 prereleases
+needs to change. Pass the typed enum member instead of a raw discriminator:
+
+```python
+from ommx import Bound, DecisionVariable, Kind
+
+# Accepted by early v3 prereleases, but not by the stable v2 public API.
+# x = DecisionVariable(0, 1, Bound(0, 1))
+
+x = DecisionVariable(0, Kind.Binary, Bound(0, 1))
+```
+
+See the [Python SDK v2 to v3 Migration Guide](../migration/python_sdk_v2_to_v3.md)
+for the complete enum compatibility policy.
+
 ### 🛠 Unified bound and constraint tolerance semantics ([#1192](https://github.com/Jij-Inc/ommx/pull/1192))
 
 {meth}`~ommx.Bound.contains` now interprets $x \in [l,u]$ through the same

--- a/docs/en/tutorial/experiment_management.md
+++ b/docs/en/tutorial/experiment_management.md
@@ -43,7 +43,7 @@ In this tutorial, we solve a simple knapsack problem twice under different condi
 First, create the source data for a knapsack problem and a {py:class}`~ommx.ParametricInstance` whose capacity is a parameter. Like {py:class}`~ommx.Instance`, an OMMX {py:class}`~ommx.ParametricInstance` can define an objective function and constraints, but it can place parameters where constants would otherwise appear. This is useful when you need to prepare multiple models that differ only in constants.
 
 ```{code-cell} ipython3
-from ommx import DecisionVariable, Parameter, Instance, ParametricInstance
+from ommx import DecisionVariable, Instance, Parameter, ParametricInstance, Sense
 
 v = [10, 13, 18, 31, 7, 15]  # value of each item
 w = [11, 25, 20, 35, 10, 33]  # weight of each item
@@ -67,7 +67,7 @@ pi = ParametricInstance.from_components(
     constraints={
         0: (sum(w[i] * x[i] for i in range(N)) <= capacity).set_name("weight limit")
     },
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/en/tutorial/implement_adapter.md
+++ b/docs/en/tutorial/implement_adapter.md
@@ -63,7 +63,17 @@ PySCIPOpt manages decision variables by name, so register the OMMX decision vari
 
 ```{code-cell} ipython3
 import pyscipopt
-from ommx import Instance, Solution, DecisionVariable, Constraint, State, Function
+from ommx import (
+    Constraint,
+    DecisionVariable,
+    Equality,
+    Function,
+    Instance,
+    Kind,
+    Sense,
+    Solution,
+    State,
+)
 
 def set_decision_variables(
     model: pyscipopt.Model,  # For tutorial purposes, we pass state as arguments, but managing with class is common
@@ -74,13 +84,13 @@ def set_decision_variables(
     """
     # Create PySCIPOpt variables from OMMX decision variable information
     for var in instance.used_decision_variables:
-        if var.kind == DecisionVariable.BINARY:
+        if var.kind == Kind.Binary:
             model.addVar(name=str(var.id), vtype="B")
-        elif var.kind == DecisionVariable.INTEGER:
+        elif var.kind == Kind.Integer:
             model.addVar(
                 name=str(var.id), vtype="I", lb=var.bound.lower, ub=var.bound.upper
             )
-        elif var.kind == DecisionVariable.CONTINUOUS:
+        elif var.kind == Kind.Continuous:
             model.addVar(
                 name=str(var.id), vtype="C", lb=var.bound.lower, ub=var.bound.upper
             )
@@ -145,9 +155,9 @@ def set_objective(model: pyscipopt.Model, instance: Instance, varname_map: dict)
     """Set the objective function for the model"""
     objective = instance.objective
 
-    if instance.sense == Instance.MAXIMIZE:
+    if instance.sense == Sense.Maximize:
         sense = "maximize"
-    elif instance.sense == Instance.MINIMIZE:
+    elif instance.sense == Sense.Minimize:
         sense = "minimize"
     else:
         raise OMMXPySCIPOptAdapterError(
@@ -191,12 +201,12 @@ def set_constraints(model: pyscipopt.Model, instance: Instance, varname_map: dic
         if degree == 0:
             # For constant constraints, check feasibility
             constant_value = f.constant_term
-            if constraint.equality == Constraint.EQUAL_TO_ZERO and math.isclose(
+            if constraint.equality == Equality.EqualToZero and math.isclose(
                 constant_value, 0, abs_tol=1e-6
             ):
                 continue
             elif (
-                constraint.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+                constraint.equality == Equality.LessThanOrEqualToZero
                 and constant_value <= 1e-6
             ):
                 continue
@@ -216,9 +226,9 @@ def set_constraints(model: pyscipopt.Model, instance: Instance, varname_map: dic
             )
 
         # Add constraints based on the type (equality/inequality)
-        if constraint.equality == Constraint.EQUAL_TO_ZERO:
+        if constraint.equality == Equality.EqualToZero:
             constr_expr = expr == 0
-        elif constraint.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO:
+        elif constraint.equality == Equality.LessThanOrEqualToZero:
             constr_expr = expr <= 0
         else:
             raise OMMXPySCIPOptAdapterError(
@@ -560,7 +570,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=sum(v[i] * x[i] for i in range(N)),
     constraints={0: sum(w[i] * x[i] for i in range(N)) - W <= 0},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 
 solution = OMMXPySCIPOptAdapter.solve(instance)
@@ -580,7 +590,7 @@ The sample results from OpenJij are obtained as `openjij.Response`, so implement
 
 ```{code-cell} ipython3
 import openjij as oj
-from ommx import Instance, SampleSet, Solution, Samples, State
+from ommx import Instance, SampleSet, Samples, Sense, Solution, State
 
 def decode_to_samples(response: oj.Response) -> Samples:
     # Generate sample IDs
@@ -726,7 +736,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=-x[0] - x[1] + 2 * x[0] * x[1],
     constraints={},
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
 )
 
 sample_set = OMMXOpenJijSAAdapter.sample(instance)

--- a/docs/en/tutorial/share_in_ommx_artifact.md
+++ b/docs/en/tutorial/share_in_ommx_artifact.md
@@ -26,7 +26,7 @@ First, let's prepare the data we want to share. We will create an `ommx.Instance
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-from ommx import Instance, DecisionVariable, Constraint
+from ommx import Constraint, DecisionVariable, Equality, Instance, Sense
 from ommx_pyscipopt_adapter.adapter import OMMXPySCIPOptAdapter
 import pandas as pd
 
@@ -67,7 +67,7 @@ constraint = Constraint(
     # Specify the left-hand side of the constraint
     function=sum(data["w"][i] * x[i] for i in range(data["N"])) - data["W"],
     # Specify equality constraint (==0) or inequality constraint (<=0)
-    equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+    equality=Equality.LessThanOrEqualToZero,
 )
 
 # Create an instance
@@ -79,7 +79,7 @@ instance = Instance.from_components(
     # Register all constraints (keys are constraint IDs)
     constraints={0: constraint},
     # Specify that it is a maximization problem
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 
 # Solve with SCIP

--- a/docs/en/tutorial/solve_with_ommx_adapter.md
+++ b/docs/en/tutorial/solve_with_ommx_adapter.md
@@ -80,7 +80,7 @@ N = len(v)  # Total number of items
 Based on this mathematical model and data, the code for describing the problem instance using the OMMX Python SDK is as follows:
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 # Define decision variables
 x = [
@@ -112,7 +112,7 @@ instance = Instance.from_components(
     # Register all constraints (keys are constraint IDs)
     constraints={0: constraint},
     # Specify that it is a maximization problem
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/en/tutorial/switching_adapters.md
+++ b/docs/en/tutorial/switching_adapters.md
@@ -25,7 +25,7 @@ $$
 $$
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 v = [10, 13, 18, 31, 7, 15]
 w = [11, 25, 20, 35, 10, 33]
@@ -44,7 +44,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=sum(v[i] * x[i] for i in range(N)),
     constraints={0: sum(w[i] * x[i] for i in range(N)) - W <= 0},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/en/tutorial/tsp_sampling_with_openjij_adapter.ipynb
+++ b/docs/en/tutorial/tsp_sampling_with_openjij_adapter.ipynb
@@ -155,7 +155,7 @@
    },
    "outputs": [],
    "source": [
-    "from ommx import DecisionVariable, Instance\n",
+    "from ommx import DecisionVariable, Instance, Sense\n",
     "\n",
     "route_variables = [\n",
     "    [\n",
@@ -204,7 +204,7 @@
     "    ],\n",
     "    objective=objective,\n",
     "    constraints={**position_constraints, **city_constraints},\n",
-    "    sense=Instance.MINIMIZE,\n",
+    "    sense=Sense.Minimize,\n",
     ")"
    ]
   },

--- a/docs/en/user_guide/adapter_initial_state.md
+++ b/docs/en/user_guide/adapter_initial_state.md
@@ -23,7 +23,7 @@ The initial solution (`initial_state`) that can be provided is of type `ToState`
 We'll demonstrate how to provide an initial solution using the following instance:
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable, State
+from ommx import DecisionVariable, Instance, Sense, State
 
 x = DecisionVariable.integer(1, lower=0, upper=5)
 y = DecisionVariable.integer(2, lower=0, upper=5)
@@ -32,7 +32,7 @@ ommx_instance = Instance.from_components(
     decision_variables=[x, y],
     objective=x - y,
     constraints={0: x + y <= 5},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/en/user_guide/capability_model.md
+++ b/docs/en/user_guide/capability_model.md
@@ -63,7 +63,13 @@ Applicability and solver-input construction are separate boundaries. Membership 
 {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` returns the set of `SpecialConstraintKind` values corresponding to the **active special constraints the instance currently holds**. When the instance uses only regular constraints the set is empty.
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable, OneHotConstraint, SpecialConstraintKind
+from ommx import (
+    DecisionVariable,
+    Instance,
+    OneHotConstraint,
+    Sense,
+    SpecialConstraintKind,
+)
 
 xs = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
 
@@ -72,7 +78,7 @@ instance = Instance.from_components(
     objective=sum(xs),
     constraints={},
     one_hot_constraints={0: OneHotConstraint(variables=xs)},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert instance.active_special_constraint_kinds == {SpecialConstraintKind.OneHot}
 assert binary_linear_with_one_hot.contains(instance)
@@ -111,7 +117,7 @@ instance2 = Instance.from_components(
     objective=sum(xs),
     constraints={},
     one_hot_constraints={1: OneHotConstraint(variables=xs)},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 new_id = instance2.convert_one_hot_to_constraint(1)
 assert isinstance(new_id, int)
@@ -138,7 +144,7 @@ instance3 = Instance.from_components(
     objective=sum(ys),
     constraints={},
     sos1_constraints={1: Sos1Constraint(variables=ys)},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 new_ids = instance3.convert_sos1_to_constraints(1)
 # An all-binary SOS1 collapses to a single cardinality constraint sum(x_i) - 1 <= 0

--- a/docs/en/user_guide/instance.md
+++ b/docs/en/user_guide/instance.md
@@ -33,7 +33,7 @@ $$
 The corresponding `ommx.Instance` is as follows.
 
 ```{code-cell} ipython3
-from ommx import Instance
+from ommx import Instance, Sense
 
 instance = Instance.maximize()
 x = instance.new_binary("x")
@@ -81,10 +81,10 @@ instance.objective
 
 Use {meth}`~ommx.Instance.maximize` for maximization problems and
 {meth}`~ommx.Instance.minimize` for minimization problems. The resulting
-`sense` is `Instance.MAXIMIZE` or `Instance.MINIMIZE`, respectively.
+`sense` is `Sense.Maximize` or `Sense.Minimize`, respectively.
 
 ```{code-cell} ipython3
-instance.sense == Instance.MAXIMIZE
+instance.sense == Sense.Maximize
 ```
 
 ## Decision Variables
@@ -141,7 +141,7 @@ instance.constraints_df()
 
 In OMMX, constraints are also managed by ID, and this ID is independent of the decision variable ID. The ID is assigned when a constraint is attached to an `Instance`: the key you use in the `constraints` dictionary passed to {meth}`~ommx.Instance.from_components` becomes the constraint ID.
 
-The essential information for constraints is `equality`. `equality` indicates whether the constraint is an equality constraint ({attr}`~ommx.Constraint.EQUAL_TO_ZERO`) or an inequality constraint ({attr}`~ommx.Constraint.LESS_THAN_OR_EQUAL_TO_ZERO`). Note that constraints of the type $f(x) \geq 0$ are treated as $-f(x) \leq 0$.
+The essential information for constraints is `equality`. `equality` indicates whether the constraint is an equality constraint ({attr}`~ommx.Equality.EqualToZero`) or an inequality constraint ({attr}`~ommx.Equality.LessThanOrEqualToZero`). Note that constraints of the type $f(x) \geq 0$ are treated as $-f(x) \leq 0$.
 
 Constraints can also store metadata similar to decision variables. You can use `name`, `description`, `subscripts`, and `parameters`. Use `set_name`, `set_description`, `set_subscripts`, and `set_parameters` to replace those metadata fields. Use `add_subscripts`, `add_parameter`, and `add_parameters` when you want to append or merge entries instead.
 

--- a/docs/en/user_guide/parametric_instance.md
+++ b/docs/en/user_guide/parametric_instance.md
@@ -28,7 +28,7 @@ $$
 Here, $N$ is the number of items, $p_i$ is the value of item i, $w_i$ is the weight of item i, and $W$ is the knapsack's capacity. The variable $x_i$ is binary and indicates whether item i is included in the knapsack. In `ommx.Instance`, fixed values were used for $p_i$ and $w_i$, but here they are treated as parameters.
 
 ```{code-cell} ipython3
-from ommx import ParametricInstance, DecisionVariable, Parameter, Instance
+from ommx import DecisionVariable, Instance, Parameter, ParametricInstance, Sense
 
 N = 6
 x = [DecisionVariable.binary(id=i, name="x", subscripts=[i]) for i in range(N)]
@@ -53,7 +53,7 @@ parametric_instance = ParametricInstance.from_components(
     parameters=p + w + [W],
     objective=objective,
     constraints={0: constraint},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/en/user_guide/sample_set.md
+++ b/docs/en/user_guide/sample_set.md
@@ -37,7 +37,7 @@ $$
 $$
 
 ```{code-cell} ipython3
-from ommx import DecisionVariable, Instance
+from ommx import DecisionVariable, Instance, Sense
 
 x = [DecisionVariable.binary(i) for i in range(3)]
 
@@ -45,7 +45,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=x[0] + 2*x[1] + 3*x[2],
     constraints={0: sum(x) == 1},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/en/user_guide/solution.md
+++ b/docs/en/user_guide/solution.md
@@ -35,7 +35,7 @@ $$
 It is clear that this has a feasible solution $x = 1, y = 0$.
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 # Create a simple instance
 x = DecisionVariable.binary(1, name='x')
@@ -45,7 +45,7 @@ instance = Instance.from_components(
     decision_variables=[x, y],
     objective=x + y,
     constraints={0: x * y == 0},
-    sense=Instance.MAXIMIZE
+    sense=Sense.Maximize
 )
 
 # Create a solution

--- a/docs/en/user_guide/special_constraints.md
+++ b/docs/en/user_guide/special_constraints.md
@@ -40,7 +40,7 @@ An **indicator constraint** enforces a constraint $f(x) \leq 0$ (or $f(x) = 0$) 
 Create an {class}`~ommx.IndicatorConstraint` from an existing {class}`~ommx.Constraint` by calling {meth}`Constraint.with_indicator() <ommx.Constraint.with_indicator>`. The indicator argument accepts a variable ID, a standalone {class}`~ommx.DecisionVariable`, or an {class}`~ommx.AttachedDecisionVariable`.
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable, Equality
+from ommx import DecisionVariable, Equality, Instance, Sense
 
 z = DecisionVariable.binary(0, name="z")
 x = DecisionVariable.continuous(1, lower=0, upper=10, name="x")
@@ -59,7 +59,7 @@ instance = Instance.from_components(
     objective=x,
     constraints={0: z == 1},       # fix z = 1
     indicator_constraints={0: ic}, # z = 1 => x <= 5
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert set(instance.indicator_constraints.keys()) == {0}
 ```
@@ -95,7 +95,7 @@ instance_oh = Instance.from_components(
     objective=sum(v * x for v, x in zip(values, xs)),
     constraints={},
     one_hot_constraints={0: oh},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert set(instance_oh.one_hot_constraints.keys()) == {0}
 ```
@@ -148,7 +148,7 @@ instance_s1 = Instance.from_components(
     objective=sum(ys),
     constraints={},
     sos1_constraints={0: s1},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert set(instance_s1.sos1_constraints.keys()) == {0}
 ```
@@ -214,7 +214,7 @@ instance_mix = Instance.from_components(
     indicator_constraints={1: (x2 <= 5).with_indicator(z2)},         # Indicator ID=1
     one_hot_constraints={1: OneHotConstraint(variables=xs)},         # OneHot ID=1
     sos1_constraints={1: Sos1Constraint(variables=ys)},              # SOS1 ID=1
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 
 # Each of the four dicts holds its own ID=1 constraint independently

--- a/docs/en/user_guide/tracing.ipynb
+++ b/docs/en/user_guide/tracing.ipynb
@@ -75,7 +75,7 @@
    ],
    "source": [
     "%%ommx_trace\n",
-    "from ommx import Instance, DecisionVariable\n",
+    "from ommx import DecisionVariable, Instance, Sense\n",
     "\n",
     "x = DecisionVariable.binary(0, name=\"x\")\n",
     "y = DecisionVariable.binary(1, name=\"y\")\n",
@@ -83,7 +83,7 @@
     "    decision_variables=[x, y],\n",
     "    objective=x + y,\n",
     "    constraints={},\n",
-    "    sense=Instance.MAXIMIZE,\n",
+    "    sense=Sense.Maximize,\n",
     ")\n",
     "solution = instance.evaluate({0: 1.0, 1: 1.0})"
    ]
@@ -140,7 +140,7 @@
    ],
    "source": [
     "from ommx.tracing import capture_trace, save_chrome_trace\n",
-    "from ommx import Instance, DecisionVariable\n",
+    "from ommx import DecisionVariable, Instance, Sense\n",
     "\n",
     "x = DecisionVariable.binary(0, name=\"x\")\n",
     "y = DecisionVariable.binary(1, name=\"y\")\n",
@@ -149,7 +149,7 @@
     "    decision_variables=[x, y],\n",
     "    objective=x + y,\n",
     "    constraints={},\n",
-    "    sense=Instance.MAXIMIZE,\n",
+    "    sense=Sense.Maximize,\n",
     ")\n",
     "\n",
     "with capture_trace() as trace:\n",

--- a/docs/ja/migration/python_sdk_v2_to_v3.md
+++ b/docs/ja/migration/python_sdk_v2_to_v3.md
@@ -34,7 +34,7 @@ from ommx.v1.linear_pb2 import Linear
 from ommx.v1.solution_pb2 import State
 
 # v3
-from ommx import Constraint, Equality, Function, Linear, State
+from ommx import Constraint, Equality, Function, Linear, Sense, State
 ```
 
 `.from_protobuf()` / `.to_protobuf()` は、protobuf object と一緒に削除されています。`Instance` / `Solution` / `SampleSet` など全体をシリアライズする場合は、protobuf version を名前に含む bytes API を使います。新しく byte 列を作る場合は `to_v2_bytes()` / `from_v2_bytes(...)` を使い、legacy な v1 payload との互換が必要な場合だけ `to_v1_bytes()` / `from_v1_bytes(...)` を使ってください。
@@ -94,10 +94,10 @@ c = Constraint(
 c.set_id(6)
 
 # v3
-c = Constraint(function=x + y, equality=Constraint.EQUAL_TO_ZERO, name="cap")
+c = Constraint(function=x + y, equality=Equality.EqualToZero, name="cap")
 
 instance = Instance.from_components(
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
     objective=objective,
     decision_variables=decision_variables,
     constraints={5: c},
@@ -148,7 +148,7 @@ Instance.from_components(
 
 # v3
 Instance.from_components(
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
     objective=obj,
     decision_variables=[x0, x1],
     constraints={0: c0, 1: c1},
@@ -269,6 +269,33 @@ if name is not None:
 linear.terms()
 quadratic.terms()
 polynomial.terms()
+```
+
+v3 alpha の初期移行では、`DecisionVariable` の constructor と `kind` property が
+protobuf の整数表現を誤って公開していました。現在の v3 API は、detached、attached、
+evaluated、sampled の各 decision variable で top-level の `Kind` enum を一貫して
+受け取り、返します。新しいコードでは `Kind.Binary`、`Kind.Integer` などを使います。
+`DecisionVariable.BINARY` / `INTEGER` / … は、同じ enum 値を返す型付き互換 alias として
+残します。
+
+同じ互換方針を `Constraint.EQUAL_TO_ZERO` / `LESS_THAN_OR_EQUAL_TO_ZERO` と
+`Instance.MINIMIZE` / `MAXIMIZE` にも適用します。これらは型付き alias として残しますが、
+新しいコードでは `Equality.*` と `Sense.*` を使います。
+
+```python
+from ommx import Bound, DecisionVariable, Kind
+
+variable = DecisionVariable(0, Kind.Binary, Bound(0, 1))
+assert variable.kind == Kind.Binary
+assert DecisionVariable.BINARY == Kind.Binary
+```
+
+各 enum は protobuf の整数値との比較・hash の互換性を維持します。通常の SDK
+constructor と property は enum 型を使います。
+
+```python
+assert Kind.Binary == 1
+assert hash(Kind.Binary) == hash(1)
 ```
 
 `SampleSet.sample_ids` は list property ではなく set を返す method になりました。list が必要な場合は `sample_ids_list` を使います。

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -8,6 +8,52 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 直近のリリース以降にマージされた変更を、このセクションに順次追記していきます。次のリリース時に新しいバージョンのセクションへ昇格します。
 
+### 🛠 モデルの識別子を型付きenumへ復元 ([#1196](https://github.com/Jij-Inc/ommx/pull/1196))
+
+v3のPyO3への書き直しで、{class}`~ommx.DecisionVariable`のconstructorと
+detached / attached variableの`kind` propertyから、protobufの整数識別子を
+誤って公開していました。これらのAPIは{class}`~ommx.Kind`を一貫して受け取り、
+返すようになりました。stable v2のPython API、および既に型付けされていた
+{class}`~ommx.Equality`と{class}`~ommx.Sense`のAPIと同じ挙動です。
+
+通常のv3 import migration後も、stable v2の書き方はそのまま利用できます。
+
+```python
+# v2
+from ommx.v1 import DecisionVariable
+
+x = DecisionVariable.binary(0)
+assert x.kind == DecisionVariable.BINARY
+```
+
+```python
+# v3
+from ommx import DecisionVariable, Kind
+
+x = DecisionVariable.binary(0)
+assert x.kind == DecisionVariable.BINARY
+assert x.kind == Kind.Binary
+```
+
+`DecisionVariable.BINARY` / `INTEGER` / …、`Constraint.EQUAL_TO_ZERO` / …、
+`Instance.MINIMIZE` / `MAXIMIZE`は、非deprecatedの型付き互換aliasとして残ります。
+また各enum memberは、protobufの整数値との比較およびhashの互換性を維持します。
+
+変更が必要なのは、v3 prereleaseで誤って公開された整数APIを直接利用したコードだけです。
+生の整数識別子ではなく、型付きenum memberを渡してください。
+
+```python
+from ommx import Bound, DecisionVariable, Kind
+
+# v3初期prereleaseでは受理されましたが、stable v2の公開APIではありませんでした。
+# x = DecisionVariable(0, 1, Bound(0, 1))
+
+x = DecisionVariable(0, Kind.Binary, Bound(0, 1))
+```
+
+enumの互換方針全体については
+[Python SDK v2 to v3 Migration Guide](../migration/python_sdk_v2_to_v3.md)を参照してください。
+
 ### 🛠 Boundとconstraintのtolerance意味論を統一 ([#1192](https://github.com/Jij-Inc/ommx/pull/1192))
 
 {meth}`~ommx.Bound.contains`は、$x \in [l,u]$を通常のconstraint feasibilityと

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -10,49 +10,14 @@ Python SDK 3.0.0にはAPIの破壊的な変更が含まれます。マイグレ�
 
 ### 🛠 モデルの識別子を型付きenumへ復元 ([#1196](https://github.com/Jij-Inc/ommx/pull/1196))
 
-v3のPyO3への書き直しで、{class}`~ommx.DecisionVariable`のconstructorと
-detached / attached variableの`kind` propertyから、protobufの整数識別子を
-誤って公開していました。これらのAPIは{class}`~ommx.Kind`を一貫して受け取り、
-返すようになりました。stable v2のPython API、および既に型付けされていた
-{class}`~ommx.Equality`と{class}`~ommx.Sense`のAPIと同じ挙動です。
+v3への書き直しで、{class}`~ommx.DecisionVariable`からprotobufの整数識別子を
+誤って公開していました。constructorと`kind` propertyは{class}`~ommx.Kind`を
+一貫して使い、stable v2の挙動を復元します。既存の`DecisionVariable.*`、
+`Constraint.*`、`Instance.*`は、非deprecatedの型付きaliasとして残ります。
 
-通常のv3 import migration後も、stable v2の書き方はそのまま利用できます。
-
-```python
-# v2
-from ommx.v1 import DecisionVariable
-
-x = DecisionVariable.binary(0)
-assert x.kind == DecisionVariable.BINARY
-```
-
-```python
-# v3
-from ommx import DecisionVariable, Kind
-
-x = DecisionVariable.binary(0)
-assert x.kind == DecisionVariable.BINARY
-assert x.kind == Kind.Binary
-```
-
-`DecisionVariable.BINARY` / `INTEGER` / …、`Constraint.EQUAL_TO_ZERO` / …、
-`Instance.MINIMIZE` / `MAXIMIZE`は、非deprecatedの型付き互換aliasとして残ります。
-また各enum memberは、protobufの整数値との比較およびhashの互換性を維持します。
-
-変更が必要なのは、v3 prereleaseで誤って公開された整数APIを直接利用したコードだけです。
-生の整数識別子ではなく、型付きenum memberを渡してください。
-
-```python
-from ommx import Bound, DecisionVariable, Kind
-
-# v3初期prereleaseでは受理されましたが、stable v2の公開APIではありませんでした。
-# x = DecisionVariable(0, 1, Bound(0, 1))
-
-x = DecisionVariable(0, Kind.Binary, Bound(0, 1))
-```
-
-enumの互換方針全体については
-[Python SDK v2 to v3 Migration Guide](../migration/python_sdk_v2_to_v3.md)を参照してください。
+生の整数を直接渡していたv3 prereleaseのコードだけが、型付きenum memberへの変更を
+必要とします。enumと整数値の比較・hash互換性は維持します。詳細は
+[migration guide](../migration/python_sdk_v2_to_v3.md)を参照してください。
 
 ### 🛠 Boundとconstraintのtolerance意味論を統一 ([#1192](https://github.com/Jij-Inc/ommx/pull/1192))
 

--- a/docs/ja/tutorial/experiment_management.md
+++ b/docs/ja/tutorial/experiment_management.md
@@ -43,7 +43,7 @@ kernelspec:
 まず、ナップサック問題の元データと、容量をパラメータとして持つ {py:class}`~ommx.ParametricInstance` を作ります。OMMXの {py:class}`~ommx.ParametricInstance` は、{py:class}`~ommx.Instance` と同様に、目的関数や制約条件を定義できますが、定数項の代わりにパラメータを置くことができます。定数だけ異なるモデルを複数用意する必要がある場合に便利です。
 
 ```{code-cell} ipython3
-from ommx import DecisionVariable, Parameter, Instance, ParametricInstance
+from ommx import DecisionVariable, Instance, Parameter, ParametricInstance, Sense
 
 v = [10, 13, 18, 31, 7, 15]  # 各アイテムの価値
 w = [11, 25, 20, 35, 10, 33]  # 各アイテムの重さ
@@ -67,7 +67,7 @@ pi = ParametricInstance.from_components(
     constraints={
         0: (sum(w[i] * x[i] for i in range(N)) <= capacity).set_name("重量制限")
     },
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/ja/tutorial/implement_adapter.md
+++ b/docs/ja/tutorial/implement_adapter.md
@@ -63,7 +63,17 @@ PySCIPOptは決定変数を名前で管理するので、OMMXの決定変数のI
 
 ```{code-cell} ipython3
 import pyscipopt
-from ommx import Instance, Solution, DecisionVariable, Constraint, State, Function
+from ommx import (
+    Constraint,
+    DecisionVariable,
+    Equality,
+    Function,
+    Instance,
+    Kind,
+    Sense,
+    Solution,
+    State,
+)
 
 def set_decision_variables(
     model: pyscipopt.Model,  # チュートリアルのために状態を引数で受け取っているがclassで管理するのが一般的
@@ -74,13 +84,13 @@ def set_decision_variables(
     """
     # OMMXの決定変数の情報からPySCIPOptの変数を作成
     for var in instance.used_decision_variables:
-        if var.kind == DecisionVariable.BINARY:
+        if var.kind == Kind.Binary:
             model.addVar(name=str(var.id), vtype="B")
-        elif var.kind == DecisionVariable.INTEGER:
+        elif var.kind == Kind.Integer:
             model.addVar(
                 name=str(var.id), vtype="I", lb=var.bound.lower, ub=var.bound.upper
             )
-        elif var.kind == DecisionVariable.CONTINUOUS:
+        elif var.kind == Kind.Continuous:
             model.addVar(
                 name=str(var.id), vtype="C", lb=var.bound.lower, ub=var.bound.upper
             )
@@ -142,9 +152,9 @@ def set_objective(model: pyscipopt.Model, instance: Instance, varname_map: dict)
     """モデルに目的関数を設定"""
     objective = instance.objective
 
-    if instance.sense == Instance.MAXIMIZE:
+    if instance.sense == Sense.Maximize:
         sense = "maximize"
-    elif instance.sense == Instance.MINIMIZE:
+    elif instance.sense == Sense.Minimize:
         sense = "minimize"
     else:
         raise OMMXPySCIPOptAdapterError(
@@ -187,12 +197,12 @@ def set_constraints(model: pyscipopt.Model, instance: Instance, varname_map: dic
         if degree == 0:
             # 定数制約の場合、実行可能かどうかをチェック
             constant_value = f.constant_term
-            if constraint.equality == Constraint.EQUAL_TO_ZERO and math.isclose(
+            if constraint.equality == Equality.EqualToZero and math.isclose(
                 constant_value, 0, abs_tol=1e-6
             ):
                 continue
             elif (
-                constraint.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+                constraint.equality == Equality.LessThanOrEqualToZero
                 and constant_value <= 1e-6
             ):
                 continue
@@ -212,9 +222,9 @@ def set_constraints(model: pyscipopt.Model, instance: Instance, varname_map: dic
             )
 
         # 制約種別（等式/不等式）に基づいて制約を追加
-        if constraint.equality == Constraint.EQUAL_TO_ZERO:
+        if constraint.equality == Equality.EqualToZero:
             constr_expr = expr == 0
-        elif constraint.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO:
+        elif constraint.equality == Equality.LessThanOrEqualToZero:
             constr_expr = expr <= 0
         else:
             raise OMMXPySCIPOptAdapterError(
@@ -550,7 +560,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=sum(v[i] * x[i] for i in range(N)),
     constraints={0: sum(w[i] * x[i] for i in range(N)) - W <= 0},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 
 solution = OMMXPySCIPOptAdapter.solve(instance)
@@ -570,7 +580,7 @@ OpenJijのサンプル結果は `openjij.Response` として得られるので�
 
 ```{code-cell} ipython3
 import openjij as oj
-from ommx import Instance, SampleSet, Solution, Samples, State
+from ommx import Instance, SampleSet, Samples, Sense, Solution, State
 
 def decode_to_samples(response: oj.Response) -> Samples:
     samples = Samples({})  # Create empty samples
@@ -709,7 +719,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=-x[0] - x[1] + 2 * x[0] * x[1],
     constraints={},
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
 )
 
 sample_set = OMMXOpenJijSAAdapter.sample(instance)

--- a/docs/ja/tutorial/share_in_ommx_artifact.md
+++ b/docs/ja/tutorial/share_in_ommx_artifact.md
@@ -26,7 +26,7 @@ OMMXは、これらの多様なデータを効率的かつシンプルに管理�
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-from ommx import Instance, DecisionVariable, Constraint
+from ommx import Constraint, DecisionVariable, Equality, Instance, Sense
 from ommx_pyscipopt_adapter.adapter import OMMXPySCIPOptAdapter
 import pandas as pd
 
@@ -67,7 +67,7 @@ constraint = Constraint(
     # 制約式の左辺を指定する
     function=sum(data["w"][i] * x[i] for i in range(data["N"])) - data["W"],
     # 等式制約 (==0) or 不等式制約 (<=0) を指定する
-    equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+    equality=Equality.LessThanOrEqualToZero,
 )
 
 # インスタンスを作成する
@@ -79,7 +79,7 @@ instance = Instance.from_components(
     # 全ての制約条件を登録する (キーは制約ID)
     constraints={0: constraint},
     # 最大化問題であることを指定する
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 
 # SCIPで解く

--- a/docs/ja/tutorial/solve_with_ommx_adapter.md
+++ b/docs/ja/tutorial/solve_with_ommx_adapter.md
@@ -81,7 +81,7 @@ N = len(v)  # アイテムの総数
 この数理モデルとデータに基づいて、OMMX Python SDKを使用して問題インスタンスを記述するコードは次のようになります：
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 # 決定変数を定義する
 x = [
@@ -113,7 +113,7 @@ instance = Instance.from_components(
     # 制約条件を登録する (キーは制約ID)
     constraints={0: constraint},
     # 最大化問題であることを指定する
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/ja/tutorial/switching_adapters.md
+++ b/docs/ja/tutorial/switching_adapters.md
@@ -25,7 +25,7 @@ $$
 $$
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 v = [10, 13, 18, 31, 7, 15]
 w = [11, 25, 20, 35, 10, 33]
@@ -44,7 +44,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=sum(v[i] * x[i] for i in range(N)),
     constraints={0: sum(w[i] * x[i] for i in range(N)) - W <= 0},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.ipynb
+++ b/docs/ja/tutorial/tsp_sampling_with_openjij_adapter.ipynb
@@ -151,7 +151,7 @@
    },
    "outputs": [],
    "source": [
-    "from ommx import DecisionVariable, Instance\n",
+    "from ommx import DecisionVariable, Instance, Sense\n",
     "\n",
     "route_variables = [\n",
     "    [\n",
@@ -200,7 +200,7 @@
     "    ],\n",
     "    objective=objective,\n",
     "    constraints={**position_constraints, **city_constraints},\n",
-    "    sense=Instance.MINIMIZE,\n",
+    "    sense=Sense.Minimize,\n",
     ")"
    ]
   },

--- a/docs/ja/user_guide/adapter_initial_state.md
+++ b/docs/ja/user_guide/adapter_initial_state.md
@@ -21,7 +21,7 @@ OMMX Adapterの中には、最適化計算実行時に初期解を渡す機能�
 以下のインスタンスを用いて、初期解を渡す方法を説明します。
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable, State
+from ommx import DecisionVariable, Instance, Sense, State
 
 x = DecisionVariable.integer(1, lower=0, upper=5)
 y = DecisionVariable.integer(2, lower=0, upper=5)
@@ -30,7 +30,7 @@ ommx_instance = Instance.from_components(
     decision_variables=[x, y],
     objective=x - y,
     constraints={0: x + y <= 5},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/ja/user_guide/capability_model.md
+++ b/docs/ja/user_guide/capability_model.md
@@ -63,7 +63,13 @@ Applicability と solver input の構築は別の境界です。Membership は�
 {attr}`Instance.active_special_constraint_kinds <ommx.Instance.active_special_constraint_kinds>` は、その {class}`~ommx.Instance` が **現在保持している active な特殊制約** に対応する `SpecialConstraintKind` の集合を返します。通常制約しか使っていない場合は空集合です。
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable, OneHotConstraint, SpecialConstraintKind
+from ommx import (
+    DecisionVariable,
+    Instance,
+    OneHotConstraint,
+    Sense,
+    SpecialConstraintKind,
+)
 
 xs = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
 
@@ -72,7 +78,7 @@ instance = Instance.from_components(
     objective=sum(xs),
     constraints={},
     one_hot_constraints={0: OneHotConstraint(variables=xs)},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert instance.active_special_constraint_kinds == {SpecialConstraintKind.OneHot}
 assert binary_linear_with_one_hot.contains(instance)
@@ -111,7 +117,7 @@ instance2 = Instance.from_components(
     objective=sum(xs),
     constraints={},
     one_hot_constraints={1: OneHotConstraint(variables=xs)},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 new_id = instance2.convert_one_hot_to_constraint(1)
 assert isinstance(new_id, int)
@@ -138,7 +144,7 @@ instance3 = Instance.from_components(
     objective=sum(ys),
     constraints={},
     sos1_constraints={1: Sos1Constraint(variables=ys)},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 new_ids = instance3.convert_sos1_to_constraints(1)
 # バイナリ変数のみの SOS1 は濃度制約 sum(x_i) - 1 <= 0 1本に変換される

--- a/docs/ja/user_guide/instance.md
+++ b/docs/ja/user_guide/instance.md
@@ -33,7 +33,7 @@ $$
 これに対応する `ommx.Instance` は次のようになります。
 
 ```{code-cell} ipython3
-from ommx import Instance
+from ommx import Instance, Sense
 
 instance = Instance.maximize()
 x = instance.new_binary("x")
@@ -62,10 +62,10 @@ Binaryのbound正規化でも、同じ規則で`0`と`1`のmembershipを判定�
 instance.objective
 ```
 
-最大化問題には {meth}`~ommx.Instance.maximize`、最小化問題には {meth}`~ommx.Instance.minimize` を使用します。作成された Instance の `sense` には、それぞれ `Instance.MAXIMIZE` または `Instance.MINIMIZE` が設定されます。
+最大化問題には {meth}`~ommx.Instance.maximize`、最小化問題には {meth}`~ommx.Instance.minimize` を使用します。作成された Instance の `sense` には、それぞれ `Sense.Maximize` または `Sense.Minimize` が設定されます。
 
 ```{code-cell} ipython3
-instance.sense == Instance.MAXIMIZE
+instance.sense == Sense.Maximize
 ```
 
 ## 決定変数
@@ -120,7 +120,7 @@ instance.constraints_df()
 
 OMMXでは制約条件もIDで管理されます。このIDは決定変数のIDとは独立です。制約条件のIDは `Instance` に登録する際に決まります: {meth}`~ommx.Instance.from_components` に渡す `constraints` 辞書のキーがそのまま制約条件のIDになります。
 
-制約条件に必須の情報は `equality` です。`equality` はその制約条件が等式制約 ({attr}`~ommx.Constraint.EQUAL_TO_ZERO`) か不等式制約 ({attr}`~ommx.Constraint.LESS_THAN_OR_EQUAL_TO_ZERO`) かを表します。$f(x) \geq 0$のタイプの制約条件は $-f(x) \leq 0$ として扱われることに注意してください。
+制約条件に必須の情報は `equality` です。`equality` はその制約条件が等式制約 ({attr}`~ommx.Equality.EqualToZero`) か不等式制約 ({attr}`~ommx.Equality.LessThanOrEqualToZero`) かを表します。$f(x) \geq 0$のタイプの制約条件は $-f(x) \leq 0$ として扱われることに注意してください。
 
 制約条件にも決定変数と同様にメタデータを保存することができます。決定変数と同様に `name`, `description`, `subscripts`, `parameters` が利用できます。これらのメタデータ全体を置き換える場合は `set_name`, `set_description`, `set_subscripts`, `set_parameters` を使います。既存の値に追記または merge したい場合は `add_subscripts`, `add_parameter`, `add_parameters` を使います。
 

--- a/docs/ja/user_guide/parametric_instance.md
+++ b/docs/ja/user_guide/parametric_instance.md
@@ -28,7 +28,7 @@ $$
 ここで、$N$はアイテムの数、$p_i$はアイテム$i$の価値、$w_i$はアイテム$i$の重さ、$W$はナップザックの容量です。$x_i$はアイテム$i$をナップザックに入れるかどうかを表すバイナリ変数です。`ommx.Instance` では $p_i$ や $w_i$ は固定値を使いましたが、ここではこれらをパラメータとして扱います。
 
 ```{code-cell} ipython3
-from ommx import ParametricInstance, DecisionVariable, Parameter, Instance
+from ommx import DecisionVariable, Instance, Parameter, ParametricInstance, Sense
 
 N = 6
 x = [DecisionVariable.binary(id=i, name="x", subscripts=[i]) for i in range(N)]
@@ -53,7 +53,7 @@ parametric_instance = ParametricInstance.from_components(
     parameters=p + w + [W],
     objective=objective,
     constraints={0: constraint},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/ja/user_guide/sample_set.md
+++ b/docs/ja/user_guide/sample_set.md
@@ -37,7 +37,7 @@ $$
 $$
 
 ```{code-cell} ipython3
-from ommx import DecisionVariable, Instance
+from ommx import DecisionVariable, Instance, Sense
 
 x = [DecisionVariable.binary(i) for i in range(3)]
 
@@ -45,7 +45,7 @@ instance = Instance.from_components(
     decision_variables=x,
     objective=x[0] + 2*x[1] + 3*x[2],
     constraints={0: sum(x) == 1},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 ```
 

--- a/docs/ja/user_guide/solution.md
+++ b/docs/ja/user_guide/solution.md
@@ -35,7 +35,7 @@ $$
 をここでも考えましょう。これは明らかに実行可能解 $x = 1, y = 0$ を持ちます。
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 # Create a simple instance
 x = DecisionVariable.binary(1, name='x')
@@ -45,7 +45,7 @@ instance = Instance.from_components(
     decision_variables=[x, y],
     objective=x + y,
     constraints={0: x * y == 0},
-    sense=Instance.MAXIMIZE
+    sense=Sense.Maximize
 )
 
 # Create a solution

--- a/docs/ja/user_guide/special_constraints.md
+++ b/docs/ja/user_guide/special_constraints.md
@@ -39,7 +39,7 @@ APIは入力をcopyし、推奨Preparation Policyを使ってOneHotを通常の�
 {class}`~ommx.IndicatorConstraint` は、既存の {class}`~ommx.Constraint` に対して {meth}`Constraint.with_indicator() <ommx.Constraint.with_indicator>` を呼ぶことで生成できます。Indicator の引数には変数 ID、detached な {class}`~ommx.DecisionVariable`、または {class}`~ommx.AttachedDecisionVariable` を渡せます。
 
 ```{code-cell} ipython3
-from ommx import Instance, DecisionVariable, Equality
+from ommx import DecisionVariable, Equality, Instance, Sense
 
 z = DecisionVariable.binary(0, name="z")
 x = DecisionVariable.continuous(1, lower=0, upper=10, name="x")
@@ -58,7 +58,7 @@ instance = Instance.from_components(
     objective=x,
     constraints={0: z == 1},       # z を 1 に固定
     indicator_constraints={0: ic}, # z = 1 => x <= 5
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert set(instance.indicator_constraints.keys()) == {0}
 ```
@@ -94,7 +94,7 @@ instance_oh = Instance.from_components(
     objective=sum(v * x for v, x in zip(values, xs)),
     constraints={},
     one_hot_constraints={0: oh},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert set(instance_oh.one_hot_constraints.keys()) == {0}
 ```
@@ -145,7 +145,7 @@ instance_s1 = Instance.from_components(
     objective=sum(ys),
     constraints={},
     sos1_constraints={0: s1},
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 assert set(instance_s1.sos1_constraints.keys()) == {0}
 ```
@@ -209,7 +209,7 @@ instance_mix = Instance.from_components(
     indicator_constraints={1: (x2 <= 5).with_indicator(z2)}, # Indicator ID=1
     one_hot_constraints={1: OneHotConstraint(variables=xs)},        # OneHot ID=1
     sos1_constraints={1: Sos1Constraint(variables=ys)},             # SOS1 ID=1
-    sense=Instance.MAXIMIZE,
+    sense=Sense.Maximize,
 )
 
 # 4 種の dict それぞれが ID=1 の制約を独立に保持している

--- a/docs/ja/user_guide/tracing.ipynb
+++ b/docs/ja/user_guide/tracing.ipynb
@@ -75,7 +75,7 @@
    ],
    "source": [
     "%%ommx_trace\n",
-    "from ommx import Instance, DecisionVariable\n",
+    "from ommx import DecisionVariable, Instance, Sense\n",
     "\n",
     "x = DecisionVariable.binary(0, name=\"x\")\n",
     "y = DecisionVariable.binary(1, name=\"y\")\n",
@@ -83,7 +83,7 @@
     "    decision_variables=[x, y],\n",
     "    objective=x + y,\n",
     "    constraints={},\n",
-    "    sense=Instance.MAXIMIZE,\n",
+    "    sense=Sense.Maximize,\n",
     ")\n",
     "solution = instance.evaluate({0: 1.0, 1: 1.0})"
    ]
@@ -140,7 +140,7 @@
    ],
    "source": [
     "from ommx.tracing import capture_trace, save_chrome_trace\n",
-    "from ommx import Instance, DecisionVariable\n",
+    "from ommx import DecisionVariable, Instance, Sense\n",
     "\n",
     "x = DecisionVariable.binary(0, name=\"x\")\n",
     "y = DecisionVariable.binary(1, name=\"y\")\n",
@@ -149,7 +149,7 @@
     "    decision_variables=[x, y],\n",
     "    objective=x + y,\n",
     "    constraints={},\n",
-    "    sense=Instance.MAXIMIZE,\n",
+    "    sense=Sense.Maximize,\n",
     ")\n",
     "\n",
     "with capture_trace() as trace:\n",

--- a/python/ommx-highs-adapter/README.md
+++ b/python/ommx-highs-adapter/README.md
@@ -14,14 +14,14 @@ An example usage of HiGHS through this adapter:
 
 ```python markdown-code-runner
 from ommx_highs_adapter import OMMXHighsAdapter
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 x1 = DecisionVariable.integer(1, lower=0, upper=5)
 ommx_instance = Instance.from_components(
     decision_variables=[x1],
     objective=x1,
     constraints={},
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
 )
 
 # Create `ommx.Solution` through `highspy.Highs`

--- a/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
+++ b/python/ommx-highs-adapter/ommx_highs_adapter/adapter.py
@@ -11,8 +11,6 @@ from highspy.highs import highs_linear_expression
 from opentelemetry import trace
 
 from ommx import (
-    Constraint,
-    DecisionVariable,
     Equality,
     Function,
     Instance,
@@ -444,19 +442,19 @@ class OMMXHighsAdapter(SolverAdapter):
        * - OMMX Type
          - HiGHS Type
          - Bounds
-       * - ``DecisionVariable.BINARY``
+       * - ``Kind.Binary``
          - ``HighsVarType.kInteger``
          - ``[0, 1]``
-       * - ``DecisionVariable.INTEGER``
+       * - ``Kind.Integer``
          - ``HighsVarType.kInteger``
          - ``[var.bound.lower, var.bound.upper]``
-       * - ``DecisionVariable.CONTINUOUS``
+       * - ``Kind.Continuous``
          - ``HighsVarType.kContinuous``
          - ``[var.bound.lower, var.bound.upper]``
-       * - ``DecisionVariable.SEMI_INTEGER``
+       * - ``Kind.SemiInteger``
          - **Not supported** (support planned)
          - \\-
-       * - ``DecisionVariable.SEMI_CONTINUOUS``
+       * - ``Kind.SemiContinuous``
          - **Not supported** (support planned)
          - \\-
 
@@ -480,10 +478,10 @@ class OMMXHighsAdapter(SolverAdapter):
        * - OMMX Constraint
          - Mathematical Form
          - HiGHS Constraint
-       * - ``Constraint.EQUAL_TO_ZERO``
+       * - ``Equality.EqualToZero``
          - f(x) = 0
          - ``const_expr == 0``
-       * - ``Constraint.LESS_THAN_OR_EQUAL_TO_ZERO``
+       * - ``Equality.LessThanOrEqualToZero``
          - f(x) ≤ 0
          - ``const_expr <= 0``
 
@@ -505,9 +503,9 @@ class OMMXHighsAdapter(SolverAdapter):
 
        * - OMMX Direction
          - HiGHS Method
-       * - ``Instance.MINIMIZE``
+       * - ``Sense.Minimize``
          - ``model.minimize(...)``
-       * - ``Instance.MAXIMIZE``
+       * - ``Sense.Maximize``
          - ``model.maximize(...)``
 
     **Function Types**:
@@ -534,9 +532,10 @@ class OMMXHighsAdapter(SolverAdapter):
     **Unsupported Features**:
 
     - Quadratic functions (HiGHS supports linear problems only)
-    - Semi-integer variables (``DecisionVariable.SEMI_INTEGER``, kind=4) - support planned
-    - Semi-continuous variables (``DecisionVariable.SEMI_CONTINUOUS``, kind=5) - support planned
-    - Constraint types other than ``EQUAL_TO_ZERO``/``LESS_THAN_OR_EQUAL_TO_ZERO``
+    - Semi-integer variables (``Kind.SemiInteger``) - support planned
+    - Semi-continuous variables (``Kind.SemiContinuous``) - support planned
+    - Constraint types other than ``Equality.EqualToZero``/
+      ``Equality.LessThanOrEqualToZero``
 
     **Solver Status Mapping**:
 
@@ -558,13 +557,13 @@ class OMMXHighsAdapter(SolverAdapter):
     2. Constraint forms limited to equality (= 0) and inequality (≤ 0)
     3. Variable types limited to Binary, Integer, and Continuous
 
-       - Semi-integer (SEMI_INTEGER) support is planned but not yet implemented
-       - Semi-continuous (SEMI_CONTINUOUS) support is planned but not yet implemented
+       - ``Kind.SemiInteger`` support is planned but not yet implemented
+       - ``Kind.SemiContinuous`` support is planned but not yet implemented
 
     Examples
     --------
     >>> from ommx_highs_adapter import OMMXHighsAdapter
-    >>> from ommx import Instance, DecisionVariable
+    >>> from ommx import DecisionVariable, Instance, Sense
     >>>
     >>> # Define problem
     >>> x = DecisionVariable.binary(0)
@@ -573,7 +572,7 @@ class OMMXHighsAdapter(SolverAdapter):
     ...     decision_variables=[x, y],
     ...     objective=2*x + 3*y,
     ...     constraints={0: x + y <= 5},
-    ...     sense=Instance.MAXIMIZE,
+    ...     sense=Sense.Maximize,
     ... )
     >>>
     >>> # Solve
@@ -707,7 +706,7 @@ class OMMXHighsAdapter(SolverAdapter):
         ...     decision_variables=x,
         ...     objective=sum(p[i] * x[i] for i in range(6)),
         ...     constraints={0: sum(w[i] * x[i] for i in range(6)) <= 47},
-        ...     sense=Instance.MAXIMIZE,
+        ...     sense=Sense.Maximize,
         ... )
         >>>
         >>> solution = OMMXHighsAdapter.solve(instance)
@@ -726,7 +725,7 @@ class OMMXHighsAdapter(SolverAdapter):
         ...     decision_variables=[x],
         ...     objective=x,
         ...     constraints={0: x >= 4},  # Impossible: x ≤ 3 and x ≥ 4
-        ...     sense=Instance.MAXIMIZE,
+        ...     sense=Sense.Maximize,
         ... )
         >>> OMMXHighsAdapter.solve(instance)  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
@@ -748,7 +747,7 @@ class OMMXHighsAdapter(SolverAdapter):
         # ...     decision_variables=[x],
         # ...     objective=x,
         # ...     constraints={},
-        # ...     sense=Instance.MAXIMIZE,
+        # ...     sense=Sense.Maximize,
         # ... )
 
         # >>> OMMXHighsAdapter.solve(instance)
@@ -866,7 +865,7 @@ class OMMXHighsAdapter(SolverAdapter):
         ...     decision_variables=[x],
         ...     objective=x,
         ...     constraints={},
-        ...     sense=Instance.MAXIMIZE,
+        ...     sense=Sense.Maximize,
         ... )
         >>>
         >>> adapter = OMMXHighsAdapter(instance)
@@ -936,7 +935,7 @@ class OMMXHighsAdapter(SolverAdapter):
         ...     decision_variables=[x1],
         ...     objective=x1,
         ...     constraints={},
-        ...     sense=Instance.MINIMIZE,
+        ...     sense=Sense.Minimize,
         ... )
         >>> adapter = OMMXHighsAdapter(instance)
         >>> model = adapter.solver_input
@@ -971,15 +970,15 @@ class OMMXHighsAdapter(SolverAdapter):
 
         for i, var in enumerate(self.instance.used_decision_variables):
             var_ids.append(var.id)
-            if var.kind == DecisionVariable.BINARY:
+            if var.kind == Kind.Binary:
                 lower[i] = 0
                 upper[i] = 1
                 types.append(highspy.HighsVarType.kInteger)
-            elif var.kind == DecisionVariable.INTEGER:
+            elif var.kind == Kind.Integer:
                 lower[i] = var.bound.lower
                 upper[i] = var.bound.upper
                 types.append(highspy.HighsVarType.kInteger)
-            elif var.kind == DecisionVariable.CONTINUOUS:
+            elif var.kind == Kind.Continuous:
                 lower[i] = var.bound.lower
                 upper[i] = var.bound.upper
                 types.append(highspy.HighsVarType.kContinuous)
@@ -1013,9 +1012,9 @@ class OMMXHighsAdapter(SolverAdapter):
         obj = self._linear_expr_conversion(self.instance.objective)
         if isinstance(obj, float):
             return
-        if self.instance.sense == Instance.MAXIMIZE:
+        if self.instance.sense == Sense.Maximize:
             self.model.maximize(highs_linear_expression(obj))
-        elif self.instance.sense == Instance.MINIMIZE:
+        elif self.instance.sense == Sense.Minimize:
             self.model.minimize(highs_linear_expression(obj))
         else:
             raise OMMXHighsAdapterError(f"Unsupported sense: {self.instance.sense}")
@@ -1025,13 +1024,13 @@ class OMMXHighsAdapter(SolverAdapter):
             const_expr = self._linear_expr_conversion(constr.function)
             if isinstance(const_expr, float):
                 val = const_expr
-                if constr.equality == Constraint.EQUAL_TO_ZERO:
+                if constr.equality == Equality.EqualToZero:
                     if abs(val) > 1e-10:
                         raise OMMXHighsAdapterError(
                             "Infeasible constant equality constraint"
                         )
                     continue
-                elif constr.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO:
+                elif constr.equality == Equality.LessThanOrEqualToZero:
                     if val > 1e-10:
                         raise OMMXHighsAdapterError(
                             "Infeasible constant inequality constraint"
@@ -1039,9 +1038,9 @@ class OMMXHighsAdapter(SolverAdapter):
                     continue
             else:
                 const_expr = highs_linear_expression(const_expr)
-                if constr.equality == Constraint.EQUAL_TO_ZERO:
+                if constr.equality == Equality.EqualToZero:
                     self.model.addConstr(const_expr == 0, str(cid))
-                elif constr.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO:
+                elif constr.equality == Equality.LessThanOrEqualToZero:
                     self.model.addConstr(const_expr <= 0, str(cid))
                 else:
                     raise OMMXHighsAdapterError(

--- a/python/ommx-highs-adapter/tests/test_adapter.py
+++ b/python/ommx-highs-adapter/tests/test_adapter.py
@@ -14,7 +14,7 @@ def test_integration_lp():
         decision_variables=[x1, x2],
         objective=x1 + 2 * x2,
         constraints={0: x1 + x2 <= 5},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     adapter = OMMXHighsAdapter(instance)
 
@@ -35,7 +35,7 @@ def test_integration_milp():
         decision_variables=[x1, x2],
         objective=-x1 - x2,
         constraints={0: 3 * x1 - x2 <= 6, 1: -x1 + 3 * x2 <= 6},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXHighsAdapter(instance)
@@ -55,7 +55,7 @@ def test_solution_optimality():
         decision_variables=[x, y],
         objective=x + y,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     solution = OMMXHighsAdapter.solve(ommx_instance)
@@ -68,7 +68,7 @@ def test_solution_optimality_is_not_transported_through_fixed_penalty():
         decision_variables=[x],
         objective=x,
         constraints={7: x == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.to_qubo(uniform_penalty_weight=0.0)
 
@@ -122,7 +122,7 @@ def test_partial_evaluate():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 1},  # one-hot constraint
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     assert instance.used_decision_variables == x
     partial = instance.partial_evaluate({0: 1})
@@ -147,7 +147,7 @@ def test_relax_constraint():
         decision_variables=x,
         objective=x[0] + x[1],
         constraints={0: x[0] + 2 * x[1] <= 1, 1: x[1] + x[2] <= 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert instance.used_decision_variables == x

--- a/python/ommx-highs-adapter/tests/test_diagnostics.py
+++ b/python/ommx-highs-adapter/tests/test_diagnostics.py
@@ -6,7 +6,7 @@ import pytest
 
 from ommx.adapter import DiagnosticCollector, InfeasibleDetected
 from ommx.experiment import Experiment
-from ommx import Constraint, DecisionVariable, Instance, Solution
+from ommx import Constraint, DecisionVariable, Instance, Sense, Solution
 from ommx_highs_adapter import (
     HighsDiagnosticsAnalyzer,
     HighsProgressSnapshot,
@@ -22,7 +22,7 @@ def _mip_instance() -> Instance:
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -36,7 +36,7 @@ def _knapsack_instance() -> Instance:
         constraints={
             0: cast(Constraint, sum(weights[i] * x[i] for i in range(30)) <= 60)
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -46,7 +46,7 @@ def _infeasible_instance() -> Instance:
         decision_variables=[x],
         objective=0,
         constraints={0: x == 0, 1: x == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
 

--- a/python/ommx-highs-adapter/tests/test_error.py
+++ b/python/ommx-highs-adapter/tests/test_error.py
@@ -63,7 +63,7 @@ def test_error_nonlinear_objective():
         decision_variables=[x],
         objective=2.3 * x * x,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(AdapterNotApplicableError) as e:
@@ -100,7 +100,7 @@ def test_error_nonlinear_constraint():
         decision_variables=[x],
         objective=0,  # constant 0
         constraints={0: 2.3 * x * x == 0},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(AdapterNotApplicableError) as e:
@@ -239,10 +239,10 @@ def test_error_infeasible_constant_equality_constraint():
         constraints={
             0: Constraint(
                 function=-1,
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
             )
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(OMMXHighsAdapterError) as e:
         OMMXHighsAdapter(ommx_instance)
@@ -256,10 +256,10 @@ def test_error_infeasible_constant_inequality_constraint():
         constraints={
             0: Constraint(
                 function=1,
-                equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+                equality=Equality.LessThanOrEqualToZero,
             )
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(OMMXHighsAdapterError) as e:
         OMMXHighsAdapter(ommx_instance)
@@ -274,14 +274,14 @@ def test_error_infeasible_model():
         constraints={
             0: Constraint(
                 function=x,
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
             ),
             1: Constraint(
                 function=x - 1,
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
             ),
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(InfeasibleDetected):
         OMMXHighsAdapter.solve(ommx_instance)

--- a/python/ommx-highs-adapter/tests/test_tracing.py
+++ b/python/ommx-highs-adapter/tests/test_tracing.py
@@ -1,5 +1,5 @@
 from ommx.tracing import capture_trace
-from ommx import DecisionVariable, Instance
+from ommx import DecisionVariable, Instance, Sense
 
 from ommx_highs_adapter import OMMXHighsAdapter
 
@@ -10,7 +10,7 @@ def test_solve_emits_convert_solve_decode_spans():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 2},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:
@@ -29,7 +29,7 @@ def test_manual_flow_emits_convert_and_decode_spans():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 2},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:

--- a/python/ommx-openjij-adapter/README.md
+++ b/python/ommx-openjij-adapter/README.md
@@ -40,7 +40,7 @@ example, prepare the Instance with a selected fixed penalty weight and use the
 preparation-free API for a constrained model:
 
 ```python markdown-code-runner
-from ommx import DecisionVariable, FixedPenaltyPreparation, Instance
+from ommx import DecisionVariable, FixedPenaltyPreparation, Instance, Sense
 from ommx_openjij_adapter import OMMXOpenJijSAAdapter
 
 x = DecisionVariable.binary(0, name="x")
@@ -48,7 +48,7 @@ instance = Instance.from_components(
     decision_variables=[x],
     objective=x,
     constraints={0: x == 1},
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
 )
 
 policy = OMMXOpenJijSAAdapter.recommended_preparation_policy()

--- a/python/ommx-openjij-adapter/tests/test_sample.py
+++ b/python/ommx-openjij-adapter/tests/test_sample.py
@@ -3,7 +3,13 @@ from typing import cast
 
 import openjij as oj
 import pytest
-from ommx import DecisionVariable, FixedPenaltyPreparation, Instance, Sos1Constraint
+from ommx import (
+    DecisionVariable,
+    FixedPenaltyPreparation,
+    Instance,
+    Sense,
+    Sos1Constraint,
+)
 from ommx_openjij_adapter import OMMXOpenJijSAAdapter
 
 
@@ -14,7 +20,7 @@ def binary_no_constraint_minimize():
         decision_variables=[x0, x1],
         objective=x0 + x1,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     ans = {(0,): 0.0, (1,): 0.0}
     return pytest.param(instance, ans, id="binary_no_constraint_minimize")
@@ -27,7 +33,7 @@ def binary_no_constraint_maximize():
         decision_variables=[x0, x1],
         objective=x0 + x1,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     ans = {(0,): 1.0, (1,): 1.0}
     return pytest.param(instance, ans, id="binary_no_constraint_maximize")
@@ -42,7 +48,7 @@ def binary_equality():
         decision_variables=[x0, x1, x2],
         objective=x0 + 2 * x1 + 3 * x2,
         constraints={0: x1 * x2 == 0},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # x0 = x2 = 1, x1 = 0 is maximum
@@ -59,7 +65,7 @@ def binary_inequality():
         decision_variables=[x0, x1, x2],
         objective=x0 + 2 * x1 + 3 * x2,
         constraints={0: x0 + x1 + x2 <= 2},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # x1 = x2 = 1, x0 = 0 is maximum
@@ -75,7 +81,7 @@ def integer_equality():
         decision_variables=[x0, x1],
         objective=x0 + 2 * x1,
         constraints={0: x0 + x1 == 0},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # x1 = -x0 = 1 is maximum
@@ -91,7 +97,7 @@ def integer_inequality():
         decision_variables=[x0, x1],
         objective=x0 + 2 * x1,
         constraints={0: x0 + x1 <= 0},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # x1 = -x0 = 1 is maximum
@@ -107,7 +113,7 @@ def hubo_binary_no_constraint_minimize():
         decision_variables=[x0, x1, x2],
         objective=x0 + x1 + x2 + x0 * x1 * x2,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     ans = {(0,): 0.0, (1,): 0.0, (2,): 0.0}
     return pytest.param(instance, ans, id="hubo_binary_no_constraint_minimize")
@@ -121,7 +127,7 @@ def hubo_binary_no_constraint_maximize():
         decision_variables=[x0, x1, x2],
         objective=x0 + x0 * x1 * x2,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     ans = {(0,): 1.0, (1,): 1.0, (2,): 1.0}
     return pytest.param(instance, ans, id="hubo_binary_no_constraint_maximize")
@@ -136,7 +142,7 @@ def hubo_binary_equality():
         decision_variables=[x0, x1, x2],
         objective=x0 + 2 * x1 + 3 * x2 + x0 * x1 * x2,
         constraints={0: x1 * x2 == 0},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # x0 = x2 = 1, x1 = 0 is maximum
@@ -153,7 +159,7 @@ def hubo_binary_inequality():
         decision_variables=[x0, x1, x2],
         objective=x0 + 2 * x1 + 3 * x2 + x0 * x1 * x2,
         constraints={0: x0 + x1 + x2 <= 2},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # x1 = x2 = 1, x0 = 0 is maximum
@@ -246,17 +252,17 @@ def test_easy_sample_restores_maximization_output_without_mutating_input():
         decision_variables=[x],
         objective=3 * x + 2,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     before = instance.to_v2_bytes()
 
     sample_set = OMMXOpenJijSAAdapter.sample(instance, num_reads=4, seed=999)
 
     assert instance.to_v2_bytes() == before
-    assert sample_set.sense == Instance.MAXIMIZE
+    assert sample_set.sense == Sense.Maximize
     for sample_id in sample_set.sample_ids():
         solution = sample_set.get(sample_id)
-        assert solution.sense == Instance.MAXIMIZE
+        assert solution.sense == Sense.Maximize
         assert solution.objective == pytest.approx(3 * solution.state.entries[0] + 2)
 
 
@@ -298,7 +304,7 @@ def test_sample_fills_evaluation_variables_omitted_from_sampler_input(
         decision_variables=[x],
         objective=objective_factory(x),
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     adapter = OMMXOpenJijSAAdapter(instance)
     assert adapter.sampler_input == {}
@@ -315,7 +321,7 @@ def test_decode_to_sampleset_uses_instance_variables():
         decision_variables=[x0, x2],
         objective=x0 + x2,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     response = SimpleNamespace(
         variables=[0, 1],  # 1 is not part of the Adapter input.
@@ -357,7 +363,7 @@ def test_prepared_instance_evaluation_populates_variable_removed_with_trivial_in
         decision_variables=[variable],
         objective=0,
         constraints={7: constraint(variable)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS
     instance.prepare(
@@ -384,7 +390,7 @@ def test_prepared_instance_evaluation_restores_integer_sos1():
         objective=integer + binary,
         constraints={},
         sos1_constraints={30: Sos1Constraint(variables=[integer, binary])},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     input_class = OMMXOpenJijSAAdapter.INPUT_CLASS

--- a/python/ommx-openjij-adapter/tests/test_tracing.py
+++ b/python/ommx-openjij-adapter/tests/test_tracing.py
@@ -1,5 +1,5 @@
 from ommx.tracing import capture_trace
-from ommx import DecisionVariable, Instance
+from ommx import DecisionVariable, Instance, Sense
 
 from ommx_openjij_adapter import OMMXOpenJijSAAdapter
 
@@ -25,7 +25,7 @@ def test_direct_sample_emits_convert_call_decode_spans():
         decision_variables=[x0, x1],
         objective=x0 + x1,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:
@@ -42,7 +42,7 @@ def test_solve_delegates_to_sample_trace():
         decision_variables=[x0, x1],
         objective=x0 + x1,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:

--- a/python/ommx-pyscipopt-adapter/README.md
+++ b/python/ommx-pyscipopt-adapter/README.md
@@ -14,14 +14,14 @@ SCIP can be used through `ommx-pyscipopt-adapter` by using the following:
 
 ```python markdown-code-runner
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 x1 = DecisionVariable.integer(1, lower=0, upper=5)
 ommx_instance = Instance.from_components(
     decision_variables=[x1],
     objective=x1,
     constraints={},
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
 )
 
 # Create `ommx.Solution` from the `pyscipot.Model`

--- a/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
+++ b/python/ommx-pyscipopt-adapter/ommx_pyscipopt_adapter/adapter.py
@@ -18,8 +18,6 @@ from ommx.adapter import (
     NoSolutionReturned,
 )
 from ommx import (
-    Constraint,
-    DecisionVariable,
     Equality,
     Function,
     Instance,
@@ -598,7 +596,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             ...     decision_variables=x,
             ...     objective=sum(p[i] * x[i] for i in range(6)),
             ...     constraints={0: sum(w[i] * x[i] for i in range(6)) <= 47},
-            ...     sense=Instance.MAXIMIZE,
+            ...     sense=Sense.Maximize,
             ... )
 
             Solve it
@@ -633,7 +631,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                 ...     decision_variables=[x],
                 ...     objective=x,
                 ...     constraints={0: x >= 4},
-                ...     sense=Instance.MAXIMIZE,
+                ...     sense=Sense.Maximize,
                 ... )
 
                 >>> OMMXPySCIPOptAdapter.solve(instance)
@@ -653,7 +651,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                 ...     decision_variables=[x],
                 ...     objective=x,
                 ...     constraints={},
-                ...     sense=Instance.MAXIMIZE,
+                ...     sense=Sense.Maximize,
                 ... )
 
                 >>> OMMXPySCIPOptAdapter.solve(instance)
@@ -735,7 +733,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             ...     decision_variables=x,
             ...     objective=sum(p[i] * x[i] for i in range(6)),
             ...     constraints={0: sum(w[i] * x[i] for i in range(6)) <= 47},
-            ...     sense=Instance.MAXIMIZE,
+            ...     sense=Sense.Maximize,
             ... )
 
             >>> adapter = OMMXPySCIPOptAdapter(instance)
@@ -783,7 +781,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             ...     decision_variables=[x1],
             ...     objective=x1,
             ...     constraints={},
-            ...     sense=Instance.MINIMIZE,
+            ...     sense=Sense.Minimize,
             ... )
             >>> adapter = OMMXPySCIPOptAdapter(ommx_instance)
             >>> model = adapter.solver_input
@@ -831,13 +829,13 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
     def _set_decision_variables(self):
         for var in self.instance.used_decision_variables:
-            if var.kind == DecisionVariable.BINARY:
+            if var.kind == Kind.Binary:
                 self.model.addVar(name=str(var.id), vtype="B")
-            elif var.kind == DecisionVariable.INTEGER:
+            elif var.kind == Kind.Integer:
                 self.model.addVar(
                     name=str(var.id), vtype="I", lb=var.bound.lower, ub=var.bound.upper
                 )
-            elif var.kind == DecisionVariable.CONTINUOUS:
+            elif var.kind == Kind.Continuous:
                 self.model.addVar(
                     name=str(var.id), vtype="C", lb=var.bound.lower, ub=var.bound.upper
                 )
@@ -864,9 +862,9 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
         self.varname_map = {var.name: var for var in self.model.getVars()}
 
     def _set_objective(self):
-        if self.instance.sense == Instance.MAXIMIZE:
+        if self.instance.sense == Sense.Maximize:
             sense = "maximize"
-        elif self.instance.sense == Instance.MINIMIZE:
+        elif self.instance.sense == Sense.Minimize:
             sense = "minimize"
         else:
             raise OMMXPySCIPOptAdapterError(
@@ -922,12 +920,12 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
             if degree == 0:
                 # Constant constraint is not passed to SCIP, but checked for feasibility
                 constant_value = f.constant_term
-                if constraint.equality == Constraint.EQUAL_TO_ZERO and math.isclose(
+                if constraint.equality == Equality.EqualToZero and math.isclose(
                     constant_value, 0, abs_tol=1e-6
                 ):
                     continue  # Skip feasible constant constraint
                 elif (
-                    constraint.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+                    constraint.equality == Equality.LessThanOrEqualToZero
                     and constant_value <= 1e-6
                 ):
                     continue  # Skip feasible constant constraint
@@ -946,9 +944,9 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                     f"degree: {degree}"
                 )
 
-            if constraint.equality == Constraint.EQUAL_TO_ZERO:
+            if constraint.equality == Equality.EqualToZero:
                 constr_expr = expr == 0
-            elif constraint.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO:
+            elif constraint.equality == Equality.LessThanOrEqualToZero:
                 constr_expr = expr <= 0
             else:
                 raise OMMXPySCIPOptAdapterError(
@@ -967,10 +965,10 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                 # When indicator is ON, the constant constraint must hold
                 constant_value = f.constant_term
                 is_feasible = (
-                    indicator.equality == Constraint.EQUAL_TO_ZERO
+                    indicator.equality == Equality.EqualToZero
                     and math.isclose(constant_value, 0, abs_tol=1e-6)
                 ) or (
-                    indicator.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+                    indicator.equality == Equality.LessThanOrEqualToZero
                     and constant_value <= 1e-6
                 )
                 if is_feasible:
@@ -990,7 +988,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
 
             binvar = self.varname_map[str(indicator.indicator_variable_id)]
 
-            if indicator.equality == Constraint.EQUAL_TO_ZERO:
+            if indicator.equality == Equality.EqualToZero:
                 # Decompose f(x) == 0 into two indicator constraints
                 self.model.addConsIndicator(
                     expr <= 0, binvar=binvar, name=f"ind_{ind_id}_le"
@@ -998,7 +996,7 @@ class OMMXPySCIPOptAdapter(SolverAdapter):
                 self.model.addConsIndicator(
                     -expr <= 0, binvar=binvar, name=f"ind_{ind_id}_ge"
                 )
-            elif indicator.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO:
+            elif indicator.equality == Equality.LessThanOrEqualToZero:
                 self.model.addConsIndicator(
                     expr <= 0, binvar=binvar, name=f"ind_{ind_id}"
                 )

--- a/python/ommx-pyscipopt-adapter/tests/test_error.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_error.py
@@ -77,7 +77,7 @@ def test_error_polynomial_objective():
         decision_variables=[DecisionVariable.continuous(1)],
         objective=Polynomial(terms={(1, 1, 1): 2.3}),
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPySCIPOptAdapter(ommx_instance)
@@ -132,10 +132,10 @@ def test_error_nonlinear_constraint():
         constraints={
             0: Constraint(
                 function=Polynomial(terms={(1, 1, 1): 2.3}),
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
             )
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(AdapterNotApplicableError) as e:
         OMMXPySCIPOptAdapter(ommx_instance)
@@ -247,7 +247,7 @@ def test_error_not_optimized_model():
         decision_variables=[],
         objective=0,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(OMMXPySCIPOptAdapterError) as e:
         OMMXPySCIPOptAdapter(instance).decode_to_state(model)
@@ -262,14 +262,14 @@ def test_error_infeasible_model():
         constraints={
             0: Constraint(
                 function=x,
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
             ),
             1: Constraint(
                 function=x - 1,
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
             ),
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(InfeasibleDetected):
         OMMXPySCIPOptAdapter.solve(ommx_instance)
@@ -282,10 +282,10 @@ def test_error_infeasible_constant_equality_constraint():
         constraints={
             0: Constraint(
                 function=-1,
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
             )
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(OMMXPySCIPOptAdapterError) as e:
         OMMXPySCIPOptAdapter(ommx_instance)
@@ -299,10 +299,10 @@ def test_error_infeasible_constant_inequality_constraint():
         constraints={
             0: Constraint(
                 function=1,
-                equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+                equality=Equality.LessThanOrEqualToZero,
             )
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     with pytest.raises(OMMXPySCIPOptAdapterError) as e:
         OMMXPySCIPOptAdapter(ommx_instance)

--- a/python/ommx-pyscipopt-adapter/tests/test_indicator.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_indicator.py
@@ -1,6 +1,6 @@
 """Tests for indicator constraint support in PySCIPOpt adapter."""
 
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
 
 
@@ -17,7 +17,7 @@ def test_indicator_constraint_le():
         objective=x,
         constraints={},
         indicator_constraints={0: ic},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     solution = OMMXPySCIPOptAdapter.solve(instance)
@@ -39,7 +39,7 @@ def test_indicator_constraint_forced_on():
         objective=x,
         constraints={0: b >= 1},  # Force b = 1
         indicator_constraints={0: ic},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     solution = OMMXPySCIPOptAdapter.solve(instance)
@@ -61,7 +61,7 @@ def test_indicator_constraint_eq():
         objective=x,
         constraints={0: b >= 1},  # Force b = 1
         indicator_constraints={0: ic},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     solution = OMMXPySCIPOptAdapter.solve(instance)
@@ -87,7 +87,7 @@ def test_indicator_constraint_multiple():
         # At least one indicator must be on
         constraints={0: b1 + b2 >= 1},
         indicator_constraints={10: ic1, 11: ic2},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     solution = OMMXPySCIPOptAdapter.solve(instance)

--- a/python/ommx-pyscipopt-adapter/tests/test_initial_state.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_initial_state.py
@@ -1,4 +1,4 @@
-from ommx import Instance, DecisionVariable, State
+from ommx import DecisionVariable, Instance, Sense, State
 
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
 
@@ -16,7 +16,7 @@ def test_adapter_class_with_initial_state():
         decision_variables=[x, y],
         objective=x - y,
         constraints={0: x + y <= 5},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     initial_state = State(
         entries={
@@ -48,7 +48,7 @@ def test_solve_with_initial_state():
         decision_variables=[x, y],
         objective=x - y,
         constraints={0: x + y <= 5},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     initial_state = State(
         entries={
@@ -76,7 +76,7 @@ def test_adapter_class_with_initial_state_from_mapping():
         decision_variables=[x, y],
         objective=x - y,
         constraints={0: x + y <= 5},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     initial_mapping = {
         1: 3.0,
@@ -105,7 +105,7 @@ def test_solve_with_initial_state_from_mapping():
         decision_variables=[x, y],
         objective=x - y,
         constraints={0: x + y <= 5},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     initial_mapping = {
         1: 3.0,

--- a/python/ommx-pyscipopt-adapter/tests/test_integration.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_integration.py
@@ -3,7 +3,15 @@ import pytest
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
 from ommx_pyscipopt_adapter.exception import OMMXPySCIPOptAdapterError
 
-from ommx import Constraint, Instance, DecisionVariable, Quadratic, Linear
+from ommx import (
+    Constraint,
+    DecisionVariable,
+    Equality,
+    Instance,
+    Linear,
+    Quadratic,
+    Sense,
+)
 from ommx.adapter import InfeasibleDetected, UnboundedDetected, NoSolutionReturned
 from ommx.testing import SingleFeasibleLPGenerator, DataType
 
@@ -52,7 +60,7 @@ def test_integration_milp():
         decision_variables=[x1, x2],
         objective=-x1 - x2,
         constraints={0: 3 * x1 - x2 <= 6, 1: -x1 + 3 * x2 <= 6},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXPySCIPOptAdapter(instance)
@@ -75,7 +83,7 @@ def test_integration_binary():
         decision_variables=[x1, x2],
         objective=-x1 + x2,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXPySCIPOptAdapter(instance)
@@ -98,7 +106,7 @@ def test_integration_maximize():
         decision_variables=[x1, x2],
         objective=-x1 + x2,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     adapter = OMMXPySCIPOptAdapter(instance)
@@ -126,7 +134,7 @@ def test_integration_constant_objective():
         decision_variables=[x1, x2],
         objective=0,
         constraints={0: x1 + x2 - 5 == 0},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXPySCIPOptAdapter(instance)
@@ -152,7 +160,7 @@ def test_integration_quadratic_objective():
     x1 = DecisionVariable.integer(1, lower=LOWER_BOUND, upper=UPPER_BOUND)
     x2 = DecisionVariable.continuous(2, lower=LOWER_BOUND, upper=UPPER_BOUND)
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         decision_variables=[x1, x2],
         objective=Quadratic(
             rows=[1, 2],
@@ -184,7 +192,7 @@ def test_integration_quadratic_constraint():
     x1 = DecisionVariable.integer(1, lower=LOWER_BOUND, upper=UPPER_BOUND)
     x2 = DecisionVariable.continuous(2, lower=LOWER_BOUND, upper=UPPER_BOUND)
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         decision_variables=[x1, x2],
         objective=-x1 - x2,
         constraints={
@@ -195,7 +203,7 @@ def test_integration_quadratic_constraint():
                     values=[1, 1],
                     linear=Linear(terms={}, constant=-100),
                 ),
-                equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+                equality=Equality.LessThanOrEqualToZero,
             )
         },
     )
@@ -231,10 +239,10 @@ def test_integration_feasible_constant_constraint():
             1: -x1 + 3 * x2 <= 6,
             2: Constraint(
                 function=-1,
-                equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+                equality=Equality.LessThanOrEqualToZero,
             ),
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXPySCIPOptAdapter(instance)
@@ -275,7 +283,7 @@ def test_integration_timelimit():
         decision_variables=x,
         objective=sum(v[i] * x[i] for i in range(n)),
         constraints={0: constraint},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     adapter = OMMXPySCIPOptAdapter(instance)
     model = adapter.solver_input
@@ -296,7 +304,7 @@ def test_partial_evaluate():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 1},  # one-hot constraint
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     assert instance.used_decision_variables == x
     partial = instance.partial_evaluate({0: 1})
@@ -321,7 +329,7 @@ def test_relax_constraint():
         decision_variables=x,
         objective=x[0] + x[1],
         constraints={0: x[0] + 2 * x[1] <= 1, 1: x[1] + x[2] <= 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert instance.used_decision_variables == x
@@ -341,7 +349,7 @@ def test_infeasible_problem():
         decision_variables=[x],
         objective=x,
         constraints={0: x >= 4},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     adapter = OMMXPySCIPOptAdapter(instance)
     model = adapter.solver_input
@@ -358,7 +366,7 @@ def test_unbounded_problem():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     adapter = OMMXPySCIPOptAdapter(instance)
     model = adapter.solver_input
@@ -374,7 +382,7 @@ def test_decode_before_optimize():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     adapter = OMMXPySCIPOptAdapter(instance)
     model = adapter.solver_input

--- a/python/ommx-pyscipopt-adapter/tests/test_ommx_pyscipopt.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_ommx_pyscipopt.py
@@ -7,7 +7,7 @@ import pytest
 
 from ommx.adapter import DiagnosticCollector, UnboundedDetected
 from ommx.experiment import Experiment
-from ommx import Constraint, DecisionVariable, Instance, Optimality, Solution
+from ommx import Constraint, DecisionVariable, Instance, Optimality, Sense, Solution
 
 from ommx_pyscipopt_adapter import (
     SCIPDiagnosticsAnalyzer,
@@ -26,7 +26,7 @@ def _knapsack_instance() -> Instance:
         decision_variables=x,
         objective=sum(p[i] * x[i] for i in range(6)),
         constraints={0: cast(Constraint, sum(w[i] * x[i] for i in range(6)) <= 47)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -156,7 +156,7 @@ def test_solution_optimality():
         decision_variables=[x, y],
         objective=x + y,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     solution = OMMXPySCIPOptAdapter.solve(ommx_instance)
@@ -169,7 +169,7 @@ def test_solution_optimality_is_not_transported_through_fixed_penalty():
         decision_variables=[x],
         objective=x,
         constraints={7: x == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.to_qubo(uniform_penalty_weight=0.0)
 
@@ -185,7 +185,7 @@ def test_direct_solve_records_termination_report():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     collector = DiagnosticCollector()
 
@@ -465,7 +465,7 @@ def test_direct_collector_keeps_termination_report_before_decode_error():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     collector = DiagnosticCollector()
 

--- a/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_pyscipopt_special_constraint_lowering.py
@@ -7,6 +7,7 @@ from ommx import (
     Instance,
     OneHotConstraint,
     ProvenanceKind,
+    Sense,
     Sos1Constraint,
     SpecialConstraintKind,
 )
@@ -25,7 +26,7 @@ def test_recommended_preparation_lowers_only_one_hot() -> None:
         indicator_constraints={30: (value <= 1).with_indicator(indicator)},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
         sos1_constraints={20: Sos1Constraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     before = instance.to_v2_bytes()
 

--- a/python/ommx-pyscipopt-adapter/tests/test_sos1_partial_evaluate.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_sos1_partial_evaluate.py
@@ -1,7 +1,7 @@
 """Test PySCIPOpt adapter behavior with partial_evaluate and SOS1 constraints."""
 
 import pytest
-from ommx import Instance, DecisionVariable, Sos1Constraint, State
+from ommx import DecisionVariable, Instance, Sense, Sos1Constraint, State
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
 
 
@@ -40,7 +40,7 @@ def sos1_instance_setup():
             5: independent_constraint,
         },
         sos1_constraints={0: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
 

--- a/python/ommx-pyscipopt-adapter/tests/test_sos1_working.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_sos1_working.py
@@ -1,6 +1,6 @@
 """Test SOS1 functionality with valid constraints."""
 
-from ommx import Instance, DecisionVariable, Sos1Constraint
+from ommx import DecisionVariable, Instance, Sense, Sos1Constraint
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
 
 
@@ -28,7 +28,7 @@ def test_sos1_constraint_functionality():
         objective=objective,
         constraints={1: dummy_constraint, 2: bigm1, 3: bigm2},  # type: ignore
         sos1_constraints={0: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Create adapter and verify SOS1 constraint is added
@@ -66,7 +66,7 @@ def test_sos1_constraint_naming():
         objective=objective,
         constraints={10: constraint1},  # type: ignore
         sos1_constraints={42: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXPySCIPOptAdapter(instance)
@@ -102,7 +102,7 @@ def test_sos1_constraint_naming_no_bigm():
         objective=objective,
         constraints={5: constraint1},  # type: ignore
         sos1_constraints={7: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXPySCIPOptAdapter(instance)

--- a/python/ommx-pyscipopt-adapter/tests/test_tracing.py
+++ b/python/ommx-pyscipopt-adapter/tests/test_tracing.py
@@ -1,5 +1,5 @@
 from ommx.tracing import capture_trace
-from ommx import DecisionVariable, Instance
+from ommx import DecisionVariable, Instance, Sense
 
 from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter
 
@@ -10,7 +10,7 @@ def test_solve_emits_convert_solve_decode_spans():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 2},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:
@@ -29,7 +29,7 @@ def test_manual_flow_emits_convert_and_decode_spans():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 2},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:

--- a/python/ommx-python-mip-adapter/README.md
+++ b/python/ommx-python-mip-adapter/README.md
@@ -46,14 +46,14 @@ Python-MIP can be used through `ommx-python-mip-adapter` by using the following:
 
 ```python markdown-code-runner
 from ommx_python_mip_adapter import OMMXPythonMIPAdapter
-from ommx import Instance, DecisionVariable
+from ommx import DecisionVariable, Instance, Sense
 
 x1 = DecisionVariable.integer(1, lower=0, upper=5)
 ommx_instance = Instance.from_components(
     decision_variables=[x1],
     objective=x1,
     constraints={},
-    sense=Instance.MINIMIZE,
+    sense=Sense.Minimize,
 )
 
 # Create `ommx.Solution` from the `mip.Model`

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/adapter.py
@@ -14,8 +14,6 @@ from ommx.adapter import (
     NoSolutionReturned,
 )
 from ommx import (
-    Constraint,
-    DecisionVariable,
     Equality,
     Function,
     Instance,
@@ -94,9 +92,9 @@ class OMMXPythonMIPAdapter(SolverAdapter):
         """
         with _tracer.start_as_current_span("convert"):
             self.require_applicable(ommx_instance)
-            if ommx_instance.sense == Instance.MAXIMIZE:
+            if ommx_instance.sense == Sense.Maximize:
                 sense = mip.MAXIMIZE
-            elif ommx_instance.sense == Instance.MINIMIZE:
+            elif ommx_instance.sense == Sense.Minimize:
                 sense = mip.MINIMIZE
             else:
                 raise OMMXPythonMIPAdapterError(
@@ -159,7 +157,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
             ...     decision_variables=x,
             ...     objective=sum(p[i] * x[i] for i in range(6)),
             ...     constraints={0: sum(w[i] * x[i] for i in range(6)) <= 47},
-            ...     sense=Instance.MAXIMIZE,
+            ...     sense=Sense.Maximize,
             ... )
 
             Solve it
@@ -194,7 +192,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
                 ...     decision_variables=[x],
                 ...     objective=x,
                 ...     constraints={0: x >= 4},
-                ...     sense=Instance.MAXIMIZE,
+                ...     sense=Sense.Maximize,
                 ... )
 
                 >>> OMMXPythonMIPAdapter.solve(instance)
@@ -214,7 +212,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
                 ...     decision_variables=[x],
                 ...     objective=x,
                 ...     constraints={},
-                ...     sense=Instance.MAXIMIZE,
+                ...     sense=Sense.Maximize,
                 ... )
 
                 >>> OMMXPythonMIPAdapter.solve(instance)
@@ -235,7 +233,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
                 ...     decision_variables=[x, y],
                 ...     objective=x + y,
                 ...     constraints={0: x + y <= 1},
-                ...     sense=Instance.MAXIMIZE,
+                ...     sense=Sense.Maximize,
                 ... )
 
                 >>> solution = OMMXPythonMIPAdapter.solve(instance)
@@ -315,7 +313,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
             ...     decision_variables=x,
             ...     objective=sum(p[i] * x[i] for i in range(6)),
             ...     constraints={0: sum(w[i] * x[i] for i in range(6)) <= 47},
-            ...     sense=Instance.MAXIMIZE,
+            ...     sense=Sense.Maximize,
             ... )
 
             >>> adapter = OMMXPythonMIPAdapter(instance)
@@ -373,7 +371,7 @@ class OMMXPythonMIPAdapter(SolverAdapter):
             ...     decision_variables=[x1],
             ...     objective=x1,
             ...     constraints={},
-            ...     sense=Instance.MINIMIZE,
+            ...     sense=Sense.Minimize,
             ... )
             >>> adapter = OMMXPythonMIPAdapter(ommx_instance)
             >>> model = adapter.solver_input
@@ -416,19 +414,19 @@ class OMMXPythonMIPAdapter(SolverAdapter):
 
     def _set_decision_variables(self):
         for var in self.instance.used_decision_variables:
-            if var.kind == DecisionVariable.BINARY:
+            if var.kind == Kind.Binary:
                 self.model.add_var(
                     name=str(var.id),
                     var_type=mip.BINARY,
                 )
-            elif var.kind == DecisionVariable.INTEGER:
+            elif var.kind == Kind.Integer:
                 self.model.add_var(
                     name=str(var.id),
                     var_type=mip.INTEGER,
                     lb=var.bound.lower,  # type: ignore
                     ub=var.bound.upper,  # type: ignore
                 )
-            elif var.kind == DecisionVariable.CONTINUOUS:
+            elif var.kind == Kind.Continuous:
                 self.model.add_var(
                     name=str(var.id),
                     var_type=mip.CONTINUOUS,
@@ -477,9 +475,9 @@ class OMMXPythonMIPAdapter(SolverAdapter):
     def _set_constraints(self):
         for cid, constraint in self.instance.constraints.items():
             lin_expr = self._as_lin_expr(constraint.function)
-            if constraint.equality == Constraint.EQUAL_TO_ZERO:
+            if constraint.equality == Equality.EqualToZero:
                 constr_expr = lin_expr == 0
-            elif constraint.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO:
+            elif constraint.equality == Equality.LessThanOrEqualToZero:
                 constr_expr = lin_expr <= 0  # type: ignore
             else:
                 raise OMMXPythonMIPAdapterError(

--- a/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
+++ b/python/ommx-python-mip-adapter/ommx_python_mip_adapter/python_mip_to_ommx.py
@@ -4,7 +4,15 @@ from typing import final
 import mip
 
 from mip.exceptions import ParameterNotAvailable
-from ommx import Instance, DecisionVariable, Constraint, Function, Linear
+from ommx import (
+    Constraint,
+    DecisionVariable,
+    Equality,
+    Function,
+    Instance,
+    Linear,
+    Sense,
+)
 
 from .exception import OMMXPythonMIPAdapterError
 
@@ -83,13 +91,13 @@ class OMMXInstanceBuilder:
             if lin_expr.sense == "=":
                 constraint = Constraint(
                     function=self.as_ommx_function(lin_expr),
-                    equality=Constraint.EQUAL_TO_ZERO,
+                    equality=Equality.EqualToZero,
                     name=name,
                 )
             elif lin_expr.sense == "<":
                 constraint = Constraint(
                     function=self.as_ommx_function(lin_expr),
-                    equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+                    equality=Equality.LessThanOrEqualToZero,
                     name=name,
                 )
             elif lin_expr.sense == ">":
@@ -97,7 +105,7 @@ class OMMXInstanceBuilder:
                 # So multiply the linear expression by -1.
                 constraint = Constraint(
                     function=self.as_ommx_function(-lin_expr),
-                    equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+                    equality=Equality.LessThanOrEqualToZero,
                     name=name,
                 )
             else:
@@ -112,9 +120,9 @@ class OMMXInstanceBuilder:
 
     def sense(self):
         if self.model.sense == mip.MAXIMIZE:
-            return Instance.MAXIMIZE
+            return Sense.Maximize
         elif self.model.sense == mip.MINIMIZE:
-            return Instance.MINIMIZE
+            return Sense.Minimize
         raise OMMXPythonMIPAdapterError(f"Not supported sense: {self.model.sense}")
 
     @final

--- a/python/ommx-python-mip-adapter/tests/test_adapter.py
+++ b/python/ommx-python-mip-adapter/tests/test_adapter.py
@@ -63,7 +63,7 @@ def test_error_nonlinear_objective():
         decision_variables=[x],
         objective=2.3 * x * x,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(AdapterNotApplicableError) as e:
@@ -98,7 +98,7 @@ def test_error_nonlinear_constraint():
         decision_variables=[x],
         objective=0.0,
         constraints={0: 2.3 * x * x == 0},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(AdapterNotApplicableError) as e:

--- a/python/ommx-python-mip-adapter/tests/test_constant_constraint.py
+++ b/python/ommx-python-mip-adapter/tests/test_constant_constraint.py
@@ -1,5 +1,5 @@
 from ommx_python_mip_adapter import OMMXPythonMIPAdapter
-from ommx import Instance, DecisionVariable, Linear
+from ommx import DecisionVariable, Instance, Linear, Sense
 from ommx.adapter import InfeasibleDetected
 import pytest
 
@@ -17,7 +17,7 @@ def test_constant_constraint_feasible():
             Linear(terms={}, constant=1) >= 0,
             1: x <= 1,
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     solution = OMMXPythonMIPAdapter.solve(instance)
 
@@ -40,7 +40,7 @@ def test_constant_constraint_infeasible():
             Linear(terms={}, constant=-1) >= 0,
             1: x <= 1,
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     with pytest.raises(InfeasibleDetected):
         OMMXPythonMIPAdapter.solve(instance)

--- a/python/ommx-python-mip-adapter/tests/test_integration.py
+++ b/python/ommx-python-mip-adapter/tests/test_integration.py
@@ -49,7 +49,7 @@ def test_integration_milp():
         decision_variables=[x1, x2],
         objective=-x1 - x2,
         constraints={0: 3 * x1 - x2 <= 6, 1: -x1 + 3 * x2 <= 6},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     adapter = OMMXPythonMIPAdapter(ommx_instance)
@@ -68,7 +68,7 @@ def test_solution_optimality():
         decision_variables=[x, y],
         objective=x + y,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     solution = OMMXPythonMIPAdapter.solve(ommx_instance)
@@ -81,7 +81,7 @@ def test_solution_optimality_is_not_transported_through_fixed_penalty():
         decision_variables=[x],
         objective=x,
         constraints={7: x == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.to_qubo(uniform_penalty_weight=0.0)
 
@@ -115,7 +115,7 @@ def test_partial_evaluate():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 1},  # one-hot constraint
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     assert instance.used_decision_variables == x
     partial = instance.partial_evaluate({0: 1})
@@ -141,7 +141,7 @@ def test_relax_constraint():
         decision_variables=x,
         objective=x[0] + x[1],
         constraints={0: x[0] + 2 * x[1] <= 1, 1: x[1] + x[2] <= 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert instance.used_decision_variables == x
@@ -182,7 +182,7 @@ def test_integration_timelimit():
         decision_variables=x,
         objective=sum(v[i] * x[i] for i in range(n)),
         constraints={0: constraint},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     adapter = OMMXPythonMIPAdapter(instance)
     model = adapter.solver_input
@@ -204,7 +204,7 @@ def test_infeasible_problem():
         decision_variables=[x],
         objective=x,
         constraints={0: x >= 4},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     adapter = OMMXPythonMIPAdapter(instance)
     model = adapter.solver_input
@@ -221,7 +221,7 @@ def test_unbounded_problem():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     adapter = OMMXPythonMIPAdapter(instance)
     model = adapter.solver_input
@@ -237,7 +237,7 @@ def test_decode_before_optimize():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     adapter = OMMXPythonMIPAdapter(instance)
     model = adapter.solver_input

--- a/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
+++ b/python/ommx-python-mip-adapter/tests/test_model_to_instance.py
@@ -1,6 +1,6 @@
 import mip
 
-from ommx import DecisionVariable, Instance, Constraint
+from ommx import Equality, Kind, Sense
 
 from ommx_python_mip_adapter import model_to_instance
 
@@ -45,25 +45,25 @@ def test_milp():
 
     ommx_instance = model_to_instance(model)
 
-    assert ommx_instance.sense == Instance.MINIMIZE
+    assert ommx_instance.sense == Sense.Minimize
 
     # Check the decision variables
     assert len(ommx_instance.decision_variables) == 3
     decision_variables_x1 = ommx_instance.get_decision_variable_by_id(0)
     assert decision_variables_x1.id == 0
-    assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
+    assert decision_variables_x1.kind == Kind.Continuous
     assert decision_variables_x1.bound.lower == CONTINUOUS_LOWER_BOUND
     assert decision_variables_x1.bound.upper == CONTINUOUS_UPPER_BOUND
     assert decision_variables_x1.name == "1"
     decision_variables_x2 = ommx_instance.get_decision_variable_by_id(1)
     assert decision_variables_x2.id == 1
-    assert decision_variables_x2.kind == DecisionVariable.INTEGER
+    assert decision_variables_x2.kind == Kind.Integer
     assert decision_variables_x2.bound.lower == INTEGER_LOWER_BOUND
     assert decision_variables_x2.bound.upper == INTEGER_UPPER_BOUND
     assert decision_variables_x2.name == "2"
     decision_variables_x3 = ommx_instance.get_decision_variable_by_id(2)
     assert decision_variables_x3.id == 2
-    assert decision_variables_x3.kind == DecisionVariable.BINARY
+    assert decision_variables_x3.kind == Kind.Binary
     assert decision_variables_x3.bound.lower == 0
     assert decision_variables_x3.bound.upper == 1
     assert decision_variables_x3.name == "3"
@@ -81,7 +81,7 @@ def test_milp():
     assert len(ommx_instance.constraints) == 3
 
     constraint1 = ommx_instance.get_constraint_by_id(0)
-    assert constraint1.equality == Constraint.EQUAL_TO_ZERO
+    assert constraint1.equality == Equality.EqualToZero
     assert constraint1.function.degree() == 1
     assert constraint1.function.constant_term == 6
     constraint1_terms = constraint1.function.linear_terms
@@ -90,7 +90,7 @@ def test_milp():
     assert constraint1_terms[1] == -5
 
     constraint2 = ommx_instance.get_constraint_by_id(1)
-    assert constraint2.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    assert constraint2.equality == Equality.LessThanOrEqualToZero
     assert constraint2.function.degree() == 1
     assert constraint2.function.constant_term == -9
     constraint2_terms = constraint2.function.linear_terms
@@ -99,7 +99,7 @@ def test_milp():
     assert constraint2_terms[2] == 8
 
     constraint3 = ommx_instance.get_constraint_by_id(2)
-    assert constraint3.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    assert constraint3.equality == Equality.LessThanOrEqualToZero
     assert constraint3.function.degree() == 1
     assert constraint3.function.constant_term == -12
     constraint3_terms = constraint3.function.linear_terms
@@ -138,19 +138,19 @@ def test_no_objective_model():
 
     ommx_instance = model_to_instance(model)
 
-    assert ommx_instance.sense == Instance.MAXIMIZE
+    assert ommx_instance.sense == Sense.Maximize
 
     # Check the decision variables
     assert len(ommx_instance.decision_variables) == 2
     decision_variables_x1 = ommx_instance.get_decision_variable_by_id(0)
     assert decision_variables_x1.id == 0
-    assert decision_variables_x1.kind == DecisionVariable.CONTINUOUS
+    assert decision_variables_x1.kind == Kind.Continuous
     assert decision_variables_x1.bound.lower == LOWER_BOUND
     assert decision_variables_x1.bound.upper == UPPER_BOUND
     assert decision_variables_x1.name == "1"
     decision_variables_x2 = ommx_instance.get_decision_variable_by_id(1)
     assert decision_variables_x2.id == 1
-    assert decision_variables_x2.kind == DecisionVariable.CONTINUOUS
+    assert decision_variables_x2.kind == Kind.Continuous
     assert decision_variables_x2.bound.lower == LOWER_BOUND
     assert decision_variables_x2.bound.upper == UPPER_BOUND
     assert decision_variables_x2.name == "2"
@@ -163,7 +163,7 @@ def test_no_objective_model():
     assert len(ommx_instance.constraints) == 2
 
     constraint1 = ommx_instance.get_constraint_by_id(0)
-    assert constraint1.equality == Constraint.EQUAL_TO_ZERO
+    assert constraint1.equality == Equality.EqualToZero
     assert constraint1.function.degree() == 1
     assert constraint1.function.constant_term == -5
     constraint1_terms = constraint1.function.linear_terms
@@ -172,7 +172,7 @@ def test_no_objective_model():
     assert constraint1_terms[1] == 2
 
     constraint2 = ommx_instance.get_constraint_by_id(1)
-    assert constraint2.equality == Constraint.EQUAL_TO_ZERO
+    assert constraint2.equality == Equality.EqualToZero
     assert constraint2.function.degree() == 1
     assert constraint2.function.constant_term == -10
     constraint2_terms = constraint2.function.linear_terms

--- a/python/ommx-python-mip-adapter/tests/test_tracing.py
+++ b/python/ommx-python-mip-adapter/tests/test_tracing.py
@@ -1,5 +1,5 @@
 from ommx.tracing import capture_trace
-from ommx import DecisionVariable, Instance
+from ommx import DecisionVariable, Instance, Sense
 
 from ommx_python_mip_adapter import OMMXPythonMIPAdapter
 
@@ -10,7 +10,7 @@ def test_solve_emits_convert_solve_decode_spans():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 2},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:
@@ -29,7 +29,7 @@ def test_manual_flow_emits_convert_and_decode_spans():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
         constraints={0: x[0] + x[1] + x[2] <= 2},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with capture_trace() as result:

--- a/python/ommx-tests/tests/test_atol.py
+++ b/python/ommx-tests/tests/test_atol.py
@@ -1,6 +1,6 @@
 import math
 
-from ommx import Bound, DecisionVariable, Instance, State
+from ommx import Bound, DecisionVariable, Instance, State, Sense
 import ommx
 import pytest
 
@@ -42,7 +42,7 @@ def test_default_atol_constraint_evaluation():
         decision_variables=[x],
         objective=x,  # minimize x
         constraints={1: constraint},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Create a state that violates the constraint by exactly 1e-5
@@ -85,7 +85,7 @@ def test_constraint_boundary_matches_scalar_sample_and_v2_validation():
         decision_variables=[x],
         objective=x,
         constraints={1: x == 0, 2: x <= 0},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     atol = 0.125
     outside = math.nextafter(atol, math.inf)
@@ -128,7 +128,7 @@ def test_bound_membership_matches_inequality_residual_feasibility():
         decision_variables=[x],
         objective=x,
         constraints={1: x <= upper, 2: x >= lower},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     above = upper + atol
@@ -195,7 +195,7 @@ def test_instance_evaluate_with_custom_atol():
         decision_variables=[x1],
         objective=x1,
         constraints={1: constraint},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Create a state where x1 = 1.0 + 1e-6 (violates constraint by 1e-6)

--- a/python/ommx-tests/tests/test_attached_constraint.py
+++ b/python/ommx-tests/tests/test_attached_constraint.py
@@ -5,6 +5,7 @@ import copy
 import pytest
 
 from ommx import (
+    Sense,
     AttachedConstraint,
     Constraint,
     DecisionVariable,
@@ -17,7 +18,7 @@ from ommx import (
 
 def _empty_instance() -> Instance:
     return Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=Function.from_linear(Linear.constant(0.0)),
         decision_variables=[DecisionVariable.binary(0), DecisionVariable.binary(1)],
         constraints={},

--- a/python/ommx-tests/tests/test_attached_decision_variable.py
+++ b/python/ommx-tests/tests/test_attached_decision_variable.py
@@ -5,6 +5,7 @@ import copy
 import pytest
 
 from ommx import (
+    Kind,
     AttachedDecisionVariable,
     DecisionVariable,
     Function,
@@ -18,7 +19,7 @@ from ommx import (
 
 def _empty_instance() -> Instance:
     return Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=Function.from_linear(Linear.constant(0.0)),
         decision_variables=[DecisionVariable.binary(0)],
         constraints={},
@@ -173,7 +174,7 @@ def test_add_rejects_duplicate_id():
 
 def test_add_rejects_substituted_variable_id_as_duplicate():
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=0,
         decision_variables=[
             DecisionVariable.binary(0),
@@ -193,7 +194,8 @@ def test_kind_and_bound_getters_read_through():
     instance = _empty_instance()
     attached = instance.add_decision_variable(_make_variable())
 
-    assert attached.kind == DecisionVariable.INTEGER
+    assert type(attached.kind) is Kind
+    assert attached.kind == Kind.Integer
     bound = attached.bound
     assert bound.lower == 0
     assert bound.upper == 10

--- a/python/ommx-tests/tests/test_attached_decision_variable_arithmetic.py
+++ b/python/ommx-tests/tests/test_attached_decision_variable_arithmetic.py
@@ -29,7 +29,7 @@ from ommx import (
 @pytest.fixture
 def instance() -> Instance:
     return Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=Function.from_linear(Linear.constant(0.0)),
         decision_variables=[
             DecisionVariable.integer(0, lower=0, upper=10, name="x"),

--- a/python/ommx-tests/tests/test_attached_indicator_constraint.py
+++ b/python/ommx-tests/tests/test_attached_indicator_constraint.py
@@ -20,7 +20,7 @@ from ommx import (
 
 def _empty_instance() -> Instance:
     return Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=Function.from_linear(Linear.constant(0.0)),
         decision_variables=[
             DecisionVariable.binary(0),
@@ -318,7 +318,7 @@ def test_add_indicator_rejects_non_binary_indicator_variable():
     post-construction add_indicator_constraint(c) with an integer indicator
     would leave the instance in an invalid state."""
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=Function.from_linear(Linear.constant(0.0)),
         decision_variables=[
             DecisionVariable.binary(0),

--- a/python/ommx-tests/tests/test_attached_structural_constraints.py
+++ b/python/ommx-tests/tests/test_attached_structural_constraints.py
@@ -26,7 +26,7 @@ from ommx import (
 
 def _empty_instance() -> Instance:
     return Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=Function.from_linear(Linear.constant(0.0)),
         decision_variables=[
             DecisionVariable.binary(0),
@@ -316,7 +316,7 @@ def test_sos1_on_parametric_rejects_parameter_id_in_variables():
 
 def _instance_with_mixed_kinds() -> Instance:
     return Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=Function.from_linear(Linear.constant(0.0)),
         decision_variables=[
             DecisionVariable.binary(0),

--- a/python/ommx-tests/tests/test_bench_evaluate.py
+++ b/python/ommx-tests/tests/test_bench_evaluate.py
@@ -8,7 +8,7 @@ algorithmic scaling is measured in ``rust/ommx/benches/evaluate.rs``.
 """
 
 import pytest
-from ommx import DecisionVariable, Instance, Rng
+from ommx import DecisionVariable, Instance, Rng, Sense
 from ommx.dataset import miplib2017
 
 
@@ -21,7 +21,7 @@ def boundary_instance():
         decision_variables=x,
         objective=sum(x),
         constraints={i: x[i] <= 1 for i in range(size)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
 

--- a/python/ommx-tests/tests/test_bench_to_qubo.py
+++ b/python/ommx-tests/tests/test_bench_to_qubo.py
@@ -13,7 +13,7 @@ because the driver consumes mutable instance state.
 import pytest
 import random
 from copy import deepcopy
-from ommx import DecisionVariable, Instance
+from ommx import DecisionVariable, Instance, Sense
 
 
 pytestmark = pytest.mark.benchmark_guardrail
@@ -29,7 +29,7 @@ def small():
         decision_variables=x,
         objective=sum(x),
         constraints={0: x[0] + 2 * x[1] <= 3},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     return instance
 
@@ -45,7 +45,7 @@ def pseudo_boolean_inequality(request):
         decision_variables=x,
         objective=0,
         constraints={0: expr <= threshold},  # type: ignore
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     return instance
 

--- a/python/ommx-tests/tests/test_constraint_context.py
+++ b/python/ommx-tests/tests/test_constraint_context.py
@@ -2,7 +2,7 @@
 Test context-field modification functionality for Constraint
 """
 
-from ommx import DecisionVariable, Constraint
+from ommx import DecisionVariable, Constraint, Equality
 
 
 def test_constraint_set_name():
@@ -172,7 +172,7 @@ def test_constraint_constructor_with_context():
     # Create constraint with all context in constructor
     constraint = Constraint(
         function=function,
-        equality=Constraint.EQUAL_TO_ZERO,
+        equality=Equality.EqualToZero,
         name="constructor_test",
         description="Created via constructor",
         subscripts=[5, 10, 15],
@@ -194,7 +194,7 @@ def test_constraint_constructor_partial_context():
     # Create constraint with only some context fields
     constraint = Constraint(
         function=function,
-        equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+        equality=Equality.LessThanOrEqualToZero,
         description="Only description set",
     )
 

--- a/python/ommx-tests/tests/test_constraint_provenance.py
+++ b/python/ommx-tests/tests/test_constraint_provenance.py
@@ -1,6 +1,8 @@
 """Tests for Constraint.provenance context (issue #819)."""
 
 from ommx import (
+    Sense,
+    Equality,
     Constraint,
     DecisionVariable,
     Instance,
@@ -19,9 +21,9 @@ def test_user_authored_constraint_has_empty_provenance():
         decision_variables=[x],
         objective=x,
         constraints={
-            5: Constraint(function=x, equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO),
+            5: Constraint(function=x, equality=Equality.LessThanOrEqualToZero),
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     c = instance.get_constraint_by_id(5)
     assert c.provenance == []
@@ -34,7 +36,7 @@ def test_convert_one_hot_populates_provenance():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     new_id = instance.convert_one_hot_to_constraint(10)
 
@@ -51,7 +53,7 @@ def test_convert_sos1_populates_provenance_on_every_generated_constraint():
         objective=sum(x),
         constraints={},
         sos1_constraints={7: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     new_ids = instance.convert_sos1_to_constraints(7)
 
@@ -71,7 +73,7 @@ def test_convert_indicator_populates_provenance():
 
     body = Constraint(
         function=x1 + x2 - 5,
-        equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+        equality=Equality.LessThanOrEqualToZero,
     )
     indicator = body.with_indicator(y)
 
@@ -80,7 +82,7 @@ def test_convert_indicator_populates_provenance():
         objective=x1 + x2,
         constraints={},
         indicator_constraints={42: indicator},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     new_ids = instance.convert_indicator_to_constraint(42)
 
@@ -100,7 +102,7 @@ def test_provenance_is_preserved_through_evaluate():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     new_id = instance.convert_one_hot_to_constraint(10)
 
@@ -119,7 +121,7 @@ def test_provenance_is_preserved_through_evaluate_samples():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     new_id = instance.convert_one_hot_to_constraint(10)
 
@@ -147,7 +149,7 @@ def test_provenance_equality_and_hash():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     new_id = instance.convert_one_hot_to_constraint(10)
     p1 = instance.get_constraint_by_id(new_id).provenance[0]

--- a/python/ommx-tests/tests/test_constraints_df.py
+++ b/python/ommx-tests/tests/test_constraints_df.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 from ommx import (
+    Sense,
     Constraint,
     DecisionVariable,
     Equality,
@@ -64,7 +65,7 @@ def _instance_all_kinds() -> Instance:
         },
         one_hot_constraints={30: OneHotConstraint(variables=x)},
         sos1_constraints={40: Sos1Constraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -82,7 +83,7 @@ def _parametric_instance() -> ParametricInstance:
     c = x[0] + x[1] + p * x[2] == 1
     assert isinstance(c, Constraint)
     return ParametricInstance.from_components(
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
         objective=sum(x),
         decision_variables=x,
         constraints={10: c},
@@ -141,7 +142,7 @@ def test_instance_constraints_df_reports_composed_function_type():
         decision_variables=[variable],
         objective=variable,
         constraints={10: constraint},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert instance.constraints_df().loc[10, "type"] == "Expression"
@@ -216,7 +217,7 @@ def test_instance_constraints_df_removed_true_id_sorted(snapshot):
             30: x[1] + x[2] == 1,
             20: x[0] + x[2] == 1,
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     inst.relax_constraint(20, "relax_middle")
     df = inst.constraints_df(kind="regular", removed=True)
@@ -254,7 +255,7 @@ def test_instance_constraints_df_one_hot_removed_true(snapshot):
             5: OneHotConstraint(variables=x[:2]),
             7: OneHotConstraint(variables=x[1:]),
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     instance.convert_one_hot_to_constraint(7)
     df = instance.constraints_df(kind="one_hot", removed=True)

--- a/python/ommx-tests/tests/test_dataframe_include.py
+++ b/python/ommx-tests/tests/test_dataframe_include.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 from ommx import (
+    Sense,
     Constraint,
     DecisionVariable,
     Instance,
@@ -40,7 +41,7 @@ def _build_instance() -> Instance:
         decision_variables=x,
         objective=sum(x),
         constraints={10: c},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -85,7 +86,7 @@ def test_decision_variables_df_state_role():
         decision_variables=list(x.values()),
         objective=x[0],
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.substitute({2: x[0] + 1})
     instance = instance.partial_evaluate({1: 2.0})

--- a/python/ommx-tests/tests/test_dataframe_sidecars.py
+++ b/python/ommx-tests/tests/test_dataframe_sidecars.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 from ommx import (
+    Sense,
     Constraint,
     DecisionVariable,
     Equality,
@@ -51,7 +52,7 @@ def _instance_with_context() -> Instance:
         decision_variables=x,
         objective=sum(x),
         constraints={10: c},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -130,7 +131,7 @@ def _special_instance() -> Instance:
         },
         one_hot_constraints={6: OneHotConstraint(variables=x[1:])},
         sos1_constraints={7: Sos1Constraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -154,7 +155,7 @@ def test_provenance_after_one_hot_conversion(snapshot):
         objective=sum(x),
         constraints={},
         one_hot_constraints={7: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.convert_one_hot_to_constraint(7)
     assert _df_snap(instance.constraint_provenance_df()) == snapshot
@@ -182,7 +183,7 @@ def test_removed_reasons_df_with_parameters_after_one_hot_conversion(snapshot):
         objective=sum(x),
         constraints={},
         one_hot_constraints={7: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.convert_one_hot_to_constraint(7)
     assert _df_snap(instance.constraint_removed_reasons_df(kind="one_hot")) == snapshot
@@ -229,7 +230,7 @@ def _instance_with_relaxed_constraint() -> Instance:
             10: (x[0] + x[1] == 1).set_name("balance").set_parameters({"k": "v"}),
             11: (x[1] + x[2] <= 1).set_name("cap"),
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     instance.relax_constraint(10, "test_reason")
     return instance

--- a/python/ommx-tests/tests/test_decision_variable_usage.py
+++ b/python/ommx-tests/tests/test_decision_variable_usage.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 
-from ommx import DecisionVariable, DecisionVariableRole, Instance
+from ommx import DecisionVariable, DecisionVariableRole, Instance, Sense
 
 
 def test_decision_variable_roles_basic():
@@ -15,7 +15,7 @@ def test_decision_variable_roles_basic():
         decision_variables=x,
         objective=x[0] + x[1],
         constraints={0: x[1] + x[2] == 1},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     assert instance.used_decision_variables == x
@@ -35,7 +35,7 @@ def test_decision_variable_role_partitions():
         decision_variables=list(x.values()),
         objective=x[0],
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.substitute({2: x[0] + 1})
     instance = instance.partial_evaluate({1: 2.0})
@@ -58,7 +58,7 @@ def _dependent_instance_y_eq_2x():
         decision_variables=list(x.values()),
         objective=x[1],
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.substitute({10: x[1] + x[1]})
     return instance
@@ -115,7 +115,7 @@ def test_partial_evaluate_normalizes_dependency_chain():
         decision_variables=list(x.values()),
         objective=x[1],
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.substitute({10: x[1] + x[1], 11: x[10] + 1})
 
@@ -152,7 +152,7 @@ def test_instance_populate_state():
         decision_variables=list(x.values()),
         objective=x[1] + x[2],
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.substitute(
         {
@@ -194,7 +194,7 @@ def test_instance_canonicalizes_discrete_solver_values():
         decision_variables=list(x.values()),
         objective=x[0],
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     state = {
         0: 1.0625,

--- a/python/ommx-tests/tests/test_enum_hash.py
+++ b/python/ommx-tests/tests/test_enum_hash.py
@@ -1,8 +1,11 @@
 import pytest
 
 from ommx import (
+    Constraint,
+    DecisionVariable,
     DecisionVariableRole,
     Equality,
+    Instance,
     Kind,
     ProvenanceKind,
     Sense,
@@ -16,8 +19,14 @@ from ommx import (
         (SpecialConstraintKind.Indicator, 1),
         (DecisionVariableRole.Used, 1),
         (Sense.Minimize, 1),
+        (Sense.Maximize, 2),
         (Equality.EqualToZero, 1),
+        (Equality.LessThanOrEqualToZero, 2),
         (Kind.Binary, 1),
+        (Kind.Integer, 2),
+        (Kind.Continuous, 3),
+        (Kind.SemiInteger, 4),
+        (Kind.SemiContinuous, 5),
         (ProvenanceKind.IndicatorConstraint, 1),
     ],
 )
@@ -29,3 +38,54 @@ def test_eq_int_enums_follow_python_hash_contract(member: object, value: int) ->
     assert hash(member) == hash(value)
     assert enum_keyed[value] == "enum"
     assert int_keyed[member] == "int"
+
+
+@pytest.mark.parametrize(
+    ("alias", "member"),
+    [
+        (DecisionVariable.BINARY, Kind.Binary),
+        (DecisionVariable.INTEGER, Kind.Integer),
+        (DecisionVariable.CONTINUOUS, Kind.Continuous),
+        (DecisionVariable.SEMI_INTEGER, Kind.SemiInteger),
+        (DecisionVariable.SEMI_CONTINUOUS, Kind.SemiContinuous),
+        (Constraint.EQUAL_TO_ZERO, Equality.EqualToZero),
+        (
+            Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+            Equality.LessThanOrEqualToZero,
+        ),
+        (Instance.MINIMIZE, Sense.Minimize),
+        (Instance.MAXIMIZE, Sense.Maximize),
+    ],
+)
+def test_compatibility_aliases_are_typed_enum_members(
+    alias: object, member: object
+) -> None:
+    assert type(alias) is type(member)
+    assert alias == member
+
+
+def test_public_model_properties_return_typed_enum_members() -> None:
+    variable = DecisionVariable.binary(0)
+    constraint = variable <= 1
+    instance = Instance.from_components(
+        decision_variables=[variable],
+        objective=variable,
+        constraints={0: constraint},
+        sense=Sense.Minimize,
+    )
+    attached_variable = instance.decision_variables[0]
+    attached_constraint = instance.constraints[0]
+    solution = instance.evaluate({0: 0})
+    sample_set = instance.evaluate_samples([{0: 0}])
+
+    assert type(variable.kind) is Kind
+    assert type(constraint.equality) is Equality
+    assert type(instance.sense) is Sense
+    assert type(attached_variable.kind) is Kind
+    assert type(attached_constraint.equality) is Equality
+    assert type(solution.sense) is Sense
+    assert type(solution.decision_variables[0].kind) is Kind
+    assert type(solution.constraints[0].equality) is Equality
+    assert type(sample_set.sense) is Sense
+    assert type(sample_set.decision_variables[0].kind) is Kind
+    assert type(sample_set.constraints[0].equality) is Equality

--- a/python/ommx-tests/tests/test_evaluation_error_translation.py
+++ b/python/ommx-tests/tests/test_evaluation_error_translation.py
@@ -11,7 +11,7 @@ def _attached_constraint_with_missing_state():
         decision_variables=[variable],
         objective=0,
         constraints={0: variable == 0},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
     return instance.constraints[0].evaluate({})
 
@@ -22,7 +22,7 @@ def _instance_with_required_variable() -> ommx.Instance:
         decision_variables=[variable],
         objective=variable,
         constraints={},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
 
 
@@ -33,7 +33,7 @@ def _instance_with_one_hot_constraint() -> ommx.Instance:
         objective=0,
         constraints={},
         one_hot_constraints={0: ommx.OneHotConstraint(variables=variables)},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
 
 
@@ -44,7 +44,7 @@ def _dependent_instance_y_eq_scaled_x(coefficient: float) -> ommx.Instance:
         decision_variables=[x, y],
         objective=y,
         constraints={},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
     instance.substitute({10: coefficient * x})
     return instance
@@ -60,7 +60,7 @@ def _instance_with_sos1_derived_bound_conflict() -> ommx.Instance:
         objective=0,
         constraints={},
         sos1_constraints={0: ommx.Sos1Constraint(variables=variables)},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
 
 
@@ -78,7 +78,7 @@ def _instance_with_indicator_constraint() -> ommx.Instance:
                 equality=ommx.Equality.LessThanOrEqualToZero,
             )
         },
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
 
 
@@ -149,7 +149,7 @@ def test_non_binary_value_without_indicator_semantics_remains_infeasible() -> No
         decision_variables=[variable],
         objective=variable,
         constraints={},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
 
     assert not instance.evaluate({1: 0.5}).feasible
@@ -175,7 +175,7 @@ def test_constraint_restore_overflow_falls_back_to_runtime_error() -> None:
         decision_variables=[variable],
         objective=0,
         constraints={0: sys.float_info.max * variable <= 0},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
     instance.relax_constraint(0, "test")
     instance = instance.partial_evaluate({1: sys.float_info.max})
@@ -201,7 +201,7 @@ def test_indicator_constraint_restore_overflow_falls_back_to_runtime_error() -> 
                 equality=ommx.Equality.LessThanOrEqualToZero,
             )
         },
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
     instance.relax_indicator_constraint(0, "test")
     instance = instance.partial_evaluate({1: sys.float_info.max})

--- a/python/ommx-tests/tests/test_experiment.py
+++ b/python/ommx-tests/tests/test_experiment.py
@@ -16,7 +16,7 @@ from ommx.experiment import (
     list_experiments,
 )
 from ommx.tracing import TraceResult, render_text_tree
-from ommx import DecisionVariable, Instance, SampleSet, Solution
+from ommx import DecisionVariable, Instance, SampleSet, Solution, Sense
 
 from conftest import get_test_exporter
 
@@ -1011,7 +1011,7 @@ def test_log_sample_records_finished_sample_set_without_feasible_samples():
         decision_variables=[x],
         objective=x,
         constraints={0: x == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     experiment = Experiment.with_temp_local_registry()
 

--- a/python/ommx-tests/tests/test_function.py
+++ b/python/ommx-tests/tests/test_function.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from ommx import (
+    Sense,
     Bound,
     DecisionVariable,
     Function,
@@ -288,7 +289,7 @@ def test_function_reverse_associative_operators_preserve_left_operand_order():
 
 def test_compact_types_reverse_magic_methods_preserve_function_lhs_order():
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=0,
         decision_variables=[DecisionVariable.continuous(2)],
         constraints={},

--- a/python/ommx-tests/tests/test_function_display.py
+++ b/python/ommx-tests/tests/test_function_display.py
@@ -1,6 +1,13 @@
 import pytest
 
-from ommx import DecisionVariable, Instance, Linear, Parameter, ParametricInstance
+from ommx import (
+    DecisionVariable,
+    Instance,
+    Linear,
+    Parameter,
+    ParametricInstance,
+    Sense,
+)
 from ommx.display import FunctionDisplay
 
 
@@ -24,7 +31,7 @@ def test_format_function_accepts_to_function_and_returns_full_text(snapshot):
         DecisionVariable.binary(1, name="x", subscripts=[1]),
     ]
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=0,
         decision_variables=x,
         constraints={},
@@ -36,7 +43,7 @@ def test_format_function_accepts_to_function_and_returns_full_text(snapshot):
 def test_display_function_returns_bounded_function_display_by_default(snapshot):
     x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(101)]
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=0,
         decision_variables=x,
         constraints={},
@@ -58,7 +65,7 @@ def test_function_display_html_escapes_labels_and_reports_truncation(snapshot):
         DecisionVariable.binary(1, name="y"),
     ]
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=0,
         decision_variables=x,
         constraints={},
@@ -79,7 +86,7 @@ def test_display_function_boundary_budgets(snapshot):
         DecisionVariable.binary(1, name="beta"),
     ]
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=0,
         decision_variables=x,
         constraints={},
@@ -105,7 +112,7 @@ def test_parametric_instance_format_function_uses_parameter_labels(snapshot):
     x = DecisionVariable.binary(0, name="x")
     p = Parameter(100, name="p", parameters={"scenario": "base"})
     instance = ParametricInstance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=x + p,
         decision_variables=[x],
         constraints={},
@@ -118,7 +125,7 @@ def test_parametric_instance_format_function_uses_parameter_labels(snapshot):
 def test_unknown_ids_error_even_beyond_preview_budget():
     x = DecisionVariable.binary(0, name="x")
     instance = Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=0,
         decision_variables=[x],
         constraints={},

--- a/python/ommx-tests/tests/test_indicator_constraint.py
+++ b/python/ommx-tests/tests/test_indicator_constraint.py
@@ -3,6 +3,7 @@
 import pandas as pd
 import pytest
 from ommx import (
+    Sense,
     Instance,
     DecisionVariable,
     IndicatorConstraint,
@@ -26,7 +27,7 @@ def _instance(ic: IndicatorConstraint, x_lower: float = 0.0, x_upper: float = 5.
         objective=x,
         constraints={},
         indicator_constraints={7: ic},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
 
@@ -122,7 +123,7 @@ def test_infinite_bound_is_rejected_without_mutation():
         objective=x,
         constraints={},
         indicator_constraints={7: ic},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(RuntimeError, match="non-finite"):
@@ -154,7 +155,7 @@ def test_convert_all_is_atomic_on_error():
         objective=x_bounded,
         constraints={},
         indicator_constraints={1: ic_ok, 2: ic_bad},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(RuntimeError, match="non-finite"):

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -6,6 +6,7 @@ from typing import Any
 import ommx
 import pytest
 from ommx import (
+    Kind,
     AttachedDecisionVariable,
     Bound,
     DecisionVariable,
@@ -53,7 +54,7 @@ def test_incremental_modeling_workflow():
     instance.objective = x + y
     constraint = instance.add_constraint(x - y == 1, "c1")
 
-    assert instance.sense == Instance.MAXIMIZE
+    assert instance.sense == Sense.Maximize
     assert (x.id, x.name) == (0, "x")
     assert (y.id, y.name) == (1, "y")
     assert instance.objective.almost_equal(Function(x + y))
@@ -64,7 +65,7 @@ def test_incremental_modeling_workflow():
 def test_minimize_creates_empty_minimization_instance():
     instance = Instance.minimize()
 
-    assert instance.sense == Instance.MINIMIZE
+    assert instance.sense == Sense.Minimize
     assert instance.decision_variables == []
     assert instance.constraints == {}
     assert instance.objective.almost_equal(Function(0))
@@ -125,34 +126,43 @@ def test_new_decision_variable_rejects_non_string_mapping_atomically():
     assert instance.decision_variables == []
 
 
+def test_decision_variable_kind_uses_kind_enum() -> None:
+    variable = DecisionVariable(0, Kind.Binary, Bound(0, 1))
+
+    assert type(variable.kind) is Kind
+    assert variable.kind == Kind.Binary
+    assert type(DecisionVariable.BINARY) is Kind
+    assert DecisionVariable.BINARY == Kind.Binary
+
+
 def test_new_non_binary_variables_assign_ids_and_preserve_domains_and_labels():
     instance = Instance.minimize()
     cases = [
         (
             instance.new_integer,
             DecisionVariable.integer,
-            DecisionVariable.INTEGER,
+            Kind.Integer,
             0.2,
             3.8,
         ),
         (
             instance.new_continuous,
             DecisionVariable.continuous,
-            DecisionVariable.CONTINUOUS,
+            Kind.Continuous,
             0.2,
             3.8,
         ),
         (
             instance.new_semi_integer,
             DecisionVariable.semi_integer,
-            DecisionVariable.SEMI_INTEGER,
+            Kind.SemiInteger,
             1.2,
             4.8,
         ),
         (
             instance.new_semi_continuous,
             DecisionVariable.semi_continuous,
-            DecisionVariable.SEMI_CONTINUOUS,
+            Kind.SemiContinuous,
             1.2,
             4.8,
         ),
@@ -173,7 +183,9 @@ def test_new_non_binary_variables_assign_ids_and_preserve_domains_and_labels():
 
         assert isinstance(attached, AttachedDecisionVariable)
         assert attached.id == expected_id
+        assert type(attached.kind) is Kind
         assert attached.kind == kind
+        assert type(expected.kind) is Kind
         assert attached.detach().equals_to(expected)
         assert attached.name == "x"
         assert attached.subscripts == [expected_id]
@@ -287,7 +299,7 @@ def test_binary_bound_normalization_uses_bound_residual_membership():
         source = Bound(0.0, 1.0 - atol)
 
         assert not source.contains(1.0, atol)
-        variable = DecisionVariable(0, DecisionVariable.BINARY, source)
+        variable = DecisionVariable(0, Kind.Binary, source)
         assert (variable.bound.lower, variable.bound.upper) == (0.0, 0.0)
     finally:
         ommx.set_default_atol(initial_atol)
@@ -321,7 +333,7 @@ def test_new_decision_variable_raises_value_error_when_automatic_id_overflows(
         decision_variables=[DecisionVariable.binary(max_id)],
         objective=0,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(
@@ -382,7 +394,7 @@ def test_convert_inequality_to_equality_with_integer_slack_limit():
         decision_variables=x,
         objective=sum(x),
         constraints={0: math.pi * x[0] + math.e * x[1] >= 1},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     with pytest.raises(ExactIntegerSlackError) as e:
         instance.convert_inequality_to_equality_with_integer_slack(0, 32)
@@ -400,7 +412,7 @@ def test_convert_inequality_to_equality_with_integer_slack_continuous():
         decision_variables=x,
         objective=sum(x),
         constraints={0: x[0] + x[1] >= 7.89},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     with pytest.raises(RuntimeError) as e:
         instance.convert_inequality_to_equality_with_integer_slack(0, 32)
@@ -422,7 +434,7 @@ def test_convert_inequality_to_equality_with_integer_slack_infeasible():
             # Never satisfied since both x0 and x1 are non-negative
             0: (x[0] + 2 * x[1] <= -1),
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     with pytest.raises(InfeasibleDetected) as e:
         instance.convert_inequality_to_equality_with_integer_slack(0, 32)
@@ -441,7 +453,7 @@ def test_convert_inequality_to_equality_with_integer_slack_trivial():
         decision_variables=x,
         objective=sum(x),
         constraints={0: x[0] + 2 * x[1] >= 0},  # Trivially satisfied
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     instance.convert_inequality_to_equality_with_integer_slack(
         constraint_id=0, max_integer_range=32
@@ -456,7 +468,7 @@ def test_convert_inequality_to_equality_with_integer_slack_uses_atol():
         decision_variables=[x],
         objective=0,
         constraints={0: x + 0.25 <= 0},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     instance.convert_inequality_to_equality_with_integer_slack(
@@ -481,7 +493,7 @@ def test_add_integer_slack_to_inequality_infeasible():
             # Never satisfied since both x0 and x1 are non-negative
             0: (x[0] + 2 * x[1] <= -1),
         },
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     with pytest.raises(InfeasibleDetected) as e:
         instance.add_integer_slack_to_inequality(0, 4)
@@ -500,7 +512,7 @@ def test_add_integer_slack_to_inequality_trivial():
         decision_variables=x,
         objective=sum(x),
         constraints={0: x[0] + 2 * x[1] >= 0},  # Trivially satisfied
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     b = instance.add_integer_slack_to_inequality(0, 4)
     assert b is None
@@ -516,7 +528,7 @@ def test_add_integer_slack_to_inequality_continuous():
         decision_variables=x,
         objective=sum(x),
         constraints={0: x[0] + x[1] >= 7.89},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     with pytest.raises(RuntimeError) as e:
         instance.add_integer_slack_to_inequality(0, 4)
@@ -532,7 +544,7 @@ def test_to_qubo_penalty_weight():
         decision_variables=x,
         objective=x[0],
         constraints={123: x[0] == 0, 456: x[1] == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     # QUBO = x0 + 1 * (x0)^2 + 2 * (x1 - 1)^2 = 2*x0 - 2*x1 + 1
     qubo, offset = instance.to_qubo(penalty_weights={123: 1.0, 456: 2.0})
@@ -628,7 +640,7 @@ def test_qubo_hubo_continuous_partial_failure(method_name: str) -> None:
         decision_variables=x,
         objective=sum(x),
         constraints={0: x[0] + x[1] >= 7.89},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     with pytest.raises(
         RuntimeError,
@@ -646,7 +658,7 @@ def test_hubo_3rd_degree():
         decision_variables=x,
         objective=(x[0] + x[0] * x[0] + x[0] * x[1] * x[2]),
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     hubo, offset = instance.to_hubo()
     assert hubo == {(0,): 2.0, (0, 1, 2): 1.0}
@@ -659,7 +671,7 @@ def test_to_hubo_penalty_weight():
         decision_variables=x,
         objective=x[0],
         constraints={123: x[0] == 0, 456: x[1] == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     # QUBO = x0 + 1 * (x0)^2 + 2 * (x1 - 1)^2 = 2*x0 - 2*x1 + 1
     hubo, offset = instance.to_hubo(penalty_weights={123: 1.0, 456: 2.0})
@@ -673,7 +685,7 @@ def test_evaluate_irrelevant_binary_variable():
         decision_variables=x,
         objective=x[0],
         constraints={0: x[1] == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     solution = instance.evaluate({0: 1, 1: 0})
     assert solution.extract_decision_variables("x") == {
@@ -699,7 +711,7 @@ def test_evaluate_irrelevant_integer_variables():
         decision_variables=x,
         objective=x[0],
         constraints={0: x[1] == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     solution = instance.evaluate({0: 1, 1: 0})
     assert solution.extract_decision_variables("x") == {
@@ -717,7 +729,7 @@ def test_stats_empty_instance():
         decision_variables=[],
         objective=Function(0),
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     stats = instance.stats()
 
@@ -746,7 +758,7 @@ def test_stats_with_variables():
         decision_variables=x,
         objective=x[0] + x[1],  # Use only binary variables in objective
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     stats = instance.stats()
 
@@ -769,7 +781,7 @@ def test_stats_with_constraints():
         decision_variables=x,
         objective=x[0],
         constraints={0: x[0] + x[1] == 1, 1: x[1] + x[2] == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Remove one constraint
@@ -794,7 +806,7 @@ def test_multiple_log_encodes():
         decision_variables=x,
         objective=x[0],
         constraints={0: x[0] + x[1] <= 5, 1: x[1] + x[2] <= 5},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     instance.log_encode()
@@ -823,7 +835,7 @@ def test_encode_methods_reject_explicit_non_integer_variables():
             decision_variables=[x],
             objective=x,
             constraints={},
-            sense=Instance.MAXIMIZE,
+            sense=Sense.Maximize,
         )
         with pytest.raises(RuntimeError, match="must be integer") as error:
             log_instance.log_encode({0})
@@ -834,7 +846,7 @@ def test_encode_methods_reject_explicit_non_integer_variables():
             decision_variables=[x],
             objective=x,
             constraints={},
-            sense=Instance.MAXIMIZE,
+            sense=Sense.Maximize,
         )
         with pytest.raises(RuntimeError, match="must be integer"):
             unary_instance.unary_encode({0})
@@ -848,7 +860,7 @@ def test_encode_methods_reject_fixed_variables():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     ).partial_evaluate({0: 1})
     with pytest.raises(RuntimeError, match="fixed decision variable") as error:
         log_instance.log_encode({0})
@@ -861,7 +873,7 @@ def test_encode_methods_reject_fixed_variables():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     ).partial_evaluate({0: 1})
     with pytest.raises(RuntimeError, match="fixed decision variable"):
         unary_instance.unary_encode({0})
@@ -879,7 +891,7 @@ def test_log_encode_auto_detect_is_transactional_on_failure():
         decision_variables=x,
         objective=sum(x),
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     before = instance.decision_variables
 
@@ -901,7 +913,7 @@ def test_unary_encode():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     instance.unary_encode({0})
@@ -935,7 +947,7 @@ def test_unary_encode_respects_max_range_on_auto_detect():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     with pytest.raises(RuntimeError, match=r"max_range\(5\)"):
@@ -969,7 +981,7 @@ def test_unary_encode_auto_detect_is_transactional_on_failure():
         decision_variables=x,
         objective=sum(x),
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     before = instance.decision_variables
 
@@ -986,13 +998,13 @@ def test_encoding_methods_validate_atol():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     unary_instance = Instance.from_components(
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     with pytest.raises(ValueError, match="ATol must be positive"):
@@ -1011,7 +1023,7 @@ def test_multiple_unary_encodes():
         decision_variables=x,
         objective=x[0],
         constraints={0: x[0] + x[1] <= 5, 1: x[1] + x[2] <= 5},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     instance.unary_encode()
@@ -1034,7 +1046,7 @@ def test_substitute_unary_encode():
         decision_variables=[x, *b],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     instance.substitute({0: b[0] + b[1] + b[2] + b[3]})  # x = sum(b_i)
@@ -1065,7 +1077,7 @@ def test_substitute_one_hot_encode():
         decision_variables=[x, *b],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     instance.substitute({0: b[1] + 2 * b[2] + 3 * b[3]})  # x = sum(v * b_v)
@@ -1090,7 +1102,7 @@ def test_substitute_recursive_assignment_raises():
         decision_variables=x,
         objective=x[0] + x[1],
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     objective_before = Function(instance.objective)
     decision_variable_ids_before = {v.id for v in instance.decision_variables}
@@ -1112,7 +1124,7 @@ def test_parametric_instance_from_components_rejects_parameter_id_collision():
             parameters=[p],
             objective=x,
             constraints={},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
 
 
@@ -1126,7 +1138,7 @@ def test_parametric_instance_substitute_with_parameterized_rhs():
         parameters=[p],
         objective=x + p * y,
         constraints={0: x <= p + 1},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     parametric.substitute({0: p * y + 1})
@@ -1146,7 +1158,7 @@ def test_parametric_instance_substitute_recursive_assignment_raises():
         parameters=[p],
         objective=x[0] + p * x[1],
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     objective_before = Function(parametric.objective)
 
@@ -1164,7 +1176,7 @@ def test_parametric_instance_substitute_parameter_id_raises():
         parameters=[p],
         objective=x + p,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     objective_before = Function(parametric.objective)
 
@@ -1181,7 +1193,7 @@ def test_parametric_instance_substitute_undefined_rhs_id_raises():
         parameters=[],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     objective_before = Function(parametric.objective)
 

--- a/python/ommx-tests/tests/test_instance_description.py
+++ b/python/ommx-tests/tests/test_instance_description.py
@@ -3,6 +3,7 @@
 import pytest
 
 from ommx import (
+    Sense,
     DecisionVariable,
     Instance,
     OneHotConstraint,
@@ -19,7 +20,7 @@ def test_instance_description_none():
     """Test that instance description is None when not set."""
     x = DecisionVariable.binary(0)
     instance = Instance.from_components(
-        decision_variables=[x], objective=x, constraints={}, sense=Instance.MINIMIZE
+        decision_variables=[x], objective=x, constraints={}, sense=Sense.Minimize
     )
 
     assert instance.description is None
@@ -41,7 +42,7 @@ def test_instance_description_with_from_components():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         description=desc,
     )
 
@@ -119,7 +120,7 @@ def test_instance_annotations_do_not_serialize_structural_constraints():
         objective=x[0],
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     instance.title = "Structural Instance"
@@ -217,7 +218,7 @@ def test_solution_annotations_preserve_structural_constraint_evaluations():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     solution = instance.evaluate({1: 0.0, 2: 1.0, 3: 0.0})
 
@@ -253,7 +254,7 @@ def test_parametric_instance_annotations_round_trip_through_bytes():
         parameters=[p],
         objective=x + p,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.title = "Parametric Proto Title"
     instance.add_user_annotation("source", "bytes")
@@ -275,7 +276,7 @@ def test_parametric_instance_replace_annotations_replaces_existing_metadata():
         parameters=[p],
         objective=x + p,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.title = "Old Parametric Title"
     instance.add_user_annotation("source", "old")
@@ -327,7 +328,7 @@ def test_sample_set_annotations_preserve_structural_constraint_samples():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     sample_set = instance.evaluate_samples(
         {

--- a/python/ommx-tests/tests/test_instance_error_translation.py
+++ b/python/ommx-tests/tests/test_instance_error_translation.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ommx import (
+    Sense,
     DecisionVariable,
     Instance,
     NamedFunction,
@@ -17,7 +18,7 @@ def test_instance_from_components_rejects_duplicate_decision_variable_ids():
             decision_variables=variables,
             objective=0,
             constraints={},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
 
 
@@ -30,7 +31,7 @@ def test_parametric_from_components_rejects_duplicate_decision_variable_ids():
             parameters=[],
             objective=0,
             constraints={},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
 
 
@@ -48,7 +49,7 @@ def test_parametric_from_components_rejects_duplicate_named_function_ids():
             parameters=[parameter],
             objective=variable + parameter,
             constraints={},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
             named_functions=named_functions,
         )
 
@@ -59,7 +60,7 @@ def test_to_qubo_rejects_missing_penalty_weight():
         decision_variables=x,
         objective=x[0],
         constraints={123: x[0] == 0, 456: x[1] == 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(

--- a/python/ommx-tests/tests/test_mps.py
+++ b/python/ommx-tests/tests/test_mps.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import ommx.mps
-from ommx import Instance, DecisionVariable, Constraint, Function
+from ommx import Instance, DecisionVariable, Function, Kind, Equality, Sense
 
 
 test_dir = Path(__file__).parent
@@ -10,7 +10,7 @@ test_dir = Path(__file__).parent
 def test_example_mps():
     instance = ommx.mps.load_file(str(test_dir / "objsense_max.mps.gz"))
 
-    assert instance.sense == Instance.MAXIMIZE  # OBJSENSE field is specified
+    assert instance.sense == Sense.Maximize  # OBJSENSE field is specified
     dvars = instance.decision_variables
     dvars.sort(key=lambda x: x.name)
     constraints = sorted(instance.constraints.values(), key=lambda c: c.name or "")
@@ -19,17 +19,17 @@ def test_example_mps():
     assert len(constraints) == 3
     x, y, z = dvars
     assert x.name == "x"
-    assert x.kind == DecisionVariable.CONTINUOUS
+    assert x.kind == Kind.Continuous
     assert x.bound.lower == 0
     assert x.bound.upper == 3
     assert x.subscripts == []
     assert y.name == "y"
-    assert y.kind == DecisionVariable.CONTINUOUS
+    assert y.kind == Kind.Continuous
     assert y.bound.lower == 0
     assert y.bound.upper == 5
     assert y.subscripts == []
     assert z.name == "z"
-    assert z.kind == DecisionVariable.CONTINUOUS
+    assert z.kind == Kind.Continuous
     assert z.bound.lower == 0
     assert z.bound.upper == 10
     assert z.subscripts == []
@@ -37,17 +37,17 @@ def test_example_mps():
     constr1 = constraints[0]
     assert constr1.name == "constr1"
     assert constr1.function.almost_equal(Function(x + y - 4.0))
-    assert constr1.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    assert constr1.equality == Equality.LessThanOrEqualToZero
     # constr2
     constr2 = constraints[1]
     assert constr2.name == "constr2"
     assert constr2.function.almost_equal(Function(x + 2 * y + z - 7))
-    assert constr2.equality == Constraint.EQUAL_TO_ZERO
+    assert constr2.equality == Equality.EqualToZero
     # constr3
     constr3 = constraints[2]
     assert constr3.name == "constr3"
     assert constr3.function.almost_equal(Function(-z - 2 * x + 10))
-    assert constr3.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    assert constr3.equality == Equality.LessThanOrEqualToZero
 
 
 def test_output():
@@ -75,7 +75,7 @@ def test_output():
         decision_variables=x,
         objective=objective,
         constraints=constraints,
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     instance.save_mps(test_out_file)

--- a/python/ommx-tests/tests/test_named_function.py
+++ b/python/ommx-tests/tests/test_named_function.py
@@ -3,6 +3,7 @@
 import sys
 
 from ommx import (
+    Sense,
     DecisionVariable,
     Function,
     Instance,
@@ -40,7 +41,7 @@ def _make_instance_with_named_functions():
         decision_variables=x,
         objective=objective,
         constraints={0: Function(sum(x)) <= 2},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
         named_functions=[nf0, nf1],
     )
     return instance, x
@@ -239,7 +240,7 @@ class TestInstanceNamedFunctions:
             decision_variables=x,
             objective=x[0] + x[1],
             constraints={},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
         assert instance.named_functions == []
 
@@ -253,7 +254,7 @@ class TestInstanceNamedFunctions:
                 decision_variables=[x],
                 objective=x,
                 constraints={},
-                sense=Instance.MINIMIZE,
+                sense=Sense.Minimize,
                 named_functions=[first, second],
             )
 
@@ -266,7 +267,7 @@ class TestInstanceNamedFunctions:
                 decision_variables=[x],
                 objective=x,
                 constraints={},
-                sense=Instance.MINIMIZE,
+                sense=Sense.Minimize,
                 named_functions=[rogue],
             )
 
@@ -280,7 +281,7 @@ class TestInstanceNamedFunctions:
             parameters=[p],
             objective=x + p,
             constraints={},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
             named_functions=[nf],
         )
 
@@ -297,7 +298,7 @@ class TestInstanceNamedFunctions:
                 parameters=[p],
                 objective=x + p,
                 constraints={},
-                sense=Instance.MINIMIZE,
+                sense=Sense.Minimize,
                 named_functions=[rogue],
             )
 

--- a/python/ommx-tests/tests/test_one_hot_sos1_constraints.py
+++ b/python/ommx-tests/tests/test_one_hot_sos1_constraints.py
@@ -5,6 +5,7 @@ from typing import cast, get_args
 import pandas as pd
 import pytest
 from ommx import (
+    Sense,
     AttachedDecisionVariable,
     DecisionVariable,
     Instance,
@@ -40,7 +41,7 @@ def test_one_hot_constraint_from_components():
         objective=objective,
         constraints={},
         one_hot_constraints={10: oh},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert len(instance.one_hot_constraints) == 1
@@ -84,7 +85,7 @@ def test_sos1_constraint_from_components():
         objective=objective,
         constraints={},
         sos1_constraints={20: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert len(instance.sos1_constraints) == 1
@@ -124,7 +125,7 @@ def test_one_hot_variable_not_defined():
             objective=objective,
             constraints={},
             one_hot_constraints={10: oh},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
 
 
@@ -143,7 +144,7 @@ def test_sos1_variable_not_defined():
             objective=objective,
             constraints={},
             sos1_constraints={20: sos1},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
 
 
@@ -165,7 +166,7 @@ def test_one_hot_variable_not_binary():
             objective=objective,
             constraints={},
             one_hot_constraints={10: oh},
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
 
 
@@ -179,7 +180,7 @@ def test_one_hot_uses_enclosing_instance_variable_kind():
         objective=x,
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=[reference])},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert instance.one_hot_constraints[10].variables == [1]
@@ -195,7 +196,7 @@ def test_serialize_not_yet_supported():
         objective=objective,
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     with pytest.raises(Exception, match="to_v2_bytes"):
@@ -216,7 +217,7 @@ def test_both_one_hot_and_sos1():
         constraints={},
         one_hot_constraints={10: oh},
         sos1_constraints={20: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert len(instance.one_hot_constraints) == 1
@@ -237,7 +238,7 @@ def test_evaluate_with_one_hot_feasible():
         objective=objective,
         constraints={},
         one_hot_constraints={10: oh},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # x1=0, x2=1, x3=0 → feasible (exactly one is 1)
@@ -260,7 +261,7 @@ def test_evaluate_with_one_hot_infeasible():
         objective=objective,
         constraints={},
         one_hot_constraints={10: oh},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # x1=1, x2=1, x3=0 → infeasible (two are 1)
@@ -283,7 +284,7 @@ def test_evaluate_with_sos1_feasible():
         objective=objective,
         constraints={},
         sos1_constraints={20: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # x1=0, x2=5, x3=0 → feasible (at most one non-zero)
@@ -305,7 +306,7 @@ def test_convert_sos1_with_integer_variables_emits_bigm_pair():
         objective=sum(x),
         constraints={},
         sos1_constraints={10: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     before_var_ids = {dv.id for dv in instance.decision_variables}
@@ -336,7 +337,7 @@ def test_convert_sos1_rejects_domain_excluding_zero():
         objective=x[0],
         constraints={},
         sos1_constraints={10: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     before_var_ids = {dv.id for dv in instance.decision_variables}
 
@@ -357,7 +358,7 @@ def test_sos1_constraints_df_roundtrips_removed_context(snapshot):
         objective=sum(x),
         constraints={},
         sos1_constraints={7: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.convert_sos1_to_constraints(7)
 
@@ -379,7 +380,7 @@ def test_evaluate_with_sos1_infeasible():
         objective=objective,
         constraints={},
         sos1_constraints={20: sos1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # x1=1, x2=2, x3=0 → infeasible (two non-zero)
@@ -397,7 +398,7 @@ def _solution_one_hot_feasible():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     return instance.evaluate({1: 0.0, 2: 1.0, 3: 0.0})
 
@@ -411,7 +412,7 @@ def _solution_one_hot_infeasible():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     return instance.evaluate({1: 1.0, 2: 1.0, 3: 0.0})
 
@@ -444,7 +445,7 @@ def _solution_sos1_one_active():
         objective=sum(x),
         constraints={},
         sos1_constraints={20: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     return instance.evaluate({1: 0.0, 2: 5.0, 3: 0.0})
 
@@ -458,7 +459,7 @@ def _solution_sos1_all_zero():
         objective=sum(x),
         constraints={},
         sos1_constraints={20: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     return instance.evaluate({1: 0.0, 2: 0.0, 3: 0.0})
 
@@ -484,7 +485,7 @@ def test_solution_one_hot_removed_reasons_df_after_conversion(snapshot):
         objective=sum(x),
         constraints={},
         one_hot_constraints={7: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.convert_one_hot_to_constraint(7)
     sol = instance.evaluate({0: 1.0, 1: 0.0, 2: 0.0})
@@ -506,7 +507,7 @@ def test_solution_sos1_removed_reasons_df_after_conversion(snapshot):
         objective=sum(x),
         constraints={},
         sos1_constraints={7: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.convert_sos1_to_constraints(7)
     sol = instance.evaluate({0: 1.0, 1: 0.0, 2: 0.0})
@@ -525,7 +526,7 @@ def _sample_set_one_hot():
         objective=sum(x),
         constraints={},
         one_hot_constraints={10: OneHotConstraint(variables=x)},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     return instance.evaluate_samples(
         {
@@ -552,7 +553,7 @@ def _sample_set_sos1():
         objective=sum(x),
         constraints={},
         sos1_constraints={20: Sos1Constraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     return instance.evaluate_samples(
         {
@@ -578,7 +579,7 @@ def test_sample_set_one_hot_removed_reasons_df_after_conversion(snapshot):
         objective=sum(x),
         constraints={},
         one_hot_constraints={7: OneHotConstraint(variables=x)},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     instance.convert_one_hot_to_constraint(7)
     ss = instance.evaluate_samples({0: {0: 1.0, 1: 0.0, 2: 0.0}})

--- a/python/ommx-tests/tests/test_random_samples.py
+++ b/python/ommx-tests/tests/test_random_samples.py
@@ -1,5 +1,5 @@
 import pytest
-from ommx import Instance, DecisionVariable, Rng
+from ommx import Instance, DecisionVariable, Rng, Sense
 
 
 def _single_binary_instance() -> Instance:
@@ -8,7 +8,7 @@ def _single_binary_instance() -> Instance:
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
 
@@ -20,7 +20,7 @@ def test_random_samples_basic():
         decision_variables=x,
         objective=sum(x),
         constraints={0: sum(x) <= 3},  # type: ignore
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # Generate random samples
@@ -52,7 +52,7 @@ def test_random_samples_only_used_variables():
         decision_variables=x,
         objective=x[0] + x[1] + x[2],  # Only use first 3 variables
         constraints={0: x[1] + x[3] <= 1},  # Also use x[3]
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # Generate samples
@@ -83,7 +83,7 @@ def test_random_samples_with_different_variable_types():
         decision_variables=[x_bin, x_int, x_cont],
         objective=x_bin + x_int + x_cont,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Generate samples
@@ -119,7 +119,7 @@ def test_random_samples_custom_max_sample_id():
         decision_variables=x,
         objective=sum(x),
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     # Generate samples with custom max_sample_id

--- a/python/ommx-tests/tests/test_removed_constraint_wrapper.py
+++ b/python/ommx-tests/tests/test_removed_constraint_wrapper.py
@@ -71,7 +71,7 @@ def test_removed_constraint_access_original_constraint():
     retrieved_constraint = removed_constraint.constraint
     assert isinstance(retrieved_constraint, rust.Constraint)
     assert retrieved_constraint.name == "original"
-    assert retrieved_constraint.equality == 1  # EqualToZero
+    assert retrieved_constraint.equality == rust.Equality.EqualToZero
 
 
 def test_removed_constraint_repr():
@@ -161,5 +161,5 @@ def test_removed_constraint_getter_properties():
     # Test that the constraint property returns the right type and values
     retrieved_constraint = removed_constraint.constraint
     assert retrieved_constraint.name == "getter_test"
-    assert retrieved_constraint.equality == 2
+    assert retrieved_constraint.equality == rust.Equality.LessThanOrEqualToZero
     assert retrieved_constraint.subscripts == [1, 2, 3]

--- a/python/ommx-tests/tests/test_sample_set.py
+++ b/python/ommx-tests/tests/test_sample_set.py
@@ -1,4 +1,4 @@
-from ommx import Instance, DecisionVariable
+from ommx import Instance, DecisionVariable, Sense
 
 
 def test_evaluate_samples_type_check():
@@ -10,7 +10,7 @@ def test_evaluate_samples_type_check():
         decision_variables=x,
         objective=x[0] + 2 * x[1] + 3 * x[2],
         constraints={0: x[1] + x[2] <= 1},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     samples = [
@@ -30,15 +30,15 @@ def test_sample_set_sense_minimize():
         decision_variables=[],
         objective=0,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     sample_set = instance.evaluate_samples([{}])
-    assert sample_set.sense == Instance.MINIMIZE
+    assert sample_set.sense == Sense.Minimize
 
     # Check that the sense is correct when creating a Solution
     # from a SampleSet using `.best_feasible`.
     solution = sample_set.best_feasible
-    assert solution.sense == Instance.MINIMIZE
+    assert solution.sense == Sense.Minimize
 
 
 def test_sample_set_sense_maximize():
@@ -46,12 +46,12 @@ def test_sample_set_sense_maximize():
         decision_variables=[],
         objective=0,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     sample_set = instance.evaluate_samples([{}])
-    assert sample_set.sense == Instance.MAXIMIZE
+    assert sample_set.sense == Sense.Maximize
 
     # Check that the sense is correct when creating a Solution
     # from a SampleSet using `.get()`.
     sokution = sample_set.get(0)
-    assert sokution.sense == Instance.MAXIMIZE
+    assert sokution.sense == Sense.Maximize

--- a/python/ommx-tests/tests/test_snapshot_print.py
+++ b/python/ommx-tests/tests/test_snapshot_print.py
@@ -1,6 +1,8 @@
 """Snapshot tests for print output of OMMX v1 classes."""
 
 from ommx import (
+    Sense,
+    Equality,
     Constraint,
     DecisionVariable,
     IndicatorConstraint,
@@ -115,7 +117,7 @@ def test_instance_stats_print(snapshot):
         decision_variables=x,
         objective=x[0] + x[1],
         constraints={0: x[0] + x[1] <= 1, 1: x[1] + x[2] >= 1},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     stats = instance.stats()
     assert str(stats) == snapshot
@@ -130,14 +132,14 @@ def test_instance_print_uses_modeling_labels(snapshot):
     ]
     capacity = Constraint(
         function=x[0] + x[1] - 1,
-        equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+        equality=Equality.LessThanOrEqualToZero,
         name="capacity",
         subscripts=[0],
     )
     indicator = IndicatorConstraint(
         indicator_variable=x[0],
         function=x[1] - 1,
-        equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+        equality=Equality.LessThanOrEqualToZero,
         name="active",
     )
     one_hot = OneHotConstraint(variables=x[:2], name="choose")
@@ -149,7 +151,7 @@ def test_instance_print_uses_modeling_labels(snapshot):
         indicator_constraints={20: indicator},
         one_hot_constraints={30: one_hot},
         named_functions=[score],
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     assert str(instance) == snapshot
@@ -165,7 +167,7 @@ def test_parametric_instance_print_uses_parameter_labels(snapshot):
         objective=x + p,
         constraints={},
         parameters=[p],
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert str(instance) == snapshot
@@ -178,14 +180,14 @@ def test_instance_print_disambiguates_duplicate_labels_across_sections(snapshot)
     x1 = DecisionVariable.binary(1, name="x")
     constraint = Constraint(
         function=x1 - 1,
-        equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+        equality=Equality.LessThanOrEqualToZero,
         name="limit",
     )
     instance = Instance.from_components(
         decision_variables=[x0, x1],
         objective=x0,
         constraints={1: constraint},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert str(instance) == snapshot
@@ -205,7 +207,7 @@ def test_parametric_instance_print_disambiguates_parameter_and_structural_variab
         constraints={},
         parameters=[p],
         one_hot_constraints={7: one_hot},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert str(instance) == snapshot
@@ -220,7 +222,7 @@ def test_instance_print_limits_section_rows(snapshot):
     constraints = {
         i: Constraint(
             function=variables[i] - 1,
-            equality=Constraint.LESS_THAN_OR_EQUAL_TO_ZERO,
+            equality=Equality.LessThanOrEqualToZero,
             name="row",
             subscripts=[i],
         )
@@ -230,7 +232,7 @@ def test_instance_print_limits_section_rows(snapshot):
         decision_variables=variables,
         objective=variables[0],
         constraints=constraints,
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert str(instance) == snapshot
@@ -248,7 +250,7 @@ def test_instance_print_limits_structural_variable_sets(snapshot):
         objective=variables[0],
         constraints={},
         one_hot_constraints={3: one_hot},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     assert str(instance) == snapshot

--- a/python/ommx-tests/tests/test_solution.py
+++ b/python/ommx-tests/tests/test_solution.py
@@ -1,4 +1,4 @@
-from ommx import Instance
+from ommx import Instance, Sense
 
 
 def test_solution_sense_minimize():
@@ -6,10 +6,10 @@ def test_solution_sense_minimize():
         decision_variables=[],
         objective=0,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
     solution = instance.evaluate({})
-    assert solution.sense == Instance.MINIMIZE
+    assert solution.sense == Sense.Minimize
 
 
 def test_solution_sense_maximize():
@@ -17,7 +17,7 @@ def test_solution_sense_maximize():
         decision_variables=[],
         objective=0,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
     solution = instance.evaluate({})
-    assert solution.sense == Instance.MAXIMIZE
+    assert solution.sense == Sense.Maximize

--- a/python/ommx-tests/tests/test_structured_error_translation.py
+++ b/python/ommx-tests/tests/test_structured_error_translation.py
@@ -11,7 +11,7 @@ def _evaluated_results() -> tuple[ommx.Solution, ommx.SampleSet]:
         decision_variables=[x],
         objective=x,
         constraints={0: constraint},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
         named_functions=[named_function],
     )
     return instance.evaluate({0: 1}), instance.evaluate_samples({7: {0: 1}})
@@ -48,7 +48,7 @@ def test_lookup_failures_raise_key_error(operation) -> None:
 @pytest.mark.parametrize(
     "operation",
     [
-        lambda: ommx.DecisionVariable(0, 1, ommx.Bound(2, 3)),
+        lambda: ommx.DecisionVariable(0, ommx.Kind.Binary, ommx.Bound(2, 3)),
         lambda: ommx.DecisionVariable.integer(0, lower=0.1, upper=0.2),
     ],
 )
@@ -57,10 +57,34 @@ def test_decision_variable_kind_bound_mismatch_raises_value_error(operation) -> 
         operation()
 
 
-@pytest.mark.parametrize("kind", [0, 99])
-def test_unknown_decision_variable_kind_raises_value_error(kind: int) -> None:
-    with pytest.raises(ValueError, match=f"Unknown decision variable kind: {kind}"):
-        ommx.DecisionVariable(0, kind, ommx.Bound(0, 1))
+@pytest.mark.parametrize("kind", [0, 1, 99])
+def test_decision_variable_rejects_raw_integer_kind(kind: int) -> None:
+    with pytest.raises(TypeError):
+        ommx.DecisionVariable(
+            0,
+            kind,  # pyright: ignore[reportArgumentType] - intentional invalid input
+            ommx.Bound(0, 1),
+        )
+
+
+def test_constraint_rejects_raw_integer_equality() -> None:
+    variable = ommx.DecisionVariable.binary(0)
+
+    with pytest.raises(TypeError):
+        ommx.Constraint(
+            function=variable,
+            equality=1,  # pyright: ignore[reportArgumentType] - intentional invalid input
+        )
+
+
+def test_instance_rejects_raw_integer_sense() -> None:
+    with pytest.raises(TypeError):
+        ommx.Instance.from_components(
+            decision_variables=[],
+            objective=0,
+            constraints={},
+            sense=1,  # pyright: ignore[reportArgumentType] - intentional invalid input
+        )
 
 
 def test_duplicate_variable_subscripts_raise_value_error() -> None:
@@ -76,7 +100,7 @@ def test_duplicate_variable_subscripts_raise_value_error() -> None:
         decision_variables=variables,
         objective=0,
         constraints={},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
     solution = instance.evaluate({0: 0, 1: 1})
     sample_set = instance.evaluate_samples({7: {0: 0, 1: 1}})
@@ -114,7 +138,7 @@ def test_duplicate_named_function_subscripts_raise_value_error() -> None:
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
         named_functions=named_functions,
     )
     solution = instance.evaluate({0: 1})
@@ -138,7 +162,7 @@ def test_parameterized_constraints_raise_value_error() -> None:
         decision_variables=[x],
         objective=x,
         constraints={0: constraint},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
     solution = instance.evaluate({0: 1})
     sample_set = instance.evaluate_samples({7: {0: 1}})
@@ -155,7 +179,7 @@ def test_missing_feasible_sample_raises_value_error_for_all_aliases() -> None:
         decision_variables=[x],
         objective=x,
         constraints={0: x == 1},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
     )
     sample_set = instance.evaluate_samples({7: {0: 0}})
 
@@ -176,7 +200,7 @@ def test_all_extractors_validate_sample_id_before_skipping_unnamed_entries() -> 
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=ommx.Instance.MINIMIZE,
+        sense=ommx.Sense.Minimize,
         named_functions=[ommx.NamedFunction(id=0, function=x)],
     )
     sample_set = instance.evaluate_samples({7: {0: 1}})

--- a/python/ommx-tests/tests/test_tracing.py
+++ b/python/ommx-tests/tests/test_tracing.py
@@ -18,6 +18,7 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan
 
 from ommx import (
+    Sense,
     DecisionVariable,
     Equality,
     IndicatorConstraint,
@@ -43,7 +44,7 @@ def _instance_with_indicator() -> Instance:
         objective=x,
         constraints={},
         indicator_constraints={7: ic},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
 
@@ -143,7 +144,7 @@ def test_evaluate_emits_rust_span_under_python_parent() -> None:
         decision_variables=[x, y],
         objective=x + y,
         constraints={},
-        sense=Instance.MAXIMIZE,
+        sense=Sense.Maximize,
     )
 
     with tracer.start_as_current_span("python_parent") as parent_span:
@@ -171,7 +172,7 @@ def test_to_qubo_emits_active_format_span() -> None:
         decision_variables=x,
         objective=sum(x),
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     instance.to_qubo()

--- a/python/ommx-tests/tests/test_v2_bytes.py
+++ b/python/ommx-tests/tests/test_v2_bytes.py
@@ -13,7 +13,7 @@ from ommx import (
 def _special_instance() -> Instance:
     variables = [DecisionVariable.binary(i) for i in range(3)]
     return Instance.from_components(
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
         objective=sum(variables),
         decision_variables=variables,
         constraints={},

--- a/python/ommx-tests/tests/test_violation.py
+++ b/python/ommx-tests/tests/test_violation.py
@@ -1,7 +1,7 @@
 """Tests for constraint violation calculation methods."""
 
 import pytest
-from ommx import Instance, DecisionVariable
+from ommx import Instance, DecisionVariable, Sense
 
 
 def test_evaluated_constraint_violation_equality():
@@ -15,7 +15,7 @@ def test_evaluated_constraint_violation_equality():
         decision_variables=[x],
         objective=x,
         constraints={1: constraint},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Evaluate at x=0, so constraint becomes 0 = 2.5, f(x) = -2.5
@@ -37,7 +37,7 @@ def test_evaluated_constraint_violation_inequality_violated():
         decision_variables=[x],
         objective=x,
         constraints={1: constraint},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Evaluate at x=3, so constraint becomes 3 <= 1.5, f(x) = 1.5
@@ -59,7 +59,7 @@ def test_evaluated_constraint_violation_inequality_satisfied():
         decision_variables=[x],
         objective=x,
         constraints={1: constraint},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Evaluate at x=2, so constraint becomes 2 <= 5, f(x) = -3
@@ -81,7 +81,7 @@ def test_solution_total_violation_l1():
             0: x == 2.5,  # Equality: x = 2.5, evaluated at x=0 gives f(x) = -2.5
             1: x <= 1.5,  # Inequality: x <= 1.5, evaluated at x=3 gives f(x) = 1.5
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Use x=0 for equality (violation=2.5) but that would make inequality satisfied
@@ -104,7 +104,7 @@ def test_solution_total_violation_l2():
             0: x == 2.5,  # Equality: x = 2.5
             1: x <= 1.5,  # Inequality: x <= 1.5
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     # Evaluate at x=5: equality violation = 2.5, inequality violation = 3.5
@@ -127,7 +127,7 @@ def test_solution_total_violation_with_satisfied_constraints():
             1: x
             <= 10.0,  # Satisfied inequality: x <= 10, evaluated at x=5 gives max(0, 5-10) = 0
         },
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     solution = instance.evaluate({1: 5.0})
@@ -146,7 +146,7 @@ def test_solution_total_violation_empty():
         decision_variables=[x],
         objective=x,
         constraints={},
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
     solution = instance.evaluate({1: 5.0})

--- a/python/ommx/ommx/_ommx_rust/__init__.pyi
+++ b/python/ommx/ommx/_ommx_rust/__init__.pyi
@@ -936,7 +936,7 @@ class AttachedDecisionVariable:
         The parent host this variable lives in.
         """
     @property
-    def kind(self) -> builtins.int: ...
+    def kind(self) -> Kind: ...
     @property
     def bound(self) -> Bound: ...
     @property
@@ -1370,11 +1370,11 @@ class Constraint:
 
     EQUAL_TO_ZERO: Equality
     r"""
-    Class constant for equality type: equal to zero (==)
+    Compatibility alias for {attr}`Equality.EqualToZero`.
     """
     LESS_THAN_OR_EQUAL_TO_ZERO: Equality
     r"""
-    Class constant for equality type: less than or equal to zero (<=)
+    Compatibility alias for {attr}`Equality.LessThanOrEqualToZero`.
     """
     @property
     def function(self) -> Function: ...
@@ -1512,8 +1512,8 @@ class DecisionVariable:
     This class represents a variable that will be optimized in a mathematical programming problem.
     It supports various types (binary, integer, continuous, semi-integer, semi-continuous) and
     can be used in arithmetic expressions to build objective functions and constraints.
-    Construction raises ValueError when the kind discriminator is unknown or
-    the requested bound cannot be normalized for the selected variable kind.
+    Construction requires a {class}`~ommx.Kind` and raises ValueError when the
+    requested bound cannot be normalized for the selected variable kind.
 
     Note that this object overloads `==` for creating a constraint, not for equality comparison.
 
@@ -1530,15 +1530,30 @@ class DecisionVariable:
     False
     """
 
-    BINARY: builtins.int = 1
-    INTEGER: builtins.int = 2
-    CONTINUOUS: builtins.int = 3
-    SEMI_INTEGER: builtins.int = 4
-    SEMI_CONTINUOUS: builtins.int = 5
+    BINARY: Kind
+    r"""
+    Compatibility alias for {attr}`Kind.Binary`.
+    """
+    INTEGER: Kind
+    r"""
+    Compatibility alias for {attr}`Kind.Integer`.
+    """
+    CONTINUOUS: Kind
+    r"""
+    Compatibility alias for {attr}`Kind.Continuous`.
+    """
+    SEMI_INTEGER: Kind
+    r"""
+    Compatibility alias for {attr}`Kind.SemiInteger`.
+    """
+    SEMI_CONTINUOUS: Kind
+    r"""
+    Compatibility alias for {attr}`Kind.SemiContinuous`.
+    """
     @property
     def id(self) -> builtins.int: ...
     @property
-    def kind(self) -> builtins.int: ...
+    def kind(self) -> Kind: ...
     @property
     def bound(self) -> Bound: ...
     @property
@@ -1600,7 +1615,7 @@ class DecisionVariable:
     def __new__(
         cls,
         id: builtins.int,
-        kind: builtins.int,
+        kind: Kind,
         bound: Bound,
         name: typing.Optional[builtins.str] = None,
         subscripts: typing.Sequence[builtins.int] = [],
@@ -2977,7 +2992,13 @@ class Instance:
     """
 
     MAXIMIZE: Sense
+    r"""
+    Compatibility alias for {attr}`Sense.Maximize`.
+    """
     MINIMIZE: Sense
+    r"""
+    Compatibility alias for {attr}`Sense.Minimize`.
+    """
     Description: type[InstanceDescription]
     @property
     def annotations(self) -> types.MappingProxyType[str, str]:
@@ -3273,9 +3294,9 @@ class Instance:
 
         # Examples
 
-        >>> from ommx import Instance
+        >>> from ommx import Instance, Sense
         >>> instance = Instance.minimize()
-        >>> instance.sense == Instance.MINIMIZE
+        >>> instance.sense == Sense.Minimize
         True
         """
     @staticmethod
@@ -4190,14 +4211,14 @@ class Instance:
 
         # Examples
 
-        >>> from ommx import Instance, DecisionVariable, OneHotConstraint
+        >>> from ommx import Instance, DecisionVariable, OneHotConstraint, Sense
         >>> x = [DecisionVariable.binary(i) for i in range(3)]
         >>> instance = Instance.from_components(
         ...     decision_variables=x,
         ...     objective=sum(x),
         ...     constraints={},
         ...     one_hot_constraints={1: OneHotConstraint(variables=x)},
-        ...     sense=Instance.MINIMIZE,
+        ...     sense=Sense.Minimize,
         ... )
         >>> new_id = instance.convert_one_hot_to_constraint(1)
         >>> instance.one_hot_constraints
@@ -4216,7 +4237,7 @@ class Instance:
 
         # Examples
 
-        >>> from ommx import Instance, DecisionVariable, OneHotConstraint
+        >>> from ommx import Instance, DecisionVariable, OneHotConstraint, Sense
         >>> x = [DecisionVariable.binary(i) for i in range(4)]
         >>> instance = Instance.from_components(
         ...     decision_variables=x,
@@ -4226,7 +4247,7 @@ class Instance:
         ...         1: OneHotConstraint(variables=x[:2]),
         ...         2: OneHotConstraint(variables=x[2:]),
         ...     },
-        ...     sense=Instance.MINIMIZE,
+        ...     sense=Sense.Minimize,
         ... )
         >>> instance.convert_all_one_hots_to_constraints()
         [0, 1]
@@ -4273,14 +4294,14 @@ class Instance:
 
         All-binary SOS1 reduces to ``sum(x_i) - 1 <= 0`` without extra variables:
 
-        >>> from ommx import Instance, DecisionVariable, Sos1Constraint
+        >>> from ommx import Instance, DecisionVariable, Sense, Sos1Constraint
         >>> x = [DecisionVariable.binary(i) for i in range(3)]
         >>> instance = Instance.from_components(
         ...     decision_variables=x,
         ...     objective=sum(x),
         ...     constraints={},
         ...     sos1_constraints={1: Sos1Constraint(variables=x)},
-        ...     sense=Instance.MINIMIZE,
+        ...     sense=Sense.Minimize,
         ... )
         >>> instance.convert_sos1_to_constraints(1)
         [0]
@@ -4308,7 +4329,7 @@ class Instance:
 
         # Examples
 
-        >>> from ommx import Instance, DecisionVariable, Sos1Constraint
+        >>> from ommx import Instance, DecisionVariable, Sense, Sos1Constraint
         >>> x = [DecisionVariable.binary(i) for i in range(4)]
         >>> instance = Instance.from_components(
         ...     decision_variables=x,
@@ -4318,7 +4339,7 @@ class Instance:
         ...         1: Sos1Constraint(variables=x[:2]),
         ...         2: Sos1Constraint(variables=x[2:]),
         ...     },
-        ...     sense=Instance.MINIMIZE,
+        ...     sense=Sense.Minimize,
         ... )
         >>> instance.convert_all_sos1_to_constraints()
         {1: [0], 2: [1]}
@@ -4381,7 +4402,7 @@ class Instance:
         Convert an inequality indicator where the upper side is active:
 
         >>> from ommx import (
-        ...     Instance, DecisionVariable, IndicatorConstraint, Equality,
+        ...     Instance, DecisionVariable, IndicatorConstraint, Equality, Sense,
         ... )
         >>> x = DecisionVariable.continuous(0, lower=0.0, upper=5.0)
         >>> y = DecisionVariable.binary(1)
@@ -4395,7 +4416,7 @@ class Instance:
         ...     objective=x,
         ...     constraints={},
         ...     indicator_constraints={1: ic},
-        ...     sense=Instance.MINIMIZE,
+        ...     sense=Sense.Minimize,
         ... )
         >>> instance.convert_indicator_to_constraint(1)
         [0]

--- a/python/ommx/ommx/testing/__init__.py
+++ b/python/ommx/ommx/testing/__init__.py
@@ -2,7 +2,16 @@ import enum
 
 import numpy as np
 
-from ommx import Instance, DecisionVariable, Function, Constraint, Linear, State
+from ommx import (
+    Instance,
+    DecisionVariable,
+    Function,
+    Constraint,
+    Linear,
+    State,
+    Equality,
+    Sense,
+)
 
 
 class DataType(enum.Enum):
@@ -112,7 +121,7 @@ class SingleFeasibleLPGenerator:
             terms = {int(j): float(value) for j, value in enumerate(self._A[i])}
             linear = Linear(terms=terms, constant=float(-self._b[i]))
             constraint = Constraint(
-                equality=Constraint.EQUAL_TO_ZERO,
+                equality=Equality.EqualToZero,
                 function=Function(linear),
             )
             constraints[i] = constraint
@@ -122,7 +131,7 @@ class SingleFeasibleLPGenerator:
             decision_variables=decision_variables,
             objective=0,
             constraints=constraints,
-            sense=Instance.MINIMIZE,
+            sense=Sense.Minimize,
         )
 
     def get_v1_state(self) -> State:

--- a/python/ommx/ommx/testing/placement.py
+++ b/python/ommx/ommx/testing/placement.py
@@ -115,7 +115,7 @@ from math import ceil, sqrt
 import random
 from typing import Dict, List, Tuple
 
-from ommx import DecisionVariable, Instance, Sos1Constraint
+from ommx import DecisionVariable, Instance, Sos1Constraint, Sense
 
 
 @dataclass
@@ -306,7 +306,7 @@ def build_sos1(input: Input) -> Instance:
         objective=_objective(input, s, c),
         constraints=constraints,
         sos1_constraints=sos1_constraints,
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
 
@@ -365,7 +365,7 @@ def _build_with_delta(
         objective=_objective(input, s, c),
         constraints=constraints,
         sos1_constraints=sos1_constraints,
-        sense=Instance.MINIMIZE,
+        sense=Sense.Minimize,
     )
 
 

--- a/python/ommx/src/constraint.rs
+++ b/python/ommx/src/constraint.rs
@@ -33,14 +33,14 @@ impl Constraint {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 #[pymethods]
 impl Constraint {
-    /// Class constant for equality type: equal to zero (==)
+    /// Compatibility alias for {attr}`Equality.EqualToZero`.
     #[classattr]
     #[pyo3(name = "EQUAL_TO_ZERO")]
     fn class_equal_to_zero() -> Equality {
         Equality::EqualToZero
     }
 
-    /// Class constant for equality type: less than or equal to zero (<=)
+    /// Compatibility alias for {attr}`Equality.LessThanOrEqualToZero`.
     #[classattr]
     #[pyo3(name = "LESS_THAN_OR_EQUAL_TO_ZERO")]
     fn class_less_than_or_equal_to_zero() -> Equality {

--- a/python/ommx/src/decision_variable.rs
+++ b/python/ommx/src/decision_variable.rs
@@ -1,7 +1,7 @@
 use crate::{
-    error::OmmxPyResult, Constraint, Function, Linear, Polynomial, Quadratic, VariableBound,
+    error::OmmxPyResult, Constraint, Function, Kind, Linear, Polynomial, Quadratic, VariableBound,
 };
-use ommx::{v1, ATol, LinearMonomial, VariableID};
+use ommx::{ATol, LinearMonomial, VariableID};
 use pyo3::{
     prelude::*,
     types::{PyBool, PyInt},
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 /// This class represents a variable that will be optimized in a mathematical programming problem.
 /// It supports various types (binary, integer, continuous, semi-integer, semi-continuous) and
 /// can be used in arithmetic expressions to build objective functions and constraints.
-/// Construction raises ValueError when the kind discriminator is unknown or
-/// the requested bound cannot be normalized for the selected variable kind.
+/// Construction requires a {class}`~ommx.Kind` and raises ValueError when the
+/// requested bound cannot be normalized for the selected variable kind.
 ///
 /// Note that this object overloads `==` for creating a constraint, not for equality comparison.
 ///
@@ -65,19 +65,6 @@ impl DecisionVariable {
         };
 
         Ok(Self(variable_id, decision_variable, label))
-    }
-
-    fn parse_kind(kind: i32) -> PyResult<ommx::Kind> {
-        match kind {
-            1 => Ok(ommx::Kind::Binary),
-            2 => Ok(ommx::Kind::Integer),
-            3 => Ok(ommx::Kind::Continuous),
-            4 => Ok(ommx::Kind::SemiInteger),
-            5 => Ok(ommx::Kind::SemiContinuous),
-            _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "Unknown decision variable kind: {kind}"
-            ))),
-        }
     }
 
     pub fn from_parts(
@@ -159,7 +146,7 @@ impl DecisionVariable {
     #[pyo3(signature = (id, kind, bound, name=None, subscripts=Vec::new(), parameters=HashMap::default(), description=None))]
     pub fn new(
         id: u64,
-        kind: i32,
+        kind: Kind,
         bound: VariableBound,
         name: Option<String>,
         subscripts: Vec<i64>,
@@ -168,7 +155,7 @@ impl DecisionVariable {
     ) -> OmmxPyResult<Self> {
         Self::try_new(
             id,
-            Self::parse_kind(kind)?,
+            kind.into(),
             bound,
             name,
             subscripts,
@@ -183,9 +170,8 @@ impl DecisionVariable {
     }
 
     #[getter]
-    pub fn kind(&self) -> i32 {
-        let kind: v1::decision_variable::Kind = self.1.kind().into();
-        kind as i32
+    pub fn kind(&self) -> Kind {
+        self.1.kind().into()
     }
 
     #[getter]
@@ -327,9 +313,9 @@ impl DecisionVariable {
 
     pub fn __repr__(&self) -> String {
         format!(
-            "DecisionVariable(id={}, kind={}, name=\"{}\", bound=[{}, {}])",
+            "DecisionVariable(id={}, kind=Kind.{:?}, name=\"{}\", bound=[{}, {}])",
             self.id(),
-            self.kind(),
+            self.1.kind(),
             self.name(),
             self.1.bound().lower(),
             self.1.bound().upper()
@@ -348,23 +334,43 @@ impl DecisionVariable {
     }
 
     // =====================
-    // Class-level constants for variable kinds
+    // Compatibility aliases for variable kinds
     // =====================
 
+    /// Compatibility alias for {attr}`Kind.Binary`.
     #[classattr]
-    const BINARY: i32 = 1;
+    #[pyo3(name = "BINARY")]
+    fn class_binary() -> Kind {
+        Kind::Binary
+    }
 
+    /// Compatibility alias for {attr}`Kind.Integer`.
     #[classattr]
-    const INTEGER: i32 = 2;
+    #[pyo3(name = "INTEGER")]
+    fn class_integer() -> Kind {
+        Kind::Integer
+    }
 
+    /// Compatibility alias for {attr}`Kind.Continuous`.
     #[classattr]
-    const CONTINUOUS: i32 = 3;
+    #[pyo3(name = "CONTINUOUS")]
+    fn class_continuous() -> Kind {
+        Kind::Continuous
+    }
 
+    /// Compatibility alias for {attr}`Kind.SemiInteger`.
     #[classattr]
-    const SEMI_INTEGER: i32 = 4;
+    #[pyo3(name = "SEMI_INTEGER")]
+    fn class_semi_integer() -> Kind {
+        Kind::SemiInteger
+    }
 
+    /// Compatibility alias for {attr}`Kind.SemiContinuous`.
     #[classattr]
-    const SEMI_CONTINUOUS: i32 = 5;
+    #[pyo3(name = "SEMI_CONTINUOUS")]
+    fn class_semi_continuous() -> Kind {
+        Kind::SemiContinuous
+    }
 
     // =====================
     // Comparison for equality (not constraint creation)
@@ -783,11 +789,8 @@ impl AttachedDecisionVariable {
     }
 
     #[getter]
-    pub fn kind(&self, py: Python<'_>) -> PyResult<i32> {
-        let with = |v: &ommx::DecisionVariable| -> i32 {
-            let kind: ommx::v1::decision_variable::Kind = v.kind().into();
-            kind as i32
-        };
+    pub fn kind(&self, py: Python<'_>) -> PyResult<Kind> {
+        let with = |v: &ommx::DecisionVariable| -> Kind { v.kind().into() };
         match &self.host {
             crate::ConstraintHost::Instance(p) => {
                 let inst = p.borrow(py);
@@ -837,11 +840,10 @@ impl AttachedDecisionVariable {
     pub fn __repr__(&self, py: Python<'_>) -> String {
         let render =
             |id: ommx::VariableID, v: &ommx::DecisionVariable, name: Option<&str>| -> String {
-                let kind: ommx::v1::decision_variable::Kind = v.kind().into();
                 format!(
-                    "AttachedDecisionVariable(id={}, kind={}, name=\"{}\", bound=[{}, {}])",
+                    "AttachedDecisionVariable(id={}, kind=Kind.{:?}, name=\"{}\", bound=[{}, {}])",
                     id.into_inner(),
-                    kind as i32,
+                    v.kind(),
                     name.unwrap_or(""),
                     v.bound().lower(),
                     v.bound().upper()

--- a/python/ommx/src/instance.rs
+++ b/python/ommx/src/instance.rs
@@ -359,9 +359,9 @@ impl Instance {
     ///
     /// # Examples
     ///
-    /// >>> from ommx import Instance
+    /// >>> from ommx import Instance, Sense
     /// >>> instance = Instance.minimize()
-    /// >>> instance.sense == Instance.MINIMIZE
+    /// >>> instance.sense == Sense.Minimize
     /// True
     #[deprecated(note = "Use Instance.minimize() instead.")]
     #[staticmethod]
@@ -387,12 +387,14 @@ impl Instance {
         Self::empty_with_sense(Sense::Maximize)
     }
 
+    /// Compatibility alias for {attr}`Sense.Maximize`.
     #[classattr]
     #[pyo3(name = "MAXIMIZE")]
     fn class_maximize() -> Sense {
         Sense::Maximize
     }
 
+    /// Compatibility alias for {attr}`Sense.Minimize`.
     #[classattr]
     #[pyo3(name = "MINIMIZE")]
     fn class_minimize() -> Sense {
@@ -1931,14 +1933,14 @@ impl Instance {
     ///
     /// # Examples
     ///
-    /// >>> from ommx import Instance, DecisionVariable, OneHotConstraint
+    /// >>> from ommx import Instance, DecisionVariable, OneHotConstraint, Sense
     /// >>> x = [DecisionVariable.binary(i) for i in range(3)]
     /// >>> instance = Instance.from_components(
     /// ...     decision_variables=x,
     /// ...     objective=sum(x),
     /// ...     constraints={},
     /// ...     one_hot_constraints={1: OneHotConstraint(variables=x)},
-    /// ...     sense=Instance.MINIMIZE,
+    /// ...     sense=Sense.Minimize,
     /// ... )
     /// >>> new_id = instance.convert_one_hot_to_constraint(1)
     /// >>> instance.one_hot_constraints
@@ -1961,7 +1963,7 @@ impl Instance {
     ///
     /// # Examples
     ///
-    /// >>> from ommx import Instance, DecisionVariable, OneHotConstraint
+    /// >>> from ommx import Instance, DecisionVariable, OneHotConstraint, Sense
     /// >>> x = [DecisionVariable.binary(i) for i in range(4)]
     /// >>> instance = Instance.from_components(
     /// ...     decision_variables=x,
@@ -1971,7 +1973,7 @@ impl Instance {
     /// ...         1: OneHotConstraint(variables=x[:2]),
     /// ...         2: OneHotConstraint(variables=x[2:]),
     /// ...     },
-    /// ...     sense=Instance.MINIMIZE,
+    /// ...     sense=Sense.Minimize,
     /// ... )
     /// >>> instance.convert_all_one_hots_to_constraints()
     /// [0, 1]
@@ -2018,14 +2020,14 @@ impl Instance {
     ///
     /// All-binary SOS1 reduces to ``sum(x_i) - 1 <= 0`` without extra variables:
     ///
-    /// >>> from ommx import Instance, DecisionVariable, Sos1Constraint
+    /// >>> from ommx import Instance, DecisionVariable, Sense, Sos1Constraint
     /// >>> x = [DecisionVariable.binary(i) for i in range(3)]
     /// >>> instance = Instance.from_components(
     /// ...     decision_variables=x,
     /// ...     objective=sum(x),
     /// ...     constraints={},
     /// ...     sos1_constraints={1: Sos1Constraint(variables=x)},
-    /// ...     sense=Instance.MINIMIZE,
+    /// ...     sense=Sense.Minimize,
     /// ... )
     /// >>> instance.convert_sos1_to_constraints(1)
     /// [0]
@@ -2053,7 +2055,7 @@ impl Instance {
     ///
     /// # Examples
     ///
-    /// >>> from ommx import Instance, DecisionVariable, Sos1Constraint
+    /// >>> from ommx import Instance, DecisionVariable, Sense, Sos1Constraint
     /// >>> x = [DecisionVariable.binary(i) for i in range(4)]
     /// >>> instance = Instance.from_components(
     /// ...     decision_variables=x,
@@ -2063,7 +2065,7 @@ impl Instance {
     /// ...         1: Sos1Constraint(variables=x[:2]),
     /// ...         2: Sos1Constraint(variables=x[2:]),
     /// ...     },
-    /// ...     sense=Instance.MINIMIZE,
+    /// ...     sense=Sense.Minimize,
     /// ... )
     /// >>> instance.convert_all_sos1_to_constraints()
     /// {1: [0], 2: [1]}
@@ -2131,7 +2133,7 @@ impl Instance {
     /// Convert an inequality indicator where the upper side is active:
     ///
     /// >>> from ommx import (
-    /// ...     Instance, DecisionVariable, IndicatorConstraint, Equality,
+    /// ...     Instance, DecisionVariable, IndicatorConstraint, Equality, Sense,
     /// ... )
     /// >>> x = DecisionVariable.continuous(0, lower=0.0, upper=5.0)
     /// >>> y = DecisionVariable.binary(1)
@@ -2145,7 +2147,7 @@ impl Instance {
     /// ...     objective=x,
     /// ...     constraints={},
     /// ...     indicator_constraints={1: ic},
-    /// ...     sense=Instance.MINIMIZE,
+    /// ...     sense=Sense.Minimize,
     /// ... )
     /// >>> instance.convert_indicator_to_constraint(1)
     /// [0]

--- a/rust/ommx-pyo3-bridge/fixture/tests/test_bridge.py
+++ b/rust/ommx-pyo3-bridge/fixture/tests/test_bridge.py
@@ -25,6 +25,7 @@ def assert_component_function(value: ommx.Function) -> None:
 
 def assert_component_constraint(value: ommx.Constraint) -> None:
     assert type(value) is ommx.Constraint
+    assert type(value.equality) is ommx.Equality
     assert value.equality == ommx.Equality.LessThanOrEqualToZero
     assert value.function.linear_terms == {7: 1.0}
     assert value.function.constant_term == -3.0
@@ -40,7 +41,8 @@ def assert_component_constraint(value: ommx.Constraint) -> None:
 def assert_component_decision_variable(value: ommx.DecisionVariable) -> None:
     assert type(value) is ommx.DecisionVariable
     assert value.id == 7
-    assert value.kind == 2
+    assert type(value.kind) is ommx.Kind
+    assert value.kind == ommx.Kind.Integer
     assert value.bound.lower == -2.0
     assert value.bound.upper == 8.0
     assert value.name == "x"
@@ -51,13 +53,15 @@ def assert_component_decision_variable(value: ommx.DecisionVariable) -> None:
 
 def assert_component_instance(value: ommx.Instance) -> None:
     assert type(value) is ommx.Instance
-    assert value.sense == ommx.Instance.MINIMIZE
+    assert type(value.sense) is ommx.Sense
+    assert value.sense == ommx.Sense.Minimize
     assert value.objective.linear_terms == {7: 1.0}
     assert value.objective.constant_term == -3.0
     assert len(value.decision_variables) == 1
     variable = value.decision_variables[0]
     assert variable.id == 7
-    assert variable.kind == 2
+    assert type(variable.kind) is ommx.Kind
+    assert variable.kind == ommx.Kind.Integer
     assert variable.bound.lower == -2.0
     assert variable.bound.upper == 8.0
     assert variable.name == "instance_x"
@@ -66,14 +70,20 @@ def assert_component_instance(value: ommx.Instance) -> None:
 
 def assert_component_parametric_instance(value: ommx.ParametricInstance) -> None:
     assert type(value) is ommx.ParametricInstance
+    assert type(value.sense) is ommx.Sense
+    assert value.sense == ommx.Sense.Minimize
     assert value.objective.linear_terms == {7: 1.0}
     assert value.objective.constant_term == -3.0
     assert len(value.decision_variables) == 1
+    assert type(value.decision_variables[0].kind) is ommx.Kind
     assert value.decision_variables[0].name == "instance_x"
 
 
 def assert_component_solution(value: ommx.Solution) -> None:
     assert type(value) is ommx.Solution
+    assert type(value.sense) is ommx.Sense
+    assert value.sense == ommx.Sense.Minimize
+    assert type(value.decision_variables[0].kind) is ommx.Kind
     assert value.objective == 1.0
     assert value.state.entries == {7: 4.0}
     assert value.feasible
@@ -81,6 +91,9 @@ def assert_component_solution(value: ommx.Solution) -> None:
 
 def assert_component_sample_set(value: ommx.SampleSet) -> None:
     assert type(value) is ommx.SampleSet
+    assert type(value.sense) is ommx.Sense
+    assert value.sense == ommx.Sense.Minimize
+    assert type(value.decision_variables[0].kind) is ommx.Kind
     assert value.sample_ids() == {0}
     assert_component_solution(value.get(0))
 


### PR DESCRIPTION
## Summary

- restore the stable-v2 typed-enum contract for `DecisionVariable` construction and detached/attached `kind` properties by using the canonical `Kind` enum instead of protobuf integer discriminators
- retain `DecisionVariable.*`, `Constraint.*`, and `Instance.*` compatibility names as non-deprecated, typed enum aliases
- preserve enum/integer equality and hash compatibility at explicit protobuf boundaries
- migrate Python SDK helpers and bundled adapters to canonical `Kind`, `Equality`, and `Sense` members
- add lifecycle and cross-extension regression coverage and update generated stubs, API metadata, examples, migration guides, and English/Japanese release notes

## Compatibility

Stable-v2 code using names such as `DecisionVariable.BINARY`, `Constraint.EQUAL_TO_ZERO`, and `Instance.MINIMIZE` remains valid. In v2 these names and the corresponding public properties were already typed enum members, and this PR restores that behavior after the initial v3 rewrite accidentally exposed protobuf integers.

Only code written specifically against the accidental raw-integer surface in v3 prereleases needs to migrate. Regular model constructors now require `Kind`, `Equality`, or `Sense` members, while explicit protobuf-boundary checks can continue comparing enum members with their integer values.
