### PR TITLE
Explain unexpanded powi in polynomial requirement errors

### DIFF
--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -634,7 +634,7 @@ def test_to_qubo_reduces_repeated_binary_power() -> None:
     assert instance.evaluate({0: 1}).objective == 1.0
 
 
-def test_to_qubo_reports_compact_polynomial_requirement_for_powi() -> None:
+def test_to_qubo_explains_unexpanded_powi() -> None:
     x = [DecisionVariable.binary(i) for i in range(3)]
     g = Function(x[0] + x[1] + x[2] - 1)
     instance = Instance.from_components(
@@ -647,11 +647,13 @@ def test_to_qubo_reports_compact_polynomial_requirement_for_powi() -> None:
     with pytest.raises(PreparationTargetNotReachedError) as error:
         instance.to_qubo()
 
+    message = str(error.value)
     assert (
-        "objective function uses the composed expression representation instead of "
-        "the compact polynomial representation required by this clause"
-        in str(error.value)
+        "objective function is not stored in the expanded polynomial form required by "
+        "this clause" in message
     )
+    assert "Found `powi` (`**` in Python) in the objective function" in message
+    assert "`g * g` instead of `g ** 2`" in message
 
 
 @pytest.mark.parametrize("method_name", ["to_qubo", "to_hubo"])

--- a/python/ommx-tests/tests/test_instance.py
+++ b/python/ommx-tests/tests/test_instance.py
@@ -20,6 +20,7 @@ from ommx import (
     Parameter,
     ParametricInstance,
     PreparationPolicy,
+    PreparationTargetNotReachedError,
     Sense,
 )
 
@@ -631,6 +632,26 @@ def test_to_qubo_reduces_repeated_binary_power() -> None:
     assert offset == 0.0
     assert InstanceClass.qubo().contains(instance)
     assert instance.evaluate({0: 1}).objective == 1.0
+
+
+def test_to_qubo_reports_compact_polynomial_requirement_for_powi() -> None:
+    x = [DecisionVariable.binary(i) for i in range(3)]
+    g = Function(x[0] + x[1] + x[2] - 1)
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=g**2,
+        constraints={},
+        sense=Sense.Minimize,
+    )
+
+    with pytest.raises(PreparationTargetNotReachedError) as error:
+        instance.to_qubo()
+
+    assert (
+        "objective function uses the composed expression representation instead of "
+        "the compact polynomial representation required by this clause"
+        in str(error.value)
+    )
 
 
 @pytest.mark.parametrize("method_name", ["to_qubo", "to_hubo"])

--- a/rust/ommx/src/function.rs
+++ b/rust/ommx/src/function.rs
@@ -171,6 +171,20 @@ impl Function {
         !matches!(self, Function::Expression(_))
     }
 
+    /// Return whether the represented expression program contains an integer-power operation.
+    ///
+    /// Compact functions return `false`, including powers folded during construction.
+    pub(crate) fn contains_powi_operation(&self) -> bool {
+        matches!(
+            self,
+            Function::Expression(expression)
+                if operation::instructions(expression).iter().any(|instruction| matches!(
+                    instruction,
+                    operation::Instruction::Unary(operation::UnaryOperator::Powi(_))
+                ))
+        )
+    }
+
     pub fn as_polynomial(&self) -> Option<Cow<'_, Polynomial>> {
         match self {
             Function::Zero => Some(Cow::Owned(Polynomial::zero())),
@@ -334,6 +348,40 @@ impl Function {
                 anyhow::bail!("content_factor is only defined for polynomial functions")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod operation_introspection_tests {
+    use super::*;
+
+    #[test]
+    fn compact_and_abs_functions_do_not_contain_powi_operation() {
+        let compact = Function::from(crate::linear!(1));
+        let absolute = compact.clone().abs();
+
+        assert!(!compact.contains_powi_operation());
+        assert!(!absolute.contains_powi_operation());
+    }
+
+    #[test]
+    fn non_folded_and_nested_powers_contain_powi_operation() {
+        let power = Function::from(crate::linear!(1)).powi(2);
+        let nested = power.clone().abs();
+
+        assert!(power.contains_powi_operation());
+        assert!(nested.contains_powi_operation());
+    }
+
+    #[test]
+    fn folded_powers_do_not_contain_powi_operation() {
+        let constant_power = Function::try_from(2.0).unwrap().powi(2);
+        let identity_power = Function::from(crate::linear!(1)).powi(1);
+
+        assert!(constant_power.is_polynomial());
+        assert!(identity_power.is_polynomial());
+        assert!(!constant_power.contains_powi_operation());
+        assert!(!identity_power.contains_powi_operation());
     }
 }
 

--- a/rust/ommx/src/instance/preparation.rs
+++ b/rust/ommx/src/instance/preparation.rs
@@ -1,6 +1,9 @@
 use super::{ExactIntegerSlackUnavailable, Instance, SpecialConstraintKinds};
-use crate::{ATol, ConstraintID, Equality, InstanceClass, InstanceClassMembershipReport, Sense};
-use std::collections::BTreeMap;
+use crate::{
+    ATol, ConstraintID, Equality, IndicatorConstraintID, InstanceClass,
+    InstanceClassMembershipReport, InstanceClassMismatch, Sense,
+};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Preparation of active special constraints.
 ///
@@ -267,15 +270,109 @@ impl PreparationPolicy {
 /// instance may retain changes committed by configured phases before this
 /// signal is returned.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("Preparation did not reach the target InstanceClass:\n{report}")]
+#[error("Preparation did not reach the target InstanceClass:\n{report}{powi_expansion_hint}")]
 pub struct PreparationTargetNotReached {
     report: InstanceClassMembershipReport,
+    powi_expansion_hint: PowiExpansionHint,
 }
 
 impl PreparationTargetNotReached {
     /// Return the final membership report for the prepared instance.
     pub fn report(&self) -> &InstanceClassMembershipReport {
         &self.report
+    }
+}
+
+/// Operation-specific recovery guidance derived from the final instance and
+/// its structural membership report.
+///
+/// The public report remains limited to instance-class facts. Preparation owns
+/// this hint because it can still inspect the functions that produced those
+/// facts and suggest a caller action without changing the mismatch API.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct PowiExpansionHint {
+    objective: bool,
+    regular_constraint_ids: BTreeSet<ConstraintID>,
+    indicator_constraint_ids: BTreeSet<IndicatorConstraintID>,
+}
+
+impl PowiExpansionHint {
+    fn new(instance: &Instance, report: &InstanceClassMembershipReport) -> Self {
+        let mut hint = Self::default();
+        for clause in report.clause_reports() {
+            for mismatch in clause.mismatches() {
+                match mismatch {
+                    InstanceClassMismatch::ObjectiveFunctionNotPolynomial => {
+                        hint.objective |= instance.objective().contains_powi_operation();
+                    }
+                    InstanceClassMismatch::RegularConstraintFunctionNotPolynomial {
+                        constraint_ids,
+                        ..
+                    } => {
+                        hint.regular_constraint_ids
+                            .extend(constraint_ids.iter().copied().filter(|id| {
+                                instance.constraints().get(id).is_some_and(|constraint| {
+                                    constraint.function().contains_powi_operation()
+                                })
+                            }));
+                    }
+                    InstanceClassMismatch::IndicatorBodyFunctionNotPolynomial {
+                        constraint_ids,
+                        ..
+                    } => {
+                        hint.indicator_constraint_ids.extend(
+                            constraint_ids.iter().copied().filter(|id| {
+                                instance
+                                    .indicator_constraints()
+                                    .get(id)
+                                    .is_some_and(|constraint| {
+                                        constraint.function().contains_powi_operation()
+                                    })
+                            }),
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+        hint
+    }
+
+    fn is_empty(&self) -> bool {
+        !self.objective
+            && self.regular_constraint_ids.is_empty()
+            && self.indicator_constraint_ids.is_empty()
+    }
+}
+
+impl std::fmt::Display for PowiExpansionHint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let mut locations = Vec::new();
+        if self.objective {
+            locations.push("the objective function".to_owned());
+        }
+        if !self.regular_constraint_ids.is_empty() {
+            locations.push(format!(
+                "regular constraint functions for IDs {:?}",
+                self.regular_constraint_ids
+            ));
+        }
+        if !self.indicator_constraint_ids.is_empty() {
+            locations.push(format!(
+                "indicator body functions for IDs {:?}",
+                self.indicator_constraint_ids
+            ));
+        }
+
+        write!(
+            f,
+            "\nHint: Found `powi` (`**` in Python) in {}. OMMX does not expand `powi` automatically into polynomial terms. If expansion is intended, write a positive integer power of a polynomial as repeated multiplication (for example, `g * g` instead of `g ** 2`).",
+            locations.join(", ")
+        )
     }
 }
 
@@ -486,7 +583,11 @@ impl Instance {
         }
 
         let report = input_class.check_membership(self);
-        crate::bail!(PreparationTargetNotReached { report })
+        let powi_expansion_hint = PowiExpansionHint::new(self, &report);
+        crate::bail!(PreparationTargetNotReached {
+            report,
+            powi_expansion_hint,
+        })
     }
 }
 
@@ -592,6 +693,42 @@ mod tests {
         assert!(InstanceClass::hubo().contains(&hubo));
         assert!(hubo.output_objective().is_none());
         hubo.as_hubo_format().unwrap();
+    }
+
+    #[test]
+    fn target_not_reached_explains_powi_without_mislabeling_other_operations() {
+        let variable = VariableID::from(1);
+        let functions = [
+            (Function::from(linear!(variable)).powi(2), true),
+            (Function::from(linear!(variable)).abs(), false),
+        ];
+
+        for (objective, expects_powi_hint) in functions {
+            let mut instance = Instance::new(
+                Sense::Minimize,
+                objective,
+                BTreeMap::from([(variable, DecisionVariable::binary())]),
+                BTreeMap::new(),
+            )
+            .unwrap();
+
+            let message = instance
+                .prepare(&InstanceClass::qubo(), &PreparationPolicy::default())
+                .unwrap_err()
+                .to_string();
+
+            assert!(message.contains(
+                "objective function is not stored in the expanded polynomial form required by this clause"
+            ));
+            assert_eq!(
+                message.contains("Found `powi` (`**` in Python) in the objective function"),
+                expects_powi_hint
+            );
+            assert_eq!(
+                message.contains("`g * g` instead of `g ** 2`"),
+                expects_powi_hint
+            );
+        }
     }
 
     #[test]

--- a/rust/ommx/src/instance/qubo.rs
+++ b/rust/ommx/src/instance/qubo.rs
@@ -3,6 +3,21 @@ use crate::{BinaryIdPair, BinaryIds, Evaluate};
 use anyhow::{bail, Result};
 use std::collections::BTreeMap;
 
+fn expanded_polynomial_objective_error(
+    format_name: &str,
+    objective: &crate::Function,
+) -> anyhow::Error {
+    if objective.contains_powi_operation() {
+        anyhow::anyhow!(
+            "{format_name} format requires the objective function to be stored in expanded polynomial form. The objective contains `powi` (`**` in Python). OMMX does not expand `powi` automatically into polynomial terms. If expansion is intended, write a positive integer power of a polynomial as repeated multiplication (for example, `g * g` instead of `g ** 2`)."
+        )
+    } else {
+        anyhow::anyhow!(
+            "{format_name} format requires the objective function to be stored in expanded polynomial form."
+        )
+    }
+}
+
 impl Instance {
     /// Create QUBO (Quadratic Unconstrained Binary Optimization) dictionary from the instance.
     ///
@@ -50,7 +65,10 @@ impl Instance {
     #[tracing::instrument(skip_all)]
     pub fn as_qubo_format(&self) -> Result<(BTreeMap<BinaryIdPair, f64>, f64)> {
         let Some(terms) = self.objective().iter() else {
-            bail!("QUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation.");
+            return Err(expanded_polynomial_objective_error(
+                "QUBO",
+                self.objective(),
+            ));
         };
         if self.sense() == Sense::Maximize {
             bail!("QUBO format is only for minimization problems.");
@@ -138,7 +156,10 @@ impl Instance {
     #[tracing::instrument(skip_all)]
     pub fn as_hubo_format(&self) -> Result<(BTreeMap<BinaryIds, f64>, f64)> {
         let Some(terms) = self.objective().iter() else {
-            bail!("HUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation.");
+            return Err(expanded_polynomial_objective_error(
+                "HUBO",
+                self.objective(),
+            ));
         };
         if self.sense() == Sense::Maximize {
             bail!("HUBO format is only for minimization problems.");
@@ -244,14 +265,38 @@ mod tests {
         let qubo_error = instance.as_qubo_format().unwrap_err();
         assert_eq!(
             qubo_error.to_string(),
-            "QUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation."
+            "QUBO format requires the objective function to be stored in expanded polynomial form."
         );
 
         let hubo_error = instance.as_hubo_format().unwrap_err();
         assert_eq!(
             hubo_error.to_string(),
-            "HUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation."
+            "HUBO format requires the objective function to be stored in expanded polynomial form."
         );
+    }
+
+    #[test]
+    fn qubo_and_hubo_explain_unexpanded_powi_objectives() {
+        let objective = Function::from(linear!(VariableID::from(1))).powi(2);
+        let instance = Instance::new(
+            Sense::Minimize,
+            objective,
+            BTreeMap::from([(VariableID::from(1), DecisionVariable::binary())]),
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        for (format_name, error) in [
+            ("QUBO", instance.as_qubo_format().unwrap_err()),
+            ("HUBO", instance.as_hubo_format().unwrap_err()),
+        ] {
+            let message = error.to_string();
+            assert!(message.starts_with(&format!(
+                "{format_name} format requires the objective function to be stored in expanded polynomial form."
+            )));
+            assert!(message.contains("The objective contains `powi` (`**` in Python)"));
+            assert!(message.contains("`g * g` instead of `g ** 2`"));
+        }
     }
 
     #[test]

--- a/rust/ommx/src/instance/qubo.rs
+++ b/rust/ommx/src/instance/qubo.rs
@@ -50,7 +50,7 @@ impl Instance {
     #[tracing::instrument(skip_all)]
     pub fn as_qubo_format(&self) -> Result<(BTreeMap<BinaryIdPair, f64>, f64)> {
         let Some(terms) = self.objective().iter() else {
-            bail!("QUBO format does not support a non-polynomial objective function.");
+            bail!("QUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation.");
         };
         if self.sense() == Sense::Maximize {
             bail!("QUBO format is only for minimization problems.");
@@ -138,7 +138,7 @@ impl Instance {
     #[tracing::instrument(skip_all)]
     pub fn as_hubo_format(&self) -> Result<(BTreeMap<BinaryIds, f64>, f64)> {
         let Some(terms) = self.objective().iter() else {
-            bail!("HUBO format does not support a non-polynomial objective function.");
+            bail!("HUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation.");
         };
         if self.sense() == Sense::Maximize {
             bail!("HUBO format is only for minimization problems.");
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn qubo_and_hubo_reject_non_polynomial_objectives() {
+    fn qubo_and_hubo_reject_composed_objectives() {
         let objective = Function::from(linear!(VariableID::from(1))).abs();
         let instance = Instance::new(
             Sense::Minimize,
@@ -242,10 +242,16 @@ mod tests {
         .unwrap();
 
         let qubo_error = instance.as_qubo_format().unwrap_err();
-        assert!(qubo_error.to_string().contains("non-polynomial objective"));
+        assert_eq!(
+            qubo_error.to_string(),
+            "QUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation."
+        );
 
         let hubo_error = instance.as_hubo_format().unwrap_err();
-        assert!(hubo_error.to_string().contains("non-polynomial objective"));
+        assert_eq!(
+            hubo_error.to_string(),
+            "HUBO format requires the objective function to use the compact polynomial representation, but it uses the composed expression representation."
+        );
     }
 
     #[test]

--- a/rust/ommx/src/instance_class.rs
+++ b/rust/ommx/src/instance_class.rs
@@ -687,9 +687,9 @@ impl std::fmt::Display for InstanceClassMismatch {
                 actual_degree,
                 bound,
             } => write!(f, "objective degree {actual_degree} exceeds {bound}"),
-            Self::ObjectiveFunctionNotPolynomial => {
-                f.write_str("objective function is not polynomial")
-            }
+            Self::ObjectiveFunctionNotPolynomial => f.write_str(
+                "objective function uses the composed expression representation instead of the compact polynomial representation required by this clause",
+            ),
             Self::RegularConstraintRelationNotAllowed {
                 relation,
                 constraint_ids,
@@ -711,7 +711,7 @@ impl std::fmt::Display for InstanceClassMismatch {
                 constraint_ids,
             } => write!(
                 f,
-                "regular {relation:?} constraint functions for IDs {constraint_ids:?} are not polynomial"
+                "regular {relation:?} constraint functions for IDs {constraint_ids:?} use the composed expression representation instead of the compact polynomial representation required by this clause"
             ),
             Self::IndicatorConstraintsNotAllowed { constraint_ids } => {
                 write!(f, "indicator constraints {constraint_ids:?} are not allowed")
@@ -737,7 +737,7 @@ impl std::fmt::Display for InstanceClassMismatch {
                 constraint_ids,
             } => write!(
                 f,
-                "indicator {relation:?} body functions for IDs {constraint_ids:?} are not polynomial"
+                "indicator {relation:?} body functions for IDs {constraint_ids:?} use the composed expression representation instead of the compact polynomial representation required by this clause"
             ),
             Self::OneHotConstraintsNotAllowed { constraint_ids } => {
                 write!(f, "one-hot constraints {constraint_ids:?} are not allowed")
@@ -1140,6 +1140,18 @@ mod tests {
                         relation: Equality::EqualToZero,
                         constraint_ids: BTreeSet::from([indicator_id]),
                     },
+                ]
+            );
+            assert_eq!(
+                report.clause_reports()[0]
+                    .mismatches()
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>(),
+                [
+                    "objective function uses the composed expression representation instead of the compact polynomial representation required by this clause",
+                    "regular EqualToZero constraint functions for IDs {ConstraintID(10)} use the composed expression representation instead of the compact polynomial representation required by this clause",
+                    "indicator EqualToZero body functions for IDs {IndicatorConstraintID(20)} use the composed expression representation instead of the compact polynomial representation required by this clause",
                 ]
             );
             assert!(!report.is_member());

--- a/rust/ommx/src/instance_class.rs
+++ b/rust/ommx/src/instance_class.rs
@@ -688,7 +688,7 @@ impl std::fmt::Display for InstanceClassMismatch {
                 bound,
             } => write!(f, "objective degree {actual_degree} exceeds {bound}"),
             Self::ObjectiveFunctionNotPolynomial => f.write_str(
-                "objective function uses the composed expression representation instead of the compact polynomial representation required by this clause",
+                "objective function is not stored in the expanded polynomial form required by this clause",
             ),
             Self::RegularConstraintRelationNotAllowed {
                 relation,
@@ -711,7 +711,7 @@ impl std::fmt::Display for InstanceClassMismatch {
                 constraint_ids,
             } => write!(
                 f,
-                "regular {relation:?} constraint functions for IDs {constraint_ids:?} use the composed expression representation instead of the compact polynomial representation required by this clause"
+                "regular {relation:?} constraint functions for IDs {constraint_ids:?} are not stored in the expanded polynomial form required by this clause"
             ),
             Self::IndicatorConstraintsNotAllowed { constraint_ids } => {
                 write!(f, "indicator constraints {constraint_ids:?} are not allowed")
@@ -737,7 +737,7 @@ impl std::fmt::Display for InstanceClassMismatch {
                 constraint_ids,
             } => write!(
                 f,
-                "indicator {relation:?} body functions for IDs {constraint_ids:?} use the composed expression representation instead of the compact polynomial representation required by this clause"
+                "indicator {relation:?} body functions for IDs {constraint_ids:?} are not stored in the expanded polynomial form required by this clause"
             ),
             Self::OneHotConstraintsNotAllowed { constraint_ids } => {
                 write!(f, "one-hot constraints {constraint_ids:?} are not allowed")
@@ -1149,9 +1149,9 @@ mod tests {
                     .map(ToString::to_string)
                     .collect::<Vec<_>>(),
                 [
-                    "objective function uses the composed expression representation instead of the compact polynomial representation required by this clause",
-                    "regular EqualToZero constraint functions for IDs {ConstraintID(10)} use the composed expression representation instead of the compact polynomial representation required by this clause",
-                    "indicator EqualToZero body functions for IDs {IndicatorConstraintID(20)} use the composed expression representation instead of the compact polynomial representation required by this clause",
+                    "objective function is not stored in the expanded polynomial form required by this clause",
+                    "regular EqualToZero constraint functions for IDs {ConstraintID(10)} are not stored in the expanded polynomial form required by this clause",
+                    "indicator EqualToZero body functions for IDs {IndicatorConstraintID(20)} are not stored in the expanded polynomial form required by this clause",
                 ]
             );
             assert!(!report.is_member());

--- a/rust/ommx/src/mps.rs
+++ b/rust/ommx/src/mps.rs
@@ -175,7 +175,7 @@ mod save_tests {
 
         assert!(error
             .to_string()
-            .contains("objective function is not polynomial"));
+            .contains("objective function uses the composed expression representation"));
         assert_eq!(std::fs::read(path).unwrap(), b"existing content");
     }
 

--- a/rust/ommx/src/mps.rs
+++ b/rust/ommx/src/mps.rs
@@ -175,7 +175,7 @@ mod save_tests {
 
         assert!(error
             .to_string()
-            .contains("objective function uses the composed expression representation"));
+            .contains("objective function is not stored in the expanded polynomial form"));
         assert_eq!(std::fs::read(path).unwrap(), b"existing content");
     }
 

--- a/rust/ommx/src/mps/format.rs
+++ b/rust/ommx/src/mps/format.rs
@@ -465,8 +465,8 @@ mod tests {
         - clause 0 (`MPS`):
           - variable kind SemiContinuous for IDs {VariableID(1)} is not allowed; allowed kinds are {Continuous, Integer, Binary}
           - variable kind SemiInteger for IDs {VariableID(2)} is not allowed; allowed kinds are {Continuous, Integer, Binary}
-          - objective function is not polynomial
-          - regular EqualToZero constraint functions for IDs {ConstraintID(1)} are not polynomial
+          - objective function uses the composed expression representation instead of the compact polynomial representation required by this clause
+          - regular EqualToZero constraint functions for IDs {ConstraintID(1)} use the composed expression representation instead of the compact polynomial representation required by this clause
           - regular LessThanOrEqualToZero constraint degrees {ConstraintID(2): Degree(3)} exceed degree <= 2
           - indicator constraints {IndicatorConstraintID(1)} are not allowed
           - one-hot constraints {OneHotConstraintID(1)} are not allowed

--- a/rust/ommx/src/mps/format.rs
+++ b/rust/ommx/src/mps/format.rs
@@ -465,8 +465,8 @@ mod tests {
         - clause 0 (`MPS`):
           - variable kind SemiContinuous for IDs {VariableID(1)} is not allowed; allowed kinds are {Continuous, Integer, Binary}
           - variable kind SemiInteger for IDs {VariableID(2)} is not allowed; allowed kinds are {Continuous, Integer, Binary}
-          - objective function uses the composed expression representation instead of the compact polynomial representation required by this clause
-          - regular EqualToZero constraint functions for IDs {ConstraintID(1)} use the composed expression representation instead of the compact polynomial representation required by this clause
+          - objective function is not stored in the expanded polynomial form required by this clause
+          - regular EqualToZero constraint functions for IDs {ConstraintID(1)} are not stored in the expanded polynomial form required by this clause
           - regular LessThanOrEqualToZero constraint degrees {ConstraintID(2): Degree(3)} exceed degree <= 2
           - indicator constraints {IndicatorConstraintID(1)} are not allowed
           - one-hot constraints {OneHotConstraintID(1)} are not allowed


### PR DESCRIPTION
## Summary

- replace the internal "composed expression representation" wording with a plain statement that the function is not stored in the expanded polynomial form required by the target
- detect `powi` operations when Preparation or direct QUBO/HUBO conversion rejects a function, explain that Python `**` is not expanded automatically, and show `g * g` as the intentional expansion for `g ** 2`
- keep the public `InstanceClassMismatch` and membership-report APIs unchanged while adding operation-specific recovery guidance at the Preparation and format-conversion boundaries
- cover both the `g ** 2` regression and non-`powi` composed functions so unrelated operations are not mislabeled

## Follow-up

Bounded, opt-in polynomialization during Preparation is tracked separately in #1198.
