### PR TITLE
Use the published v2.7 MIPLIB distribution in v3 SDK loaders

### DIFF
--- a/docs/en/release_note/ommx-3.0.md
+++ b/docs/en/release_note/ommx-3.0.md
@@ -61,6 +61,16 @@ $M=-L$, while undersized links remain rejected. See the
 [Instance user guide](../user_guide/instance.md) and
 [special-constraint guide](../user_guide/special_constraints.md) for details.
 
+### 🛠 Adopt the published v2.7 MIPLIB distribution ([#1205](https://github.com/Jij-Inc/ommx/pull/1205))
+
+`ommx.dataset.miplib2017` now reads
+`ghcr.io/jij-inc/ommx/v2.7/miplib2017:{instance-name}`, the distribution
+generated with corrected MPS integer bounds in OMMX 2.7.0. The v3 SDK reuses
+these published Artifacts, even when the old unversioned distribution is cached,
+and does not fall back to the old models. See the
+[MIPLIB tutorial](../tutorial/download_miplib_instance.md) for distribution
+versioning and the publication record.
+
 ## 3.0.0 Beta 5
 
 [![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b5-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b5)

--- a/docs/en/tutorial/download_miplib_instance.md
+++ b/docs/en/tutorial/download_miplib_instance.md
@@ -16,7 +16,21 @@ kernelspec:
 The OMMX repository provides mixed-integer programming benchmark instances from MIPLIB 2017 in OMMX Artifact format.
 
 ```{note}
-More details: The MIPLIB 2017 instances in OMMX Artifact format are hosted in the GitHub Container Registry for the OMMX repository ([link](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017)).
+`dataset.miplib2017` uses the published
+`ghcr.io/jij-inc/ommx/v2.7/miplib2017:{instance-name}` distribution
+([package](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fv2.7%2Fmiplib2017)).
+These Artifacts were generated with the corrected MPS integer bounds in OMMX
+2.7.0 and can also be read by the v3 SDK. The distribution version identifies
+the adopted dataset, independently of the installed SDK version.
+
+Distribution format or mathematical-model changes require an SDK minor or
+major release and a new `/v{major}.{minor}/` namespace. Patch releases keep
+their adopted distribution; published path/tag references are never overwritten.
+The previous unversioned repository remains available for reproducibility,
+but the loader does not fall back to it, including when old Artifacts are cached.
+
+The [v2.7 publication record](https://github.com/Jij-Inc/ommx/blob/1ec99bbe3c36696e5fce3cac2cd87616e457af49/rust/dataset/distributions/v2.7/README.md)
+lists the source archive, published instances, unsupported inputs, and model digests.
 
 Please see [this page](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for information on GitHub Container Registry.
 ```

--- a/docs/ja/release_note/ommx-3.0.md
+++ b/docs/ja/release_note/ommx-3.0.md
@@ -59,6 +59,15 @@ unit-scale linkではtightな $M=U$ と $M=-L$ を利用でき、小さすぎる
 拒否されます。詳細は [Instance user guide](../user_guide/instance.md) と
 [special constraint guide](../user_guide/special_constraints.md) を参照してください。
 
+### 🛠 公開済みの v2.7 MIPLIB 配布を採用 ([#1205](https://github.com/Jij-Inc/ommx/pull/1205))
+
+`ommx.dataset.miplib2017` の参照先を
+`ghcr.io/jij-inc/ommx/v2.7/miplib2017:{instance-name}` に変更しました。
+MPS の整数変数の境界を修正した OMMX 2.7.0 で生成された配布を、v3 SDK でも
+利用します。旧バージョンなし配布がキャッシュされている場合もこの配布を読み、
+旧モデルにはフォールバックしません。配布のバージョン規則と配布記録は
+[MIPLIB チュートリアル](../tutorial/download_miplib_instance.md)を参照してください。
+
 ## 3.0.0 Beta 5
 
 [![Static Badge](https://img.shields.io/badge/GitHub_Release-Python_SDK_3.0.0b5-orange?logo=github)](https://github.com/Jij-Inc/ommx/releases/tag/python-3.0.0b5)

--- a/docs/ja/tutorial/download_miplib_instance.md
+++ b/docs/ja/tutorial/download_miplib_instance.md
@@ -16,7 +16,21 @@ kernelspec:
 OMMXリポジトリでは、MIPLIB 2017の混合整数計画問題ベンチマークインスタンスをOMMX Artifact形式のデータとして提供しています。
 
 ```{note}
-より詳細な説明：MIPLIB 2017のインスタンスに対応するOMMX ArtifactはOMMXリポジトリのGitHub コンテナーレジストリ ([link](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fmiplib2017))で管理されています。
+`dataset.miplib2017` は、公開済みの
+`ghcr.io/jij-inc/ommx/v2.7/miplib2017:{instance-name}` 配布を使用します
+（[パッケージ](https://github.com/Jij-Inc/ommx/pkgs/container/ommx%2Fv2.7%2Fmiplib2017)）。
+この Artifact は MPS の整数変数の境界を修正した OMMX 2.7.0 で生成されており、
+v3 SDK でも読み込めます。配布バージョンは採用したデータセットを表し、
+インストール済み SDK のバージョンとは独立しています。
+
+配布フォーマットや数学的モデルを変更する場合は、SDK の minor または major
+リリースと新しい `/v{major}.{minor}/` 名前空間が必要です。patch リリースでは
+採用済みの配布を維持し、公開済みのパス・タグは上書きしません。
+再現性のため旧バージョンなしリポジトリも維持しますが、ローダーはそこへ
+フォールバックしません。旧 Artifact がキャッシュされている場合も同様です。
+
+[v2.7 の配布記録](https://github.com/Jij-Inc/ommx/blob/1ec99bbe3c36696e5fce3cac2cd87616e457af49/rust/dataset/distributions/v2.7/README.md)
+に、元アーカイブ、公開済みインスタンス、非対応の入力、モデルのダイジェストを記載しています。
 
 GitHub コンテナーレジストリについては[こちら](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry)を参照してください。
 ```

--- a/python/ommx-tests/tests/test_dataset.py
+++ b/python/ommx-tests/tests/test_dataset.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import sys
+
+
+def test_miplib2017_uses_versioned_distribution_with_legacy_cache(tmp_path):
+    # The registry root is process-global. Isolate both versions of the cache
+    # from other tests and from the user's registry.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+from ommx import DecisionVariable, Instance, Kind, Sense
+from ommx.artifact import Artifact, ArtifactDraft
+from ommx.dataset import miplib2017
+
+name = "neos-2626858-aoos"
+legacy_ref = f"ghcr.io/jij-inc/ommx/miplib2017:{name}"
+versioned_ref = f"ghcr.io/jij-inc/ommx/v2.7/miplib2017:{name}"
+corrected = Instance.from_components(
+    sense=Sense.Minimize,
+    objective=0,
+    decision_variables=[DecisionVariable.binary(506, name="C0506")],
+    constraints={},
+)
+for ref, model in [(legacy_ref, Instance.empty()), (versioned_ref, corrected)]:
+    draft = ArtifactDraft.new(ref)
+    # Published v2.7 Artifacts have v1 protobuf layers and descriptor annotations.
+    draft.add_layer(
+        "application/org.ommx.v1.instance",
+        model.to_v1_bytes(),
+        {"org.ommx.v1.instance.title": name},
+    )
+    draft.commit()
+
+instance = miplib2017(name)
+assert instance.title == name
+assert len(instance.decision_variables) == 1
+variable = instance.decision_variables[0]
+assert variable.id == 506 and variable.name == "C0506"
+assert variable.kind == Kind.Binary
+assert variable.bound.lower == 0 and variable.bound.upper == 1
+assert len(Artifact.load(legacy_ref).instance.decision_variables) == 0
+""",
+        ],
+        env={**os.environ, "OMMX_LOCAL_REGISTRY_ROOT": str(tmp_path)},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/python/ommx/ommx/dataset.py
+++ b/python/ommx/ommx/dataset.py
@@ -8,6 +8,11 @@ def miplib2017(name: str) -> Instance:
     """
     Load a MIPLIB 2017 instance as OMMX Artifact.
 
+    Uses the published ``ghcr.io/jij-inc/ommx/v2.7/miplib2017`` distribution,
+    generated with the corrected MPS integer bounds in OMMX 2.7.0. The
+    distribution version is fixed independently of the installed SDK version;
+    existing unversioned Artifacts are not used as a fallback.
+
     >>> from ommx.dataset import miplib2017
 
     Loading the instance requires remote registry access, so the following
@@ -49,7 +54,7 @@ def miplib2017(name: str) -> Instance:
     'benchmark,binary,benchmark_suitable,set_partitioning'
 
     """
-    artifact = Artifact.load(f"ghcr.io/jij-inc/ommx/miplib2017:{name}")
+    artifact = Artifact.load(f"ghcr.io/jij-inc/ommx/v2.7/miplib2017:{name}")
     return artifact.instance
 
 

--- a/rust/ommx/doc/release_note/3.0.md
+++ b/rust/ommx/doc/release_note/3.0.md
@@ -972,18 +972,27 @@ the decoded domain object. The descriptor is therefore an OCI projection and
 compatibility layer, not a second mutable metadata owner; the high-level raw v1
 Artifact add paths have been removed.
 
-The MIPLIB 2017 and QPLIB loaders now return [`Instance`](crate::Instance)
+The MIPLIB 2017 and QPLIB loaders now return [`Instance`](crate::v1::Instance)
 directly. Dataset catalog annotations are queried separately through
 `miplib2017::instance_annotations` or `qplib::instance_annotations` instead of
-being returned as a tuple with every loaded instance. v3 dataset artifacts are
-published under the `ghcr.io/jij-inc/ommx/v3/{miplib2017,qplib}` namespace,
-leaving the legacy repositories unchanged.
+being returned as a tuple with every loaded instance.
+
+[`miplib2017::load`](crate::dataset::miplib2017::load) adopts the published
+`ghcr.io/jij-inc/ommx/v2.7/miplib2017:{instance-name}` distribution, generated
+with corrected MPS integer bounds in OMMX 2.7.0. The v3 SDK reads its v1
+Instance layers and descriptor annotations without regenerating the Artifacts.
+The adopted distribution version is independent of the installed SDK version;
+old unversioned cache entries are neither preferred nor used as a fallback.
+Distribution format or mathematical-model changes require an SDK minor or
+major release and a new `/v{major}.{minor}/` namespace. Published path/tag
+references remain immutable. QPLIB keeps its existing unversioned distribution.
 
 See the [dataset loader migration](crate::doc::migration_guide#dataset-loader-return-shapes)
 for updated call patterns.
 
 Related PRs: [#866](https://github.com/Jij-Inc/ommx/pull/866),
-[#939](https://github.com/Jij-Inc/ommx/pull/939).
+[#939](https://github.com/Jij-Inc/ommx/pull/939),
+[#1205](https://github.com/Jij-Inc/ommx/pull/1205).
 
 ## ⚙️ `ommx::artifact::ImageRef` replaces `ocipkg::ImageName`
 

--- a/rust/ommx/src/dataset/miplib2017.rs
+++ b/rust/ommx/src/dataset/miplib2017.rs
@@ -263,6 +263,11 @@ fn check_unsupported(name: &str) -> Result<()> {
 }
 
 /// Load an instance from the MIPLIB 2017 dataset
+///
+/// Uses the published `ghcr.io/jij-inc/ommx/v2.7/miplib2017` distribution,
+/// generated with the corrected MPS integer bounds in OMMX 2.7.0. The
+/// distribution version is fixed independently of the installed SDK version;
+/// existing unversioned Artifacts are not used as a fallback.
 pub fn load(name: &str) -> Result<Instance> {
     let annotations = instance_annotations();
     ensure!(
@@ -271,7 +276,7 @@ pub fn load(name: &str) -> Result<Instance> {
     );
     check_unsupported(name)?;
 
-    let image_name = ghcr("Jij-Inc", "ommx", "miplib2017", name)?;
+    let image_name = ghcr("Jij-Inc", "ommx", "v2.7/miplib2017", name)?;
     let registry = LocalRegistry::shared_default()?;
     registry.pull_image(&image_name)?;
     let artifact = LocalArtifact::open_in_registry(registry, image_name)?;

--- a/rust/ommx/tests/dataset_miplib2017.rs
+++ b/rust/ommx/tests/dataset_miplib2017.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "remote-artifact")]
+
+use ommx::{
+    artifact::{ghcr, media_types, set_local_registry_root, ArtifactDraft, LocalArtifact},
+    dataset::miplib2017,
+    v1::decision_variable::Kind,
+    DecisionVariable, Function, Instance, Sense, VariableID,
+};
+use std::collections::HashMap;
+
+#[test]
+fn versioned_distribution_takes_precedence_over_legacy_cache() -> ommx::Result<()> {
+    // This integration test runs in its own process because the root is global.
+    let registry = tempfile::tempdir()?;
+    set_local_registry_root(registry.path())?;
+    let name = "neos-2626858-aoos";
+    let legacy_ref = ghcr("Jij-Inc", "ommx", "miplib2017", name)?;
+    let versioned_ref = ghcr("Jij-Inc", "ommx", "v2.7/miplib2017", name)?;
+    let empty = Instance::new(
+        Sense::Minimize,
+        Function::Zero,
+        Default::default(),
+        Default::default(),
+    )?;
+    let corrected = Instance::new(
+        Sense::Minimize,
+        Function::Zero,
+        [(VariableID::from(506), DecisionVariable::binary())].into(),
+        Default::default(),
+    )?;
+    let empty_bytes = empty.to_v1_bytes()?;
+    for (image_name, instance) in [(legacy_ref.clone(), empty), (versioned_ref, corrected)] {
+        let mut draft = ArtifactDraft::new(image_name)?;
+        // Published v2.7 Artifacts have v1 protobuf layers and descriptor annotations.
+        draft.add_layer_bytes(
+            media_types::v1_instance(),
+            instance.to_v1_bytes()?,
+            HashMap::from([("org.ommx.v1.instance.title".into(), name.into())]),
+        )?;
+        draft.commit()?;
+    }
+
+    let instance = miplib2017::load(name)?;
+    assert_eq!(
+        instance.description.as_ref().unwrap().name.as_deref(),
+        Some(name)
+    );
+    assert_eq!(instance.decision_variables.len(), 1);
+    let variable = &instance.decision_variables[0];
+    assert_eq!(variable.id, 506);
+    assert_eq!(variable.kind(), Kind::Binary);
+    let bound = variable.bound.as_ref().unwrap();
+    assert_eq!(bound.lower, 0.0);
+    assert_eq!(bound.upper, 1.0);
+
+    let legacy = LocalArtifact::open(legacy_ref)?;
+    assert_eq!(legacy.get_blob(&legacy.layers()?[0])?, empty_bytes);
+    Ok(())
+}


### PR DESCRIPTION
The v3 MIPLIB loaders still select the unversioned Artifacts generated before the MPS integer-bound correction. Updating the SDK can therefore continue to load a relaxed model of an originally infeasible instance such as `neos-2626858-aoos`.

Point both `ommx.dataset.miplib2017` and the Rust `miplib2017::load` at the published `ghcr.io/jij-inc/ommx/v2.7/miplib2017:{instance-name}` distribution from #1204. The adopted distribution is explicit and independent of the installed SDK version; existing unversioned cache entries do not take precedence or serve as a fallback.

Add regression coverage for loading legacy v1 Instance layers and descriptor annotations through v3 with both distribution references cached. Update the English/Japanese tutorials and SDK release notes to describe the adopted distribution, immutable references, and the minor/major namespace policy, with a link to the v2.7 publication record.

This port reuses the published v2.7 Artifacts. Generation and publication under a v3.0 namespace remain a separate follow-up; the v3 MPS parser fix is tracked in #1202.
